### PR TITLE
Use -p in hadoop mkdir

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -270,7 +270,7 @@ class HadoopJobRunner(MRJobRunner):
 
     def _mkdir_on_hdfs(self, path):
         log.debug('Making directory %s on HDFS' % path)
-        self.invoke_hadoop(['fs', '-mkdir', path])
+        self.invoke_hadoop(['fs', '-mkdir', '-p', path])
 
     def _upload_to_hdfs(self, path, target):
         log.debug('Uploading %s -> %s on HDFS' % (path, target))


### PR DESCRIPTION
E.g. `hadoop fs -mkdir -p <path>`. Otherwise the mkdir will fail since the temp directory path hasn't been created, like:

```
STDERR: mkdir: `hdfs:///user/sjpaavol/tmp/mrjob/jobs.sjpaavol.20140127.092439.798924/files/': No such file or directory
./job1.py: ERROR: STDERR: mkdir: `hdfs:///user/sjpaavol/tmp/mrjob/jobs.sjpaavol.20140127.092439.798924/files/': No such file or directory
```
