### PR TITLE
Fix for issue 8 - bootstrap modules get uploaded to S3 twice

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -209,7 +209,6 @@ class EMRJobRunner(MRJobRunner):
             if not path.endswith('.tar.gz'):
                 raise ValueError('bootstrap_python_packages only accepts .tar.gz files!')
             file_dict = self._add_bootstrap_file(path)
-            self._files.append(file_dict)
             self._bootstrap_python_packages.append(file_dict)
 
         # if we're bootstrapping mrjob, keep track of the file_dict


### PR DESCRIPTION
The call to _add_bootstrap_file was adding files to self._files, then the caller was doing the same. The caller no longer does that with this change.
