### PR TITLE
Removed hardcoded s3n check.

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -35,6 +35,7 @@ from mrjob.logparsers import HADOOP_JOB_LOG_URI_RE
 from mrjob.logparsers import scan_for_counters_in_files
 from mrjob.logparsers import best_error_from_logs
 from mrjob.parse import HADOOP_STREAMING_JAR_RE
+from mrjob.parse import urlparse
 from mrjob.runner import MRJobRunner
 from mrjob.runner import RunnerOptionStore
 from mrjob.util import cmd_line


### PR DESCRIPTION
As far as I can see this is the only place that could potentially cause issues when using urls hadoop supports, for instance `s3:///...`. This fix should make this method scheme independent.

Test output: https://gist.github.com/a76e10d1a02722e49463
