### PR TITLE
fix invalid formatting crash bug

### DIFF
--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -246,7 +246,7 @@ class LocalMRJobRunner(MRJobRunner):
                     (args, returncode, ''.join(tb_lines)))
             else:
                 raise Exception(
-                    'Command %r returned non-zero exit status %d: %s' %
+                    'Command %r returned non-zero exit status %d' %
                     (args, returncode))
 
         # flush file descriptors


### PR DESCRIPTION
This commit fixes a bug where a format string requires more params than are supplied, causing mrjob to crash:

'Command %r returned non-zero exit status %d: %s' %
                    (args, returncode)
