### PR TITLE
Added __future__ import for tool test cases to work on py2.5

### DIFF
--- a/tests/tools/emr/__init__.py
+++ b/tests/tools/emr/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import with_statement
+
 from StringIO import StringIO
 import sys
 


### PR DESCRIPTION
Otherwise a bunch of the tool tests fail.
