### PR TITLE
Update contrib guide to discuss config option standards

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -27,5 +27,12 @@ Things that will make your branch more likely to be pulled:
 * Reference relevant issue numbers in the tracker
 * API backward compatibility
 
+If you add a new configuration option, please try to do all of these things:
+
+* Make its name unambiguous in the context of multiple runners (e.g.
+  ``ec2_task_instance_type`` instead of ``instance_type``)
+* Add command line switches that allow full control over the option
+* Document the option and its switches in the appropriate file under ``docs``
+
 .. Copied from docs/guides/contributing.rst, which is the canonical text. This
    version exists only for Github.

--- a/docs/guides/contributing.rst
+++ b/docs/guides/contributing.rst
@@ -27,6 +27,13 @@ Things that will make your branch more likely to be pulled:
 * Reference relevant issue numbers in the tracker
 * API backward compatibility
 
+If you add a new configuration option, please try to do all of these things:
+
+* Make its name unambiguous in the context of multiple runners (e.g.
+  ``ec2_task_instance_type`` instead of ``instance_type``)
+* Add command line switches that allow full control over the option
+* Document the option and its switches in the appropriate file under ``docs``
+
 A quick tour through the code
 -----------------------------
 


### PR DESCRIPTION
Over time, I've seen a lot of people adding config options without doing the whole job. Here are the guidelines the project has used in the past when adding new options.
