### PR TITLE
Bug/exec get steps os error 8

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1326,18 +1326,6 @@ class EMRJobRunner(MRJobRunner):
         else:
             return 'TERMINATE_JOB_FLOW'
 
-    def _executable(self, steps=False):
-        # detect executable files so we can discard the explicit interpreter if
-        # possible
-        if os.access(self._script_path, os.X_OK):
-            if steps:
-                return [os.path.abspath(self._script_path)]
-            else:
-                return ['./' +
-                        self._working_dir_mgr.name('file', self._script_path)]
-        else:
-            return super(EMRJobRunner, self)._executable(steps)
-
     def _build_streaming_step(self, step, step_num, num_steps):
         streaming_step_kwargs = {
             'name': '%s: Step %d of %d' % (


### PR DESCRIPTION
In rare cases, files that are installed via a setup.py seem to get their
executable bit set (even when they shouldn't). This causes the
emr._executable method to assume they are executable and causes it to
skip adding the interepretter to the command to be exectuted. If the
script in questions lacks (or has an incorrect) #! line then the job
will fail.

I decided the best way to fix this is safety first and always include
the interpreter.
