### PR TITLE
Fixing a typo in option name in docs

### DIFF
--- a/docs/guides/emr-quickstart.rst
+++ b/docs/guides/emr-quickstart.rst
@@ -137,7 +137,7 @@ The basic way to control type and number of instances is with the
 *ec2_instance_type* and *num_ec2_instances* options, on the command line like
 this::
 
-    --ec2_instance_type c1.medium --num-ec2-instances 5
+    --ec2-instance-type c1.medium --num-ec2-instances 5
 
 or in :py:mod:`mrjob.conf`, like this::
 


### PR DESCRIPTION
Doc mentions "--ec2_instance_type" for command line invocation, but the option is actually "--ec-instance-type" (hyphen, not underscore) for its command line usage. Fixing the typo.
