### PR TITLE
Update CHANGES.txt with info about #634

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v0.4.1-dev
+ * EMR runner throws IOError if output path already exists (#634)
+
 v0.4, 2013-04-30 -- Slouching toward nirvana
  * Changes:
    * 'mrjob' command (#225)


### PR DESCRIPTION
Would have just committed it but I wanted to make it clear that I added the `v0.4.1-dev` section at the top for the next version that we should keep up to date.

Anything else I should add given recent merges?
