### PR TITLE
filter out any steps that have their kwarg set to None

### DIFF
--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -96,13 +96,13 @@ class MRStep(object):
             raise ValueError("Step has no mappers and no reducers")
 
         self.has_explicit_mapper = any(
-            name for name in kwargs if name in _MAPPER_FUNCS)
+            value for name, value in kwargs.iteritems() if name in _MAPPER_FUNCS)
 
         self.has_explicit_combiner = any(
-            name for name in kwargs if name in _COMBINER_FUNCS)
+            value for name, value in kwargs.iteritems() if name in _COMBINER_FUNCS)
 
         self.has_explicit_reducer = any(
-            name for name in kwargs if name in _REDUCER_FUNCS)
+            value for name, value in kwargs.iteritems() if name in _REDUCER_FUNCS)
 
         steps = dict((f, None) for f in _JOB_STEP_PARAMS)
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -129,6 +129,15 @@ class MRStepInitTestCase(TestCase):
     def test_explicit_reducer(self):
         self._test_explicit(reducer=identity_reducer, r=True)
 
+    def test_no_explicit_mapper(self):
+        self._test_explicit(mapper=None, m=False)
+
+    def test_no_explicit_combiner(self):
+        self._test_explicit(combiner=None, c=False)
+
+    def test_no_explicit_reducer(self):
+        self._test_explicit(reducer=None, r=False)
+
     # final
 
     def test_explicit_mapper_final(self):
@@ -140,6 +149,15 @@ class MRStepInitTestCase(TestCase):
     def test_explicit_reducer_final(self):
         self._test_explicit(reducer_final=identity_reducer, r=True)
 
+    def test_no_explicit_mapper_final(self):
+        self._test_explicit(mapper_final=None, m=False)
+
+    def test_no_explicit_combiner_final(self):
+        self._test_explicit(combiner_final=None, c=False)
+
+    def test_no_explicit_reducer_final(self):
+        self._test_explicit(reducer_final=None, r=False)
+
     # init
 
     def test_explicit_mapper_init(self):
@@ -150,6 +168,15 @@ class MRStepInitTestCase(TestCase):
 
     def test_explicit_reducer_init(self):
         self._test_explicit(reducer_init=identity_reducer, r=True)
+
+    def test_no_explicit_mapper_init(self):
+        self._test_explicit(mapper_init=None, m=False)
+
+    def test_no_explicit_combiner_init(self):
+        self._test_explicit(combiner_init=None, c=False)
+
+    def test_no_explicit_reducer_init(self):
+        self._test_explicit(reducer_init=None, r=False)
 
     # cmd
 


### PR DESCRIPTION
When explicitly setting step kwargs as None, i.e. mapper=None, reducer=None, it should not count as having an actual mapper or reducer.

Previously these end up counting as an "identity" process.