### PR TITLE
Clean up bucket validation

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -82,6 +82,7 @@ from mrjob.conf import combine_paths
 from mrjob.fs.composite import CompositeFilesystem
 from mrjob.fs.local import LocalFilesystem
 from mrjob.fs.s3 import S3Filesystem
+from mrjob.fs.s3 import _get_bucket
 from mrjob.fs.s3 import wrap_aws_conn
 from mrjob.fs.ssh import SSHFilesystem
 from mrjob.logparsers import EMR_JOB_LOG_URI_RE
@@ -113,7 +114,6 @@ from mrjob.ssh import ssh_terminate_single_job
 from mrjob.util import cmd_line
 from mrjob.util import hash_object
 from mrjob.util import shlex_split
-from mrjob.util import VALIDATE_BUCKET
 
 
 log = logging.getLogger(__name__)
@@ -262,7 +262,7 @@ def make_lock_uri(s3_tmp_uri, emr_job_flow_id, step_num):
 
 def _lock_acquire_step_1(s3_conn, lock_uri, job_name, mins_to_expiration=None):
     bucket_name, key_prefix = parse_s3_uri(lock_uri)
-    bucket = s3_conn.get_bucket(bucket_name, validate=VALIDATE_BUCKET)
+    bucket = _get_bucket(s3_conn, bucket_name)
     key = bucket.get_key(key_prefix)
 
     # EMRJobRunner should start using a job flow within about a second of
@@ -652,8 +652,7 @@ class EMRJobRunner(MRJobRunner):
         # check s3_scratch_uri against aws_region if specified
         if self._opts['s3_scratch_uri']:
             bucket_name, _ = parse_s3_uri(self._opts['s3_scratch_uri'])
-            bucket_loc = s3_conn.get_bucket(
-                bucket_name, validate=VALIDATE_BUCKET).get_location()
+            bucket_loc = _get_bucket(s3_conn, bucket_name).get_location()
 
             # make sure they can communicate if both specified
             if (self._aws_region and bucket_loc and
@@ -1966,9 +1965,13 @@ class EMRJobRunner(MRJobRunner):
 
         # bootstrap_python_packages
         if self._opts['bootstrap_python_packages']:
-            # 3.0.x AMIs use yum rather than apt-get;
-            # can't determine which AMI `latest` is at
-            # job flow creation time so we call both
+            # 1.x and 2.x AMIs use Debian (apt-get) and 3.x AMIs use
+            # Amazon Linux (yum). Who knows what 4.x AMIs will use?
+            #
+            # Rather than keeping mrjob in sync with AMI versions, just
+            # run whatever package manager works (until
+            # bootstrap_python_packages becomes obsolete, and we can
+            # rip this code out entirely)
             bootstrap.append(['sudo apt-get install -y python-pip || '
                               'sudo yum install -y python-pip'])
             # Print a warning

--- a/mrjob/tools/emr/s3_tmpwatch.py
+++ b/mrjob/tools/emr/s3_tmpwatch.py
@@ -53,6 +53,7 @@ except ImportError:
 
 from mrjob.emr import EMRJobRunner
 from mrjob.emr import iso8601_to_datetime
+from mrjob.fs.s3 import _get_bucket
 from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
 from mrjob.parse import parse_s3_uri
@@ -92,7 +93,7 @@ def s3_cleanup(glob_path, time_old, dry_run=False, conf_paths=None):
 
     for path in runner.ls(glob_path):
         bucket_name, key_name = parse_s3_uri(path)
-        bucket = s3_conn.get_bucket(bucket_name)
+        bucket = _get_bucket(s3_conn, bucket_name)
 
         for key in bucket.list(key_name):
             last_modified = iso8601_to_datetime(key.last_modified)

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -36,14 +36,6 @@ try:
     bz2  # redefine bz2 for pepflakes
 except ImportError:
     bz2 = None
-try:
-    import boto
-except ImportError:
-    boto = None
-
-# Should we suppress boto validating a bucket? (2.25.0+ uses a cheap
-#    HEAD request avoids the scaling problem with large buckets)
-VALIDATE_BUCKET = boto and boto.Version >= '2.25.0'
 
 #: .. deprecated:: 0.4
 is_ironpython = "IronPython" in sys.version

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -26,8 +26,6 @@ try:
 except ImportError:
     import unittest
 
-from unittest import TestCase
-
 from mock import Mock
 from mock import patch
 
@@ -151,7 +149,7 @@ class S3FSTestCase(SandboxedTestCase):
         self.assertEqual(self.fs.path_exists(path), False)
 
 
-class GetBucketTestCase(TestCase):
+class GetBucketTestCase(unittest.TestCase):
 
     def assert_bucket_validation(self, boto_version, should_validate):
         with patch('boto.Version', boto_version):

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -20,7 +20,19 @@ try:
 except ImportError:
     boto = None
 
+try:
+    import unittest2 as unittest
+    unittest  # quiet "redefinition of unused ..." warning from pyflakes
+except ImportError:
+    import unittest
+
+from unittest import TestCase
+
+from mock import Mock
+from mock import patch
+
 from mrjob.fs.s3 import S3Filesystem
+from mrjob.fs.s3 import _get_bucket
 
 from tests.compress import gzip_compress
 from tests.mockboto import MockS3Connection
@@ -137,3 +149,25 @@ class S3FSTestCase(SandboxedTestCase):
 
         self.fs.rm(path)
         self.assertEqual(self.fs.path_exists(path), False)
+
+
+class GetBucketTestCase(TestCase):
+
+    def assert_bucket_validation(self, boto_version, should_validate):
+        with patch('boto.Version', boto_version):
+            s3_conn = Mock()
+            _get_bucket(s3_conn, 'walrus')
+            s3_conn.get_bucket.assert_called_once_with(
+                'walrus', validate=should_validate)
+
+    def test_boto_2_2_0(self):
+        self.assert_bucket_validation('2.2.0', False)
+
+    def test_boto_2_3_0(self):
+        # original version check used string comparison, which
+        # would determine that 2.3.0 >= 2.25.0
+        self.assertGreaterEqual('2.3.0', '2.25.0')
+        self.assert_bucket_validation('2.3.0', False)
+
+    def test_boto_2_25_0(self):
+        self.assert_bucket_validation('2.25.0', True)


### PR DESCRIPTION
Cleanup of pull request #952.

This gets rid of `mrjob.util.VALIDATE_BUCKET` in favor of a wrapper method, `mrjob.fs.s3._get_bucket()`.

Also fixes a bug where string comparison was used to compare versions of `boto`, and added tests.