### PR TITLE
Adding option to specify IAM job flow role to use with EMR cluster

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -116,6 +116,20 @@ Job flow creation and configuration
     necessary to set this by hand.
 
 .. mrjob-opt::
+    :config: iam_job_flow_role
+    :switch: --iam-job-flow-role
+    :type: :ref:`string <data-type=string>`
+    :set: emr
+    :default: ``None``
+
+    IAM job flow role to use on the EMR cluster. See 
+    http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-iam-roles.html
+    for more details on using IAM roles with EMR.
+    Needs AMI version 2.3.0 or later to work.
+
+    .. versionadded:: 0.4.3
+
+.. mrjob-opt::
     :config: max_hours_idle
     :switch: --max-hours-idle
     :type: :ref:`string <data-type-string>`

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -368,6 +368,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         'enable_emr_debugging',
         'hadoop_streaming_jar_on_emr',
         'hadoop_version',
+        'iam_job_flow_role',
         'max_hours_idle',
         'mins_to_end_of_hour',
         'num_ec2_core_instances',
@@ -415,6 +416,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'hadoop_version': None,
             'hadoop_streaming_jar_on_emr': (
                 '/home/hadoop/contrib/streaming/hadoop-streaming.jar'),
+            'iam_job_flow_role': None,
             'mins_to_end_of_hour': 5.0,
             'num_ec2_core_instances': 0,
             'num_ec2_instances': 1,
@@ -1297,6 +1299,11 @@ class EMRJobRunner(MRJobRunner):
             args.setdefault('api_params', {})
             args['api_params']['VisibleToAllUsers'] = 'true'
 
+        if self._opts['iam_job_flow_role']:
+            if 'api_params' not in args:
+                args.setdefault('api_params', {})
+            args['api_params']['JobFlowRole'] = self._opts['iam_job_flow_role']
+             
         if steps:
             args['steps'] = steps
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -429,6 +429,11 @@ def add_emr_opts(opt_group):
                   ' Rarely necessary.')),
 
         opt_group.add_option(
+            '--iam-job-flow-role', dest='iam_job_flow_role',
+            default=None,
+            help='IAM Job flow role to use for the EMR cluster - see AWS docs on EMR for info on using IAM roles with EMR'),
+         
+        opt_group.add_option(
             '--max-hours-idle', dest='max_hours_idle',
             default=None, type='float',
             help=("If we create a persistent job flow, have it automatically"
@@ -539,6 +544,7 @@ def add_emr_opts(opt_group):
             '--ssh-tunnel-to-job-tracker', dest='ssh_tunnel_to_job_tracker',
             default=None, action='store_true',
             help='Open up an SSH tunnel to the Hadoop job tracker'),
+
         opt_group.add_option(
             '--visible-to-all-users', dest='visible_to_all_users',
             default=None, action='store_true',
@@ -547,7 +553,7 @@ def add_emr_opts(opt_group):
                  ' to True, all IAM users of that AWS account can view and'
                  ' (if they have the proper policy permissions set) manage'
                  ' the job flow. If it is set to False, only the IAM user'
-                 ' that created the job flow can view and manage it.'),
+                 ' that created the job flow can view and manage it.')
     ]
 
 

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -521,6 +521,7 @@ class MockEmrConnection(object):
             creationdatetime=to_iso8601(now),
             ec2keyname=ec2_keyname,
             hadoopversion=hadoop_version,
+            iamjobflowrole=None,
             instancecount=str(num_instances),
             instancegroups=mock_groups,
             jobflowid=jobflow_id,
@@ -550,6 +551,8 @@ class MockEmrConnection(object):
         if api_params:
             for k, v in api_params.iteritems():
                 setattr(job_flow, k.lower(), v)
+            if 'JobFlowRole' in api_params:
+                job_flow.iamjobflowrole = api_params['JobFlowRole']
 
         self.mock_emr_job_flows[jobflow_id] = job_flow
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -593,6 +593,28 @@ class VisibleToAllUsersTestCase(MockEMRAndS3TestCase):
         self.assertTrue(job_flow.visibletoallusers, 'true')
 
 
+class IAMJobFlowRoleTestCase(MockEMRAndS3TestCase):
+
+    def run_and_get_job_flow(self, *args):
+        stdin = StringIO('foo\nbar\n')
+        mr_job = MRTwoStepJob(
+            ['-r', 'emr', '-v'] + list(args))
+        mr_job.sandbox(stdin=stdin)
+
+        with mr_job.make_runner() as runner:
+            runner.run()
+            emr_conn = runner.make_emr_conn()
+            return emr_conn.describe_jobflow(runner.get_emr_job_flow_id())
+
+    def test_defaults(self):
+        job_flow = self.run_and_get_job_flow()
+        self.assertEqual(job_flow.iamjobflowrole, None)
+
+    def test_iamjobflowrole(self):
+        job_flow = self.run_and_get_job_flow('--iam-job-flow-role=EMRDefaultRole')
+        self.assertEqual(job_flow.iamjobflowrole, 'EMRDefaultRole')
+
+
 class AMIAndHadoopVersionTestCase(MockEMRAndS3TestCase):
 
     def run_and_get_job_flow(self, *args):


### PR DESCRIPTION
This fixes issue: https://github.com/Yelp/mrjob/issues/856

EMR can take in an IAM role for the job flow. Restrictions placed on the IAM role will then be placed on the machines of the EMR cluster too, helping organizations use these roles for additional security.

(see http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-iam-roles.html for more info on using IAM roles in EMR)
