### PR TITLE
Added check to only fetch counters from S3 if job flow is not persistent (fixes #211)

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1352,6 +1352,13 @@ class EMRJobRunner(MRJobRunner):
         if not self._s3_job_log_uri:
             return {}
 
+        job_flow = self._describe_jobflow()
+        if job_flow.keepjobflowalivewhennosteps:
+            log.info("Can't fetch counters from S3 for five more minutes. Try"
+                     " 'python -m mrjob.tools.emr.fetch_logs --counters %s'"
+                     " in five minutes." % job_flow.jobflowid)
+            return {}
+
         log.info('Fetching counters from S3...')
 
         if not skip_s3_wait:


### PR DESCRIPTION
Counter fetching from S3 only happens (waits for job flow to terminate) if job flow is not persistent. This means you can actually get the output of steps in persistent job flows when they complete, which is...you know...nice.

This fixes #211.
