### PR TITLE
Help Sphinx find options_extension

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = PYTHONPATH=$(PYTHONPATH):$(PWD) sphinx-build
+SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,9 @@ from better import better_theme_path
 
 import mrjob
 
+# Help sphinx find options_extension
+sys.path += [os.path.abspath(os.path.split(__file__)[0])]
+
 READ_THE_DOCS = os.environ.get('READTHEDOCS', None) == 'True'
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
This is the actually-correct way to do it according to the Sphinx docs.

RtD is still failing because it's using `sphinx-build` instead of `make html`.
