### PR TITLE
Fixing a typo in docs, for the newly added iam-job-flow-role option

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -118,7 +118,7 @@ Job flow creation and configuration
 .. mrjob-opt::
     :config: iam_job_flow_role
     :switch: --iam-job-flow-role
-    :type: :ref:`string <data-type=string>`
+    :type: :ref:`string <data-type-string>`
     :set: emr
     :default: ``None``
 


### PR DESCRIPTION
Bug fix - a typo in docs, in the description for --iam-job-flow-role option
http://mrjob.readthedocs.org/en/latest/guides/emr-opts.html#job-flow-creation-and-configuration
