### PR TITLE
Fix HADOOP_HOME test failures if you don't have it set

### DIFF
--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -31,17 +31,17 @@ from mrjob import runner
 # simple config that also silences 'no config options for runner' logging
 EMPTY_MRJOB_CONF = {'runners': {
     'local': {
-        'label': 'test_job'
+        'label': 'test_job',
     },
     'emr': {
         'check_emr_status_every': 0.00,
         's3_sync_wait_time': 0.00,
     },
     'hadoop': {
-        'label': 'test_job'
+        'label': 'test_job',
     },
     'inline': {
-        'label': 'test_job'
+        'label': 'test_job',
     },
 }}
 

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -207,6 +207,11 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
 class StreamingArgsTestCase(EmptyMrjobConfTestCase):
 
+    MRJOB_CONF_CONTENTS = {'runners': {'hadoop': {
+        'hadoop_home': 'kansas',
+        'hadoop_streaming_jar': 'binks.jar.jar',
+    }}}
+
     def setUp(self):
         super(StreamingArgsTestCase, self).setUp()
         self.runner = HadoopJobRunner(


### PR DESCRIPTION
Quite a simple fix.
