### PR TITLE
Fix hashing of jobflow arguments to account for uncertain dictionary ord...

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2292,7 +2292,12 @@ class EMRJobRunner(MRJobRunner):
         things_to_hash = [
             # exclude mrjob.tar.gz because it's only created if the
             # job starts its own job flow (also, its hash changes every time
-            # since the tarball contains different timestamps)
+            # since the tarball contains different timestamps).
+            # The filenames/md5sums are sorted because we need to
+            # ensure the order they're added doesn't affect the hash
+            # here. Previously this used a dict, but Python doesn't
+            # guarantee the ordering of dicts -- they can vary
+            # depending on insertion/deletion order.
             sorted(
                 (name, self.md5sum(path)) for name, path
                 in self._bootstrap_dir_mgr.name_to_path('file').iteritems()


### PR DESCRIPTION
...ering.

According to the Python docs
(http://docs.python.org/release/2.6.4/library/stdtypes.html#dict.items):

"CPython implementation detail: Keys and values are listed in an
arbitrary order which is non-random, varies across Python
implementations, and depends on the dictionary’s history of insertions
and deletions."

This causes a problem when hashing the arguments for a jobflow. Some
of the arguments -- the uploaded files and their hashes -- have been
passed to the function that generates the hash as a
dictionary. However, the order of this dictionary is not guaranteed
and can therefore return different results if the dictionary happens
to have a different order.

This fix makes sure the ordering is consistent by sorting the
dictionary items (key,value tuples) rather than relying on the
dictionary itself. The uploaded files appear to be the only dictionary
actually dependent on ordering, so sorting the values for the files
should be sufficient. The bootstrap actions also contain dictionaries,
but seem to always be constructed consistently.
