### PR TITLE
Windows sort 288

### DIFF
--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -26,8 +26,10 @@ import random
 import re
 import shutil
 import sys
+from subprocess import CalledProcessError
 from subprocess import Popen
 from subprocess import PIPE
+from subprocess import check_call
 import tempfile
 
 try:
@@ -72,8 +74,10 @@ CLEANUP_CHOICES = ['ALL', 'LOCAL_SCRATCH', 'LOGS', 'NONE', 'REMOTE_SCRATCH',
 #: DEPRECATED: the default cleanup-on-success option: ``'IF_SUCCESSFUL'``
 CLEANUP_DEFAULT = 'IF_SUCCESSFUL'
 
-
 _STEP_RE = re.compile(r'^M?C?R?$')
+
+# buffer for piping files into sort on Windows
+_BUFFER_SIZE = 4096
 
 
 class MRJobRunner(object):
@@ -402,6 +406,10 @@ class MRJobRunner(object):
 
         # info about our steps. this is basically a cache for self._get_steps()
         self._steps = None
+
+        # if this is True, we have to pipe input into the sort command
+        # rather than feed it multiple files
+        self._sort_is_windows_sort = None
 
     @classmethod
     def _allowed_opts(cls):
@@ -1223,3 +1231,70 @@ class MRJobRunner(object):
                 args.extend(['-jobconf', '%s=%s' % (key, value)])
 
         return args
+
+    def _invoke_sort(self, input_paths, output_path):
+        """Use the local sort command to sort one or more input files. Raise
+        an exception if there is a problem.
+
+        This is is just a wrapper to handle limitations of Windows sort
+        (see Issue #288).
+
+        :type input_paths: list of str
+        :param input_paths: paths of one or more input files
+        :type output_path: str
+        :param output_path: where to pipe sorted output into
+        """
+        if not input_paths:
+            raise ValueError('Must specify at least one input path.')
+
+        # ignore locale when sorting
+        env = os.environ.copy()
+        env['LC_ALL'] = 'C'
+
+        log.info('writing to %s' % output_path)
+
+        err_path = os.path.join(self._get_local_tmp_dir(), 'sort-stderr')
+
+        # assume we're using UNIX sort unless we know otherwise
+        if (not self._sort_is_windows_sort) or len(input_paths) == 1:
+            with open(output_path, 'w') as output:
+                with open(err_path, 'w') as err:
+                    args = ['sort'] + list(input_paths)
+                    log.info('> %s' % cmd_line(args))
+                    try:
+                        check_call(args, stdout=output, stderr=err, env=env)
+                        return
+                    except CalledProcessError:
+                        pass
+
+        # Looks like we're using Windows sort
+        self._sort_is_windows_sort = True
+
+        log.info('Piping files into sort for Windows compatibility')
+        with open(output_path, 'w') as output:
+            with open(err_path, 'w') as err:
+                args = ['sort']
+                log.info('> %s' % cmd_line(args))
+                proc = Popen(args, stdin=PIPE, stdout=output, stderr=err,
+                             env=env)
+
+                # shovel bytes into the sort process
+                for input_path in input_paths:
+                    with open(input_path) as input:
+                        while True:
+                            buf = input.read(_BUFFER_SIZE)
+                            if not buf:
+                                break
+                            proc.stdin.write(buf)
+
+                proc.stdin.close()
+                proc.wait()
+
+                if proc.returncode == 0:
+                    return
+
+        # looks like there was a problem. log it and raise an error
+        with open(err_path) as err:
+            for line in err:
+                log.error('STDERR: %s' % line.rstrip('\n'))
+        raise CalledProcessError(proc.returncode, args)

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -53,6 +53,7 @@ def buffer_iterator_to_line_iterator(iterator):
                     yield buf + '\n'
                 return
 
+
 def cmd_line(args):
     """build a command line that works in a shell.
     """


### PR DESCRIPTION
This change allows `mrjob` to use the `sort` command on Windows, which can only take one file as input.
