### PR TITLE
Introduce "null" global variable into safeeval context for more intuitive interoperation between JSON and Repr protocols

### DIFF
--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -444,7 +444,7 @@ def safeeval(expr, globals=None, locals=None):
     """
     # blank out builtins, but keep None, True, and False
     safe_globals = {'__builtins__': None, 'True': True, 'False': False,
-                    'None': None, 'set': set, 'xrange': xrange}
+                    'None': None, 'set': set, 'xrange': xrange, 'null': None}
 
     # add the user-specified global variables
     if globals:


### PR DESCRIPTION
Consider an identity map/reduce job that leverages the repr input-protocol, but leaves default JSON-compatible output:

``` python
def mapper(self, key, value):
    yield key, value

def reducer(self, key, values):        
    return imap(lambda v: (key, v), values)
```
## Input

```
0\tNone
```
## Execution

```
python identity.py --input-protocol repr input-data
```
## Output

```
0\tnull
```

Note that act of making the output JSON-compatible has transformed Python None values to nulls.  This is great, but is problematic when executing a multi-step map/reduce job where input depends on the output of a prior step (and output- or internal-protocol has not been specified):

```
python identity.py --input-protocol repr input-data > output-data
python identity.py --input-protocol repr output-data # NameErrors -- token "null" not recognized!
```

I recognize that this problem may be avoided by specifying an output protocol (or, in the case of multi-step jobs, an internal protocol); however, I assert that the introduction of a null global variable into the safe-evaluation context produces a result that is less surprising and more accessible to new users.  It certainly caught me by surprise.
