### PR TITLE
Multipart upload to S3

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -593,12 +593,20 @@ which is set to True if boto.Version >= '2.25.0'
    :set: emr
    :default: 100
 
-   Upload files to S3 in parts no bigger than this many megabytes. Default is
-   100 MB, as `recommended by Amazon`_. Set to 0 to disable multipart uploading
+   Upload files to S3 in parts no bigger than this many megabytes
+   (technically, `mebibytes`_). Default is 100 MiB, as
+   `recommended by Amazon`_. Set to 0 to disable multipart uploading
    entirely.
 
+   Currently, Amazon `requires parts to be between 5 MiB and 5 GiB`_.
+   mrjob does not enforce these limits.
+
+   .. _`mebibytes`:
+       http://en.wikipedia.org/wiki/Mebibyte
    .. _`recommended by Amazon`:
        http://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html
+   .. _`requires parts to be between 5 MiB and 5 GiB`:
+       http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
 
 SSH access and tunneling
 ------------------------

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -586,6 +586,20 @@ which is set to True if boto.Version >= '2.25.0'
     How long to wait for S3 to reach eventual consistency. This is typically
     less than a second (zero in U.S. West), but the default is 5.0 to be safe.
 
+.. mrjob-opt::
+   :config: s3_upload_part_size
+   :switch: --s3-upload-part-size
+   :type: integer
+   :set: emr
+   :default: 100
+
+   Upload files to S3 in parts no bigger than this many megabytes. Default is
+   100 MB, as `recommended by Amazon`_. Set to 0 to disable multipart uploading
+   entirely.
+
+   .. _`recommended by Amazon`:
+       http://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html
+
 SSH access and tunneling
 ------------------------
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -20,6 +20,11 @@ this job flow.
 You can now use ``--check-input-paths`` and ``--no-check-input-paths`` on EMR
 as well as Hadoop.
 
+Files larger than 100MB will be uploaded to S3 using multipart upload if you
+have the `filechunkio` module installed. You can change the limit/part size
+with the ``--s3-upload-part-size`` option, or disable multipart upload by
+setting this option to 0.
+
 You can now require protocols to be strict from :ref:`mrjob.conf <mrjob.conf>`;
 this means unencodable input/output will result in an exception rather
 than the job quietly incrementing a counter. It is recommended you set this

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -901,7 +901,7 @@ class EMRJobRunner(MRJobRunner):
         """ Determines if the file needs to be done as a multipart upload."""
         fsize = os.stat(path).st_size
         s3_key = None
-        if fsize > CHUNKY_FSIZE_LIMIT:
+        if fsize <= CHUNKY_FSIZE_LIMIT:
             s3_key = self.make_s3_key(s3_uri, s3_conn)
             s3_key.set_contents_from_filename(path)
         else:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -693,7 +693,6 @@ class EMRJobRunner(MRJobRunner):
     def _set_s3_scratch_uri(self, s3_conn):
         """Helper for _fix_s3_scratch_and_log_uri_opts"""
         buckets = s3_conn.get_all_buckets()
-        print type(buckets), buckets
         mrjob_buckets = [b for b in buckets if b.name.startswith('mrjob-')]
 
         # Loop over buckets until we find one that is not region-

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -84,6 +84,7 @@ from mrjob.conf import combine_paths
 from mrjob.fs.composite import CompositeFilesystem
 from mrjob.fs.local import LocalFilesystem
 from mrjob.fs.s3 import S3Filesystem
+from mrjob.fs.s3 import _get_bucket
 from mrjob.fs.s3 import wrap_aws_conn
 from mrjob.fs.ssh import SSHFilesystem
 from mrjob.logparsers import EMR_JOB_LOG_URI_RE
@@ -115,7 +116,6 @@ from mrjob.ssh import ssh_terminate_single_job
 from mrjob.util import cmd_line
 from mrjob.util import hash_object
 from mrjob.util import shlex_split
-from mrjob.util import VALIDATE_BUCKET
 
 
 log = logging.getLogger(__name__)
@@ -268,7 +268,7 @@ def make_lock_uri(s3_tmp_uri, emr_job_flow_id, step_num):
 
 def _lock_acquire_step_1(s3_conn, lock_uri, job_name, mins_to_expiration=None):
     bucket_name, key_prefix = parse_s3_uri(lock_uri)
-    bucket = s3_conn.get_bucket(bucket_name, validate=VALIDATE_BUCKET)
+    bucket = _get_bucket(s3_conn, bucket_name)
     key = bucket.get_key(key_prefix)
 
     # EMRJobRunner should start using a job flow within about a second of
@@ -658,10 +658,7 @@ class EMRJobRunner(MRJobRunner):
         # check s3_scratch_uri against aws_region if specified
         if self._opts['s3_scratch_uri']:
             bucket_name, _ = parse_s3_uri(self._opts['s3_scratch_uri'])
-            print bucket_name
-            print s3_conn
-            bucket_loc = s3_conn.get_bucket(
-                bucket_name, validate=VALIDATE_BUCKET).get_location()
+            bucket_loc = _get_bucket(s3_conn, bucket_name).get_location()
 
             # make sure they can communicate if both specified
             if (self._aws_region and bucket_loc and

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -918,7 +918,8 @@ class EMRJobRunner(MRJobRunner):
             mpul = bucket.initiate_multipart_upload(key_name)
             try:
                 for i, offset in enumerate(offsets):
-                    log.debug("uploading %d/%d of %s" % (i, num_chunks, key_name))
+                    log.debug("uploading %d/%d of %s" % (
+                        i, num_chunks, key_name))
                     chunk_bytes = min(part_size, fsize - offset)
 
                     with filechunkio.FileChunkIO(
@@ -926,7 +927,8 @@ class EMRJobRunner(MRJobRunner):
                         mpul.upload_part_from_file(fp, part_num=i + 1)
 
                 s3_key = bucket.new_key(key_name)
-                log.debug("Completed multipart upload of %s to %s" % path, key_name)
+                log.debug("Completed multipart upload of %s to %s" % (
+                    path, key_name))
                 mpul.complete_upload()
             except:
                 mpul.cancel_multipart_upload(key_name)
@@ -942,6 +944,9 @@ class EMRJobRunner(MRJobRunner):
         return int((self._opts['s3_upload_part_size'] or 0) * 1000 * 1000)
 
     def _should_use_multipart_upload(self, fsize, part_size, path):
+        """Decide if we want to use multipart uploading.
+
+        path is only used to log warnings."""
         if not part_size:  # disabled
             return False
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -913,13 +913,12 @@ class EMRJobRunner(MRJobRunner):
             bucket = s3_conn.get_bucket(bucket_name)
 
             offsets = xrange(0, fsize, part_size)
-            num_chunks = len(offsets)
 
             mpul = bucket.initiate_multipart_upload(key_name)
             try:
                 for i, offset in enumerate(offsets):
                     log.debug("uploading %d/%d of %s" % (
-                        i, num_chunks, key_name))
+                        i + 1, len(offsets), key_name))
                     chunk_bytes = min(part_size, fsize - offset)
 
                     with filechunkio.FileChunkIO(

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -911,13 +911,14 @@ class EMRJobRunner(MRJobRunner):
             log.debug("Starting multipart upload of %s" % (path,))
             bucket_name, key_name = parse_s3_uri(s3_uri)
             bucket = s3_conn.get_bucket(bucket_name)
-            num_chunks = fsize / part_size + (1 if fsize % part_size else 0)
+
+            offsets = xrange(0, fsize, part_size)
+            num_chunks = len(offsets)
 
             mpul = bucket.initiate_multipart_upload(key_name)
             try:
-                for i in xrange(num_of_chunks):
-                    log.debug("uploading %d/%d of %s" % (i, num_of_chunks, key_name))
-                    offset = part_size * i
+                for i, offset in enumerate(offsets):
+                    log.debug("uploading %d/%d of %s" % (i, num_chunks, key_name))
                     chunk_bytes = min(part_size, fsize - offset)
 
                     with filechunkio.FileChunkIO(

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -900,7 +900,8 @@ class EMRJobRunner(MRJobRunner):
             self._upload_contents(s3_uri, s3_conn, path)
 
     def _upload_contents(self, s3_uri, s3_conn, path):
-        """ Determines if the file needs to be done as a multipart upload."""
+        """Uploads the file at the given path to S3, possibly using
+        multipart upload."""
         fsize = os.stat(path).st_size
         part_size = self._get_upload_part_size()
 
@@ -932,8 +933,6 @@ class EMRJobRunner(MRJobRunner):
                 raise
         else:
             s3_key.set_contents_from_filename(path)
-
-        return s3_key
 
     def _get_upload_part_size(self):
         # part size is in MB, as the minimum is 5 MB

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -917,9 +917,9 @@ class EMRJobRunner(MRJobRunner):
                 mpul.cancel_upload()
                 raise
 
+            mpul.complete_upload()
             log.debug("Completed multipart upload of %s to %s" % (
                       path, s3_key.name))
-            mpul.complete_upload()
         else:
             s3_key.set_contents_from_filename(path)
 
@@ -939,7 +939,7 @@ class EMRJobRunner(MRJobRunner):
 
     def _get_upload_part_size(self):
         # part size is in MB, as the minimum is 5 MB
-        return int((self._opts['s3_upload_part_size'] or 0) * 1000 * 1000)
+        return int((self._opts['s3_upload_part_size'] or 0) * 1024 * 1024)
 
     def _should_use_multipart_upload(self, fsize, part_size, path):
         """Decide if we want to use multipart uploading.

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -532,7 +532,7 @@ def add_emr_opts(opt_group):
             '--s3-upload-part-size', dest='s3_upload_part_size', default=None,
             type='float',
             help=('Upload files to S3 in parts no bigger than this many'
-                  ' megabytes. Default is 100 MB. Set to 0 to disable'
+                  ' megabytes. Default is 100 MiB. Set to 0 to disable'
                   ' multipart uploading entirely.')),
 
         opt_group.add_option(

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -529,6 +529,13 @@ def add_emr_opts(opt_group):
                   ' default is 5.0 to be safe.')),
 
         opt_group.add_option(
+            '--s3-upload-part-size', dest='s3_upload_part_size', default=None,
+            type='float',
+            help=('Upload files to S3 in parts no bigger than this many'
+                  ' megabytes. Default is 100 MB. Set to 0 to disable'
+                  ' multipart uploading entirely.')),
+
+        opt_group.add_option(
             '--ssh-bin', dest='ssh_bin', default=None,
             help=("Name/path of ssh binary. Arguments are allowed (e.g."
                   " --ssh-bin 'ssh -v')")),

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ try:
     setuptools_kwargs = {
         'install_requires': [
             'boto>=2.2.0',
+            'filechunkio',
             'PyYAML',
             'simplejson>=2.0.9',
         ],

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -34,6 +34,8 @@ try:
 except ImportError:
     boto = None
 
+from mock import Mock
+
 from mrjob.conf import combine_values
 from mrjob.parse import is_s3_uri
 from mrjob.parse import parse_s3_uri
@@ -173,6 +175,8 @@ class MockBucket(object):
         return MockMultiPartUpload(key)
 
 
+
+
 class MockKey(object):
     """Mock out boto.s3.Key"""
 
@@ -192,6 +196,9 @@ class MockKey(object):
             return self.bucket.mock_state()[self.name][0]
         else:
             raise boto.exception.S3ResponseError(404, 'Not Found')
+
+    def mock_multipart_upload_was_cancelled(self):
+        return isinstance(self.read_mock_data(), MultiPartUploadCancelled)
 
     def write_mock_data(self, data):
         if self.name in self.bucket.mock_state():
@@ -269,6 +276,9 @@ class MockKey(object):
         return len(self.get_contents_as_string())
 
 
+class MultiPartUploadCancelled(str):
+    pass
+
 class MockMultiPartUpload(object):
 
     def __init__(self, key):
@@ -287,17 +297,26 @@ class MockMultiPartUpload(object):
         if part_num < 1:
             raise ValueError('Part numbers must be greater than zero')
 
-        self.parts[part_num] = part_num
+        self.parts[part_num] = fp.read()
 
     def complete_upload(self):
         data = ''
 
         if self.parts:
-            num_parts = max(self.parts.itervalues())
+            num_parts = max(self.parts)
             for part_num in xrange(1, num_parts + 1):
                 # S3 might be more graceful about missing parts. But we
                 # certainly don't want this to slip past testing
                 data += self.parts[part_num]
+
+        self.key.set_contents_from_string(data)
+
+    def cancel_upload(self):
+        self.parts = None  # should break any further calls
+
+        # record that multipart upload was cancelled
+        cancelled = MultiPartUploadCancelled(self.key.get_contents_as_string())
+        self.key.set_contents_from_string(cancelled)
 
 
 ### EMR ###

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -168,6 +168,10 @@ class MockBucket(object):
                 yield MockKey(bucket=self, name=key_name,
                               date_to_str=to_iso8601)
 
+    def initiate_multipart_upload(self, key_name):
+        key = self.new_key(key_name)
+        return MockMultiPartUpload(key)
+
 
 class MockKey(object):
     """Mock out boto.s3.Key"""
@@ -263,6 +267,37 @@ class MockKey(object):
     @property
     def size(self):
         return len(self.get_contents_as_string())
+
+
+class MockMultiPartUpload(object):
+
+    def __init__(self, key):
+        """Mock out boto.s3.MultiPartUpload
+
+        Note that real MultiPartUpload objects don't actually know which key
+        they're associated with. It's just simpler this way.
+        """
+        self.key = key
+        self.parts = {}
+
+    def upload_part_from_file(self, fp, part_num):
+        part_num = int(part_num)  # boto leaves this to a format string
+
+        # this check is actually in boto
+        if part_num < 1:
+            raise ValueError('Part numbers must be greater than zero')
+
+        self.parts[part_num] = part_num
+
+    def complete_upload(self):
+        data = ''
+
+        if self.parts:
+            num_parts = max(self.parts.itervalues())
+            for part_num in xrange(1, num_parts + 1):
+                # S3 might be more graceful about missing parts. But we
+                # certainly don't want this to slip past testing
+                data += self.parts[part_num]
 
 
 ### EMR ###

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3486,6 +3486,7 @@ class ActionOnFailureTestCase(MockEMRAndS3TestCase):
 
 class MultiPartUploadTestCase(MockEMRAndS3TestCase):
 
+    PART_SIZE_IN_MB = 50.0 / 1024 / 1024
     TEST_BUCKET = 'walrus'
     TEST_FILENAME = 'data.dat'
     TEST_S3_URI = 's3://%s/%s' % (TEST_BUCKET, TEST_FILENAME)
@@ -3525,14 +3526,14 @@ class MultiPartUploadTestCase(MockEMRAndS3TestCase):
     def test_large_file(self):
         # Real S3 has a minimum chunk size of 5MB, but I'd rather not
         # store that in memory (in our mock S3 filesystem)
-        runner = EMRJobRunner(s3_upload_part_size=0.00005)
+        runner = EMRJobRunner(s3_upload_part_size=self.PART_SIZE_IN_MB)
         self.assertEqual(runner._get_upload_part_size(), 50)
 
         data = 'Mew' * 20
         self.assert_upload_succeeds(runner, data, expect_multipart=True)
 
     def test_file_size_equals_part_size(self):
-        runner = EMRJobRunner(s3_upload_part_size=0.00005)
+        runner = EMRJobRunner(s3_upload_part_size=self.PART_SIZE_IN_MB)
         self.assertEqual(runner._get_upload_part_size(), 50)
 
         data = 'o' * 50
@@ -3547,7 +3548,7 @@ class MultiPartUploadTestCase(MockEMRAndS3TestCase):
 
     def test_no_filechunkio(self):
         with patch.object(mrjob.emr, 'filechunkio', None):
-            runner = EMRJobRunner(s3_upload_part_size=0.00005)
+            runner = EMRJobRunner(s3_upload_part_size=self.PART_SIZE_IN_MB)
             self.assertEqual(runner._get_upload_part_size(), 50)
 
             data = 'Mew' * 20
@@ -3557,7 +3558,7 @@ class MultiPartUploadTestCase(MockEMRAndS3TestCase):
 
     def test_exception_while_uploading_large_file(self):
 
-        runner = EMRJobRunner(s3_upload_part_size=0.00005)
+        runner = EMRJobRunner(s3_upload_part_size=self.PART_SIZE_IN_MB)
         self.assertEqual(runner._get_upload_part_size(), 50)
 
         data = 'Mew' * 20

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ envlist = py26, py27, pypy
 
 [testenv]
 deps =
+    ipdb
+    filechunkio
     mock
     pytest
     pytest-sugar

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist = py26, py27, pypy
 
 [testenv]
 deps =
-    ipdb
     filechunkio
     mock
     pytest


### PR DESCRIPTION
This is a heavily reworked version of #985 that enables multipart upload for large files (by default, larger than 100MB).

#985 had two (hard-coded options), a threshold to enable multipart uploading, and a minimum part size. I made these the same thing for simplicity.

Tests pass, but I still need to hand-test this change!