### PR TITLE
Fix issue 79

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -270,6 +270,11 @@ class HadoopJobRunner(MRJobRunner):
 
             streaming_args = [self._opts['hadoop_bin'], 'jar', self._opts['hadoop_streaming_jar']]
 
+            # Add extra hadoop args first as hadoop args could be a hadoop
+            # specific argument (e.g. -libjar) which must come before job
+            # specific args.
+            streaming_args.extend(self._opts['hadoop_extra_args'])
+
             # add environment variables
             for key, value in sorted(self._cmdenv.iteritems()):
                 streaming_args.append('-cmdenv')
@@ -289,9 +294,6 @@ class HadoopJobRunner(MRJobRunner):
             # add jobconf args
             for key, value in sorted(self._opts['jobconf'].iteritems()):
                 streaming_args.extend(['-jobconf', '%s=%s' % (key, value)])
-
-            # add extra hadoop args
-            streaming_args.extend(self._opts['hadoop_extra_args'])
 
             # set up mapper and reducer
             streaming_args.append('-mapper')

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -680,9 +680,9 @@ class MRJob(object):
             'multiple times.')
 
         self.runner_opt_group.add_option(
-            '--hadoop-arg', dest='hadoop_arg', default=[], action='append',
-            help='Argument of any type to pass to hadoop '
-            'streaming. You can use --hadoop arg multiple times.')
+            '--hadoop-arg', dest='hadoop_extra_args', default=[],
+            action='append', help='Argument of any type to pass to hadoop '
+            'streaming. You can use --hadoop-arg multiple times.')
 
         # options for running the job on Hadoop
         self.hadoop_opt_group = OptionGroup(


### PR DESCRIPTION
This patch fixes a bug where the --hadoop-arg flag isn't hooked up to hadoop_extra_args list. Furthermore, hadoop_extra_args is added first to the streaming_args in hadoop.py so that hadoop specific arguments can be passed on the command line (e.g. -libjars.)
