### PR TITLE
First arg is script_path unless explicitly set

### DIFF
--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -369,11 +369,11 @@ class MRJobLauncher(object):
         MRJobLauncher takes off the first arg as the script path.
         """
         if not self._script_path:
-            self._script_path = os.path.abspath(args[0])
-        elif len(args) < 1:
-            self.option_parser.error('Must supply script path')
-
-        self.args = args[1:]
+            if len(args) < 1:
+                self.option_parser.error('Must supply script path')
+            else:
+                self._script_path = os.path.abspath(args[0])
+                self.args = args[1:]
 
     def _help_main(self):
         self.option_parser.option_groups = []

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -278,3 +278,7 @@ class CommandLineArgsTestCase(unittest.TestCase):
     def test_no_conf_overridden(self):
         mr_job = MRCustomJobLauncher(args=['', '--no-conf', '-c', 'blah.conf'])
         self.assertEqual(mr_job.options.conf_paths, ['blah.conf'])
+
+    def test_requires_script_path(self):
+        self.assertRaises(ValueError, MRCustomJobLauncher, args=[])
+


### PR DESCRIPTION
If _script_path is not set at this point, use the first argument.
