### PR TITLE
Fix slightly erroneous docstring for S3 filesystem

### DIFF
--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -79,7 +79,8 @@ class S3Filesystem(Filesystem):
         """
         :param aws_access_key_id: Your AWS access key ID
         :param aws_secret_access_key: Your AWS secret access key
-        :param s3_endpoint: S3 endpoint to access, e.g. ``us-west-1``
+        :param s3_endpoint: S3 endpoint to access, e.g. 
+                            ``s3-us-west-2.amazonaws.com``
         """
         super(S3Filesystem, self).__init__()
         self._s3_endpoint = s3_endpoint


### PR DESCRIPTION
This tripped me up. The endpoint isn't the same thing as the region name.
