### PR TITLE
use the xtrace flag to get more debugging output during bootstrap/runner

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -397,7 +397,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'num_ec2_instances': 1,
             'num_ec2_task_instances': 0,
             's3_sync_wait_time': 5.0,
-            'sh_bin': ['/bin/sh', '-e'],
+            'sh_bin': ['/bin/sh', '-ex'],
             'ssh_bin': ['ssh'],
             'ssh_bind_ports': range(40001, 40841),
             'ssh_tunnel_to_job_tracker': False,

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -199,7 +199,7 @@ class RunnerOptionStore(OptionStore):
             'cleanup_on_failure': ['NONE'],
             'hadoop_version': '0.20',
             'owner': owner,
-            'sh_bin': ['sh', '-e'],
+            'sh_bin': ['sh', '-ex'],
         })
 
     def _validate_cleanup(self):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1937,7 +1937,7 @@ class TestMasterBootstrapScript(MockEMRAndS3TestCase):
         lines = [line.rstrip() for line in
                  open(runner._master_bootstrap_script_path)]
 
-        self.assertEqual(lines[0], '#!/bin/sh -e')
+        self.assertEqual(lines[0], '#!/bin/sh -ex')
 
         # check PWD gets stored
         self.assertIn('__mrjob_PWD=$PWD', lines)


### PR DESCRIPTION
When running bootstrap commands, failures can be very mysterious. What command was actually run?  What environment variables were properly interpolated?  By adding the xtrace flag, the script will send to stderr the commands that are actually run.  This should allow the user to debug the error.

This can be set by the user, but setting it as a default makes sense because the helpfulness of the output should outweigh the few extra statements logged.
