### PR TITLE
Added required -p flag to mkdir for CDH5

### DIFF
--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -191,7 +191,7 @@ class HadoopFilesystem(Filesystem):
     def mkdir(self, path):
         try:
             self.invoke_hadoop(
-                ['fs', '-mkdir', path], ok_stderr=[HADOOP_FILE_EXISTS_RE])
+                ['fs', '-mkdir', '-p', path], ok_stderr=[HADOOP_FILE_EXISTS_RE])
         except CalledProcessError:
             raise IOError("Could not mkdir %s" % path)
 


### PR DESCRIPTION
In 0.23 HDFS made the -p flag mandatory to silently make parent directories. MrJob was failing on CDH5 because mkdir was no longer working. -p has been in the hdfs client for a long time, so adding it shouldn't break old versions.

JIRA for the change here: https://issues.apache.org/jira/browse/HADOOP-8551
