### PR TITLE
Change default hadoop streaming version to 0.20

### DIFF
--- a/mrjob/botoemr/connection.py
+++ b/mrjob/botoemr/connection.py
@@ -157,7 +157,7 @@ class EmrConnection(AWSQueryConnection):
                     slave_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
-                    hadoop_version='0.18',
+                    hadoop_version='0.20',
                     steps=[],
                     bootstrap_actions=[]):
         """

--- a/mrjob/botoemr/step.py
+++ b/mrjob/botoemr/step.py
@@ -131,7 +131,7 @@ class StreamingStep(Step):
         self.cache_archives = cache_archives
         self.input = input
         self.output = output
-        self._jar = jar or '/home/hadoop/contrib/streaming/hadoop-0.18-streaming.jar'
+        self._jar = jar or '/home/hadoop/contrib/streaming/hadoop-0.20-streaming.jar'
 
         if isinstance(step_args, basestring):
             step_args = [step_args]

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -220,7 +220,7 @@ class MockEmrConnection(object):
                     slave_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
-                    hadoop_version='0.18',
+                    hadoop_version='0.20',
                     steps=[],
                     bootstrap_actions=[],
                     now=None):

--- a/tests/tools/emr/terminate_idle_job_flows_test.py
+++ b/tests/tools/emr/terminate_idle_job_flows_test.py
@@ -54,7 +54,7 @@ class JobFlowInspectionTestCase(MockEMRAndS3TestCase):
             startdatetime=to_iso8601(self.now - timedelta(hours=5)),
             steps=[MockEmrObject(
                 startdatetime=to_iso8601(self.now - timedelta(hours=4)),
-                jar='/home/hadoop/contrib/streaming/hadoop-0.18-streaming.jar',
+                jar='/home/hadoop/contrib/streaming/hadoop-0.20-streaming.jar',
                 state='RUNNING',
             )],
         )
@@ -68,7 +68,7 @@ class JobFlowInspectionTestCase(MockEMRAndS3TestCase):
             steps=[MockEmrObject(
                 startdatetime=to_iso8601(self.now - timedelta(hours=8)),
                 enddatetime=to_iso8601(self.now - timedelta(hours=6)),
-                jar='/home/hadoop/contrib/streaming/hadoop-0.18-streaming.jar',
+                jar='/home/hadoop/contrib/streaming/hadoop-0.20-streaming.jar',
                 state='COMPLETE',
             )],
         )
@@ -81,7 +81,7 @@ class JobFlowInspectionTestCase(MockEMRAndS3TestCase):
             steps=[MockEmrObject(
                 startdatetime=to_iso8601(self.now - timedelta(hours=4)),
                 enddatetime=to_iso8601(self.now - timedelta(hours=2)),
-                jar='/home/hadoop/contrib/streaming/hadoop-0.18-streaming.jar',
+                jar='/home/hadoop/contrib/streaming/hadoop-0.20-streaming.jar',
                 state='COMPLETE',
             )],
         )
@@ -116,7 +116,7 @@ class JobFlowInspectionTestCase(MockEMRAndS3TestCase):
                 MockEmrObject(
                     startdatetime=to_iso8601(self.now - timedelta(hours=4)),
                     enddatetime=to_iso8601(self.now - timedelta(hours=2)),
-                    jar='/home/hadoop/contrib/streaming/hadoop-0.18-streaming.jar',
+                    jar='/home/hadoop/contrib/streaming/hadoop-0.20-streaming.jar',
                     state='COMPLETE',
                 )
             ],
@@ -132,11 +132,11 @@ class JobFlowInspectionTestCase(MockEMRAndS3TestCase):
                 MockEmrObject(
                     startdatetime=to_iso8601(self.now - timedelta(hours=4)),
                     enddatetime=to_iso8601(self.now - timedelta(hours=3)),
-                    jar='/home/hadoop/contrib/streaming/hadoop-0.18-streaming.jar',
+                    jar='/home/hadoop/contrib/streaming/hadoop-0.20-streaming.jar',
                     state='FAILED',
                 ),
                 MockEmrObject(
-                    jar='/home/hadoop/contrib/streaming/hadoop-0.18-streaming.jar',
+                    jar='/home/hadoop/contrib/streaming/hadoop-0.20-streaming.jar',
                     state='CANCELLED',
                 )
             ],


### PR DESCRIPTION
The default hadoop streaming jar version on EMR is 0.20. 
See http://docs.amazonwebservices.com/ElasticMapReduce/latest/DeveloperGuide/index.html?usingemr_config_supportedversions.html

mrjob defaults to 0.18 and will throw an error about not being able to find that version on the system.
