### PR TITLE
Automatically tar path and attach result as a Python archive

### DIFF
--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -1033,6 +1033,12 @@ class MRJob(object):
                   ' output should be sorted and distributed to reducers. For'
                   ' example: org.apache.hadoop.mapred.lib.HashPartitioner'))
 
+        self.add_passthrough_option(
+            '--python-files', type='string', default=[], action='append',
+            help=('Path to be archived and included in the PYTHONPATH of the mrjob'
+                  ' script when it runs (e.g., "~/mypath/*.py").  Inclusion is'
+                  'recursive.'))
+
         self.runner_opt_group.add_option(
             '--python-archive', dest='python_archives', default=[],
             action='append',
@@ -1629,6 +1635,7 @@ class MRJob(object):
             'output_dir': self.options.output_dir,
             'owner': self.options.owner,
             'partitioner': self.partitioner(),
+            'python_files': self.options.python_files,
             'python_archives': self.options.python_archives,
             'python_bin': self.options.python_bin,
             'setup_cmds': self.options.setup_cmds,


### PR DESCRIPTION
This changeset introduces a new parameter "python-files" which accepts a path, optional file criteria (e.g. "_.py"), and optional archive name of the general form "my-relative-path/_.py#myarchivename".  The set of files matching those criteria are tarred into the specified name, or, if none is specified, into an arbitrary archive.  

The bulk of the action is in MRJobRunner.__convert_to_archive.  The implementation adjusts the python_archive option at runtime.

Addresses issue #23.
