### PR TITLE
#863 EMR AMIs 3.0.x use yum, not apt-get.

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1968,7 +1968,7 @@ class EMRJobRunner(MRJobRunner):
 
         # bootstrap_python_packages
         if self._opts['bootstrap_python_packages']:
-            bootstrap.append(['sudo apt-get install -y python-pip'])
+            bootstrap.append(['sudo apt-get install -y python-pip || sudo yum install -y python-pip'])
 
         for path in self._opts['bootstrap_python_packages']:
             path_dict = parse_legacy_hash_path('file', path)


### PR DESCRIPTION
Let me know if this change needs tests.
