### PR TITLE
catting a file *containing* an error is not an error

### DIFF
--- a/mrjob/ssh.py
+++ b/mrjob/ssh.py
@@ -158,8 +158,6 @@ def ssh_cat(ssh_bin, address, ec2_key_pair_file, path, keyfile=None):
     out = check_output(*ssh_run_with_recursion(ssh_bin, address,
                                                ec2_key_pair_file,
                                                keyfile, ['cat', path]))
-    if 'No such file or directory' in out:
-        raise IOError("File not found: %s" % path)
     return out
 
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2877,6 +2877,17 @@ class TestCatFallback(MockEMRAndS3TestCase):
             IOError, list,
             runner.cat(SSH_PREFIX + runner._address + '/does_not_exist'))
 
+    def test_ssh_cat_errlog(self):
+        # A file *containing* an error message shouldn't cause an error.
+        runner = EMRJobRunner(conf_paths=[])
+        self.prepare_runner_for_ssh(runner)
+
+        error_message = 'cat: logs/err.log: No such file or directory\n'
+        mock_ssh_file('testmaster', 'logs/err.log', error_message)
+        self.assertEqual(
+            list(runner.cat(SSH_PREFIX + runner._address + '/logs/err.log')),
+            [error_message])
+
 
 class CleanUpJobTestCase(MockEMRAndS3TestCase):
 


### PR DESCRIPTION
This solves our long-standing p0 ticket:

IOError: File not found: /mnt/var/log/hadoop/userlogs/job_201302120935_0003/attempt_201302120935_0003_m_000005_0/syslog

The issue is that the file itself was being checked for no-such-file errors, which would mask the actual error.

I've added a failing test as well.
