### PR TITLE
Added support for the 'api_params' parameter of boto

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -366,6 +366,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
     ALLOWED_KEYS = RunnerOptionStore.ALLOWED_KEYS.union(set([
         'additional_emr_info',
         'ami_version',
+        'api_params',
         'aws_access_key_id',
         'aws_availability_zone',
         'aws_region',
@@ -1206,6 +1207,7 @@ class EMRJobRunner(MRJobRunner):
 
         args['ami_version'] = self._opts['ami_version']
         args['hadoop_version'] = self._opts['hadoop_version']
+        args['api_params'] = self._opts['api_params']
 
         if self._opts['aws_availability_zone']:
             args['availability_zone'] = self._opts['aws_availability_zone']


### PR DESCRIPTION
Boto uses the `api_params` parameter to use new characteristics of AWS if there aren't yet implemented in the package. With this change, mrjob supports this parameter in the config file (mrjob.conf) with the same format as the `additional_emr_info` parameter (JSON strings or object).

For example, now it's possible to start a job flow on a subnet of a VPC adding something like this to the mrjob.conf file

```
api_params: {'Instances.Ec2SubnetId': 'subnetID'}
```
