### PR TITLE
unable to run non-streaming jar

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1344,9 +1344,10 @@ class EMRJobRunner(MRJobRunner):
 
         return boto.emr.StreamingStep(**streaming_step_kwargs)
 
-    def _build_jar_step(self, step):
+    def _build_jar_step(self, step, step_num, num_steps):
         return boto.emr.JarStep(
-            name=step['name'],
+            name='%s: Step %d of %d' % (
+                self._job_name, step_num + 1, num_steps),
             jar=step['jar'],
             main_class=step['main_class'],
             step_args=step['step_args'],
@@ -1720,7 +1721,7 @@ class EMRJobRunner(MRJobRunner):
         """
         # empty list is a valid value for lg_step_nums, but it is an optional
         # parameter
-        if lg_step_num_mapping is None:
+        if lg_step_num_mapping is None or len(lg_step_num_mapping) == 0:
             lg_step_num_mapping = dict((n, n) for n in step_nums)
         lg_step_nums = list(sorted(lg_step_num_mapping[k] for k in step_nums))
 


### PR DESCRIPTION
I've run into some issues when trying to run non-hadoop streaming jar files.

Example for installing Hive:

```
from mrjob.job import MRJob

class InstallHive(MRJob):

    def steps(self):
        return [self.jar(
            name='install hive',
            jar='s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar',
            main_class=None,
            step_args=[
            "s3://us-east-1.elasticmapreduce/libs/hive/hive-script",
            "--base-path",
            "s3://us-east-1.elasticmapreduce/libs/hive/",
            "--install-hive",
            "--hive-versions",
            "latest"])]

if __name__ == '__main__':
    InstallHive.run()
```

Solution:
The first problem was the `_build_jar_step` function had the incorrect signature which would cause an exception before mrjob could submit the job to emr:

```
TypeError: _build_jar_step() takes exactly 2 arguments (4 given)
```

After fixing this the job would run and complete successfully, however an exception would be thrown from `_fetch_counters` afterwards:

```
File "/lib/python2.6/site-packages/mrjob/emr.py", line 1727, in _fetch_counters
    lg_step_nums = list(sorted(lg_step_num_mapping[k] for k in step_nums))
File "/lib/python2.6/site-packages/mrjob/emr.py", line 1727, in <genexpr>
    lg_step_nums = list(sorted(lg_step_num_mapping[k] for k in step_nums))
KeyError: 18
```

`_fetch_counters` was being passed an empty list for `lg_step_num_mapping` since there was a step run but it was not a log generating step (i.e. not a hadoop streaming step) and the method was only handling the case where `lg_step_num_mapping` was `None`.  I think #635 is the same issue.
