### PR TITLE
documentation in packaging was broken

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mrjob (0.2.2-1) unstable; urgency=low
+
+  * Fix debian docs installation
+
+ -- James Brown <jbrown@yelp.com>  Wed, 16 Feb 2011 13:21:01 -0800
+
 mrjob (0.2.2) unstable; urgency=low
 
   * See CHANGES.txt

--- a/debian/docs
+++ b/debian/docs
@@ -1,4 +1,4 @@
 AUTHORS.txt
 CHANGES.txt
 LICENSE.txt
-README.md
+README.rst


### PR DESCRIPTION
simple fix. bumps debian version number; doesn't really need a new tag.
