### PR TITLE
make all tests work without mrjob installed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,8 @@ v0.4.3, 2014-03-?? -- SO many bugfixes
      * exclude hadoop source jars when looking for streaming jar (#861)
      * Fixed mkdir_on_hdfs for Hadoop version 2.x (#923)
      * Fixed hadoop_bin on Windows (#843)
+   * Local
+     * bootstrap mrjob by default (#984)
    * Inline
      * fix for add_file_option() (#851)
  * Use pytest to run tests (#898)

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -346,25 +346,27 @@ Other
         python my_job.py -c left.conf --no-conf -c right.conf
 
 
-Options ignored by the inline runner
-------------------------------------
+Options ignored by the local and inline runners
+-----------------------------------------------
 
 These options are ignored because they require a real instance of Hadoop:
 
 * :mrjob-opt:`hadoop_extra_args`
 * :py:meth:`hadoop_input_format <mrjob.runner.MRJobRunner.__init__>`
-* :py:meth:`hadoop_output_format <mrjob.runner.MRJobRunner.__init__>`,
+* :py:meth:`hadoop_output_format <mrjob.runner.MRJobRunner.__init__>`
 * :mrjob-opt:`hadoop_streaming_jar`
-* :mrjob-opt:`jobconf`
 * :mrjob-opt:`partitioner`
 
-These options are ignored because the ``inline`` runner does not invoke the job
-as a subprocess or run it in its own directory:
 
-* :mrjob-opt:`cmdenv`
+Options ignored by the inline runner
+------------------------------------
+
+These options are ignored because the ``inline`` runner does not invoke the job
+as a subprocess:
+
+* :mrjob-opt:`bootstrap_mrjob`
 * :mrjob-opt:`python_bin`
+* :mrjob-opt:`setup`
 * :mrjob-opt:`setup_cmds`
 * :mrjob-opt:`setup_scripts`
 * :mrjob-opt:`steps_python_bin`
-* :mrjob-opt:`upload_archives`
-* :mrjob-opt:`upload_files`

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -40,13 +40,6 @@ class SimRunnerOptionStore(RunnerOptionStore):
         'cmdenv': combine_local_envs,
     })
 
-    def default_options(self):
-        # don't bootstrap mrjob by default when running locally
-        super_opts = super(SimRunnerOptionStore, self).default_options()
-        return combine_dicts(super_opts, {
-            'bootstrap_mrjob': False,
-        })
-
 
 class SimMRJobRunner(MRJobRunner):
     """Abstract base class for runners for testing jobs in development

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -138,6 +138,9 @@ class MockHadoopTestCase(SandboxedTestCase):
         mock_log_path = self.makefile('mock_hadoop_logs', '')
         os.environ['MOCK_HADOOP_LOG'] = mock_log_path
 
+        # make sure the fake hadoop binaries can find mrjob
+        self.add_mrjob_to_pythonpath()
+
 
 class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
@@ -172,6 +175,7 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
         with mr_job.make_runner() as runner:
             assert isinstance(runner, HadoopJobRunner)
+
             runner.run()
 
             for line in runner.stream_output():

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -263,11 +263,15 @@ class SimRunnerJobConfTestCase(SandboxedTestCase):
         with open(upload_path, 'wb') as upload_file:
             upload_file.write('PAYLOAD')
 
+        # use --no-bootstrap-mrjob so we don't have to worry about
+        # mrjob.tar.gz and the setup wrapper script
         mr_job = MRTestJobConf(['-r', self.RUNNER,
+                                '--no-bootstrap-mrjob',
                                 '--jobconf=user.defined=something',
                                 '--jobconf=mapred.map.tasks=1',
                                 '--file', upload_path,
                                input_path])
+
         mr_job.sandbox()
 
         results = {}

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -265,6 +265,7 @@ class SimRunnerJobConfTestCase(SandboxedTestCase):
 
         # use --no-bootstrap-mrjob so we don't have to worry about
         # mrjob.tar.gz and the setup wrapper script
+        self.add_mrjob_to_pythonpath()
         mr_job = MRTestJobConf(['-r', self.RUNNER,
                                 '--no-bootstrap-mrjob',
                                 '--jobconf=user.defined=something',
@@ -370,6 +371,7 @@ class ErrorOnBadPathsTestCase(unittest.TestCase):
     def test_no_paths(self):
         self.fs.path_exists.return_value = False
         self.assertRaises(ValueError, _error_on_bad_paths, self.fs, self.paths)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -747,7 +747,7 @@ class SetupTestCase(SandboxedTestCase):
         try:
             self._old_alarm_handler = signal.signal(
                 signal.SIGALRM, alarm_handler)
-            signal.alarm(2)
+            signal.alarm(10)
 
             with job.make_runner() as r:
                 r.run()


### PR DESCRIPTION
This fixes #984 and does away with the weird quirk that mrjob's tests could only pass if mrjob was installed.

Basically this does two things:
* re-enables bootstrapping mrjob in `local` mode (by deleting lines from `mrjob/sim.py`). This *does* change a default, but it isn't a breaking change, and this actually just re-aligns mrjob with its docs
* for the handful of tests where we don't want to bootstrap mrjob, or where we're running some other subprocess that needs mrjob (mock hadoop), we update `PYTHONPATH` so that our version of mrjob comes first.

I also fixed some related docs that happened to have been wrong for a while, now that local/inline mode simulate Hadoop.
