### PR TITLE
Fix HADOOP_HOME regression

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -211,7 +211,7 @@ class HadoopJobRunner(MRJobRunner):
         # temp dir for input
         self._hdfs_input_dir = None
 
-        self._hadoop_log_dir = hadoop_log_dir()
+        self._hadoop_log_dir = hadoop_log_dir(self._opts['hadoop_home'])
 
         # Running jobs via hadoop assigns a new timestamp to each job.
         # Running jobs via mrjob only adds steps.

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -41,6 +41,26 @@ from mrjob.hadoop import HadoopJobRunner
 from mrjob.hadoop import find_hadoop_streaming_jar
 
 
+class TestHadoopHomeRegression(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self._old_environ = os.environ.copy()
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+        shutil.rmtree(self.tmp_dir)
+
+    def test_hadoop_home_regression(self):
+        mason_jar_path = os.path.join(
+            self.tmp_dir, 'hadoop-0.20.20-streaming.jar')
+        open(mason_jar_path, 'w').close()
+
+        del os.environ['HADOOP_HOME']
+        HadoopJobRunner(hadoop_home=self.tmp_dir, conf_path=False)
+
+
 class TestFindHadoopStreamingJar(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Fixes #482.

I wrote some bad code last August that assumed $HADOOP_HOME would be set. I wasn't aware of the `hadoop_home` option at the time.

Test coverage in mrjob.hadoop is suboptimal to say the least.
