### PR TITLE
Adding inline job runner for use with debuggers

### DIFF
--- a/mrjob/__init__.py
+++ b/mrjob/__init__.py
@@ -31,4 +31,4 @@ __credits__ = [
     'Paul Wais <pwais@yelp.com>',
 ]
 
-__version__ = '0.2.5'
+__version__ = '0.2.5-inline'

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -1,0 +1,160 @@
+# Copyright 2009-2011 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run an MRJob inline by running all mappers and reducers through the same process.  Useful for debugging."""
+
+import logging
+import os
+import pprint
+import shutil
+import subprocess
+import sys
+
+from mrjob.conf import combine_dicts, combine_local_envs
+from mrjob.runner import MRJobRunner
+from mrjob.job import MRJob
+
+log = logging.getLogger('mrjob.inline')
+
+
+class InlineJobRunner(MRJobRunner):
+    """Runs an :py:class:`~mrjob.job.MRJob` inline, for testing
+    purposes and use with debuggers.
+
+    This is NOT the default way of running jobs; to more accurately
+    simulate your environment prior to running on Hadoop/EMR, use --runner local
+
+    It's rare to need to instantiate this class directly (see
+    :py:meth:`~InlineJobRunner.__init__` for details).
+    """
+
+    alias = 'inline'
+
+    def __init__(self, mrjob_cls=None, **kwargs):
+        """InlineJobRunner takes the same keyword args as :py:class:`~mrjob.runner.MRJobRunner`. However, please note:
+
+        * *hadoop_extra_args*, *hadoop_input_format*, *hadoop_output_format*, and *hadoop_streaming_jar*, and *jobconf* are ignored because they require Java. If you need to test these, consider starting up a standalone Hadoop instance and running your job with ``-r hadoop``.
+        """
+        super(InlineJobRunner, self).__init__(**kwargs)
+        assert issubclass(mrjob_cls, MRJob)
+
+        self._mrjob_cls = mrjob_cls
+        self._prev_outfile = None
+        self._final_outfile = None
+
+    @classmethod
+    def _opts_combiners(cls):
+        # on windows, PYTHONPATH should use ;, not :
+        return combine_dicts(
+            super(InlineJobRunner, cls)._opts_combiners(),
+            {'cmdenv': combine_local_envs})
+
+    # options that we ignore because they require real Hadoop
+    IGNORED_OPTS = [
+        'hadoop_extra_args',
+        'hadoop_input_format',
+        'hadoop_output_format',
+        'hadoop_streaming_jar',
+        'jobconf',
+    ]
+
+    def _run(self):
+        self._setup_output_dir()
+
+        assert self._script # shouldn't be able to run if no script
+
+        for ignored_opt in self.IGNORED_OPTS:
+            if self._opts[ignored_opt]:
+                log.warning('ignoring %s option (requires real Hadoop): %r' %
+                            (ignored_opt, self._opts[ignored_opt]))
+
+        # run mapper, sort, reducer for each step
+        for step_number, step_name in enumerate(self._get_steps()):
+            self._invoke_inline_mrjob(step_number, 'step-%d-mapper' % step_number, is_mapper=True)
+
+            if 'R' in step_name:
+                mapper_output_path = self._prev_outfile
+                sorted_mapper_output_path = self._decide_output_path('step-%d-mapper-sorted' % step_number)
+                proc = subprocess.Popen(['sort', '-o', sorted_mapper_output_path, mapper_output_path], env={'LC_ALL': 'C'})
+                proc.wait()
+
+                # This'll read from sorted_mapper_output_path
+                self._invoke_inline_mrjob(step_number, 'step-%d-reducer' % step_number, is_reducer=True)
+
+        # move final output to output directory
+        self._final_outfile = os.path.join(self._output_dir, 'part-00000')
+        log.info('Moving %s -> %s' % (self._prev_outfile, self._final_outfile))
+        shutil.move(self._prev_outfile, self._final_outfile)
+
+    def _invoke_inline_mrjob(self, step_number, outfile_name, is_mapper=False, is_reducer=False):
+        common_args = ['--step-num=%d' % step_number] + self._mr_job_extra_args() + self._decide_input_paths()
+        if is_mapper:
+            child_args = ['--mapper'] + common_args
+        elif is_reducer:
+            child_args = ['--reducer'] + common_args
+
+        outfile = self._decide_output_path(outfile_name)
+
+        child_instance = self._mrjob_cls(args=child_args)
+
+        # Tweak IO
+        child_stdout = open(outfile, 'w')
+        child_instance.sandbox(stdin=sys.stdin, stdout=child_stdout)
+        child_instance.execute()
+        child_stdout.flush()
+        child_stdout.close()
+
+        log.info('counters: %s', pprint.pformat(child_instance.parse_counters()))
+
+    def _decide_input_paths(self):
+        # decide where to get input
+        if self._prev_outfile is not None:
+            input_paths = [self._prev_outfile]
+        else:
+            input_paths = []
+            for path in self._input_paths:
+                if path == '-':
+                    input_paths.append(self._dump_stdin_to_local_file())
+                else:
+                    input_paths.append(path)
+
+        return input_paths
+
+    def _decide_output_path(self, outfile_name):
+        # run the mapper
+        outfile = os.path.join(self._get_local_tmp_dir(), outfile_name)
+        log.info('writing to %s' % outfile)
+        log.debug('')
+
+        self._prev_outfile = outfile
+        return outfile
+
+    def _setup_output_dir(self):
+        if not self._output_dir:
+            self._output_dir = os.path.join(self._get_local_tmp_dir(), 'output')
+
+        if not os.path.isdir(self._output_dir):
+            log.debug('Creating output directory %s' % self._output_dir)
+            self.mkdir(self._output_dir)
+
+    def _stream_output(self):
+        """Read output from the final outfile."""
+        if self._final_outfile:
+            output_file = self._final_outfile
+        else:
+            output_file = os.path.join(self._output_dir, 'part-00000')
+        log.info('streaming final output from %s' % output_file)
+
+        for line in open(output_file):
+            yield line

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -330,18 +330,20 @@ class MRJob(object):
         """
         # load options from the command line
         mr_job = cls(args=_READ_ARGS_FROM_SYS_ARGV)
+        mr_job.execute()
 
-        if mr_job.options.show_steps:
-            mr_job.show_steps()
+    def execute(self):
+        if self.options.show_steps:
+            self.show_steps()
 
-        elif mr_job.options.run_mapper:
-            mr_job.run_mapper(mr_job.options.step_num)
+        elif self.options.run_mapper:
+            self.run_mapper(self.options.step_num)
 
-        elif mr_job.options.run_reducer:
-            mr_job.run_reducer(mr_job.options.step_num)
+        elif self.options.run_reducer:
+            self.run_reducer(self.options.step_num)
 
         else:
-            mr_job.run_job()
+            self.run_job()
 
     def make_runner(self):
         """Make a runner based on command-line arguments, so we can
@@ -354,12 +356,16 @@ class MRJob(object):
         from mrjob.emr import EMRJobRunner
         from mrjob.hadoop import HadoopJobRunner
         from mrjob.local import LocalMRJobRunner
+        from mrjob.inline import InlineJobRunner
 
         if self.options.runner == 'emr':
             return EMRJobRunner(**self.emr_job_runner_kwargs())
 
         elif self.options.runner == 'hadoop':
             return HadoopJobRunner(**self.hadoop_job_runner_kwargs())
+
+        elif self.options.runner == 'inline':
+            return InlineJobRunner(mrjob_cls=self.__class__, **self.inline_job_runner_kwargs())
 
         else:
             # run locally by default
@@ -628,7 +634,7 @@ class MRJob(object):
 
         self.runner_opt_group.add_option(
             '-r', '--runner', dest='runner', default='local',
-            choices=('local', 'hadoop', 'emr'),
+            choices=('local', 'hadoop', 'emr', 'inline'),
             help='Where to run the job: local to run locally, hadoop to run on your Hadoop cluster, emr to run on Amazon ElasticMapReduce. Default is local.')
         self.runner_opt_group.add_option(
             '-c', '--conf-path', dest='conf_path', default=None,
@@ -902,6 +908,17 @@ class MRJob(object):
             'upload_archives': self.options.upload_archives,
             'upload_files': self.options.upload_files,
         }
+
+    def inline_job_runner_kwargs(self):
+        """Keyword arguments to create create runners when
+        :py:meth:`make_runner` is called, when we run a job locally
+        (``-r inline``).
+
+        :return: map from arg name to value
+
+        Re-define this if you want finer control when running jobs locally.
+        """
+        return self.job_runner_kwargs()
 
     def local_job_runner_kwargs(self):
         """Keyword arguments to create create runners when

--- a/tests/inline_test.py
+++ b/tests/inline_test.py
@@ -1,0 +1,73 @@
+"""Tests for InlineJobRunner"""
+
+from __future__ import with_statement
+
+from StringIO import StringIO
+import gzip
+import mrjob
+import os
+import shutil
+import signal
+from testify import TestCase, assert_in, assert_equal, assert_not_equal, assert_not_in, setup, teardown
+import tempfile
+
+from mrjob.conf import dump_mrjob_conf
+from mrjob.inline import InlineJobRunner
+from tests.mr_job_where_are_you import MRJobWhereAreYou
+from tests.mr_two_step_job import MRTwoStepJob
+from tests.mr_verbose_job import MRVerboseJob
+from tests.quiet import no_handlers_for_logger
+
+
+class InlineJobRunnerEndToEndTestCase(TestCase):
+
+    @setup
+    def make_tmp_dir_and_mrjob_conf(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.mrjob_conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
+        dump_mrjob_conf({'runners': {'inline': {}}},
+                        open(self.mrjob_conf_path, 'w'))
+
+    @teardown
+    def rm_tmp_dir(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_end_to_end(self):
+        # read from STDIN, a regular file, and a .gz
+        stdin = StringIO('foo\nbar\n')
+
+        input_path = os.path.join(self.tmp_dir, 'input')
+        with open(input_path, 'w') as input_file:
+            input_file.write('bar\nqux\n')
+
+        input_gz_path = os.path.join(self.tmp_dir, 'input.gz')
+        input_gz = gzip.GzipFile(input_gz_path, 'w')
+        input_gz.write('foo\n')
+        input_gz.close()
+
+        mr_job = MRTwoStepJob(['--runner', 'inline', '-c', self.mrjob_conf_path,
+                               '-', input_path, input_gz_path])
+        mr_job.sandbox(stdin=stdin)
+
+        local_tmp_dir = None
+        results = []
+
+        with mr_job.make_runner() as runner:
+            assert isinstance(runner, InlineJobRunner)
+            runner.run()
+
+            for line in runner.stream_output():
+                key, value = mr_job.parse_output_line(line)
+                results.append((key, value))
+
+            local_tmp_dir = runner._get_local_tmp_dir()
+            assert os.path.exists(local_tmp_dir)
+
+        # make sure cleanup happens
+        assert not os.path.exists(local_tmp_dir)
+
+        assert_equal(sorted(results),
+                     [(1, 'qux'), (2, 'bar'), (2, 'foo'), (5, None)])
+
+class TimeoutException(Exception):
+    pass

--- a/tests/mr_verbose_job.py
+++ b/tests/mr_verbose_job.py
@@ -22,10 +22,10 @@ class MRVerboseJob(MRJob):
     def mapper_final(self):
         # the UNIX pipe buffer can hold 65536 bytes, so this should
         # definitely exceed that
-        for i in range(10000):
+        for i in xrange(10000):
             self.increment_counter('Foo', 'Bar')
 
-        for i in range(100):
+        for i in xrange(100):
             self.set_status(str(i))
 
         print >> sys.stderr, 'Qux'


### PR DESCRIPTION
Hey guys, long time no see :)

I added a job runner that would run all mappers/reducers in the same process so we can use debuggers with MRJob.  Previously, when we would try to attach a debugger to a job with --runner=local, we could only attach to the launcher and not the subprocesses.  This basically meant we couldn't debug the map/reduce phases. 

This should be used in tandem with --runner=local for testing as it does NOT attempt to replicate the Hadoop environment like --runner=local does.  Hope you find it useful!

-Matt
