### PR TITLE
Fixed failing tests

### DIFF
--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -187,7 +187,7 @@ class LocalMRJobRunnerEndToEndTestCase(SandboxedTestCase):
                           '2\tfoo\n', '2\tfoo\n', '2\tfoo\n',
                           '3\tqux\n', '3\tqux\n', '3\tqux\n'])
 
-    def gz_test(self, dir_path_name):
+    def gz_assert(self, dir_path_name):
         contents_gz = ['bar\n', 'qux\n', 'foo\n', 'bar\n', 'qux\n', 'foo\n']
         contents_normal = ['foo\n', 'bar\n', 'bar\n']
         all_contents_sorted = sorted(contents_gz + contents_normal)
@@ -231,7 +231,7 @@ class LocalMRJobRunnerEndToEndTestCase(SandboxedTestCase):
                          all_contents_sorted)
 
     def test_dont_split_gz(self):
-        self.gz_test(self.tmp_dir)
+        self.gz_assert(self.tmp_dir)
 
     def test_relative_gz_path(self):
         current_directory = os.getcwd()
@@ -241,7 +241,7 @@ class LocalMRJobRunnerEndToEndTestCase(SandboxedTestCase):
 
         self.addCleanup(change_back_directory)
         os.chdir(self.tmp_dir)
-        self.gz_test('')
+        self.gz_assert('')
 
     def test_multi_step_counters(self):
         stdin = StringIO('foo\nbar\n')

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -540,7 +540,7 @@ class URITestCase(unittest.TestCase):
         self.assertEqual(urlparse('s3://bucket/path'),
                          ('s3', 'bucket', '/path', '', '', ''))
         self.assertEqual(urlparse('s3://bucket/path#customname'),
-                         ('s3', 'bucket', '/path#customname', '', '', ''))
+                         ('s3', 'bucket', '/path', '', '', 'customname'))
         self.assertEqual(urlparse('s3://bucket'),
                          ('s3', 'bucket', '', '', '', ''))
         self.assertEqual(urlparse('s3://bucket/'),


### PR DESCRIPTION
1. In tests.test_parse line 543 the assert was incorrect. Fixed
2. In tests.test_local the name "gz_test" was causing nose to think that
   function was a test. Which it is not. I renamed it "gz_assert" now it
   works.

Signed-off-by: Tim Henderson tim.tadh@gmail.com
