### PR TITLE
Just use value error

### DIFF
--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -27,10 +27,8 @@ from mrjob.util import expand_path
 
 try:
     import simplejson as json  # preferred because of C speedups
-    JSONDecodeError = json.JSONDecodeError
 except ImportError:
     import json  # built in to Python 2.6 and later
-    JSONDecodeError = ValueError
 
 # yaml is nice to have, but we can fall back on JSON if need be
 try:
@@ -165,11 +163,10 @@ def conf_object_at_path(conf_path):
         else:
             try:
                 return json.load(f)
-            except JSONDecodeError, e:
+            except ValueError, e:
                 msg = ('If your mrjob.conf is in YAML, you need to install'
                        ' yaml; see http://pypi.python.org/pypi/PyYAML/')
-                # JSONDecodeError currently has a msg attr, but it may not in
-                # the future
+                # Use msg attr if it's set
                 if hasattr(e, 'msg'):
                     e.msg = '%s (%s)' % (e.msg, msg)
                 else:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -267,7 +267,7 @@ class MRJobConfNoYAMLTestCase(MRJobConfTestCase):
         try:
             load_mrjob_conf(conf_path)
             assert False
-        except mrjob.conf.JSONDecodeError, e:
+        except ValueError, e:
             self.assertIn('If your mrjob.conf is in YAML', e.msg)
 
 


### PR DESCRIPTION
Use `ValueError` rather than `JSONDecodeError` (which only exists in `simplejson`). Fixes #544 (again).
