### PR TITLE
Drop Python 2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 .project
 .pydevproject
 .ropeproject/
-build
-dist
-mrjob.egg-info
+/build
+/dist
+/mrjob.egg-info
+/docs/_build
 .tox

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,7 +30,8 @@ v0.4.3, 2014-01-15 -- mostly cleanup and bugfixes
  * Fix to avoid interpreting windows paths as URIs (#880)
  * Better error message when ssh keyfile is missing (#858)
  * Update EMR tool ISO8601 parsing to be consistent with EMR runner (#870)
- * Dropped support for Python 2.5
+ * Dropped support for Python 2.5 (#713)
+   * Dropped support for the 1.x EMR AMI series, which uses Python 2.5
 
 v0.4.2, 2013-11-27 -- that's one small step for a JAR
  * jobs:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,7 @@ v0.4.3, 2014-01-15 -- mostly cleanup and bugfixes
  * Fix to avoid interpreting windows paths as URIs (#880)
  * Better error message when ssh keyfile is missing (#858)
  * Update EMR tool ISO8601 parsing to be consistent with EMR runner (#870)
+ * Dropped support for Python 2.5
 
 v0.4.2, 2013-11-27 -- that's one small step for a JAR
  * jobs:

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ mrjob: the Python MapReduce library
 
 .. image:: docs/logos/logo_medium.png
 
-mrjob is a Python 2.5+ package that helps you write and run Hadoop Streaming
+mrjob is a Python 2.6+ package that helps you write and run Hadoop Streaming
 jobs.
 
 `Stable version (v0.4.2) documentation <http://packages.python.org/mrjob/>`_

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -201,7 +201,7 @@ Job execution context
 
     Interpreter to launch your script with. Defaults to the value of
     **python_bin**, which is deprecated. Change this if you're using a
-    language besides Python 2.5-2.7.
+    language besides Python 2.6-2.7.
 
 .. mrjob-opt::
     :config: python_bin

--- a/docs/guides/configs-reference.rst
+++ b/docs/guides/configs-reference.rst
@@ -17,9 +17,9 @@ You can set an option by:
 
     runners:
         local:
-            python_bin: python2.6  # only used in local runner
+            python_bin: python2.7  # only used in local runner
         emr:
-            python_bin: python2.5  # only used in Elastic MapReduce runner
+            python_bin: python2.6  # only used in Elastic MapReduce runner
 
   See :ref:`mrjob.conf` for information on where to put config files.
 

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -74,6 +74,11 @@ Job flow creation and configuration
     .. _`the AWS docs on specifying the AMI version`:
         http://docs.amazonwebservices.com/ElasticMapReduce/latest/DeveloperGuide/EnvironmentConfig_AMIVersion.html
 
+    .. warning::
+
+        The 1.x series of AMIs is no longer supported because they use Python
+        2.5.
+
 .. mrjob-opt::
     :config: aws_availability_zone
     :switch: --aws-availability-zone
@@ -122,7 +127,7 @@ Job flow creation and configuration
     :set: emr
     :default: ``None``
 
-    IAM job flow role to use on the EMR cluster. See 
+    IAM job flow role to use on the EMR cluster. See
     http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-iam-roles.html
     for more details on using IAM roles with EMR.
     Needs AMI version 2.3.0 or later to work.

--- a/docs/guides/emr-troubleshooting.rst
+++ b/docs/guides/emr-troubleshooting.rst
@@ -70,11 +70,11 @@ Now you can use the job flow ID to start the troublesome job::
     Traceback (most recent call last):
       File "buggy_job.py", line 36, in <module>
         MRWordFreqCount.run()
-      File "/usr/lib/python2.5/site-packages/mrjob/job.py", line 448, in run
+      File "/usr/lib/python2.7/site-packages/mrjob/job.py", line 448, in run
         mr_job.execute()
-      File "/usr/lib/python2.5/site-packages/mrjob/job.py", line 455, in execute
+      File "/usr/lib/python2.7/site-packages/mrjob/job.py", line 455, in execute
         self.run_mapper(self.options.step_num)
-      File "/usr/lib/python2.5/site-packages/mrjob/job.py", line 548, in run_mapper
+      File "/usr/lib/python2.7/site-packages/mrjob/job.py", line 548, in run_mapper
         for out_key, out_value in mapper(key, value) or ():
       File "buggy_job.py", line 24, in mapper
         raise IndexError
@@ -82,7 +82,7 @@ Now you can use the job flow ID to start the troublesome job::
     Traceback (most recent call last):
       File "wrapper.py", line 16, in <module>
         check_call(sys.argv[1:])
-      File "/usr/lib/python2.5/subprocess.py", line 462, in check_call
+      File "/usr/lib/python2.7/subprocess.py", line 462, in check_call
         raise CalledProcessError(retcode, cmd)
     subprocess.CalledProcessError: Command '['python', 'buggy_job.py', '--step-num=0', '--mapper']' returned non-zero exit status 1
     (while reading from s3://scratch-bucket/tmp/buggy_job.username.20110811.185410.536519/input/00000-README.rst)
@@ -108,11 +108,11 @@ you can use the :py:mod:`mrjob.tools.emr.fetch_logs` tool to scan the logs::
     Traceback (most recent call last):
       File "buggy_job.py", line 36, in <module>
         MRWordFreqCount.run()
-      File "/usr/lib/python2.5/site-packages/mrjob/job.py", line 448, in run
+      File "/usr/lib/python2.7/site-packages/mrjob/job.py", line 448, in run
         mr_job.execute()
-      File "/usr/lib/python2.5/site-packages/mrjob/job.py", line 455, in execute
+      File "/usr/lib/python2.7/site-packages/mrjob/job.py", line 455, in execute
         self.run_mapper(self.options.step_num)
-      File "/usr/lib/python2.5/site-packages/mrjob/job.py", line 548, in run_mapper
+      File "/usr/lib/python2.7/site-packages/mrjob/job.py", line 548, in run_mapper
         for out_key, out_value in mapper(key, value) or ():
       File "buggy_job.py", line 24, in mapper
         raise IndexError
@@ -120,7 +120,7 @@ you can use the :py:mod:`mrjob.tools.emr.fetch_logs` tool to scan the logs::
     Traceback (most recent call last):
       File "wrapper.py", line 16, in <module>
         check_call(sys.argv[1:])
-      File "/usr/lib/python2.5/subprocess.py", line 462, in check_call
+      File "/usr/lib/python2.7/subprocess.py", line 462, in check_call
         raise CalledProcessError(retcode, cmd)
     subprocess.CalledProcessError: Command '['python', 'buggy_job.py', '--step-num=0', '--mapper']' returned non-zero exit status 1
     (while reading from s3://scratch-bucket/tmp/buggy_job.username.20110811.185410.536519/input/00000-README.rst)
@@ -145,11 +145,11 @@ problem. You can look at the logs yourself by using Amazon's `elastic-mapreduce
     Traceback (most recent call last):
       File "mr_word_freq_count.py", line 36, in <module>
         MRWordFreqCount.run()
-      File "/usr/lib/python2.5/site-packages/mrjob/job.py", line 448, in run
+      File "/usr/lib/python2.7/site-packages/mrjob/job.py", line 448, in run
         mr_job.execute()
-      File "/usr/lib/python2.5/site-packages/mrjob/job.py", line 455, in execute
+      File "/usr/lib/python2.7/site-packages/mrjob/job.py", line 455, in execute
         self.run_mapper(self.options.step_num)
-      File "/usr/lib/python2.5/site-packages/mrjob/job.py", line 548, in run_mapper
+      File "/usr/lib/python2.7/site-packages/mrjob/job.py", line 548, in run_mapper
         for out_key, out_value in mapper(key, value) or ():
       File "mr_word_freq_count.py", line 24, in mapper
         raise IndexError
@@ -157,7 +157,7 @@ problem. You can look at the logs yourself by using Amazon's `elastic-mapreduce
     Traceback (most recent call last):
       File "wrapper.py", line 16, in <module>
         check_call(sys.argv[1:])
-      File "/usr/lib/python2.5/subprocess.py", line 462, in check_call
+      File "/usr/lib/python2.7/subprocess.py", line 462, in check_call
         raise CalledProcessError(retcode, cmd)
     subprocess.CalledProcessError: Command '['python', 'mr_word_freq_count.py', '--step-num=0', '--mapper']' returned non-zero exit status 1
     java.lang.RuntimeException: PipeMapRed.waitOutputThreads(): subprocess failed with code 1

--- a/docs/guides/runners.rst
+++ b/docs/guides/runners.rst
@@ -114,6 +114,7 @@ files are cleaned up regardless of the success or failure of your job.
 This pattern can also be used to write integration tests (see :doc:`testing`).
 
 ::
+
     mr_job = MRWordCounter(args=['-r', 'emr'])
     with mr_job.make_runner() as runner:
         runner.run()
@@ -232,6 +233,7 @@ example below demonstrates the use of counters in a test case.
 
 ``test_counters.py``
 ::
+
     try:
         import unittest2 as unittest
     except ImportError:

--- a/docs/guides/runners.rst
+++ b/docs/guides/runners.rst
@@ -114,9 +114,6 @@ files are cleaned up regardless of the success or failure of your job.
 This pattern can also be used to write integration tests (see :doc:`testing`).
 
 ::
-
-    from __future__ import with_statement # only needed on Python 2.5
-
     mr_job = MRWordCounter(args=['-r', 'emr'])
     with mr_job.make_runner() as runner:
         runner.run()
@@ -235,9 +232,6 @@ example below demonstrates the use of counters in a test case.
 
 ``test_counters.py``
 ::
-
-    from __future__ import with_statement
-
     try:
         import unittest2 as unittest
     except ImportError:

--- a/docs/guides/runners.rst
+++ b/docs/guides/runners.rst
@@ -72,8 +72,6 @@ Running on your own Hadoop cluster
 ----------------------------------
 
 * Set up a hadoop cluster (see http://hadoop.apache.org/common/docs/current/)
-* If running Python 2.5 on your cluster, install the :py:mod:`simplejson`
-  module on all nodes (recommended but not required for Python 2.6+).
 * Make sure :envvar:`HADOOP_HOME` is set
 * Run your job with ``-r hadoop``::
 

--- a/docs/guides/testing.rst
+++ b/docs/guides/testing.rst
@@ -42,9 +42,6 @@ mrjob's test cases use the :py:mod:`unittest2` module, which is available
 for Python 2.3 and up. Most tests also require the :keyword:`with` statement.
 
 ::
-
-    from __future__ import with_statement
-
     try:
         import unittest2 as unittest
     except ImportError:

--- a/docs/guides/testing.rst
+++ b/docs/guides/testing.rst
@@ -38,10 +38,8 @@ See :py:class:`~mrjob.local.LocalMRJobRunner` for reference about its behavior.
 Anatomy of a test case
 ----------------------
 
-mrjob's test cases use the :py:mod:`unittest2` module, which is available
-for Python 2.3 and up. Most tests also require the :keyword:`with` statement.
+mrjob's test cases use the :py:mod:`unittest2` module::
 
-::
     try:
         import unittest2 as unittest
     except ImportError:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 mrjob
 =====
 
-**mrjob lets you write MapReduce jobs in Python 2.5+ and run them on several
+**mrjob lets you write MapReduce jobs in Python 2.6+ and run them on several
 platforms.** You can:
 
 * Write multi-step MapReduce jobs in pure Python

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -18,6 +18,8 @@ Job flows are now visible to all IAM users by default.
 
 Tests now use pytest and support tox.
 
+Support for Python 2.5 has been dropped.
+
 This release also contains many `bugfixes
 <https://github.com/Yelp/mrjob/blob/master/CHANGES.txt>`_, including
 problems with documentation.

--- a/mrjob/aws.py
+++ b/mrjob/aws.py
@@ -15,7 +15,6 @@
 """General information about Amazon Web Services, such as region-to-endpoint
 mappings.
 """
-from __future__ import with_statement
 
 ### EC2 Instances ###
 

--- a/mrjob/cmd.py
+++ b/mrjob/cmd.py
@@ -11,12 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import with_statement
-
 from sys import argv
 from sys import stderr
-
 
 commands = {}
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -149,7 +149,7 @@ def conf_object_at_path(conf_path):
         else:
             try:
                 return json.load(f)
-            except ValueError, e:
+            except ValueError as e:
                 msg = ('If your mrjob.conf is in YAML, you need to install'
                        ' yaml; see http://pypi.python.org/pypi/PyYAML/')
                 # Use msg attr if it's set

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -16,9 +16,6 @@
 """"mrjob.conf" is the name of both this module, and the global config file
 for :py:mod:`mrjob`.
 """
-
-from __future__ import with_statement
-
 import glob
 from itertools import chain
 import logging

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import with_statement
 
 import logging
 import os

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -220,7 +220,7 @@ def describe_all_job_flows(emr_conn, states=None, jobflow_ids=None,
             results = emr_conn.describe_jobflows(
                 states=states, jobflow_ids=jobflow_ids,
                 created_after=created_after, created_before=created_before)
-        except boto.exception.BotoServerError, ex:
+        except boto.exception.BotoServerError as ex:
             if 'ValidationError' in ex.body:
                 log.debug(
                     '  reached earliest allowed created_before time, done!')
@@ -999,7 +999,7 @@ class EMRJobRunner(MRJobRunner):
                 try:
                     os.kill(self._ssh_proc.pid, signal.SIGKILL)
                     self._ssh_proc = None
-                except Exception, e:
+                except Exception as e:
                     log.exception(e)
 
         # stop the job flow if it belongs to us (it may have stopped on its
@@ -1011,7 +1011,7 @@ class EMRJobRunner(MRJobRunner):
             log.info('Terminating job flow: %s' % self._emr_job_flow_id)
             try:
                 self.make_emr_conn().terminate_jobflow(self._emr_job_flow_id)
-            except Exception, e:
+            except Exception as e:
                 log.exception(e)
 
     def _cleanup_remote_scratch(self):
@@ -1021,7 +1021,7 @@ class EMRJobRunner(MRJobRunner):
                 log.info('Removing all files in %s' % self._s3_tmp_uri)
                 self.rm(self._s3_tmp_uri)
                 self._s3_tmp_uri = None
-            except Exception, e:
+            except Exception as e:
                 log.exception(e)
 
     def _cleanup_logs(self):
@@ -1035,7 +1035,7 @@ class EMRJobRunner(MRJobRunner):
                 log.info('Removing all files in %s' % self._s3_job_log_uri)
                 self.rm(self._s3_job_log_uri)
                 self._s3_job_log_uri = None
-            except Exception, e:
+            except Exception as e:
                 log.exception(e)
 
     def _cleanup_job(self):
@@ -1079,7 +1079,7 @@ class EMRJobRunner(MRJobRunner):
         try:
             log.info("Attempting to terminate job flow")
             emr_conn.terminate_jobflow(self._emr_job_flow_id)
-        except Exception, e:
+        except Exception as e:
             # Something happened with boto and the user should know.
             log.exception(e)
             return
@@ -1630,7 +1630,7 @@ class EMRJobRunner(MRJobRunner):
             self._enable_slave_ssh_access()
             log.debug('Search %s for logs' % self._ssh_path(relative_path))
             return self.ls(self._ssh_path(relative_path))
-        except IOError, e:
+        except IOError as e:
             raise LogFetchError(e)
 
     def _ls_slave_ssh_logs(self, addr, relative_path):
@@ -1797,7 +1797,7 @@ class EMRJobRunner(MRJobRunner):
                              " mrjob fetch-logs --counters %s" %
                              job_flow.jobflowid)
             return results
-        except LogFetchError, e:
+        except LogFetchError as e:
             log.info("Unable to fetch counters: %s" % e)
             return {}
 
@@ -1850,7 +1850,7 @@ class EMRJobRunner(MRJobRunner):
             task_attempt_logs = self.ls_task_attempt_logs_ssh(step_nums)
             step_logs = self.ls_step_logs_ssh(lg_step_nums)
             job_logs = self.ls_job_logs_ssh(step_nums)
-        except IOError, e:
+        except IOError as e:
             raise LogFetchError(e)
         log.info('Scanning SSH logs for probable cause of failure')
         return best_error_from_logs(self, task_attempt_logs, step_logs,

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -564,6 +564,11 @@ class EMRJobRunner(MRJobRunner):
         else:
             self._output_dir = self._s3_tmp_uri + 'output/'
 
+        # check AMI version
+        if self._opts['ami_version'].startswith('1.'):
+            log.warning('1.x AMIs will probably not work because they use'
+                        ' Python 2.5. Use a later AMI version or mrjob v0.4.2')
+
         # manage working dir for bootstrap script
         self._bootstrap_dir_mgr = BootstrapWorkingDirManager()
 

--- a/mrjob/examples/mr_postfix_bounce/mr_postfix_bounce.py
+++ b/mrjob/examples/mr_postfix_bounce/mr_postfix_bounce.py
@@ -17,8 +17,6 @@ messages that have bounced and yielding the (email address, date ordinal).
 The emitted email addresses can then be unconfirmed or handled in some other
 way.
 """
-from __future__ import with_statement
-
 __author__ = 'Adam Derewecki <derewecki@gmail.com>'
 
 import datetime
@@ -27,7 +25,6 @@ import simplejson
 import time
 
 from mrjob.job import MRJob
-
 
 PROCESS_TYPE_PATTERN = re.compile(
     r'postfix-(?P<queue>[^/]+)/(?P<process>[^[]+)\[\d+\]:')

--- a/mrjob/fs/composite.py
+++ b/mrjob/fs/composite.py
@@ -52,7 +52,7 @@ class CompositeFilesystem(Filesystem):
             if fs.can_handle_path(path):
                 try:
                     return getattr(fs, action)(path, *args, **kwargs)
-                except IOError, e:
+                except IOError as e:
                     if first_exception is None:
                         first_exception = e
 

--- a/mrjob/fs/local.py
+++ b/mrjob/fs/local.py
@@ -9,8 +9,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import with_statement
-
 import glob
 import hashlib
 import logging
@@ -20,7 +18,6 @@ import shutil
 from mrjob.fs.base import Filesystem
 from mrjob.parse import is_uri
 from mrjob.util import read_file
-
 
 log = logging.getLogger(__name__)
 

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -243,7 +243,7 @@ class S3Filesystem(Filesystem):
 
         try:
             bucket = s3_conn.get_bucket(bucket_name, validate=VALIDATE_BUCKET)
-        except boto.exception.S3ResponseError, e:
+        except boto.exception.S3ResponseError as e:
             if e.status != 404:
                 raise e
             key = None

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -374,7 +374,7 @@ class HadoopJobRunner(MRJobRunner):
             while True:
                 try:
                     yield iter.next()  # okay for StopIteration to bubble up
-                except IOError, e:
+                except IOError as e:
                     if e.errno == errno.EIO:
                         return
                     else:
@@ -509,7 +509,7 @@ class HadoopJobRunner(MRJobRunner):
 
             try:
                 self.invoke_hadoop(['fs', '-rmr', self._hdfs_tmp_dir])
-            except Exception, e:
+            except Exception as e:
                 log.exception(e)
 
     ### LOG FETCHING/PARSING ###

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 """Run an MRJob inline by running all mappers and reducers through the same
 process. Useful for debugging."""
-from __future__ import with_statement
-
 __author__ = 'Matthew Tai <mtai@adku.com>'
 
 import logging
@@ -36,7 +34,6 @@ from mrjob.util import save_current_environment
 from mrjob.util import save_cwd
 
 log = logging.getLogger(__name__)
-
 
 # Deprecated in favor of class variables, remove in v0.5.0
 DEFAULT_MAP_TASKS = 1

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -695,7 +695,7 @@ class MRJob(MRJobLauncher):
                 try:
                     key, value = read(line.rstrip('\r\n'))
                     yield key, value
-                except Exception, e:
+                except Exception as e:
                     if self.options.strict_protocols:
                         raise
                     else:
@@ -705,7 +705,7 @@ class MRJob(MRJobLauncher):
         def write_line(key, value):
             try:
                 print >> self.stdout, write(key, value)
-            except Exception, e:
+            except Exception as e:
                 if self.options.strict_protocols:
                     raise
                 else:

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 """Class to inherit your MapReduce jobs from. See :doc:`guides/writing-mrjobs`
 for more information."""
+
 # don't add imports here that aren't part of the standard Python library,
 # since MRJobs need to run in Amazon's generic EMR environment
-from __future__ import with_statement
-
 import codecs
 import inspect
 import itertools

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import with_statement
-
 import logging
 from optparse import Option
 from optparse import OptionError

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -424,7 +424,7 @@ class MRJobLauncher(object):
         if self.options.ssh_bind_ports:
             try:
                 ports = parse_port_range_list(self.options.ssh_bind_ports)
-            except ValueError, e:
+            except ValueError as e:
                 self.option_parser.error('invalid port range list "%s": \n%s' %
                                          (self.options.ssh_bind_ports,
                                           e.args[0]))

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 """Run an MRJob locally by forking off a bunch of processes and piping
 them together. Useful for testing."""
-from __future__ import with_statement
-
-
 import logging
 from subprocess import Popen
 from subprocess import PIPE

--- a/mrjob/logparsers.py
+++ b/mrjob/logparsers.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Parsing classes to find errors in Hadoop logs"""
-from __future__ import with_statement
-
 import logging
 import posixpath
 import re
@@ -25,9 +23,7 @@ from mrjob.parse import find_python_traceback
 from mrjob.parse import find_timeout_error
 from mrjob.parse import parse_hadoop_counters_from_line
 
-
 log = logging.getLogger(__name__)
-
 
 # Constants used to distinguish between different kinds of logs
 TASK_ATTEMPT_LOGS = 'TASK_ATTEMPT_LOGS'

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -292,9 +292,7 @@ def add_emr_opts(opt_group):
 
         opt_group.add_option(
             '--ami-version', dest='ami_version', default=None,
-            help=(
-                'AMI Version to use (currently 1.0, 2.0, or latest, default'
-                ' latest).')),
+            help=('AMI Version to use, e.g. "2.4.11" (default "latest").')),
 
         opt_group.add_option(
             '--aws-availability-zone', dest='aws_availability_zone',

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -52,7 +52,7 @@ log = logging.getLogger(__name__)
 ### URI PARSING ###
 
 
-# Used to parse the real netloc out of a malformed path from Python 2.5
+# Used to parse the real netloc out of a malformed path from early Python 2.6
 # urlparse()
 NETLOC_RE = re.compile(r'//(.*?)((/.*?)?)$')
 
@@ -72,10 +72,10 @@ def is_uri(uri):
     """Return True if *uri* is any sort of URI."""
     if is_windows_path(uri):
         return False
-    
+
     return bool(urlparse(uri).scheme)
 
-    
+
 def is_s3_uri(uri):
     """Return True if *uri* can be parsed into an S3 URI, False otherwise."""
     try:

--- a/mrjob/retry.py
+++ b/mrjob/retry.py
@@ -71,7 +71,7 @@ class RetryGoRound(object):
                     # this one works, start here next time!
                     self.__start_index = index
                     return result
-                except Exception, ex:
+                except Exception as ex:
                     # that one didn't work out, retry if we can
                     if i < n - 1 and self.__retry_if(ex):
                         log.info('%r.%s() raised %r, trying next alternative'
@@ -146,7 +146,7 @@ class RetryWrapper(object):
             while (not self.__max_tries or tries < self.__max_tries):
                 try:
                     return f(*args, **kwargs)
-                except Exception, ex:
+                except Exception as ex:
                     if self.__retry_if(ex):
                         log.info('Got retriable error: %r' % ex)
                         log.info('Backing off for %.1f seconds' % backoff)

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -524,7 +524,7 @@ class MRJobRunner(object):
             log.info('removing tmp directory %s' % self._local_tmp_dir)
             try:
                 shutil.rmtree(self._local_tmp_dir)
-            except OSError, e:
+            except OSError as e:
                 log.exception(e)
 
         self._local_tmp_dir = None

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import with_statement
-
 """Base class for all runners."""
 
 import copy

--- a/mrjob/setup.py
+++ b/mrjob/setup.py
@@ -32,8 +32,6 @@ Hadoop can see them (HDFS or S3), we provide :py:class:`UploadDirManager`.
 Path dictionaries are meant to be immutable; all state is handled by
 manager classes.
 """
-from __future__ import with_statement
-
 import itertools
 import logging
 import os.path

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Run an MRJob locally by forking off a bunch of processes and piping
 them together. Useful for testing."""
-from __future__ import with_statement
-
 import itertools
 import logging
 import os

--- a/mrjob/ssh.py
+++ b/mrjob/ssh.py
@@ -12,12 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Shortcuts for SSH operations"""
 
 # don't add imports here that aren't part of the standard Python library,
 # since MRJobs need to run in Amazon's generic EMR environment
-from __future__ import with_statement
 
 import logging
 import os

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -31,8 +31,6 @@ Options::
                         go back as far as EMR supports (currently about 2
                         months)
 """
-from __future__ import with_statement
-
 from datetime import datetime
 from datetime import timedelta
 import math

--- a/mrjob/tools/emr/create_job_flow.py
+++ b/mrjob/tools/emr/create_job_flow.py
@@ -23,8 +23,6 @@ Usage::
 :py:mod:`mrjob.tools.emr.terminate_idle_job_flows` in your crontab; job flows
 left idle can quickly become expensive!
 """
-from __future__ import with_statement
-
 from optparse import OptionParser
 from optparse import OptionGroup
 

--- a/mrjob/tools/emr/fetch_logs.py
+++ b/mrjob/tools/emr/fetch_logs.py
@@ -41,8 +41,6 @@ Options::
                         and --cat.
   -v, --verbose         print more messages to stderr
 """
-from __future__ import with_statement
-
 from optparse import OptionError
 from optparse import OptionParser
 import sys

--- a/mrjob/tools/emr/job_flow_pool.py
+++ b/mrjob/tools/emr/job_flow_pool.py
@@ -18,8 +18,6 @@ Usage::
 
     python -m mrjob.tools.emr.job_flow_pool
 """
-from __future__ import with_statement
-
 from optparse import OptionError
 from optparse import OptionGroup
 from optparse import OptionParser

--- a/mrjob/tools/emr/mrboss.py
+++ b/mrjob/tools/emr/mrboss.py
@@ -29,8 +29,6 @@ Options::
   -q, --quiet           Don't print anything to stderr
   -v, --verbose         print more messages to stderr
 """
-from __future__ import with_statement
-
 from optparse import OptionParser
 import os
 import sys

--- a/mrjob/tools/emr/report_long_jobs.py
+++ b/mrjob/tools/emr/report_long_jobs.py
@@ -31,8 +31,6 @@ Options::
                         Minimum number of hours a job can run before we report
                         it. Default: 24.0
 """
-from __future__ import with_statement
-
 from datetime import datetime
 from datetime import timedelta
 import logging

--- a/mrjob/tools/emr/terminate_job_flow.py
+++ b/mrjob/tools/emr/terminate_job_flow.py
@@ -30,8 +30,6 @@ Options::
   --no-conf             Don't load mrjob.conf even if it's available
 
 """
-from __future__ import with_statement
-
 import logging
 from optparse import OptionParser
 

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -671,8 +671,6 @@ def tar_and_gzip(dir, out_path, filter=None, prefix=''):
     if not filter:
         filter = lambda path: True
 
-    # supposedly you can also call tarfile.TarFile(), but I couldn't
-    # get this to work in Python 2.5.1. Please leave as-is.
     tar_gz = tarfile.open(out_path, mode='w:gz')
 
     for dirpath, dirnames, filenames in os.walk(dir):

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -11,13 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Utility functions for MRJob that have no external dependencies."""
 
 # don't add imports here that aren't part of the standard Python library,
 # since MRJobs need to run in Amazon's generic EMR environment
-from __future__ import with_statement
-
 from collections import defaultdict
 import contextlib
 from copy import deepcopy

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.5',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Topic :: System :: Distributed Computing',

--- a/tests/fs/__init__.py
+++ b/tests/fs/__init__.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import with_statement
-
 from StringIO import StringIO
 
 from tests.sandbox import SandboxedTestCase

--- a/tests/fs/test_local.py
+++ b/tests/fs/test_local.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import with_statement
-
 import bz2
 import gzip
 import os

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -21,7 +21,6 @@ If you need a more extensive set of mock boto objects, we recommend adding
 some sort of sandboxing feature to boto, rather than extending these somewhat
 ad-hoc mock objects.
 """
-from __future__ import with_statement
 from datetime import datetime
 from datetime import timedelta
 import hashlib
@@ -39,7 +38,6 @@ from mrjob.conf import combine_values
 from mrjob.parse import is_s3_uri
 from mrjob.parse import parse_s3_uri
 from mrjob.parse import RFC1123
-
 
 DEFAULT_MAX_JOB_FLOWS_RETURNED = 500
 DEFAULT_MAX_DAYS_AGO = 61

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """A mock version of the hadoop binary that actually manipulates the
 filesystem. This imitates only things that mrjob actually uses.
 
@@ -32,9 +31,6 @@ mrjob requires a single binary (no args) to stand in for hadoop, so
 use create_mock_hadoop_script() to write out a shell script that runs
 mockhadoop.
 """
-
-from __future__ import with_statement
-
 import datetime
 import glob
 import os

--- a/tests/mockssh.py
+++ b/tests/mockssh.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """A mock version of the ssh binary that actually manipulates the
 filesystem. This imitates only things that mrjob actually uses.
 
@@ -27,9 +26,6 @@ mrjob requires a single binary (no args) to stand in for ssh, so
 use create_mock_hadoop_script() to write out a shell script that runs
 mockssh.
 """
-
-from __future__ import with_statement
-
 import os
 import pipes
 import posixpath

--- a/tests/mr_tower_of_powers.py
+++ b/tests/mr_tower_of_powers.py
@@ -16,8 +16,6 @@
 
 This is basically a contrived way of taking a number to the nth power,
 n times."""
-from __future__ import with_statement
-
 import os
 
 from mrjob.protocol import JSONValueProtocol

--- a/tests/quiet.py
+++ b/tests/quiet.py
@@ -38,9 +38,10 @@ def logger_disabled(name=None):
     was_disabled = log.disabled
     log.disabled = True
 
-    yield
-
-    log.disabled = was_disabled
+    try:
+        yield
+    finally:
+        log.disabled = was_disabled
 
 
 @contextmanager
@@ -67,13 +68,15 @@ def no_handlers_for_logger(name=None):
     # add null handler so logging doesn't yell about there being no handlers
     log.handlers = [NullHandler()]
 
-    yield
+    try:
+        yield
 
-    # logging module logic for setting handlers and propagate is opaque.
-    # Setting both effectively ends with propagate = 0 in all cases.
-    # We just want to avoid 'no handlers for logger...' junk messages in tests
-    # cases.
-    if old_handlers:
-        log.handlers = old_handlers
-    else:
-        log.propagate = old_propagate
+    finally:
+        # logging module logic for setting handlers and propagate is opaque.
+        # Setting both effectively ends with propagate = 0 in all cases.
+        # We just want to avoid 'no handlers for logger...' junk messages in
+        # test cases.
+        if old_handlers:
+            log.handlers = old_handlers
+        else:
+            log.propagate = old_propagate

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import with_statement
-
 import os
 from tempfile import mkdtemp
 from shutil import rmtree

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import with_statement
-
 try:
     from unittest2 import TestCase
     TestCase  # pyflakes

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 
 """Test configuration parsing and option combining"""
-
-from __future__ import with_statement
-
 import os
 
 try:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -200,7 +200,7 @@ class MRJobConfNoYAMLTestCase(MRJobConfTestCase):
         try:
             load_mrjob_conf(conf_path)
             assert False
-        except ValueError, e:
+        except ValueError as e:
             self.assertIn('If your mrjob.conf is in YAML', e.msg)
 
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -648,19 +648,22 @@ class EMRApiParamsTestCase(MockEMRAndS3TestCase):
 class AMIAndHadoopVersionTestCase(MockEMRAndS3TestCase):
 
     def test_defaults(self):
-        job_flow = self.run_and_get_job_flow('--ami-version=1.0')
+        with logger_disabled('mrjob.emr'):
+            job_flow = self.run_and_get_job_flow('--ami-version=1.0')
         self.assertEqual(job_flow.amiversion, '1.0')
         self.assertEqual(job_flow.hadoopversion, '0.18')
 
     def test_hadoop_version_0_18(self):
-        job_flow = self.run_and_get_job_flow(
-            '--hadoop-version=0.18', '--ami-version=1.0')
+        with logger_disabled('mrjob.emr'):
+            job_flow = self.run_and_get_job_flow(
+                '--hadoop-version=0.18', '--ami-version=1.0')
         self.assertEqual(job_flow.amiversion, '1.0')
         self.assertEqual(job_flow.hadoopversion, '0.18')
 
     def test_hadoop_version_0_20(self):
-        job_flow = self.run_and_get_job_flow(
-            '--hadoop-version=0.20', '--ami-version=1.0')
+        with logger_disabled('mrjob.emr'):
+            job_flow = self.run_and_get_job_flow(
+                '--hadoop-version=0.20', '--ami-version=1.0')
         self.assertEqual(job_flow.amiversion, '1.0')
         self.assertEqual(job_flow.hadoopversion, '0.20')
 
@@ -670,7 +673,8 @@ class AMIAndHadoopVersionTestCase(MockEMRAndS3TestCase):
                           '--hadoop-version', '0.99')
 
     def test_ami_version_1_0(self):
-        job_flow = self.run_and_get_job_flow('--ami-version', '1.0')
+        with logger_disabled('mrjob.emr'):
+            job_flow = self.run_and_get_job_flow('--ami-version', '1.0')
         self.assertEqual(job_flow.amiversion, '1.0')
         self.assertEqual(job_flow.hadoopversion, '0.18')
 
@@ -690,22 +694,25 @@ class AMIAndHadoopVersionTestCase(MockEMRAndS3TestCase):
                           '--ami-version', '1.5')
 
     def test_ami_version_1_0_hadoop_version_0_18(self):
-        job_flow = self.run_and_get_job_flow('--ami-version', '1.0',
-                                             '--hadoop-version', '0.18')
+        with logger_disabled('mrjob.emr'):
+            job_flow = self.run_and_get_job_flow('--ami-version', '1.0',
+                                                 '--hadoop-version', '0.18')
         self.assertEqual(job_flow.amiversion, '1.0')
         self.assertEqual(job_flow.hadoopversion, '0.18')
 
     def test_ami_version_1_0_hadoop_version_0_20(self):
-        job_flow = self.run_and_get_job_flow('--ami-version', '1.0',
-                                             '--hadoop-version', '0.20')
+        with logger_disabled('mrjob.emr'):
+            job_flow = self.run_and_get_job_flow('--ami-version', '1.0',
+                                                 '--hadoop-version', '0.20')
         self.assertEqual(job_flow.amiversion, '1.0')
         self.assertEqual(job_flow.hadoopversion, '0.20')
 
     def test_mismatched_ami_and_hadoop_versions(self):
-        self.assertRaises(boto.exception.EmrResponseError,
-                          self.run_and_get_job_flow,
-                          '--ami-version', '1.0',
-                          '--hadoop-version', '0.20.205')
+        with logger_disabled('mrjob.emr'):
+            self.assertRaises(boto.exception.EmrResponseError,
+                              self.run_and_get_job_flow,
+                              '--ami-version', '1.0',
+                              '--hadoop-version', '0.20.205')
 
 
 class AvailabilityZoneTestCase(MockEMRAndS3TestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -12,11 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for EMRJobRunner"""
-
-from __future__ import with_statement
-
 from contextlib import contextmanager
 from contextlib import nested
 import copy

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -12,11 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Test the hadoop job runner."""
-
-from __future__ import with_statement
-
 from StringIO import StringIO
 import getpass
 import os

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -15,9 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for InlineMRJobRunner"""
-
-from __future__ import with_statement
-
 from StringIO import StringIO
 
 import gzip

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -12,11 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Unit testing of MRJob."""
-
-from __future__ import with_statement
-
 import os
 from subprocess import Popen
 from subprocess import PIPE

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -12,9 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import with_statement
-
 import cStringIO
 import inspect
 import logging
@@ -306,4 +303,3 @@ class TestToolLogging(unittest.TestCase):
                 log.info('INFO')
                 log.debug('DEBUG')
                 self.assertEqual(stderr.getvalue(), 'INFO\nDEBUG\n')
-

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -12,11 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for LocalMRJobRunner"""
-
-from __future__ import with_statement
-
 from StringIO import StringIO
 import gzip
 import os

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -331,7 +331,7 @@ class LargeAmountsOfStderrTestCase(unittest.TestCase):
                 mr_job.run_job()
         except TimeoutException:
             raise
-        except Exception, e:
+        except Exception as e:
             # we expect the job to throw an exception
 
             # look for expected output from MRVerboseJob
@@ -356,7 +356,7 @@ class ExitWithoutExceptionTestCase(unittest.TestCase):
 
         try:
             mr_job.run_job()
-        except Exception, e:
+        except Exception as e:
             self.assertIn('returned non-zero exit status 42', repr(e))
             return
 
@@ -491,7 +491,7 @@ class LocalBootstrapMrjobTestCase(unittest.TestCase):
                 try:
                     with no_handlers_for_logger():
                         runner.run()
-                except Exception, e:
+                except Exception as e:
                     # if mrjob is not installed, script won't be able to run
                     self.assertIn('ImportError', str(e))
                     return

--- a/tests/test_option_store.py
+++ b/tests/test_option_store.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test OptionStore's functionality"""
-
-from __future__ import with_statement
-
 import os
 
 from tempfile import mkdtemp

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import with_statement
-
 import logging
 import sys
 from StringIO import StringIO

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -53,7 +53,7 @@ ImportError: No module named mr3po.mysqldump
 Traceback (most recent call last):
   File "wrapper.py", line 16, in <module>
     check_call(sys.argv[1:])
-  File "/usr/lib/python2.5/subprocess.py", line 462, in check_call
+  File "/usr/lib/python2.7/subprocess.py", line 462, in check_call
     raise CalledProcessError(retcode, cmd)
 subprocess.CalledProcessError: Command '['python', 'mr_collect_per_search_info_remote.py', '--step-num=0', '--mapper']' returned non-  zero exit status 1
 """
@@ -66,7 +66,7 @@ SyntaxError: invalid syntax
 Traceback (most recent call last):
   File "wrapper.py", line 16, in <module>
     check_call(sys.argv[1:])
-  File "/usr/lib/python2.5/subprocess.py", line 462, in check_call
+  File "/usr/lib/python2.7/subprocess.py", line 462, in check_call
     raise CalledProcessError(retcode, cmd)
 subprocess.CalledProcessError: Command '['python', 'mr_profile_test.py', '--step-num=0', '--reducer', '--input-protocol', 'raw_value', '--output-protocol', 'json', '--protocol', 'json']' returned non-zero exit status 1
 """
@@ -76,7 +76,7 @@ make: *** [tools/csv-to-myisam] Error 1
 Traceback (most recent call last):
   File "wrapper.py", line 11, in <module>
     check_call('cd yelp-src-tree.tar.gz; ln -sf $(readlink -f config/emr/level.py) config/level.py; make -f Makefile.emr', shell=True, stdout=open('/dev/null', 'w'))
-  File "/usr/lib/python2.5/subprocess.py", line 462, in check_call
+  File "/usr/lib/python2.7/subprocess.py", line 462, in check_call
     raise CalledProcessError(retcode, cmd)
 subprocess.CalledProcessError: Command 'cd yelp-src-tree.tar.gz; ln -sf $(readlink -f config/emr/level.py) config/level.py; make -f    Makefile.emr' returned non-zero exit status 2
 """

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test the runner base class MRJobRunner"""
-
-from __future__ import with_statement
-
 import datetime
 import getpass
 import os

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import with_statement
-
 import os
 
 from mock import patch

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -11,11 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for mrjob.ssh"""
-
-from __future__ import with_statement
-
 from subprocess import PIPE
 
 from mock import Mock

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for mrjob.step"""
-from __future__ import with_statement
-
 try:
     from unittest2 import TestCase
     TestCase  # silency pyflakes

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,10 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests of all the amazing utilities in mrjob.util"""
-from __future__ import with_statement
-
 import bz2
 import gzip
 import optparse

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -323,10 +323,6 @@ class ArchiveTestCase(unittest.TestCase):
         expected_files = (set(expected_files + added_files) -
                           set(excluded_files))
 
-        # Python <= 2.5 inserts this into tarballs by default and doesn't strip
-        # it out again when unarchiving. Don't let it mess up our tests.
-        no_pax = lambda paths: (x for x in paths if x != 'PaxHeader')
-
         self.assertEqual(
             sorted(no_pax(os.listdir(join(self.tmp_dir, 'b')))),
             sorted(expected_files))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -324,11 +324,11 @@ class ArchiveTestCase(unittest.TestCase):
                           set(excluded_files))
 
         self.assertEqual(
-            sorted(no_pax(os.listdir(join(self.tmp_dir, 'b')))),
+            sorted(os.listdir(join(self.tmp_dir, 'b'))),
             sorted(expected_files))
 
         self.assertEqual(
-            list(no_pax(os.listdir(join(self.tmp_dir, 'b', 'qux')))), ['quux'])
+            list(os.listdir(join(self.tmp_dir, 'b', 'qux'))), ['quux'])
 
         # make sure their contents are intact
         with open(join(self.tmp_dir, 'b', 'foo')) as foo:

--- a/tests/tools/emr/__init__.py
+++ b/tests/tools/emr/__init__.py
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import with_statement
-
 from StringIO import StringIO
 import sys
 

--- a/tests/tools/emr/test_create_job_flow.py
+++ b/tests/tools/emr/test_create_job_flow.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test the create-job-flow script"""
-
-from __future__ import with_statement
-
 from mrjob.tools.emr.create_job_flow import main as create_job_flow_main
 from mrjob.tools.emr.create_job_flow import runner_kwargs
 

--- a/tests/tools/emr/test_fetch_logs.py
+++ b/tests/tools/emr/test_fetch_logs.py
@@ -11,11 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Test the log flow fetcher"""
-
-from __future__ import with_statement
-
 from optparse import OptionError
 
 from mrjob.emr import EMRJobRunner

--- a/tests/tools/emr/test_job_flow_pool.py
+++ b/tests/tools/emr/test_job_flow_pool.py
@@ -11,11 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Test the job flow pooling tool"""
-
-from __future__ import with_statement
-
 from optparse import OptionError
 
 from mrjob.emr import EMRJobRunner

--- a/tests/tools/emr/test_mrboss.py
+++ b/tests/tools/emr/test_mrboss.py
@@ -13,13 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test the mrboss tool"""
-
-from __future__ import with_statement
-
 import os
 import shutil
 import tempfile
-
 
 from mrjob.emr import EMRJobRunner
 from mrjob.tools.emr.mrboss import run_on_all_nodes

--- a/tests/tools/emr/test_s3_tmpwatch.py
+++ b/tests/tools/emr/test_s3_tmpwatch.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test the S3 tmpwatch script"""
-
-from __future__ import with_statement
-
 from datetime import datetime
 from datetime import timedelta
 import tempfile

--- a/tests/tools/emr/test_terminate_idle_job_flows.py
+++ b/tests/tools/emr/test_terminate_idle_job_flows.py
@@ -12,11 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Test the idle job flow terminator"""
-
-from __future__ import with_statement
-
 from StringIO import StringIO
 from datetime import datetime
 from datetime import timedelta

--- a/tests/tools/emr/test_terminate_job_flow.py
+++ b/tests/tools/emr/test_terminate_job_flow.py
@@ -11,11 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Test the job flow termination tool"""
-
-from __future__ import with_statement
-
 from mrjob.emr import EMRJobRunner
 from mrjob.tools.emr.terminate_job_flow import main as terminate_main
 from mrjob.tools.emr.terminate_job_flow import make_option_parser


### PR DESCRIPTION
This drops support for Python 2.5 (#713), and updates documentation and code to reflect that.

We don't traditionally break backwards compatibility in a minor/point release, but Python 2.5 is seriously deprecated at this point; the last feature release was in December 2008. We actually broke Python 2.5 in mrjob v0.4.1 and no one complained!

Note that this implicitly drops support for the 1.x EMR AMIs, which use Python 2.5. EMR has supported Python 2.6 since December 2011, so this should not be a major hardship for anyone.