### PR TITLE
Fix counter parsing when multiple *COUNTERS= present in same line

### DIFF
--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -414,7 +414,7 @@ def parse_mr_job_stderr(stderr, counters=None):
 # We just want to pull out the counter string, which varies between
 # Hadoop versions.
 _KV_EXPR = r'\s+\w+=".*?"'  # this matches KEY="VALUE"
-_COUNTER_LINE_EXPR = r'^.*?JOBID=".*?_%s".*?COUNTERS="%s".*?$' % \
+_COUNTER_LINE_EXPR = r'^.*?JOBID=".*?_%s".*?\bCOUNTERS="%s".*?$' % \
     ('(?P<step_num>\d+)', r'(?P<counters>.*?)')
 _COUNTER_LINE_RE = re.compile(_COUNTER_LINE_EXPR)
 


### PR DESCRIPTION
Reducer counters were being ignored in some cases.
