### PR TITLE
Use self.addCleanup to schedule tmpdir cleanups

### DIFF
--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import bz2
 import os
+import shutil
 
 from mrjob.fs.ssh import SSHFilesystem
 from mrjob import ssh
@@ -40,6 +41,13 @@ class SSHFSTestCase(MockSubprocessTestCase):
             MOCK_SSH_ROOTS='testmaster=%s' % self.master_ssh_root,
         )
         self.ssh_slave_roots = []
+
+        self.addCleanup(self.teardown_ssh, self.master_ssh_root)
+
+    def teardown_ssh(self, master_ssh_root):
+        shutil.rmtree(master_ssh_root)
+        for path in self.ssh_slave_roots:
+            shutil.rmtree(path)
 
     def add_slave(self):
         slave_num = len(self.ssh_slave_roots) + 1

--- a/tests/tools/emr/test_mrboss.py
+++ b/tests/tools/emr/test_mrboss.py
@@ -57,7 +57,6 @@ class MRBossTestCase(MockEMRAndS3TestCase):
         """
         shutil.rmtree(self.output_dir)
         self.runner.cleanup()
-        self.teardown_ssh()
 
     def test_one_node(self):
         mock_ssh_file('testmaster', 'some_file', 'file contents')


### PR DESCRIPTION
After prepare_runner_for_ssh was called, the tmpdirs created were
unreliably cleaned up. Use self.addCleanup to schedule the cleanup so
that users of the function don't need to cleanup manually.
