### PR TITLE
Switch to pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,28 @@
+[pytest]
+norecursedirs = build docs/_build *.egg .tox *.venv
+addopts =
+    # Shows a line for every test
+    # You probably want to turn this off if you use pytest-sugar.
+    # Or you can keep it and run `py.test -q`.
+    # --verbose
+
+    # Shorter tracebacks are sometimes easier to read
+    --tb=short
+
+    # Turn on --capture to have brief, less noisy output.
+    # You will only see output if the test fails.
+    # Use --capture no (same as -s) if you want to see it all or have problems
+    # debugging.
+    # --capture=fd
+    # --capture=no
+
+    # Show extra test summary info as specified by chars (f)ailed, (E)error, (s)skipped, (x)failed, (X)passed.
+    -rfEsxX
+
+    # Output test results to junit.xml for Jenkins to consume
+    # --junitxml=junit.xml
+
+    # Measure code coverage
+    # --cov=mrjob
+    # --cov-report=xml
+    # --cov-report=term-missing

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,10 @@
 envlist = py26, py27, pypy
 
 [testenv]
-commands = {envpython} setup.py test
+deps =
+    mock
+    pytest
+    pytest-sugar
+    pytest-xdist
+    unittest2
+commands = py.test {posargs}


### PR DESCRIPTION
This switches from using `python setup.py test` to run tests to using [pytest](http://pytest.org/latest/) (and [pytest-sugar](https://pypi.python.org/pypi/pytest-sugar)).

Advantages are that pytest gives you more control over running tests like only running selected tests and gives you options of nicer output, easily displaying coverage or generating JUnit and Cobertura XML files that can be consumed by Jenkins, etc.. [pytest-sugar](https://pypi.python.org/pypi/pytest-sugar) in particular gives you nice output with progress info and shows failures immediately instead of waiting until the end.

Give it a shot and see if you like it.

If not, no biggie.

```
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
  congratulations :)
```

![screen shot 2014-04-10 at 10 57 34 am](https://cloud.githubusercontent.com/assets/305268/2671370/ae024026-c0d9-11e3-9a4f-7eb7f4b3f676.png)
