### PR TITLE
Remove exclusive file lock in runner wrapper

### DIFF
--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1011,6 +1011,7 @@ class MRJobRunner(object):
 
         writeln('# release exclusive file lock')
         writeln('exec 9>&-')
+        writeln('rm /tmp/wrapper.lock.%s' % self._job_name)
         writeln()
 
         writeln('# run task from the original working directory')


### PR DESCRIPTION
Cleanup the manually created file lock on script completion.
