### PR TITLE
fixed typo, ec2_core_instace_type should be ec2_core_instance_type

### DIFF
--- a/docs/guides/configs-basics.rst
+++ b/docs/guides/configs-basics.rst
@@ -219,7 +219,7 @@ accomplish this, use the ``include`` option:
     runners:
         emr:
             num_ec2_core_instances: 20
-            ec2_core_instace_type: m1.xlarge
+            ec2_core_instance_type: m1.xlarge
 
 :file:`~/mrjob.very-small.conf`:
 
@@ -229,7 +229,7 @@ accomplish this, use the ``include`` option:
     runners:
         emr:
             num_ec2_core_instances: 2
-            ec2_core_instace_type: m1.small
+            ec2_core_instance_type: m1.small
 
 :file:`~/.mrjob.base.conf`:
 


### PR DESCRIPTION
Just a small typo, but it's in a place where users may copy verbatim for their own config.
