### PR TITLE
InlineJobRunner now gets steps in the same process too.

### DIFF
--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -125,6 +125,9 @@ class InlineMRJobRunner(MRJobRunner):
         log.info('Moving %s -> %s' % (self._prev_outfile, self._final_outfile))
         shutil.move(self._prev_outfile, self._final_outfile)
 
+    def _get_steps(self):
+        return self._mrjob_cls()._steps_desc()
+
     def _invoke_inline_mrjob(self, step_number, outfile_name, is_mapper=False, is_reducer=False):
         common_args = (['--step-num=%d' % step_number] +
                        self._mr_job_extra_args(local=True) +


### PR DESCRIPTION
Previously, the inline job runner would still spawn a subprocess to get steps.  This removes that subprocess.
