### PR TITLE
Catches all errors during fetching of SSH logs and re-raises.

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1836,12 +1836,11 @@ class EMRJobRunner(MRJobRunner):
             lg_step_nums = step_nums
 
         try:
-            self._enable_slave_ssh_access()
-        except IOError, e:
+			task_attempt_logs = self.ls_task_attempt_logs_ssh(step_nums)
+			step_logs = self.ls_step_logs_ssh(lg_step_nums)
+			job_logs = self.ls_job_logs_ssh(step_nums)
+        except IOError as e:
             raise LogFetchError(e)
-        task_attempt_logs = self.ls_task_attempt_logs_ssh(step_nums)
-        step_logs = self.ls_step_logs_ssh(lg_step_nums)
-        job_logs = self.ls_job_logs_ssh(step_nums)
         log.info('Scanning SSH logs for probable cause of failure')
         return best_error_from_logs(self, task_attempt_logs, step_logs,
                                     job_logs)


### PR DESCRIPTION
Any of these SSH ls-ing operations can fail, so all of them should be handled as a LogFetchError. These other fetch actions raising an IOError was preventing the rest of the log failure logic from running.
