### PR TITLE
Local-runner compatibility with IronPython 2.7.2 Alpha-2

### DIFF
--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -33,6 +33,7 @@ from mrjob.runner import MRJobRunner
 from mrjob.util import cmd_line
 from mrjob.util import read_input
 from mrjob.util import unarchive
+from mrjob.util import is_ironpython
 
 
 log = logging.getLogger('mrjob.local')
@@ -364,31 +365,33 @@ class LocalMRJobRunner(MRJobRunner):
 
             # initialize file and accumulators
             outfile_name = create_outfile(path, 0)
-            outfile = open(outfile_name, 'w')
             bytes_written = 0
             total_bytes = 0
 
-            # write each line to a file as long as we are within the limit
-            # (split_size)
-            for line_group in line_group_generator(path):
-                if bytes_written >= split_size:
-                    # new split file if we exceeded the limit
-                    file_names[outfile_name]['length'] = bytes_written
-                    total_bytes += bytes_written
+            try:
+                outfile = open(outfile_name, 'w')
 
-                    outfile.close()
-                    outfile_name = create_outfile(path, total_bytes)
-                    outfile = open(outfile_name, 'w')
+                # write each line to a file as long as we are within the limit
+                # (split_size)
+                for line_group in line_group_generator(path):
+                    if bytes_written >= split_size:
+                        # new split file if we exceeded the limit
+                        file_names[outfile_name]['length'] = bytes_written
+                        total_bytes += bytes_written 
 
-                    bytes_written = 0
+                        outfile_name = create_outfile(path, total_bytes)
+                        outfile.close()
+                        outfile = open(outfile_name, 'w')
 
-                for line in line_group:
-                    outfile.write(line)
-                    bytes_written += len(line)
+                        bytes_written = 0
 
-            file_names[outfile_name]['length'] = bytes_written
+                    for line in line_group:
+                        outfile.write(line)
+                        bytes_written += len(line)
 
-            outfile.close()
+                file_names[outfile_name]['length'] = bytes_written
+            finally:
+                outfile.close()
 
         return file_names
 
@@ -490,9 +493,12 @@ class LocalMRJobRunner(MRJobRunner):
             (translate_jobconf(k, version).replace('.', '_'), str(v))
             for (k, v) in internal_jobconf.iteritems())
 
+        ironpython_env = {'IRONPYTHONPATH': os.getcwd()} if is_ironpython else {}
+
         # keep the current environment because we need PATH to find binaries
         # and make PYTHONPATH work
         return combine_local_envs({'PYTHONPATH': os.getcwd()},
+                                  ironpython_env,
                                   os.environ,
                                   jobconf_env,
                                   internal_jobconf_env,
@@ -586,7 +592,6 @@ class LocalMRJobRunner(MRJobRunner):
         log.info('writing to %s' % outfile)
 
         self._prev_outfiles.append(outfile)
-        write_to = open(outfile, 'w')
 
         with open(outfile, 'w') as write_to:
             if combiner_args:

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1147,13 +1147,12 @@ class MRJobRunner(object):
 
             stdin_path = os.path.join(self._get_local_tmp_dir(), 'STDIN')
             log.debug('dumping stdin to local file %s' % stdin_path)
-            stdin_file = open(stdin_path, 'w')
-            for line in self._stdin:
-                # catch missing newlines (this often happens with test data)
-                if not line.endswith('\n'):
-                    line += '\n'
-                stdin_file.write(line)
-            stdin_file.close()
+            with open(stdin_path, 'w') as stdin_file:
+                for line in self._stdin:
+                    # catch missing newlines (this often happens with test data)
+                    if not line.endswith('\n'):
+                        line += '\n'
+                    stdin_file.write(line)
 
             self._stdin_path = stdin_path
 
@@ -1292,7 +1291,7 @@ class MRJobRunner(object):
 
                 # shovel bytes into the sort process
                 for input_path in input_paths:
-                    with open(input_path) as input:
+                    with open(input_path, 'r') as input:
                         while True:
                             buf = input.read(_BUFFER_SIZE)
                             if not buf:

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -18,7 +18,6 @@
 # since MRJobs need to run in Amazon's generic EMR environment
 from __future__ import with_statement
 
-import bz2
 from collections import defaultdict
 import contextlib
 from copy import deepcopy
@@ -34,6 +33,9 @@ import sys
 import tarfile
 import zipfile
 
+IRONPYTHON_TOKEN = "IronPython"
+is_ironpython = IRONPYTHON_TOKEN in sys.version
+if not is_ironpython: import bz2
 
 class NullHandler(logging.Handler):
     def emit(self, record):
@@ -348,21 +350,24 @@ def read_file(path, fileobj=None):
     - Decompress ``.gz`` and ``.bz2`` files.
     - If *fileobj* is not ``None``, stream lines from the *fileobj*
     """
-    if path.endswith('.gz'):
-        f = gzip.GzipFile(path, fileobj=fileobj)
-    elif path.endswith('.bz2'):
-        if fileobj is None:
-            f = bz2.BZ2File(path)
+    try:
+        if path.endswith('.gz'):
+           f = gzip.GzipFile(path, fileobj=fileobj)
+        elif path.endswith('.bz2'):
+            if fileobj is None:
+                f = bz2.BZ2File(path)
+            else:
+                f = bunzip2_stream(fileobj)
+        elif fileobj is None:
+            f = open(path)
         else:
-            f = bunzip2_stream(fileobj)
-    elif fileobj is None:
-        f = open(path)
-    else:
-        f = fileobj
+            f = fileobj 
 
-    for line in f:
-        yield line
-
+        for line in f:
+            yield line
+    finally:
+        if fileobj is None and not f is None: 
+            f.close()
 
 def bunzip2_stream(fileobj):
     """Return an uncompressed bz2 stream from a file object


### PR DESCRIPTION
A number of minor issues resulted in errors under IronPython when using the local runner.  These issues are mostly related to deterministic closing of file handles; correcting these issues is a "good thing" for the project in general.

An implementation issue in the GZip module in IronPython 2.7.1 prevents compatibility with this release.  While a small MRJob change would sidestep this problem (by not gziping in the local runner), the 2.7.2 release is due shortly and corrects this issue.
