### PR TITLE
Refer to correct terminate_idle_job_flows function

### DIFF
--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -1351,7 +1351,7 @@ class MRJob(object):
                  ' flow-related options including EC2 instance configuration.'
                  ' Joins pool "default" if emr_job_flow_pool_name is not'
                  ' specified. WARNING: do not run this without'
-                 ' mrjob.tools.emr.terminate.idle_job_flows in your crontab;'
+                 ' mrjob.tools.emr.terminate_idle_job_flows in your crontab;'
                  ' job flows left idle can quickly become expensive!')
 
         self.emr_opt_group.add_option(

--- a/mrjob/tools/emr/create_job_flow.py
+++ b/mrjob/tools/emr/create_job_flow.py
@@ -19,7 +19,7 @@ Usage::
     python -m mrjob.tools.emr.create_job_flow
 
 **WARNING**: do not run this without having
-:py:mod:`mrjob.tools.emr.terminate.idle_job_flows` in your crontab; job flows
+:py:mod:`mrjob.tools.emr.terminate_idle_job_flows` in your crontab; job flows
 left idle can quickly become expensive!
 """
 from __future__ import with_statement
@@ -56,7 +56,7 @@ def make_option_parser():
     usage = '%prog [options]'
     description = (
         'Create a persistent EMR job flow to run jobs in. WARNING: do not run'
-        ' this without mrjob.tools.emr.terminate.idle_job_flows in your'
+        ' this without mrjob.tools.emr.terminate_idle_job_flows in your'
         ' crontab; job flows left idle can quickly become expensive!')
     option_parser = OptionParser(usage=usage, description=description)
 

--- a/mrjob/tools/emr/terminate_idle_job_flows.py
+++ b/mrjob/tools/emr/terminate_idle_job_flows.py
@@ -16,7 +16,7 @@ line (or, by default, job flows that have been idle for one hour).
 
 Suggested usage: run this as a cron job with the -q option::
 
-    */30 * * * * python -m mrjob.tools.emr.terminate_idle_emr_job_flows -q
+    */30 * * * * python -m mrjob.tools.emr.terminate_idle_job_flows -q
 
 Options::
 


### PR DESCRIPTION
The documentation spells the name of the function incorrectly in various ways, leading to user errors.
