### PR TITLE
avoid import of mrjob library (and its dependencies) to version on setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.pyc
 *~
 *.swp
+.eggs
+.idea
 .project
 .pydevproject
 .ropeproject/

--- a/mrjob/__init__.py
+++ b/mrjob/__init__.py
@@ -16,6 +16,8 @@
 Hadoop cluster.
 """
 
+from .version import __version__
+
 __author__ = 'David Marin <dm@davidmarin.org>'
 
 __credits__ = [
@@ -73,5 +75,3 @@ __credits__ = [
     'Paul Wais <pwais@yelp.com>',
     'Derek Wilson <jderekwilson@gmail.com>',
 ]
-
-__version__ = '0.4.3-dev'

--- a/mrjob/version.py
+++ b/mrjob/version.py
@@ -1,0 +1,17 @@
+# Copyright 2009-2013 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Version module."""
+
+__version__ = '0.4.3-dev'

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ except ImportError:
     from distutils.core import setup
     setuptools_kwargs = {}
 
-import mrjob
+execfile('mrjob/version.py')
 
 setup(
     author='David Marin',
@@ -70,6 +70,6 @@ setup(
     },
     scripts=['bin/mrjob'],
     url='http://github.com/Yelp/mrjob',
-    version=mrjob.__version__,
+    version=__version__,
     **setuptools_kwargs
 )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,31 @@
+# Copyright 2009-2013 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test for the mrjob.version module"""
+
+try:
+    import unittest2 as unittest
+    unittest  # quiet "redefinition of unused ..." warning from pyflakes
+except ImportError:
+    import unittest
+
+import mrjob
+import mrjob.version
+
+
+class VersionTestCase(unittest.TestCase):
+    def test_version_module(self):
+        self.assertTrue(hasattr(mrjob.version, '__version__'))
+        self.assertTrue(hasattr(mrjob, '__version__'))
+        self.assertEqual(mrjob.version.__version__, mrjob.__version__)


### PR DESCRIPTION
1. added a version module.
2. moved `mrjob.__version__` to `mrjob.version.__version__`
3. linked `mrjob.__version__` attribute to `mrjob.version.__version__` attribute.
4. added test case for `mrjob.version` module.

not really related but I also added 2 lines on .gitignore to ignore PyCharm .idea directory and .eggs directory.