### PR TITLE
Kill more jars

### DIFF
--- a/mrjob/tools/emr/terminate_idle_job_flows.py
+++ b/mrjob/tools/emr/terminate_idle_job_flows.py
@@ -118,7 +118,7 @@ def is_job_flow_non_streaming(job_flow):
         return False
 
     for step in job_flow.steps:
-        args = [a.value for a in step.args]
+        args = [a.value for a in step.args()]
         for arg in args:
             # This is hadoop streaming
             if arg == '-mapper':

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -340,7 +340,7 @@ class MockEmrConnection(object):
                 state='PENDING',
                 name=step.name,
                 actiononfailure=step.action_on_failure,
-                args=step.args(),
+                args=step.args,
             )
 
             job_flow.steps.append(step_object)


### PR DESCRIPTION
`terminate_idle_job_flows` detects custom hadoop streaming jars (anything with mappers/reducers).
