### PR TITLE
Fixes 595 (fix failing fs test cases)

### DIFF
--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -61,27 +61,27 @@ class HadoopFSTestCase(MockSubprocessTestCase):
     def test_ls_basic_2(self):
         self.make_mock_file('f')
         self.make_mock_file('f2')
-        self.assertEqual(list(self.fs.ls('hdfs:///')), ['hdfs:///f',
+        self.assertItemsEqual(list(self.fs.ls('hdfs:///')), ['hdfs:///f',
                                                         'hdfs:///f2'])
     def test_ls_recurse(self):
         self.make_mock_file('f')
         self.make_mock_file('d/f2')
-        self.assertEqual(list(self.fs.ls('hdfs:///')),
+        self.assertItemsEqual(list(self.fs.ls('hdfs:///')),
                          ['hdfs:///f', 'hdfs:///d/f2'])
 
     def test_ls_s3n(self):
         # hadoop fs -lsr doesn't have user and group info when reading from s3
         self.make_mock_file('f')
-        self.assertEqual(list(self.fs.ls('s3n://bucket/')),
+        self.assertItemsEqual(list(self.fs.ls('s3n://bucket/')),
                          ['s3n://bucket/f'])
 
     def test_single_space(self):
         self.make_mock_file('foo bar')
-        self.assertEqual(list(self.fs.ls('hdfs:///')), ['hdfs:///foo bar'])
+        self.assertItemsEqual(list(self.fs.ls('hdfs:///')), ['hdfs:///foo bar'])
 
     def test_double_space(self):
         self.make_mock_file('foo  bar')
-        self.assertEqual(list(self.fs.ls('hdfs:///')), ['hdfs:///foo  bar'])
+        self.assertItemsEqual(list(self.fs.ls('hdfs:///')), ['hdfs:///foo  bar'])
 
     def test_cat_uncompressed(self):
         # mockhadoop doesn't support compressed files, so we won't test for it.

--- a/tests/fs/test_local.py
+++ b/tests/fs/test_local.py
@@ -54,13 +54,13 @@ class LocalFSTestCase(SandboxedTestCase):
     def test_ls_basic_2(self):
         self.makefile('f', 'contents')
         self.makefile('f2', 'contents')
-        self.assertEqual(list(self.fs.ls(self.tmp_dir)),
+        self.assertItemsEqual(list(self.fs.ls(self.tmp_dir)),
                          self.abs_paths('f', 'f2'))
 
     def test_ls_recurse(self):
         self.makefile('f', 'contents')
         self.makefile('d/f2', 'contents')
-        self.assertEqual(list(self.fs.ls(self.tmp_dir)),
+        self.assertItemsEqual(list(self.fs.ls(self.tmp_dir)),
                          self.abs_paths('f', 'd/f2'))
 
     def test_cat_uncompressed(self):

--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -66,13 +66,13 @@ class SSHFSTestCase(MockSubprocessTestCase):
     def test_ls_basic_2(self):
         self.make_master_file('f', 'contents')
         self.make_master_file('f2', 'contents')
-        self.assertEqual(list(self.fs.ls('ssh://testmaster/')),
+        self.assertItemsEqual(list(self.fs.ls('ssh://testmaster/')),
                          ['ssh://testmaster/f', 'ssh://testmaster/f2'])
 
     def test_ls_recurse(self):
         self.make_master_file('f', 'contents')
         self.make_master_file('d/f2', 'contents')
-        self.assertEqual(list(self.fs.ls('ssh://testmaster/')),
+        self.assertItemsEqual(list(self.fs.ls('ssh://testmaster/')),
                          ['ssh://testmaster/f', 'ssh://testmaster/d/f2'])
 
     def test_cat_uncompressed(self):


### PR DESCRIPTION
fs test cases were failing because fs.ls does not make any garuntees on the
order of the files it returns. The test only fix was to modify the test to
use assertItemsEqual
