### PR TITLE
Exclude source jars from jar lookup

### DIFF
--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -29,7 +29,7 @@ from mrjob.compat import uses_020_counters
 
 
 # match the filename of a hadoop streaming jar
-HADOOP_STREAMING_JAR_RE = re.compile(r'^hadoop.*streaming.*\.jar$')
+HADOOP_STREAMING_JAR_RE = re.compile(r'^hadoop.*streaming.*(?<!-sources)\.jar$')
 
 # match an mrjob job name (these are used to name EMR job flows)
 JOB_NAME_RE = re.compile(r'^(.*)\.(.*)\.(\d+)\.(\d+)\.(\d+)$')


### PR DESCRIPTION
Added negative lookbehind assertion to ensure that the source jar is **not** picked up if it is present.

For example, with this structure the old picked up the `hadoop-streaming-2.2.0-test-sources.jar` jar, with the fixed version the correct `hadoop-streaming-2.2.0.jar`.

```
$ ls -gG */*streaming*.jar
-rw-rwxr-x 1 102785 Jan 11 21:47 lib/hadoop-streaming-2.2.0.jar
-rw-rwxr-x 1  71832 Jan 11 21:47 sources/hadoop-streaming-2.2.0-sources.jar
-rw-rwxr-x 1  76358 Jan 11 21:47 sources/hadoop-streaming-2.2.0-test-sources.jar
```
