### PR TITLE
Adding deprecation warnings for setup/bootstrap* options

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -359,6 +359,18 @@ Other
 
     .. versionadded:: 0.4.3
 
+.. mrjob-opt::
+    :config: export_job_name
+    :switch: --export-job-name
+    :type: boolean
+    :set: all
+    :default: False
+
+    If this option is specified, the environment variable MRJOB_JOB_NAME is set to the name of this job.
+
+    .. versionadded:: 0.4.3
+
+
 Options ignored by the inline runner
 ------------------------------------
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -586,7 +586,7 @@ class EMRJobRunner(MRJobRunner):
             })
 
         if self._opts['bootstrap_files']:
-            log.warning("bootstrap_files is deprecated since v0.4.2 and may be removed in future releases. Consider using bootstrap instead.")
+            log.warning("bootstrap_files is deprecated since v0.4.2 and will be removed in v0.6.0. Consider using bootstrap instead.")
         for path in self._opts['bootstrap_files']:
             self._bootstrap_dir_mgr.add(**parse_legacy_hash_path(
                 'file', path, must_name='bootstrap_files'))
@@ -1961,7 +1961,7 @@ class EMRJobRunner(MRJobRunner):
             bootstrap.append(['sudo apt-get install -y python-pip || '
                 'sudo yum install -y python-pip'])
             # Print a warning
-            log.warning("bootstrap_python_packages is deprecated since v0.4.2 and may be removed in future releases. Consider using bootstrap.")
+            log.warning("bootstrap_python_packages is deprecated since v0.4.2 and will be removed in v0.6.0. Consider using bootstrap instead.")
 
 
         for path in self._opts['bootstrap_python_packages']:
@@ -1972,7 +1972,7 @@ class EMRJobRunner(MRJobRunner):
 
         # setup_cmds
         if self._opts['bootstrap_cmds']:
-            log.warning("bootstrap_cmds is deprecated since v0.4.2 and may be removed in future releases. Consider using bootstrap.")
+            log.warning("bootstrap_cmds is deprecated since v0.4.2 and will be removed in v0.6.0. Consider using bootstrap instead.")
         for cmd in self._opts['bootstrap_cmds']:
             if not isinstance(cmd, basestring):
                 cmd = cmd_line(cmd)
@@ -1980,7 +1980,7 @@ class EMRJobRunner(MRJobRunner):
 
         # bootstrap_scripts
         if self._opts['bootstrap_scripts']:
-            log.warning("bootstrap_scripts is deprecated since v0.4.2 and may be removed in future releases. Consider using bootstrap.")
+            log.warning("bootstrap_scripts is deprecated since v0.4.2 and will be removed in v0.6.0. Consider using bootstrap instead.")
 
         for path in self._opts['bootstrap_scripts']:
             path_dict = parse_legacy_hash_path('file', path)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -585,6 +585,8 @@ class EMRJobRunner(MRJobRunner):
                 'args': args[1:],
             })
 
+        if self._opts['bootstrap_files']:
+            log.warning("bootstrap_files is deprecated since v0.4.2 and may be removed in future releases. Consider using bootstrap instead.")
         for path in self._opts['bootstrap_files']:
             self._bootstrap_dir_mgr.add(**parse_legacy_hash_path(
                 'file', path, must_name='bootstrap_files'))
@@ -1958,6 +1960,9 @@ class EMRJobRunner(MRJobRunner):
             # job flow creation time so we call both
             bootstrap.append(['sudo apt-get install -y python-pip || '
                 'sudo yum install -y python-pip'])
+            # Print a warning
+            log.warning("bootstrap_python_packages is deprecated since v0.4.2 and may be removed in future releases. Consider using bootstrap.")
+
 
         for path in self._opts['bootstrap_python_packages']:
             path_dict = parse_legacy_hash_path('file', path)
@@ -1966,12 +1971,17 @@ class EMRJobRunner(MRJobRunner):
             bootstrap.append(['sudo pip install ', path_dict])
 
         # setup_cmds
+        if self._opts['bootstrap_cmds']:
+            log.warning("bootstrap_cmds is deprecated since v0.4.2 and may be removed in future releases. Consider using bootstrap.")
         for cmd in self._opts['bootstrap_cmds']:
             if not isinstance(cmd, basestring):
                 cmd = cmd_line(cmd)
             bootstrap.append([cmd])
 
         # bootstrap_scripts
+        if self._opts['bootstrap_scripts']:
+            log.warning("bootstrap_scripts is deprecated since v0.4.2 and may be removed in future releases. Consider using bootstrap.")
+
         for path in self._opts['bootstrap_scripts']:
             path_dict = parse_legacy_hash_path('file', path)
             bootstrap.append([path_dict])

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -344,7 +344,7 @@ class MRJob(MRJobLauncher):
 
         kwargs.update(updates)
 
-        return [self.mr(**kwargs)]
+        return [MRStep(**kwargs)]
 
     @classmethod
     def mr(cls, *args, **kwargs):

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -37,7 +37,7 @@ except ImportError:
     boto = None
 
 # match the filename of a hadoop streaming jar
-HADOOP_STREAMING_JAR_RE = re.compile(r'^hadoop.*streaming.*\.jar$')
+HADOOP_STREAMING_JAR_RE = re.compile(r'^hadoop.*streaming.*(?<!-sources)\.jar$')
 
 # match an mrjob job name (these are used to name EMR job flows)
 JOB_NAME_RE = re.compile(r'^(.*)\.(.*)\.(\d+)\.(\d+)\.(\d+)$')

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -950,12 +950,18 @@ class MRJobRunner(object):
             setup.append(parse_setup_cmd(cmd))
 
         # setup_cmds
+        if self._opts['setup_cmds']:
+            log.warning("setup_cmds is deprecated since v0.4.2 and may be removed in future versions. Consider using setup instead.")
+
         for cmd in self._opts['setup_cmds']:
             if not isinstance(cmd, basestring):
                 cmd = cmd_line(cmd)
             setup.append([cmd])
 
         # setup_scripts
+        if self._opts['setup_scripts']:
+            log.warning("setup_scripts is deprecated since v0.4.2 and may be removed in future versions. Consider using setup instead.")
+
         for path in self._opts['setup_scripts']:
             path_dict = parse_legacy_hash_path('file', path)
             setup.append([path_dict])

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -434,6 +434,10 @@ class MRJobRunner(object):
         # rather than feed it multiple files
         self._sort_is_windows_sort = None
 
+        # this variable marks whether a cleanup has happened and this runner's
+        # output stream is no longer available.
+        self._closed = False
+
     ### Filesystem object ###
 
     @property
@@ -477,6 +481,9 @@ class MRJobRunner(object):
         output_dir = self.get_output_dir()
         if output_dir is None:
             raise AssertionError('Run the job before streaming output')
+
+        if self._closed is True:
+            log.warn('WARNING! Trying to stream output from a closed runner, output will probably be empty.')
 
         log.info('Streaming final output from %s' % output_dir)
 
@@ -579,6 +586,8 @@ class MRJobRunner(object):
 
         if mode_has('ALL', 'LOGS'):
             self._cleanup_logs()
+
+        self._closed = True
 
     def counters(self):
         """Get counters associated with this run in this form::

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -960,7 +960,7 @@ class MRJobRunner(object):
 
         # setup_cmds
         if self._opts['setup_cmds']:
-            log.warning("setup_cmds is deprecated since v0.4.2 and may be removed in future versions. Consider using setup instead.")
+            log.warning("setup_cmds is deprecated since v0.4.2 and will be removed in v0.6.0. Consider using setup instead.")
 
         for cmd in self._opts['setup_cmds']:
             if not isinstance(cmd, basestring):
@@ -969,7 +969,7 @@ class MRJobRunner(object):
 
         # setup_scripts
         if self._opts['setup_scripts']:
-            log.warning("setup_scripts is deprecated since v0.4.2 and may be removed in future versions. Consider using setup instead.")
+            log.warning("setup_scripts is deprecated since v0.4.2 and will be removed in v0.6.0. Consider using setup instead.")
 
         for path in self._opts['setup_scripts']:
             path_dict = parse_legacy_hash_path('file', path)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,28 @@
+[pytest]
+norecursedirs = build docs/_build *.egg .tox *.venv
+addopts =
+    # Shows a line for every test
+    # You probably want to turn this off if you use pytest-sugar.
+    # Or you can keep it and run `py.test -q`.
+    # --verbose
+
+    # Shorter tracebacks are sometimes easier to read
+    --tb=short
+
+    # Turn on --capture to have brief, less noisy output.
+    # You will only see output if the test fails.
+    # Use --capture no (same as -s) if you want to see it all or have problems
+    # debugging.
+    # --capture=fd
+    # --capture=no
+
+    # Show extra test summary info as specified by chars (f)ailed, (E)error, (s)skipped, (x)failed, (X)passed.
+    -rfEsxX
+
+    # Output test results to junit.xml for Jenkins to consume
+    # --junitxml=junit.xml
+
+    # Measure code coverage
+    # --cov=mrjob
+    # --cov-report=xml
+    # --cov-report=term-missing

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -802,6 +802,14 @@ class ExportJobNameTestCase(EmptyMrjobConfTestCase):
             self.assertFalse(runner._opts['export_job_name'])
             self.assertEqual(runner._opts['cmdenv'], {})
 
+class ClosedRunnerTestCase(EmptyMrjobConfTestCase):
+
+    def test_job_closed_on_cleanup(self):
+        job = MRWordCount()
+        with job.make_runner() as runner:
+            # do nothing
+            self.assertFalse(runner._closed)
+        self.assertTrue(runner._closed)
 
 class JobNameTestCase(EmptyMrjobConfTestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,10 @@
 envlist = py26, py27, pypy
 
 [testenv]
-commands = {envpython} setup.py test
+deps =
+    mock
+    pytest
+    pytest-sugar
+    pytest-xdist
+    unittest2
+commands = py.test {posargs}


### PR DESCRIPTION
This is a straightforward check against deprecated options mentioned in #805.
Not sure if there's a cleaner way to do this and to tackle differences in option names between config file and command line (setup_cmd VS --setup-cmd)