### PR TITLE
Fix #932: handle spaces in hadoop job -list output

### DIFF
--- a/mrjob/bootstrap/terminate_idle_job_flow.sh
+++ b/mrjob/bootstrap/terminate_idle_job_flow.sh
@@ -60,7 +60,7 @@ do
     # first time through this loop, we just initialize LAST_ACTIVE
     # might as well nice hadoop; if there's other activity, it's Hadoop jobs
     if [ -z "$LAST_ACTIVE" ] || \
-        nice hadoop job -list 2> /dev/null | grep -q '^job_'
+        nice hadoop job -list 2> /dev/null | grep -q '^\s*job_'
     then
         LAST_ACTIVE=$UPTIME
 


### PR DESCRIPTION
As mentioned in #932, spaces in the output of `hadoop job -list` cause listings for running jobs to be ignored by the following `grep`. This fixes the bug by allowing spaces at the beginning of job listing lines.
