### PR TITLE
Fix instance type (Issue #311)

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -704,15 +704,21 @@ class EMRJobRunner(MRJobRunner):
 
     def _fix_ec2_instance_types(self):
         """If the *ec2_instance_type* option is set, override instance
-        type for the nodes that actually run tasks (see Issue #66)
+        type for the nodes that actually run tasks (see Issue #66). Allow
+        command-line arguments to override defaults and arguments
+        in mrjob.conf (see Issue #311).
 
         Helper for __init__.
         """
         ec2_instance_type = self._opts['ec2_instance_type']
         if ec2_instance_type:
-            self._opts['ec2_slave_instance_type'] = ec2_instance_type
+            if (self._opt_priority['ec2_instance_type'] >
+                self._opt_priority['ec2_slave_instance_type']):
+                self._opts['ec2_slave_instance_type'] = ec2_instance_type
             # master instance only does work when it's the only instance
-            if self._opts['num_ec2_instances'] == 1:
+            if (self._opts['num_ec2_instances'] == 1 and
+                self._opt_priority['ec2_instance_type'] >
+                self._opt_priority['ec2_master_instance_type']):
                 self._opts['ec2_master_instance_type'] = ec2_instance_type
 
     def _fix_s3_scratch_and_log_uri_opts(self):

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -293,8 +293,17 @@ class MRJobRunner(object):
 
         # combine all of these options
         # only __init__() methods should modify self._opts!
-        self._opts = self.combine_opts(blank_opts, self._default_opts(),
-                                       mrjob_conf_opts, opts)
+        opt_dicts = [blank_opts, self._default_opts(),
+                     mrjob_conf_opts, opts]
+        self._opts = self.combine_opts(*opt_dicts)
+        # keep track of where in the order opts were specified,
+        # to handle opts that affect the same thing (e.g. ec2_*instance_type)
+        self._opt_priority = dict((opt, -1) for opt in self._opts)
+        for priority, opt_dict in enumerate(opt_dicts):
+            if opt_dict:
+                for opt, value in opt_dict.iteritems():
+                    if value is not None:
+                        self._opt_priority[opt] = priority
 
         # we potentially have a lot of files to copy, so we keep track
         # of them as a list of dictionaries, with the following keys:

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -831,7 +831,7 @@ class EC2InstanceTypeTestCase(MockEMRAndS3TestCase):
             'm1.large', 'm2.xlarge')
 
         # set master and slave in mrjob.conf, 1 instance
-        self.set_in_mrjob_conf(ec2_master_instance_type='m1.xlarge',
+        self.set_in_mrjob_conf(ec2_master_instance_type='m1.large',
                                ec2_slave_instance_type='m2.xlarge')
 
         self._test_instance_types(
@@ -842,7 +842,7 @@ class EC2InstanceTypeTestCase(MockEMRAndS3TestCase):
             'c1.xlarge', 'c1.xlarge')
 
         # set master and slave in mrjob.conf, 2 instances
-        self.set_in_mrjob_conf(ec2_master_instance_type='m1.xlarge',
+        self.set_in_mrjob_conf(ec2_master_instance_type='m1.large',
                                ec2_slave_instance_type='m2.xlarge',
                                num_ec2_instances=2)
 


### PR DESCRIPTION
`ec2_*instance_type` options specified on the command line now take precedence over those in `mrjob.conf`. Fixes #311.
