### PR TITLE
Hadoop runner uploads input files (fixes #272)

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -246,7 +246,7 @@ class HadoopJobRunner(MRJobRunner):
         local_input_files = []
 
         for path in self._input_paths:
-            if is_uri:
+            if is_uri(path):
                 # Don't even bother running the job if the input isn't there.
                 if not self.ls(path):
                     raise AssertionError(


### PR DESCRIPTION
I had written `if is_uri:` instead of `if is_uri(path):`

Not sure how to test for this and I haven't actually completed a test by hand with it because I messed up my local Hadoop installation and I am pretty tired. But I just wanted to have the basic fix available.
