### PR TITLE
Adding in the optional aws_security_token to allow temporary aws credentials to be used.

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -29,6 +29,15 @@ about setting these options.
     your "password" on AWS
 
 .. mrjob-opt::
+    :config: aws_security_token
+    :switch: --aws-security_token
+    :type: :ref:`string <data-type-string>`
+    :set: emr
+    :default: ``None``
+
+    your temporary session token on AWS
+
+.. mrjob-opt::
     :config: ec2_key_pair
     :switch: --ec2-key-pair
     :type: :ref:`string <data-type-string>`

--- a/mrjob.conf.example
+++ b/mrjob.conf.example
@@ -22,6 +22,8 @@ runners:
     # and there are no eventual consistency issues with newly created S3 keys.
     aws_region: us-west-1
     aws_secret_access_key: MEMIMOMADOOPBANANAFANAFOFADOOPHADOOP
+    # security token for temporary credentials
+    aws_security_token: AREALLYLONGYOURMOMAHASH
     # alternate tmp dir
     base_tmp_dir: /scratch/$USER
     # $BT is the path to our source tree. This lets us add modules to

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -324,6 +324,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         'aws_availability_zone',
         'aws_region',
         'aws_secret_access_key',
+        'aws_security_token',
         'bootstrap',
         'bootstrap_actions',
         'bootstrap_cmds',
@@ -391,6 +392,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         super_opts = super(EMRRunnerOptionStore, self).default_options()
         return combine_dicts(super_opts, {
             'ami_version': 'latest',
+            'aws_security_token': None,
             'check_emr_status_every': 30,
             'cleanup_on_failure': ['JOB'],
             'ec2_core_instance_type': 'm1.small',
@@ -783,7 +785,8 @@ class EMRJobRunner(MRJobRunner):
 
             self._s3_fs = S3Filesystem(self._opts['aws_access_key_id'],
                                        self._opts['aws_secret_access_key'],
-                                       s3_endpoint)
+                                       s3_endpoint,
+                                       self._opts['aws_security_token'])
 
             if self._opts['ec2_key_pair_file']:
                 self._ssh_fs = SSHFilesystem(self._opts['ssh_bin'],
@@ -2452,7 +2455,8 @@ class EMRJobRunner(MRJobRunner):
                 aws_secret_access_key=self._opts['aws_secret_access_key'],
                 region=boto.regioninfo.RegionInfo(
                     name=region_name, endpoint=endpoint,
-                    connection_cls=boto.emr.connection.EmrConnection))
+                    connection_cls=boto.emr.connection.EmrConnection),
+                security_token=self._opts['aws_security_token'])
 
             # Issue #778: EMR's odd endpoint hostnames mess up
             # HMAC v4 authentication in boto 2.10.0 thru 2.15.0.

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -87,7 +87,7 @@ class S3Filesystem(Filesystem):
     """
 
     def __init__(self, aws_access_key_id, aws_secret_access_key, s3_endpoint,
-                 aws_security_token):
+                 aws_security_token=None):
         """
         :param aws_access_key_id: Your AWS access key ID
         :param aws_secret_access_key: Your AWS secret access key

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -86,7 +86,8 @@ class S3Filesystem(Filesystem):
     :py:class:`~mrjob.fs.local.LocalFilesystem`.
     """
 
-    def __init__(self, aws_access_key_id, aws_secret_access_key, s3_endpoint):
+    def __init__(self, aws_access_key_id, aws_secret_access_key, s3_endpoint,
+                 aws_security_token):
         """
         :param aws_access_key_id: Your AWS access key ID
         :param aws_secret_access_key: Your AWS secret access key
@@ -97,6 +98,7 @@ class S3Filesystem(Filesystem):
         self._s3_endpoint = s3_endpoint
         self._aws_access_key_id = aws_access_key_id
         self._aws_secret_access_key = aws_secret_access_key
+        self._aws_security_token = aws_security_token
 
     def can_handle_path(self, path):
         return is_s3_uri(path)
@@ -235,7 +237,8 @@ class S3Filesystem(Filesystem):
         raw_s3_conn = boto.connect_s3(
             aws_access_key_id=self._aws_access_key_id,
             aws_secret_access_key=self._aws_secret_access_key,
-            host=self._s3_endpoint)
+            host=self._s3_endpoint,
+            security_token=self._aws_security_token)
         return wrap_aws_conn(raw_s3_conn)
 
     def get_s3_key(self, uri, s3_conn=None):

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -96,7 +96,7 @@ class MockS3Connection(object):
                  proxy_user=None, proxy_pass=None,
                  host=None, debug=0, https_connection_factory=None,
                  calling_format=None, path='/', provider='aws',
-                 bucket_class=None, mock_s3_fs=None, aws_security_token=None):
+                 bucket_class=None, mock_s3_fs=None, security_token=None):
         """Mock out a connection to S3. Most of these args are the same
         as for the real S3Connection, and are ignored.
 
@@ -354,7 +354,7 @@ class MockEmrConnection(object):
                  mock_emr_failures=None, mock_emr_output=None,
                  max_days_ago=DEFAULT_MAX_DAYS_AGO,
                  max_job_flows_returned=DEFAULT_MAX_JOB_FLOWS_RETURNED,
-                 simulation_iterator=None, aws_security_token=None):
+                 simulation_iterator=None, security_token=None):
         """Create a mock version of EmrConnection. Most of these args are
         the same as for the real EmrConnection, and are ignored.
 

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -96,7 +96,7 @@ class MockS3Connection(object):
                  proxy_user=None, proxy_pass=None,
                  host=None, debug=0, https_connection_factory=None,
                  calling_format=None, path='/', provider='aws',
-                 bucket_class=None, mock_s3_fs=None):
+                 bucket_class=None, mock_s3_fs=None, aws_security_token=None):
         """Mock out a connection to S3. Most of these args are the same
         as for the real S3Connection, and are ignored.
 
@@ -146,8 +146,10 @@ class MockBucket(object):
 
     def new_key(self, key_name):
         if key_name not in self.mock_state():
-            self.mock_state()[key_name] = ('',
-                    to_iso8601(datetime.utcnow()))
+            self.mock_state()[key_name] = (
+                '',
+                to_iso8601(datetime.utcnow())
+            )
         return MockKey(bucket=self, name=key_name)
 
     def get_key(self, key_name):
@@ -352,7 +354,7 @@ class MockEmrConnection(object):
                  mock_emr_failures=None, mock_emr_output=None,
                  max_days_ago=DEFAULT_MAX_DAYS_AGO,
                  max_job_flows_returned=DEFAULT_MAX_JOB_FLOWS_RETURNED,
-                 simulation_iterator=None):
+                 simulation_iterator=None, aws_security_token=None):
         """Create a mock version of EmrConnection. Most of these args are
         the same as for the real EmrConnection, and are ignored.
 


### PR DESCRIPTION
Owing to how permissions are handed out here, I have to use aws temporary credentials.

Fortunately aws temporary credentials are already supported by to boto library. So I have exposed this piece of boto functionality with an optional config variable. I have tested this locally and it works for me (tm) :)

Is this patch in an acceptable format? Is this a piece of functionality you are willing to add to this project?

Any feedback is welcome.

Thank you  