### PR TITLE
Development v0.2.x

### DIFF
--- a/mrjob/botoemr/step.py
+++ b/mrjob/botoemr/step.py
@@ -97,7 +97,8 @@ class StreamingStep(Step):
     def __init__(self, name, mapper, reducer=None,
                  action_on_failure='TERMINATE_JOB_FLOW',
                  cache_files=None, cache_archives=None,
-                 step_args=None, input=None, output=None):
+                 step_args=None, input=None, output=None,
+				 jar=None):
         """
         A hadoop streaming elastic mapreduce step
 
@@ -128,17 +129,18 @@ class StreamingStep(Step):
         self.cache_archives = cache_archives
         self.input = input
         self.output = output
+        self._jar = jar or '/home/hadoop/contrib/streaming/hadoop-0.18-streaming.jar'
 
         if isinstance(step_args, basestring):
             step_args = [step_args]
 
         self.step_args = step_args
 
-    def jar(self):
-        return '/home/hadoop/contrib/streaming/hadoop-0.18-streaming.jar'
-
     def main_class(self):
         return None
+
+    def jar(self):
+        return self._jar
 
     def args(self):
         args = ['-mapper', self.mapper]

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -145,7 +145,8 @@ class HadoopJobRunner(MRJobRunner):
         """A list of which keyword args we can pass to __init__()"""
         return super(HadoopJobRunner, cls)._allowed_opts() + [
             'hadoop_bin', 'hadoop_home', 'hdfs_scratch_dir',
-            'hadoop_streaming_jar']
+            'hadoop_streaming_jar',
+            'input_format', 'output_format']
 
     @classmethod
     def _default_opts(cls):
@@ -279,6 +280,11 @@ class HadoopJobRunner(MRJobRunner):
             # specific argument (e.g. -libjar) which must come before job
             # specific args.
             streaming_args.extend(self._opts['hadoop_extra_args'])
+
+            if step_num == 0 and self._opts.get('input_format'):
+                streaming_args.extend(("-inputformat", self._opts['input_format']))
+            if step_num == len(steps)-1 and self._opts.get('output_format'):
+                streaming_args.extend(("-outputformat", self._opts['output_format']))
 
             # add environment variables
             for key, value in sorted(self._get_cmdenv().iteritems()):

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -692,6 +692,21 @@ class MRJob(object):
             'streaming. You can use --hadoop-arg multiple times.')
 
         self.runner_opt_group.add_option(
+            '--outputformat', dest='output_format', default=None,
+            help='the hadoop OutputFormat class used to write the data. '
+            'Class must be defined in --hadoop-streaming-jar')
+
+        self.runner_opt_group.add_option(
+            '--inputformat', dest='input_format', default=None,
+            help='the hadoop OutputFormat class used to read the data. '
+            'Class must be defined in --hadoop-streaming-jar')
+
+        self.runner_opt_group.add_option(
+            '--hadoop-streaming-jar', dest='hadoop_streaming_jar',
+            default=None,
+            help='Path of your hadoop streaming jar (REQUIRED with -r hadoop)')
+
+        self.runner_opt_group.add_option(
             '--python-bin', dest='python_bin', default=None,
             help='Name/path of alternate python binary for mappers/reducers.')
 
@@ -703,10 +718,6 @@ class MRJob(object):
         self.hadoop_opt_group.add_option(
             '--hadoop-bin', dest='hadoop_bin', default=None,
             help='hadoop binary. Defaults to $HADOOP_HOME/bin/hadoop')
-        self.hadoop_opt_group.add_option(
-            '--hadoop-streaming-jar', dest='hadoop_streaming_jar',
-            default=None,
-            help='Path of your hadoop streaming jar (REQUIRED)')
         self.hadoop_opt_group.add_option(
             '--hdfs-scratch-dir', dest='hdfs_scratch_dir',
             default=None,
@@ -870,6 +881,9 @@ class MRJob(object):
             'extra_args': self.generate_passthrough_arguments(),
             'file_upload_args': self.generate_file_upload_args(),
             'hadoop_extra_args': self.options.hadoop_extra_args,
+            'input_format': self.options.input_format,
+            'output_format': self.options.output_format,
+            'hadoop_streaming_jar': self.options.hadoop_streaming_jar,
             'input_paths': self.args,
             'jobconf': self.options.jobconf,
             'mr_job_script': self.mr_job_script(),


### PR DESCRIPTION
Support for custom jar for --inputformat and --outputformat hadoop args.

Example usage is outputing job data to different files based on a key's value.
