### PR TITLE
Fixed terminate_idle_job_flows.py

### DIFF
--- a/mrjob/tools/emr/terminate_idle_job_flows.py
+++ b/mrjob/tools/emr/terminate_idle_job_flows.py
@@ -118,7 +118,7 @@ def is_job_flow_non_streaming(job_flow):
         return False
 
     for step in job_flow.steps:
-        args = [a.value for a in step.args()]
+        args = [a.value for a in step.args]
         for arg in args:
             # This is hadoop streaming
             if arg == '-mapper':

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -298,12 +298,12 @@ class MockEmrConnection(object):
         self.mock_emr_job_flows[jobflow_id] = job_flow
 
         if enable_debugging:
-            debugging_step = JarStep(name='Setup Hadoop Debugging',
-                                     action_on_failure='TERMINATE_JOB_FLOW',
-                                     main_class=None,
-                                     jar=EmrConnection.DebuggingJar,
-                                     step_args=[MockEmrObject(value=EmrConnection.DebuggingArgs)])
-            debugging_step.state = 'COMPLETED'
+            debugging_step = MockEmrObject(
+                name='Setup Hadoop Debugging',
+                action_on_failure='TERMINATE_JOB_FLOW',
+                jar=EmrConnection.DebuggingJar,
+                args=[MockEmrObject(value=EmrConnection.DebuggingArgs)],
+                state='COMPLETED')
             steps.insert(0, debugging_step)
         self.add_jobflow_steps(jobflow_id, steps)
 

--- a/tests/tools/emr/terminate_idle_job_flows_test.py
+++ b/tests/tools/emr/terminate_idle_job_flows_test.py
@@ -50,9 +50,9 @@ class JobFlowInspectionTestCase(MockEMRAndS3TestCase):
         # Build a step object easily
         # also make it respond to .args()
         def step(jar='/home/hadoop/contrib/streaming/hadoop-streaming.jar',
-                 args=['-mapper', 'my_job.py --mapper', 
+                 args=['-mapper', 'my_job.py --mapper',
                        '-reducer', 'my_job.py --reducer'],
-                 state='COMPLETE', 
+                 state='COMPLETE',
                  start_time_back=None,
                  end_time_back=None,
                  name='Streaming Step',
@@ -64,9 +64,9 @@ class JobFlowInspectionTestCase(MockEMRAndS3TestCase):
             if end_time_back:
                 kwargs['enddatetime'] = to_iso8601(
                     self.now - timedelta(hours=end_time_back))
-            kwargs['args'] = lambda: [MockEmrObject(value=a) for a in args]
+            kwargs['args'] = [MockEmrObject(value=a) for a in args]
             return MockEmrObject(
-                jar=jar, state=state, name=name, 
+                jar=jar, state=state, name=name,
                 action_on_failure=action_on_failure, **kwargs)
 
         # currently running job


### PR DESCRIPTION
Fixed mockboto's abuse of JarStep in favor of MockEmrObject. Fixed bug in terminate_idle_job_flows that wasn't failing due to this error.
