### PR TITLE
Support for s3n:// in S3Filesystem.ls()

### DIFF
--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -15,6 +15,7 @@ import fnmatch
 import logging
 import posixpath
 import socket
+from urlparse import urlparse
 
 try:
     import boto
@@ -103,6 +104,11 @@ class S3Filesystem(Filesystem):
         To list a directory, path_glob must end with a trailing
         slash (foo and foo/ are different on S3)
         """
+
+        # clean up the  base uri to ensure we have an equal uri to boto (s3://)
+        # just incase we get passed s3n://
+        scheme = urlparse(path_glob).scheme
+
         # support globs
         glob_match = GLOB_RE.match(path_glob)
 
@@ -121,6 +127,8 @@ class S3Filesystem(Filesystem):
             base_uri = path_glob
 
         for uri in self._s3_ls(base_uri):
+            uri = "%s://%s/%s" % ((scheme,) + parse_s3_uri(uri))
+
             # enforce globbing
             if glob_match and not fnmatch.fnmatchcase(uri, path_glob):
                 continue

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -86,6 +86,15 @@ class S3FSTestCase(SandboxedTestCase):
 
         self.assertEqual(list(self.fs.ls('s3://walrus/*/baz')), [paths[1]])
 
+    def test_ls_s3n(self):
+        paths = [
+            self.add_mock_s3_data('walrus', 'data/bar', 'abc123'),
+            self.add_mock_s3_data('walrus', 'data/baz', '123abc')
+        ]
+
+        self.assertEqual(list(self.fs.ls('s3n://walrus/data/*')),
+                         [ p.replace('s3://', 's3n://') for p in paths ])
+
     def test_du(self):
         paths = [
             self.add_mock_s3_data('walrus', 'data/foo', 'abcd'),


### PR DESCRIPTION
I've added support for the `s3n://` schema when calling the `ls` method on `S3Filesystem`. This allows us to use a composite filesystem with `S3Filesystem` in front of `HadoopFilesystem` to gain extra performance (boto is much faster than hadoop for s3).

This fix transparently passes though `s3n://` to `s3://` for boto and then back to `s3n://` for the list of uris returned.
