### PR TITLE
Wrapped sys pipes, files in unicode readers/writers so we no longer barf on unicode

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import with_statement
 
+import codecs
 from cStringIO import StringIO
 import datetime
 import fnmatch
@@ -1108,7 +1109,7 @@ class EMRJobRunner(MRJobRunner):
             s3_key.get_contents_to_filename(
                 output_dir, headers={'Accept-Encoding': 'gzip'})
             log.debug('reading lines from %s' % output_dir)
-            for line in open(output_dir):
+            for line in codecs.open(output_dir, encoding='UTF-8'):
                 yield line
 
     def _script_args(self):

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import codecs
 import getpass
 import logging
 import os
@@ -438,11 +439,11 @@ class HadoopJobRunner(MRJobRunner):
 
         cat_proc = Popen(cat_args, stdout=PIPE, stderr=PIPE)
 
-        for line in cat_proc.stdout:
+        for line in codecs.getreader('UTF-8')(cat_proc.stdout):
             yield line
 
         # there shouldn't be any stderr
-        for line in cat_proc.stderr:
+        for line in codecs.getreader('UTF-8')(cat_proc.stderr):
             log.error('STDERR: ' + line)
 
         returncode = cat_proc.wait()

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -17,6 +17,7 @@ from __future__ import with_statement
 
 __author__ = 'Matthew Tai <mtai@adku.com>'
 
+import codecs
 import logging
 import os
 import pprint
@@ -192,5 +193,5 @@ class InlineMRJobRunner(MRJobRunner):
             output_file = os.path.join(self._output_dir, 'part-00000')
         log.info('streaming final output from %s' % output_file)
 
-        for line in open(output_file):
+        for line in codecs.open(output_file, encoding='UTF-8'):
             yield line

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -93,6 +93,7 @@ See :py:mod:`mrjob.examples` for more examples.
 # since MRJobs need to run in Amazon's generic EMR environment
 from __future__ import with_statement
 
+import codecs
 from copy import copy
 import inspect
 import itertools
@@ -186,9 +187,9 @@ class MRJob(object):
 
         # Make it possible to redirect stdin, stdout, and stderr, for testing
         # See sandbox(), below.
-        self.stdin = sys.stdin
-        self.stdout = sys.stdout
-        self.stderr = sys.stderr
+        self.stdin = codecs.getwriter('UTF-8')(sys.stdin)
+        self.stdout = codecs.getwriter('UTF-8')(sys.stdout)
+        self.stderr = codecs.getwriter('UTF-8')(sys.stderr)
 
     ### Defining one-step jobs ###
 

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -15,6 +15,7 @@
 """Run an MRJob locally by forking off a bunch of processes and piping
 them together. Useful for testing."""
 
+import codecs
 import logging
 import os
 import pprint
@@ -181,7 +182,7 @@ class LocalMRJobRunner(MRJobRunner):
             output_file = os.path.join(self._output_dir, 'part-00000')
         log.info('streaming final output from %s' % output_file)
 
-        for line in open(output_file):
+        for line in codecs.open(output_file, encoding='UTF-8'):
             yield line
 
     def _invoke_step(self, args, outfile_name, env=None, step_num=0):


### PR DESCRIPTION
Jim wrote a new protocol that turns a Python list into Unicode-encoded CSV. Unicode characters were throwing `UnicodeDecodeError`s in `std*.write()`/`std*.read()`, though, and the reason was that the I/O file objects on the jobs and runners were not Unicode-enabled.

This branch fixes the problem. It works as expected when I run it by hand, but I have had trouble getting automated tests to work properly.

The error did not manifest before because the JSON encoder escapes non-ASCII characters by default.

This (or something like it) will be necessary for Yelp to use Jim's new stuff, so it targets 0.2.x.

A related improvement would be to allow the user to specify an encoding to be used for input and output, possibly related to the protocols.
