### PR TITLE
Dont mess with self._job_name

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,8 +9,6 @@ v0.4.3, 2014-03-?? -- mostly cleanup and bugfixes
        * new --no-strict-protocols command-line option
      * streaming output from closed runner shows a warning (#853)
      * --job-name option lets you set a specific name for the job (#955)
-     * --export-job-name option exports the job name to the MRJOB_JOB_NAME
-       environment variable (#916)
    * EMR:
      * --check-input-paths and --no-check-input-paths options (#864)
      * skip (very slow) validation of s3 buckets if boto < 2.25.0 (#865)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,6 @@ v0.4.3, 2014-03-?? -- mostly cleanup and bugfixes
      * You can now set strict_protocols from mrjob.conf (#726)
        * new --no-strict-protocols command-line option
      * streaming output from closed runner shows a warning (#853)
-     * --job-name option lets you set a specific name for the job (#955)
    * EMR:
      * --check-input-paths and --no-check-input-paths options (#864)
      * skip (very slow) validation of s3 buckets if boto < 2.25.0 (#865)

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -359,18 +359,6 @@ Other
 
     .. versionadded:: 0.4.3
 
-.. mrjob-opt::
-    :config: export_job_name
-    :switch: --export-job-name
-    :type: boolean
-    :set: all
-    :default: False
-
-    If this option is specified, the environment variable MRJOB_JOB_NAME is set to the name of this job.
-
-    .. versionadded:: 0.4.3
-
-
 Options ignored by the inline runner
 ------------------------------------
 

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -345,19 +345,6 @@ Other
 
         python my_job.py -c left.conf --no-conf -c right.conf
 
-.. mrjob-opt::
-    :config: job_name
-    :switch: --job-name
-    :type: :ref:`string <data-type-string>`
-    :set: all
-    :default: (automatic)
-
-    Specifies the name of the job. If this option is omitted, mrjob assigns
-    a name automatically, which is guaranteed to be unique, though not
-    necessarily descriptive. Use this option to give the job a user-friendly
-    name.
-
-    .. versionadded:: 0.4.3
 
 Options ignored by the inline runner
 ------------------------------------

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -499,7 +499,6 @@ class MRJobLauncher(object):
             'cmdenv': self.options.cmdenv,
             'conf_path': None,
             'conf_paths': self.options.conf_paths,
-            'export_job_name': self.options.export_job_name,
             'extra_args': self.generate_passthrough_arguments(),
             'file_upload_args': self.generate_file_upload_args(),
             'hadoop_extra_args': self.options.hadoop_extra_args,

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -113,14 +113,6 @@ def add_runner_opts(opt_group, default_runner='local'):
             'multiple times.'),
 
         opt_group.add_option(
-            '--export-job-name', dest='export_job_name', action='store_true',
-            default=None,
-            help="Export the internal job name that uniquely identifies each"
-                 " task to the environment variable MRJOB_JOB_NAME as if using"
-                 " --cmdenv, which can be useful for, e.g., setup scripts."
-        ),
-
-        opt_group.add_option(
             '--file', dest='upload_files', action='append',
             default=[],
             help=('Copy file to the working directory of this script. You can'

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -106,7 +106,6 @@ class RunnerOptionStore(OptionStore):
         'cleanup',
         'cleanup_on_failure',
         'cmdenv',
-        'export_job_name',
         'hadoop_extra_args',
         'hadoop_streaming_jar',
         'hadoop_version',
@@ -367,10 +366,6 @@ class MRJobRunner(object):
         else:
             self._job_name = self._make_unique_job_name(
                 label=self._opts['label'], owner=self._opts['owner'])
-
-        # export the unique name to a environment variable
-        if self._opts['export_job_name']:
-            self._opts['cmdenv'].update({'MRJOB_JOB_NAME': self._job_name})
 
         # we'll create the wrapper script later
         self._setup_wrapper_script_path = None

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -361,11 +361,8 @@ class MRJobRunner(object):
             self._working_dir_mgr.add('file', self._script_path)
 
         # give this job a unique name
-        if len((self._opts['job_name'] or '').strip()) > 0:
-            self._job_name = self._opts['job_name']
-        else:
-            self._job_name = self._make_unique_job_name(
-                label=self._opts['label'], owner=self._opts['owner'])
+        self._job_name = self._make_unique_job_name(
+            label=self._opts['label'], owner=self._opts['owner'])
 
         # we'll create the wrapper script later
         self._setup_wrapper_script_path = None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -784,21 +784,6 @@ class SetupTestCase(SandboxedTestCase):
                 self.assertNotIn('stray output', output)
 
 
-class ExportJobNameTestCase(EmptyMrjobConfTestCase):
-
-    def test_export_job_name_true(self):
-        job = MRWordCount(['--export-job-name'])
-        with job.make_runner() as runner:
-            self.assertTrue(runner._opts['export_job_name'])
-            self.assertEqual(runner._opts['cmdenv']['MRJOB_JOB_NAME'],
-                             runner.get_job_name())
-
-    def test_export_job_name_default_false(self):
-        job = MRWordCount()
-        with job.make_runner() as runner:
-            self.assertFalse(runner._opts['export_job_name'])
-            self.assertEqual(runner._opts['cmdenv'], {})
-
 class ClosedRunnerTestCase(EmptyMrjobConfTestCase):
 
     def test_job_closed_on_cleanup(self):
@@ -807,6 +792,7 @@ class ClosedRunnerTestCase(EmptyMrjobConfTestCase):
             # do nothing
             self.assertFalse(runner._closed)
         self.assertTrue(runner._closed)
+
 
 class JobNameTestCase(EmptyMrjobConfTestCase):
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -792,32 +792,3 @@ class ClosedRunnerTestCase(EmptyMrjobConfTestCase):
             # do nothing
             self.assertFalse(runner._closed)
         self.assertTrue(runner._closed)
-
-
-class JobNameTestCase(EmptyMrjobConfTestCase):
-
-    def test_job_name_specified(self):
-        job_name = datetime.datetime.now().strftime('WordCount-%Y%m%d%H%M%S')
-        job = MRWordCount(['--job-name', job_name])
-        with job.make_runner() as runner:
-            self.assertTrue(runner._opts['job_name'])
-            self.assertEqual(job_name, runner.get_job_name())
-
-    def test_job_name_not_specified(self):
-        job = MRWordCount()
-        with job.make_runner() as runner:
-            self.assertFalse(runner._opts['job_name'])
-            self.assertIsNotNone(JOB_NAME_RE.match(runner.get_job_name()))
-
-    def test_job_name_specified_run_twice(self):
-        job_name = datetime.datetime.now().strftime('WordCount2-%Y%m%d%H%M%S')
-        try:
-            job = MRWordCount(['--job-name', job_name,
-                               '--cleanup', 'NONE', __file__])
-            with job.make_runner() as runner:
-                runner.run()
-            job2 = MRWordCount(['--job-name', job_name, __file__])
-            with job2.make_runner() as runner2:
-                runner2.run()
-        except OSError:
-            self.fail('Local scratch was not auto-deleted')


### PR DESCRIPTION
Backed out the `--job-name` and `--export-job-name` options.

In brief `self._job_name` is meant to be a unique key for the job, and it only used internally. Setting it to a non-unique value causes unexpected behavior.

It seems like it `self._job_name` ought to be the same as the job's name on Hadoop (`mapreduce.job.name`), but it's just confusingly named (see #952).