### PR TITLE
Expand regex to account for INFO: being prepended to logs

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -61,7 +61,7 @@ HADOOP_RMR_NO_SUCH_FILE = re.compile(r'^rmr: hdfs://.*$')
 
 # used to extract the job timestamp from stderr
 HADOOP_JOB_TIMESTAMP_RE = re.compile(
-    'Running job: job_(?P<timestamp>\d+)_(?P<step_num>\d+)')
+    r'(INFO: )?Running job: job_(?P<timestamp>\d+)_(?P<step_num>\d+)')
 
 # find version string in "Hadoop 0.20.203" etc.
 HADOOP_VERSION_RE = re.compile(r'^.*?(?P<version>(\d|\.)+).*?$')


### PR DESCRIPTION
In `hadoop.py`, `HADOOP_JOB_TIMESTAMP_RE` is used to parse output from hadoop to determine the job's timestamp and step number. In my usage, I found that "INFO: " was being prepended to hadoop's log output (possibly due to my own failure to set up the logs correctly), and the regex was failing to pick the line up. This resulted in mrjob raising an error despite the job apparently running fine otherwise. 

I simply added an optional check for "INFO: " in this regex. It's possible that something more generic would be desirable, but this seems to fix things for me and I don't think it would screw things up for anyone else.

(fwiw, I am using hadoop 0.20.2 and python 2.5, but the original regex seemed to fail with python 2.7 as well)
