### PR TITLE
--emr-action-on-failure

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -431,6 +431,26 @@ Choosing/creating a job flow to join
 ------------------------------------
 
 .. mrjob-opt::
+    :config: emr_action_on_failure
+    :switch: --emr-action-on-failure
+    :type: :ref:`string <data-type-string>`
+    :set: emr
+    :default: (automatic)
+
+    What happens if step of your job fails
+
+    * ``'CANCEL_AND_WAIT'`` cancels all steps on the job flow
+    * ``'CONTINUE'`` continues to the next step (useful when submitting several
+        jobs to the same job flow)
+    * ``'TERMINATE_CLUSTER'`` shuts down the job flow entirely
+
+    The default is ``'CANCEL_AND_WAIT'`` when using pooling (see
+    :mrjob-opt:`pool_emr_job_flows`) or an existing job flow (see
+    :mrjob-opt:`emr_job_flow_id`), and ``'TERMINATE_CLUSTER'`` otherwise.
+
+    .. versionadded:: 0.4.3
+
+.. mrjob-opt::
     :config: emr_job_flow_id
     :switch: --emr-job-flow-id
     :type: :ref:`string <data-type-string>`
@@ -478,14 +498,6 @@ Choosing/creating a job flow to join
     flow every 30 seconds until this many minutes have passed, then start a new
     job flow instead of joining one.
 
-.. mrjob-opt::
-    :config: emr_action_on_failure
-    :switch: --emr-action-on-failure
-    :type: :ref:`string <data-type-string>`
-    :set: emr
-    :default: ``'CANCEL_AND_WAIT'``
-
-    The options are TERMINATE_JOB_FLOW | TERMINATE_CLUSTER | CANCEL_AND_WAIT | CONTINUE
 
 S3 paths and options
 --------------------

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1299,7 +1299,7 @@ class EMRJobRunner(MRJobRunner):
                 self._opts['pool_emr_job_flows']):
             return 'CANCEL_AND_WAIT'
         else:
-            return 'TERMINATE_JOB_FLOW'
+            return 'TERMINATE_CLUSTER'
 
     def _build_steps(self):
         """Return a list of boto Step objects corresponding to the

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -428,7 +428,7 @@ def add_emr_opts(opt_group):
         opt_group.add_option(
             '--emr-action-on-failure', dest='emr_action_on_failure', default=None,
             help=('Action to take when a step fails'
-                 ' (eg. TERMINATE_JOB_FLOW | TERMINATE_CLUSTER | CANCEL_AND_WAIT | CONTINUE)')),
+                 ' (e.g. TERMINATE_CLUSTER | CANCEL_AND_WAIT | CONTINUE)')),
 
         opt_group.add_option(
             '--enable-emr-debugging', dest='enable_emr_debugging',

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -361,7 +361,7 @@ class MockEmrConnection(object):
                     name, log_uri, ec2_keyname=None, availability_zone=None,
                     master_instance_type='m1.small',
                     slave_instance_type='m1.small', num_instances=1,
-                    action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
+                    action_on_failure='TERMINATE_CLUSTER', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
                     steps=None,
@@ -560,7 +560,7 @@ class MockEmrConnection(object):
 
         if enable_debugging:
             debugging_step = JarStep(name='Setup Hadoop Debugging',
-                                     action_on_failure='TERMINATE_JOB_FLOW',
+                                     action_on_failure='TERMINATE_CLUSTER',
                                      main_class=None,
                                      jar=EmrConnection.DebuggingJar,
                                      step_args=EmrConnection.DebuggingArgs)
@@ -748,7 +748,9 @@ class MockEmrConnection(object):
                 reason = self.mock_emr_failures[(jobflow_id, step_num)]
                 if reason:
                     job_flow.reason = reason
-                if step.actiononfailure == 'TERMINATE_JOB_FLOW':
+                # TERMINATED_JOB_FLOW is the old name for TERMINATE_CLUSTER
+                if step.actiononfailure in (
+                        'TERMINATE_CLUSTER','TERMINATE_JOB_FLOW'):
                     job_flow.state = 'SHUTTING_DOWN'
                     if not reason:
                         job_flow.reason = 'Shut down as step failed'

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3404,7 +3404,7 @@ class ActionOnFailureTestCase(MockEMRAndS3TestCase):
     def test_default(self):
         runner = EMRJobRunner()
         self.assertEqual(runner._action_on_failure,
-                         'TERMINATE_JOB_FLOW')
+                         'TERMINATE_CLUSTER')
 
     def test_default_with_job_flow_id(self):
         runner = EMRJobRunner(emr_job_flow_id='j-JOBFLOW')

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3397,3 +3397,34 @@ class JarStepTestCase(MockEMRAndS3TestCase):
             streaming_input_arg = streaming_args[
                 streaming_args.index('-input') + 1]
             self.assertEqual(jar_output_arg, streaming_input_arg)
+
+
+class ActionOnFailureTestCase(MockEMRAndS3TestCase):
+
+    def test_default(self):
+        runner = EMRJobRunner()
+        self.assertEqual(runner._action_on_failure,
+                         'TERMINATE_JOB_FLOW')
+
+    def test_default_with_job_flow_id(self):
+        runner = EMRJobRunner(emr_job_flow_id='j-JOBFLOW')
+        self.assertEqual(runner._action_on_failure,
+                         'CANCEL_AND_WAIT')
+
+    def test_default_with_pooling(self):
+        runner = EMRJobRunner(pool_emr_job_flows=True)
+        self.assertEqual(runner._action_on_failure,
+                         'CANCEL_AND_WAIT')
+
+    def test_option(self):
+        runner = EMRJobRunner(emr_action_on_failure='CONTINUE')
+        self.assertEqual(runner._action_on_failure,
+                         'CONTINUE')
+
+    def test_switch(self):
+        mr_job = MRWordCount(
+            ['-r', 'emr', '--emr-action-on-failure', 'CONTINUE'])
+        mr_job.sandbox()
+
+        with mr_job.make_runner() as runner:
+            self.assertEqual(runner._action_on_failure, 'CONTINUE')

--- a/tests/tools/emr/test_terminate_idle_job_flows.py
+++ b/tests/tools/emr/test_terminate_idle_job_flows.py
@@ -60,7 +60,7 @@ class JobFlowInspectionTestCase(MockEMRAndS3TestCase):
                  start_hours_ago=None,
                  end_hours_ago=None,
                  name='Streaming Step',
-                 action_on_failure='TERMINATE_JOB_FLOW',
+                 action_on_failure='TERMINATE_CLUSTER',
                  **kwargs):
             if create_hours_ago:
                 kwargs['creationdatetime'] = to_iso8601(


### PR DESCRIPTION
Added test to #911, improved documentation.

Also updated code to use `TERMINATE_CLUSTER` rather than `TERMINATE_JOB_FLOW`, which is deprecated (#974).