### PR TITLE
self.mr -> MRStep to fix deprecation warning

### DIFF
--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -344,7 +344,7 @@ class MRJob(MRJobLauncher):
 
         kwargs.update(updates)
 
-        return [self.mr(**kwargs)]
+        return [MRStep(**kwargs)]
 
     @classmethod
     def mr(cls, *args, **kwargs):


### PR DESCRIPTION
There were deprecation warnings about using self.mr.  This fixes those.
