### PR TITLE
'fetch_logs -A' fix (#261)

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1639,6 +1639,8 @@ class EMRJobRunner(MRJobRunner):
 
     def ls_all_logs_s3(self):
         """List all log files in the S3 log root directory"""
+        if not self._s3_job_log_uri:
+            self._set_s3_job_log_uri(self._describe_jobflow())
         return self.ls(self._s3_job_log_uri)
 
     ## LOG PARSING ##


### PR DESCRIPTION
`runner._s3_job_log_uri` needed to be set. This issue did not affect anything outside the one tool function.
