### PR TITLE
Using the task id in local runner better-reflects the current partition

### DIFF
--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -555,7 +555,7 @@ class LocalMRJobRunner(MRJobRunner):
         # be true if we're just using pipes to simulate a combiner though
         j['mapreduce.task.ismap'] = str(step_type in ('M', 'C')).lower()
 
-        j['mapreduce.task.partition'] = str(step_num)
+        j['mapreduce.task.partition'] = str(task_num)
 
         if input_file is not None:
             j['mapreduce.map.input.file'] = input_file


### PR DESCRIPTION
I believe this change would result in better consistency between EMR and the local runner, especially when reconstructing filenames given the current step and partition.  Without this change, the partitions for the current step are not in the range [0,n) since step_num strictly increases.
