### PR TITLE
Fixed a problem that wouldn't let me run mrjob

### DIFF
--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -366,7 +366,7 @@ class MRJob(object):
             return LocalMRJobRunner(**self.local_job_runner_kwargs())
 
     def run_job(self):
-        """Run the all steps of the job, logging errors (and debugging output
+        """Run all steps of the job, logging errors (and debugging output
         if :option:`--verbose` is specified) to STDERR and streaming the
         output to STDOUT.
 
@@ -596,7 +596,7 @@ class MRJob(object):
             help='run a reducer')
 
         self.option_parser.add_option(
-            '--step-num', dest='step_num', type='int', default=0, default=False,
+            '--step-num', dest='step_num', type='int', default=0,
             help='which step to execute (default is 0)')
 
         # protocol stuff


### PR DESCRIPTION
When trying to run one of the example jobs, I see the stack trace reproduced below. This change fixes that along with a trivial wording mistake in a comment.

```
Traceback (most recent call last):
  File "dog.py", line 1, in <module>
    from mrjob.job import MRJob
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/mrjob/job.py", line 599
    '--step-num', dest='step_num', type='int', default=0, default=False,
SyntaxError: keyword argument repeated
```
