### PR TITLE
mrjob.conf aliases JSONDecodeError to ValueError if not using simplejson

### DIFF
--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -27,9 +27,10 @@ from mrjob.util import expand_path
 
 try:
     import simplejson as json  # preferred because of C speedups
-    json  # quiet "redefinition of unused ..." warning from pyflakes
+    JSONDecodeError = json.JSONDecodeError
 except ImportError:
     import json  # built in to Python 2.6 and later
+    JSONDecodeError = ValueError
 
 # yaml is nice to have, but we can fall back on JSON if need be
 try:
@@ -164,7 +165,7 @@ def conf_object_at_path(conf_path):
         else:
             try:
                 return json.load(f)
-            except json.JSONDecodeError, e:
+            except JSONDecodeError, e:
                 msg = ('If your mrjob.conf is in YAML, you need to install'
                        ' yaml; see http://pypi.python.org/pypi/PyYAML/')
                 # JSONDecodeError currently has a msg attr, but it may not in

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -267,7 +267,7 @@ class MRJobConfNoYAMLTestCase(MRJobConfTestCase):
         try:
             load_mrjob_conf(conf_path)
             assert False
-        except mrjob.conf.json.JSONDecodeError, e:
+        except mrjob.conf.JSONDecodeError, e:
             self.assertIn('If your mrjob.conf is in YAML', e.msg)
 
 


### PR DESCRIPTION
I made sure the tests fail without `simplejson` if this change isn't applied.
