### PR TITLE
Corrects issue with a non-string jobconf variable in local runner

### DIFF
--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -479,7 +479,7 @@ class LocalMRJobRunner(MRJobRunner):
         version = self.get_hadoop_version()
 
         jobconf_env = dict(
-            (translate_jobconf(k, version).replace('.', '_'), v)
+            (translate_jobconf(k, version).replace('.', '_'), str(v))
             for (k, v) in self._opts['jobconf'].iteritems())
 
         internal_jobconf = self._simulate_jobconf_for_step(
@@ -487,7 +487,7 @@ class LocalMRJobRunner(MRJobRunner):
             input_start=input_start, input_length=input_length)
 
         internal_jobconf_env = dict(
-            (translate_jobconf(k, version).replace('.', '_'), v)
+            (translate_jobconf(k, version).replace('.', '_'), str(v))
             for (k, v) in internal_jobconf.iteritems())
 
         # keep the current environment because we need PATH to find binaries


### PR DESCRIPTION
As part of my job initialization, I am specifying a desired number of reducers (where n is an integer):

self.options.jobconf['mapred.reduce.tasks'] = n

After upgrading from 0.2.x to 0.3.1, I began receiving the following error while using a local runner:

File "/.../mrjob/local.py", line 583, in _invoke_process
    cwd=self._working_dir, env=env)
...
TypeError: execve() arg 3 contains a non-string value

Clearly this is due to the environment being passed to Popen containing non-string values.

While I could manually convert my jobconf values to strings prior to assignment (and this does correct this issue), this feels a bit unnatural and unnecessary.  Other runners (e.g. Amazon EMR) do not require this conversion.

I suggest performing this conversion explicitly within the local runner to minimize surprise.
