### PR TITLE
Adds a command line flag for the python_archives option

### DIFF
--- a/docs/configs-reference.rst
+++ b/docs/configs-reference.rst
@@ -33,7 +33,7 @@ Option                 Default                        Combined by               
 *jobconf*              ``{}``                         :py:func:`~mrjob.conf.combine_dicts`      :option:`--jobconf`
 *label*                (automatic)                    :py:func:`~mrjob.conf.combine_values`     :option:`--label`
 *owner*                (automatic)                    :py:func:`~mrjob.conf.combine_values`     :option:`--owner`
-*python_archives*      ``[]``                         :py:func:`~mrjob.conf.combine_path_lists`
+*python_archives*      ``[]``                         :py:func:`~mrjob.conf.combine_path_lists` :option:`--python-archive`
 *python_bin*           :command:`python`              :py:func:`~mrjob.conf.combine_values`     :option:`--python-bin`
 *setup_cmds*           ``[]``                         :py:func:`~mrjob.conf.combine_lists`
 *setup_scripts*        ``[]``                         :py:func:`~mrjob.conf.combine_path_lists`

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -679,6 +679,10 @@ class MRJob(object):
             '--archive', dest='upload_archives', action='append',
             default=[],
             help='Unpack archive in the working directory of this script. You can use --archive multiple times.')
+        self.runner_opt_group.add_option(
+            '--python-archive', dest='python_archives', action='append',
+            default=[],
+            help='Same as --archive, except it gets added to the job\'s PYTHONPATH. You can use --python-archive multiple times.')
 
         self.runner_opt_group.add_option(
             '-o', '--output-dir', dest='output_dir', default=None,
@@ -925,6 +929,7 @@ class MRJob(object):
             'label': self.options.label,
             'output_dir': self.options.output_dir,
             'owner': self.options.owner,
+            'python_archives': self.options.python_archives,
             'python_bin': self.options.python_bin,
             'stdin': self.stdin,
             'steps_python_bin': self.options.steps_python_bin,


### PR DESCRIPTION
Note:
I haven't run the unittests.
I made these changes in the copy installed on my machine, got it working
and copied the changes into a git repo clone without testing
from within the repo.
