### PR TITLE
Correct sort-split file ordering

### DIFF
--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -313,6 +313,7 @@ class LocalMRJobRunner(MRJobRunner):
                     file_names[path] = {
                         'orig_name': path,
                         'start': 0,
+                        'task_num': 0,
                         'length': os.stat(path)[stat.ST_SIZE],
                     }
                     # this counts as "one split"


### PR DESCRIPTION
Because the current flow of `LocalMRJobRunner` depends on the order of keys coming out of an `enumerate` key we occasionally/inconsistently find that the parts are in the wrong order post-sort:

```
> /usr/bin/python test.py --step-num=0 --reducer --strict-protocols /tmp/snapshot/test.paul.20120412.175015.452279/input_part-00001
writing to /tmp/snapshot/test.paul.20120412.175015.452279/step-0-reducer_part-00000
> /usr/bin/python test.py --step-num=0 --reducer --strict-protocols /tmp/snapshot/test.paul.20120412.175015.452279/input_part-00000
writing to /tmp/snapshot/test.paul.20120412.175015.452279/step-0-reducer_part-00001
```

Notice `input_part-00001` writing to `step-0-reducer_part-00000` and vice-versa.

This alteration ensures that the `task_num, file_name` pairs are maintained correctly and ordering is consistent.
