### PR TITLE
Fixes #607 IOError if bootstrap action on master node fails

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1838,7 +1838,11 @@ class EMRJobRunner(MRJobRunner):
         # parameter
         if lg_step_nums is None:
             lg_step_nums = step_nums
-        self._enable_slave_ssh_access()
+
+        try:
+            self._enable_slave_ssh_access()
+        except IOError, e:
+            raise LogFetchError(e)
         task_attempt_logs = self.ls_task_attempt_logs_ssh(step_nums)
         step_logs = self.ls_step_logs_ssh(lg_step_nums)
         job_logs = self.ls_job_logs_ssh(step_nums)


### PR DESCRIPTION
This is a partial fix to the problem, instead of reporting an IOError if a boostrap action on the master node fails we now log that a boostrap action has failed. A better fix would be to download the node logs and grep through them for errors
