### PR TITLE
The RawProtocol only handles strings

### DIFF
--- a/mrjob/protocol.py
+++ b/mrjob/protocol.py
@@ -161,7 +161,7 @@ class RawProtocol(object):
         return tuple(key_value)
 
     def write(cls, key, value):
-        return '\t'.join(x for x in (key, value) if x is not None)
+        return '\t'.join(x for x in (str(key), str(value)) if x is not None)
 
 
 class RawValueProtocol(object):
@@ -176,7 +176,7 @@ class RawValueProtocol(object):
 
     @classmethod
     def write(cls, key, value):
-        return value
+        return str(value)
 
 
 class ReprProtocol(_ClassBasedKeyCachingProtocol):


### PR DESCRIPTION
Since the JSONProtocol and PickleProtocol end up calling into libraries that can handle
any output that the mapper or reducer yields. For the RawProtocol since it was doing a
string.join, errors would occur if a non string was yielded. For example I had a reducer
that was yielding a string for the key and an int as the value.

The stack trace I was getting was

Traceback (most recent call last):
  File "package_mobile_usage.py", line 66, in <module>
    Job.run()
  File "/usr/local/lib/python2.7/dist-packages/mrjob/job.py", line 500, in run
    mr_job.execute()
  File "/usr/local/lib/python2.7/dist-packages/mrjob/job.py", line 515, in execute
    self.run_reducer(self.options.step_num)
  File "/usr/local/lib/python2.7/dist-packages/mrjob/job.py", line 620, in run_reducer
    write_line(out_key, out_value)
  File "/usr/local/lib/python2.7/dist-packages/mrjob/job.py", line 746, in write_line
    print >> self.stdout, write(key, value)
  File "/usr/local/lib/python2.7/dist-packages/mrjob/protocol.py", line 152, in write
    return '\t'.join(x for x in (key, value) if x is not None)
TypeError: sequence item 1: expected string, int found

I'm not sure if just calling str() is the best way to handle this so let me know what you think.
