### PR TITLE
steps_python_bin option

### DIFF
--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -712,6 +712,10 @@ class MRJob(object):
             '--python-bin', dest='python_bin', default=None,
             help='Name/path of alternate python binary for mappers/reducers.')
 
+        self.runner_opt_group.add_option(
+            '--steps-python-bin', dest='steps_python_bin', default=None,
+            help='Name/path of alternate python binary for steps.')
+
         # options for running the job on Hadoop
         self.hadoop_opt_group = OptionGroup(
             self.option_parser, 'Running on Hadoop (these apply when you set -r hadoop)')
@@ -898,6 +902,7 @@ class MRJob(object):
             'output_dir': self.options.output_dir,
             'owner': self.options.owner,
             'python_bin': self.options.python_bin,
+            'steps_python_bin': self.options.steps_python_bin,
             'stdin': self.stdin,
             'upload_archives': self.options.upload_archives,
             'upload_files': self.options.upload_files,

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -50,6 +50,7 @@ class LocalMRJobRunner(MRJobRunner):
 
         * *cmdenv* is combined with :py:func:`~mrjob.conf.combine_local_envs`
         * *python_bin* defaults to ``sys.executable`` (the current python interpreter)
+        * *steps_python_bin* defaults to ``sys.executable`` (the current python interpreter)
         * *hadoop_extra_args*, *hadoop_input_format*, *hadoop_output_format*, and *hadoop_streaming_jar*, and *jobconf* are ignored because they require Java. If you need to test these, consider starting up a standalone Hadoop instance and running your job with ``-r hadoop``.
         """
         super(LocalMRJobRunner, self).__init__(**kwargs)
@@ -65,6 +66,7 @@ class LocalMRJobRunner(MRJobRunner):
         return combine_dicts(super(LocalMRJobRunner, cls)._default_opts(), {
             # prefer whatever interpreter we're currently using
             'python_bin': sys.executable or 'python',
+            'steps_python_bin': sys.executable or 'python',
         })
 
     @classmethod

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -133,6 +133,8 @@ class MRJobRunner(object):
         :param python_archives: same as upload_archives, except they get added to the job's :envvar:`PYTHONPATH`
         :type python_bin: str
         :param python_bin: Name/path of alternate python binary for mappers/reducers (e.g. for use with :py:mod:`virtualenv`). Defaults to ``'python'``.
+        :type steps_python_bin: str
+        :param steps_python_bin: Name/path of alternate python binary for steps (e.g. for use with :py:mod:`virtualenv`). Defaults to ``'python'``.
         :type setup_cmds: list
         :param setup_cmds: a list of commands to run before each mapper/reducer step (e.g. ``['cd my-src-tree; make', 'mkdir -p /tmp/foo']``). You can specify commands as strings, which will be run through the shell, or lists of args, which will be invoked directly. We'll use file locking to ensure that multiple mappers/reducers running on the same node won't run *setup_cmds* simultaneously (it's safe to run ``make``).
         :type setup_scripts: list of str
@@ -267,6 +269,7 @@ class MRJobRunner(object):
             'owner',
             'python_archives',
             'python_bin',
+            'steps_python_bin',
             'setup_cmds',
             'setup_scripts',
             'upload_archives',
@@ -288,6 +291,7 @@ class MRJobRunner(object):
             'cleanup': CLEANUP_DEFAULT,
             'owner': owner,
             'python_bin': 'python',
+            'steps_python_bin': 'python',
         }
 
     @classmethod
@@ -302,6 +306,7 @@ class MRJobRunner(object):
             'jobconf': combine_dicts,
             'python_archives': combine_path_lists,
             'python_bin': combine_paths,
+            'steps_python_bin': combine_paths,
             'setup_cmds': combine_lists,
             'setup_scripts': combine_path_lists,
             'upload_archives': combine_path_lists,
@@ -710,9 +715,7 @@ class MRJobRunner(object):
             if not self._script:
                 self._steps = []
             else:
-                # don't use self._opts['python_bin'] because that
-                # refers to the python binary to use inside Hadoop
-                python_bin = sys.executable or 'python'
+                python_bin = self._opts['steps_python_bin']
                 args = ([python_bin, self._script['path'], '--steps'] +
                         self._mr_job_extra_args(local=True))
                 log.debug('> %s' % cmd_line(args))

--- a/tests/local_test.py
+++ b/tests/local_test.py
@@ -163,6 +163,25 @@ class PythonBinTestCase(TestCase):
         assert_in('--mapper', output)
  
 
+class StepsPythonBinTestCase(TestCase):
+
+    def test_echo_as_steps_python_bin(self):
+        mr_job = MRTwoStepJob(['--steps', '--steps-python-bin', 'echo', '--no-conf'])
+        mr_job.sandbox()
+        
+        with mr_job.make_runner() as runner:
+            assert isinstance(runner, LocalMRJobRunner)
+            try:
+                runner._get_steps()
+                assert False, 'Should throw exception'
+            except ValueError, ex:
+                output = str(ex)
+                # the output should basically be the command used to
+                # run the steps command
+                assert_in('mr_two_step_job.py', output)
+                assert_in('--steps', output)
+ 
+
 class LocalBootstrapMrjobTestCase(TestCase):
 
     @setup


### PR DESCRIPTION
Took a _lot_ longer than I had planned to find the time, but here are the changes as discussed wrt Issue 54 https://github.com/Yelp/mrjob/issues/54.

Added a steps_python_bin option to allow a specific python to be used for the steps process
