### PR TITLE
Inline fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v0.4.3, 2014-03-?? -- SO many bugfixes
+v0.4.3, 2014-03-24 -- SO many bugfixes
  * jobs:
    * MRStep's constructor treats kwarg=None same as not setting it (#970)
    * parse_counters() and parse_output() are deprecated (#829)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v0.4.3, 2014-03-24 -- SO many bugfixes
+v0.4.3, 2014-04-02 -- SO many bugfixes
  * jobs:
    * MRStep's constructor treats kwarg=None same as not setting it (#970)
    * parse_counters() and parse_output() are deprecated (#829)

--- a/mrjob/__init__.py
+++ b/mrjob/__init__.py
@@ -105,4 +105,4 @@ __credits__ = [
     'Andrea Zonca <andrea.zonca@gmail.com>',
 ]
 
-__version__ = '0.4.3-dev'
+__version__ = '0.4.3'

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -140,8 +140,6 @@ class InlineMRJobRunner(SimMRJobRunner):
         elif step_type == 'combiner':
             child_args = ['--combiner'] + common_args + ['-']
 
-        child_instance = self._mrjob_cls(args=child_args)
-
         has_combiner = (step_type == 'mapper' and 'combiner' in step)
 
         # Use custom stdin
@@ -155,6 +153,7 @@ class InlineMRJobRunner(SimMRJobRunner):
                 os.environ.update(env)
                 os.chdir(working_dir)
 
+                child_instance = self._mrjob_cls(args=child_args)
                 child_instance.sandbox(stdin=child_stdin, stdout=child_stdout)
                 child_instance.execute()
 


### PR DESCRIPTION
instantiate the mrjob class inside the new working directory, because some mrjobs load files inside load_options()