### PR TITLE
Give better error message if keyfile is missing

### DIFF
--- a/mrjob/ssh.py
+++ b/mrjob/ssh.py
@@ -45,6 +45,8 @@ def _ssh_args(ssh_bin, address, ec2_key_pair_file):
     ``subprocess``. Specifies an identity, disables strict host key checking,
     and adds the ``hadoop`` username.
     """
+    if ec2_key_pair_file is None:
+        raise ValueError('SSH key file path cannot be None')
     return ssh_bin + [
         '-i', ec2_key_pair_file,
         '-o', 'StrictHostKeyChecking=no',


### PR DESCRIPTION
Previously, on missing key file it will create error message like this:

```
Traceback (most recent call last):
  .....
  File "<python_lib>lib/python2.7/site-packages/mrjob/emr.py", line 1010, in cleanup
    super(EMRJobRunner, self).cleanup(mode=mode)
  File "<python_lib>lib/python2.7/site-packages/mrjob/runner.py", line 560, in cleanup
    self._cleanup_job()
  File "<python_lib>lib/python2.7/site-packages/mrjob/emr.py", line 1084, in _cleanup_job
    self._opts['ec2_key_pair_file'])
  File "<python_lib>lib/python2.7/site-packages/mrjob/ssh.py", line 200, in ssh_terminate_single_job
    ssh_bin, address, ec2_key_pair_file, ['hadoop', 'job', '-list']))
  File "<python_lib>lib/python2.7/site-packages/mrjob/ssh.py", line 82, in ssh_run
    p = Popen(args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
  File "<python_lib>lib/python2.7/subprocess.py", line 709, in __init__
    errread, errwrite)
  File "<python_lib>lib/python2.7/subprocess.py", line 1326, in _execute_child
    raise child_exception
TypeError: execv() arg 2 must contain only strings
```

The reason for this is the missing keyfile.

The same fatal error have have been guarded in other code path (e.g. `ssh_run_with_recursion`).  

So just porting this guard to the `ssh_run` code path. to give more sensible error message for other debugging the same problem.

Thanks.
