### PR TITLE
Fixed virtualenv sample script

### DIFF
--- a/docs/guides/setup-cookbook.rst
+++ b/docs/guides/setup-cookbook.rst
@@ -114,7 +114,7 @@ machine, something like this:
       hadoop:
         setup:
         - VENV=/tmp/$mapreduce_job_id
-        - if [ -e $VENV ]; then virtualenv $VENV; fi
+        - if [ ! -e $VENV ]; then virtualenv $VENV; fi
         - . $VENV/bin/activate
         - pip install mr3po simplejson
 


### PR DESCRIPTION
virtualenv should be created if the venv directory _does not_ exist (now it did the opposite -- created it if it existed!).
