### PR TITLE
work with new IAM requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,6 @@ Setting up EMR on Amazon
 ------------------------
 
 * create an `Amazon Web Services account <http://aws.amazon.com/>`_
-* sign up for `Elastic MapReduce <http://aws.amazon.com/elasticmapreduce/>`__
 * Get your access and secret keys (click "Security Credentials" on
   `your account page <http://aws.amazon.com/account/>`_)
 * Set the environment variables ``$AWS_ACCESS_KEY_ID`` and
@@ -125,7 +124,7 @@ Reference
 ---------
 
 * `Hadoop Streaming <http://hadoop.apache.org/docs/stable1/streaming.html>`_
-* `Elastic MapReduce <http://aws.amazon.com/documentation/elasticmapreduce/>`__
+* `Elastic MapReduce <http://aws.amazon.com/documentation/elasticmapreduce/>`_
 
 More Information
 ----------------

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -162,16 +162,15 @@ Job flow creation and configuration
     necessary to set this by hand.
 
 .. mrjob-opt::
-    :config: iam_job_flow_role
-    :switch: --iam-job-flow-role
+    :config: iam_instance_profile
+    :switch: --iam-instance-profile
     :type: :ref:`string <data-type-string>`
     :set: emr
     :default: ``None``
 
-    IAM job flow role to use on the EMR cluster. See
+    IAM instance profile to use on the EMR cluster. See
     http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-iam-roles.html
     for more details on using IAM roles with EMR.
-    Needs AMI version 2.3.0 or later to work.
 
     .. versionadded:: 0.4.3
 

--- a/mrjob/aws.py
+++ b/mrjob/aws.py
@@ -15,6 +15,7 @@
 """General information about Amazon Web Services, such as region-to-endpoint
 mappings.
 """
+import random
 
 ### EC2 Instances ###
 
@@ -213,3 +214,8 @@ def s3_location_constraint_for_region(region):
         return ''
     else:
         return region
+
+
+def random_identifier():
+    """Used to randomly name new buckets and roles."""
+    return '016x' % random.randint(0, 2 ** 64 - 1)

--- a/mrjob/aws.py
+++ b/mrjob/aws.py
@@ -218,4 +218,4 @@ def s3_location_constraint_for_region(region):
 
 def random_identifier():
     """Used to randomly name new buckets and roles."""
-    return '016x' % random.randint(0, 2 ** 64 - 1)
+    return '%016x' % random.randint(0, 2 ** 64 - 1)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1377,7 +1377,6 @@ class EMRJobRunner(MRJobRunner):
 
         instance_profile = (self._opts['iam_instance_profile'] or
             get_or_create_mrjob_instance_profile(self.make_iam_conn()))
-
         args['api_params']['JobFlowRole'] = instance_profile
 
         service_role = (self._opts['iam_service_role'] or

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -341,22 +341,23 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         'ec2_slave_instance_type',
         'ec2_task_instance_bid_price',
         'ec2_task_instance_type',
+        'emr_action_on_failure',
         'emr_api_params',
         'emr_endpoint',
         'emr_job_flow_id',
         'emr_job_flow_pool_name',
-        'emr_action_on_failure',
         'enable_emr_debugging',
         'hadoop_streaming_jar_on_emr',
         'hadoop_version',
         'iam_job_flow_role',
+        'iam_service_role',
         'max_hours_idle',
         'mins_to_end_of_hour',
         'num_ec2_core_instances',
-        'pool_wait_minutes',
         'num_ec2_instances',
         'num_ec2_task_instances',
         'pool_emr_job_flows',
+        'pool_wait_minutes',
         's3_endpoint',
         's3_log_uri',
         's3_scratch_uri',
@@ -396,10 +397,9 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'ec2_core_instance_type': 'm1.small',
             'ec2_master_instance_type': 'm1.small',
             'emr_job_flow_pool_name': 'default',
-            'hadoop_version': None,
             'hadoop_streaming_jar_on_emr': (
                 '/home/hadoop/contrib/streaming/hadoop-streaming.jar'),
-            'iam_job_flow_role': None,
+            'hadoop_version': None,  # override runner default
             'mins_to_end_of_hour': 5.0,
             'num_ec2_core_instances': 0,
             'num_ec2_instances': 1,
@@ -1357,6 +1357,11 @@ class EMRJobRunner(MRJobRunner):
             if 'api_params' not in args:
                 args.setdefault('api_params', {})
             args['api_params']['JobFlowRole'] = self._opts['iam_job_flow_role']
+
+        if self._opts['iam_service_role']:
+            if 'api_params' not in args:
+                args.setdefault('api_params', {})
+            args['api_params']['ServiceRole'] = self._opts['iam_service_role']
 
         if steps:
             args['steps'] = steps

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -350,6 +350,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         'enable_emr_debugging',
         'hadoop_streaming_jar_on_emr',
         'hadoop_version',
+        'iam_instance_profile',
         'iam_job_flow_role',
         'iam_service_role',
         'max_hours_idle',

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2574,7 +2574,7 @@ class EMRJobRunner(MRJobRunner):
     def make_iam_conn(self):
         """Create a connection to S3.
 
-        :return: a :py:class:`boto.s3.connection.S3Connection`, wrapped in a
+        :return: a :py:class:`boto.iam.connection.IAMConnection`, wrapped in a
                  :py:class:`mrjob.retry.RetryWrapper`
         """
         # give a non-cryptic error message if boto isn't installed

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -77,6 +77,7 @@ from mrjob.aws import EC2_INSTANCE_TYPE_TO_MEMORY
 from mrjob.aws import MAX_STEPS_PER_JOB_FLOW
 from mrjob.aws import emr_endpoint_for_region
 from mrjob.aws import emr_ssl_host_for_region
+from mrjob.aws import random_identifier
 from mrjob.aws import s3_endpoint_for_region
 from mrjob.aws import s3_location_constraint_for_region
 from mrjob.compat import supports_new_distributed_cache_options
@@ -732,7 +733,7 @@ class EMRJobRunner(MRJobRunner):
                 return
 
         # That may have all failed. If so, pick a name.
-        scratch_bucket_name = 'mrjob-%016x' % random.randint(0, 2 ** 64 - 1)
+        scratch_bucket_name = 'mrjob-' + random_identifier()
         self._s3_temp_bucket_to_create = scratch_bucket_name
         log.info("creating new scratch bucket %s" % scratch_bucket_name)
         self._opts['s3_scratch_uri'] = 's3://%s/tmp/' % scratch_bucket_name

--- a/mrjob/iam.py
+++ b/mrjob/iam.py
@@ -1,0 +1,123 @@
+"""Utilities for dealing with AWS IAM, mostly creating roles."""
+
+# recommended IAM roles and policies for EMR, from:
+# http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-iam-roles-defaultroles.html
+import json
+from urllib import unquote_plus
+
+
+# where to store roles created by mrjob
+MRJOB_EMR_ROLE_PATH = '/mrjob/emr/'
+MRJOB_EMR_EC2_ROLE_PATH = '/mrjob/ec2/'
+
+# use this for service_role
+DEFAULT_EMR_ROLE = {
+    "Version": "2008-10-17",
+    "Statement": [{
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+            "Service": ["elasticmapreduce.amazonaws.com"]
+        },
+        "Action": "sts:AssumeRole"
+    }]
+}
+
+# policy to add to DEFAULT_EMR_ROLE
+DEFAULT_EMR_ROLE_POLICY = {
+    "Statement": [{
+        "Action": [
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:CancelSpotInstanceRequests",
+            "ec2:CreateSecurityGroup",
+            "ec2:CreateTags",
+            "ec2:DeleteTags",
+            "ec2:Describe*",
+            "ec2:ModifyImageAttribute",
+            "ec2:ModifyInstanceAttribute",
+            "ec2:RequestSpotInstances",
+            "ec2:RunInstances",
+            "ec2:TerminateInstances",
+            "iam:PassRole",
+            "iam:ListRolePolicies",
+            "iam:GetRole",
+            "iam:GetRolePolicy",
+            "iam:ListInstanceProfiles",
+            "s3:Get*",
+            "s3:CreateBucket",
+            "s3:List*",
+            "sdb:BatchPutAttributes",
+            "sdb:Select"
+        ],
+    "Effect": "Allow",
+    "Resource": "*"
+    }]
+}
+
+# use this for job_flow_role
+DEFAULT_EMR_EC2_ROLE = {
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+
+# policies to attach to DEFAULT_EMR_EC2_ROLE
+DEFAULT_EMR_EC2_ROLE_POLICY = {
+    "Statement": [{
+        "Action": [
+            "cloudwatch:*",
+            "dynamodb:*",
+            "ec2:Describe*",
+            "elasticmapreduce:Describe*",
+            "rds:Describe*",
+            "s3:*",
+            "sdb:*",
+            "sns:*",
+            "sqs:*"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+    }]
+}
+
+
+def get_policies_for_role(conn, role_name):
+    """Given a role name, return a map from role policy name to the (decoded)
+    policy document.
+
+    conn should be an boto.iam.IAMConnection
+    """
+    # just using raw IAMConnection.get_response(); the role stuff didn't exist
+    # in boto 2.2.0, and newer boto adds very little value (you still have to
+    # unpack the response like we do below).
+    resp = conn.get_response('ListRolePolicies',
+                             {'RoleName': role_name},
+                             list_marker='PolicyNames')
+
+    policy_names = resp['list_role_policies_response'][
+            'list_role_policies_result']['policy_names']
+
+    policies_by_name = {}
+
+    for policy_name in policy_names:
+        resp = conn.get_response('GetRolePolicy',
+                                 {'RoleName': role_name,
+                                  'PolicyName': policy_name})
+        policy_document_quoted = resp['get_role_policy_response'][
+            'get_role_policy_result']['policy_document']
+        policy_document_json = unquote_plus(policy_document_quoted)
+        policy_document = json.loads(policy_document_json)
+
+        policies_by_name[policy_name] = policy_document
+
+    return policies_by_name

--- a/mrjob/iam.py
+++ b/mrjob/iam.py
@@ -31,7 +31,7 @@ MRJOB_SERVICE_ROLE = {
         "Sid": "",
         "Effect": "Allow",
         "Principal": {
-            "Service": ["elasticmapreduce.amazonaws.com"]
+            "Service": "elasticmapreduce.amazonaws.com"
         },
         "Action": "sts:AssumeRole"
     }]
@@ -76,9 +76,7 @@ MRJOB_INSTANCE_PROFILE_ROLE = {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": [
-          "ec2.amazonaws.com"
-        ]
+        "Service": "ec2.amazonaws.com"
       },
       "Action": "sts:AssumeRole"
     }
@@ -226,9 +224,13 @@ def role_with_policies_matches(rp1, rp2):
     role1, policies1 = rp1
     role2, policies2 = rp2
 
+    # JSON-encode to allow sorting in Python 3
+    def dumps(x):
+        json.dumps(x, sort_keys=True)
+
     return (role1 == role2 and
-            sorted(json.dumps(p, sort_keys=True) for p in policies1) ==
-            sorted(json.dumps(p, sort_keys=True) for p in policies2))
+            sorted(dumps(p) for p in policies1) ==
+            sorted(dumps(p) for p in policies2))
 
 
 def get_or_create_mrjob_service_role(conn):

--- a/mrjob/iam.py
+++ b/mrjob/iam.py
@@ -172,11 +172,14 @@ def yield_instance_profiles_with_policies(conn):
         for profile_data in resp['instance_profiles']:
             profile_name = profile_data['instance_profile_name']
 
-            # doesn't look like boto can handle two list markers, hence
-            # the extra "member" layer
-            role_data = profile_data['roles']['member']
-
-            _, role_with_policies = _get_role_with_policies(conn, role_data)
+            if profile_data['roles']:
+                # doesn't look like boto can handle two list markers, hence
+                # the extra "member" layer
+                role_data = profile_data['roles']['member']
+                _, role_with_policies = _get_role_with_policies(
+                    conn, role_data)
+            else:
+                role_with_policies = None
 
             yield (profile_name, role_with_policies)
 

--- a/mrjob/iam.py
+++ b/mrjob/iam.py
@@ -47,8 +47,8 @@ MRJOB_SERVICE_ROLE_POLICY = {
             "ec2:CancelSpotInstanceRequests",
             "ec2:CreateSecurityGroup",
             "ec2:CreateTags",
-            "ec2:DeleteTags",
             "ec2:Describe*",
+            "ec2:DeleteTags",
             "ec2:ModifyImageAttribute",
             "ec2:ModifyInstanceAttribute",
             "ec2:RequestSpotInstances",
@@ -60,8 +60,8 @@ MRJOB_SERVICE_ROLE_POLICY = {
             "iam:GetRolePolicy",
             "iam:ListInstanceProfiles",
             "s3:Get*",
-            "s3:CreateBucket",
             "s3:List*",
+            "s3:CreateBucket",
             "sdb:BatchPutAttributes",
             "sdb:Select"
         ],
@@ -233,11 +233,11 @@ def role_with_policies_matches(rp1, rp2):
 
     # JSON-encode to allow sorting in Python 3
     def dumps(x):
-        json.dumps(x, sort_keys=True)
+        return json.dumps(x, sort_keys=True)
 
     return (role1 == role2 and
-            sorted(dumps(p) for p in policies1) ==
-            sorted(dumps(p) for p in policies2))
+            sorted(dumps(p1) for p1 in policies1) ==
+            sorted(dumps(p2) for p2 in policies2))
 
 
 def get_or_create_mrjob_service_role(conn):
@@ -249,7 +249,7 @@ def get_or_create_mrjob_service_role(conn):
                 conn, path_prefix=MRJOB_SERVICE_ROLE_PATH)):
 
         if role_with_policies_matches(role_with_policies,
-                                     target_role_with_policies):
+                                      target_role_with_policies):
             return role_name
 
     role_name = _create_mrjob_role_with_policies(

--- a/mrjob/iam.py
+++ b/mrjob/iam.py
@@ -114,6 +114,26 @@ def _get_result(resp):
     raise ValueError
 
 
+def list_roles_with_policies(conn, path_prefix=None):
+    """Get a map from role name to (role, [policy])."""
+    params = {}
+    if path_prefix is not None:
+        params['PathPrefix'] = path_prefix
+    resp = conn.get_response('ListRoles', params, list_marker='Roles')
+
+    roles_with_policies = {}
+
+    for role_data in _get_result(resp)['roles']:
+        role_name = role_data['role_name']
+        role = _unquote_json(role_data['assume_role_policy_document'])
+
+        policies = get_policies_for_role(conn, role_name)
+
+        roles_with_policies[role_name] = (role, policies)
+
+    return roles_with_policies
+
+
 def get_policies_for_role(conn, role_name):
     """Given a role name, return a list of policy documents.
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -439,11 +439,15 @@ def add_emr_opts(opt_group):
                   ' Rarely necessary.')),
 
         opt_group.add_option(
+            '--iam-instance-profile', dest='iam_instance_profile',
+            default=None,
+            help=('EC2 instance profile to use for the EMR cluster - see'
+                  ' "Configure IAM Roles for Amazon EMR" in AWS docs')),
+
+        opt_group.add_option(
             '--iam-job-flow-role', dest='iam_job_flow_role',
             default=None,
-            help=('IAM Job flow role (also called "instance profile") to use'
-                  ' for the EMR cluster - see'
-                  ' "Configure IAM Roles for Amazon EMR" in AWS docs')),
+            help='Deprecated alias for --iam-instance-profile'),
 
         opt_group.add_option(
             '--iam-service-role', dest='iam_service_role',

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -441,8 +441,15 @@ def add_emr_opts(opt_group):
         opt_group.add_option(
             '--iam-job-flow-role', dest='iam_job_flow_role',
             default=None,
-            help=('IAM Job flow role to use for the EMR cluster - see AWS '
-                  'docs on EMR for info on using IAM roles with EMR')),
+            help=('IAM Job flow role (also called "instance profile") to use'
+                  ' for the EMR cluster - see'
+                  ' "Configure IAM Roles for Amazon EMR" in AWS docs')),
+
+        opt_group.add_option(
+            '--iam-service-role', dest='iam_service_role',
+            default=None,
+            help=('IAM Job flow role to use for the EMR cluster - see'
+                  ' "Configure IAM Roles for Amazon EMR" in AWS docs')),
 
         opt_group.add_option(
             '--max-hours-idle', dest='max_hours_idle',

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2009-2013 Yelp and Contributors
+# Copyright 2009-2015 Yelp and Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,16 +14,13 @@
 # limitations under the License.
 """Mercilessly taunt an Amazonian river dolphin.
 
-This is by no means a complete mock of boto; I just added the methods I needed
-to make tests work.
-
-If you need a more extensive set of mock boto objects, we recommend adding
-some sort of sandboxing feature to boto, rather than extending these somewhat
-ad-hoc mock objects.
+This is by no means a complete mock of boto, just what we need for tests.
 """
+import hashlib
+import json
 from datetime import datetime
 from datetime import timedelta
-import hashlib
+from urllib import quote
 
 try:
     from boto.emr.connection import EmrConnection
@@ -874,3 +871,349 @@ class MockEmrObject(object):
             self.__class__.__name__,
             ', '.join('%s=%r' % (k, v)
                       for k, v in sorted(self.__dict__.iteritems()))))
+
+
+class MockIAMConnection(object):
+
+    DEFAULT_PATH = '/'
+
+    DEFAULT_MAX_ITEMS = 100
+
+    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
+                 is_secure=True, port=None, proxy=None, proxy_port=None,
+                 proxy_user=None, proxy_pass=None, host='iam.amazonaws.com',
+                 debug=0, https_connection_factory=None, path='/',
+                 security_token=None, validate_certs=True, profile_name=None,
+                 mock_iam_instance_profiles=None, mock_iam_roles=None,
+                 mock_iam_role_policies=None):
+        """Mock out connection to IAM.
+
+        mock_iam_instance_profiles maps profile name to a dictionary containing:
+            create_date -- ISO creation datetime
+            path -- IAM path
+            role_name -- name of single role for this instance profile, or None
+
+        mock_iam_roles maps role name to a dictionary containing:
+            assume_role_policy_document -- a JSON-then-URI-encoded policy doc
+            create_date -- ISO creation datetime
+            path -- IAM path
+
+        mock_iam_role_policies maps policy name to a dictionary containing:
+            policy_document -- JSON-then-URI-encoded policy doc
+            role_name -- name of single role for this policy (always defined)
+
+        We don't currently support role IDs or ARNs because our code doesn't
+        use them.
+        """
+        self.mock_iam_instance_profiles = combine_values(
+            {}, mock_iam_instance_profiles)
+        self.mock_iam_roles = combine_values({}, mock_iam_roles)
+        self.mock_iam_role_policies = combine_values(
+            {}, mock_iam_role_policies)
+
+    def get_response(self, action, params, path='/', parent=None,
+                     verb='POST', list_marker='Set'):
+        # mrjob.iam currently only calls get_response(), to support old
+        # versions of boto. In real boto, the other methods call
+        # this one, but in mockboto, this method fans out to the other ones
+        if action == 'AddRoleToInstanceProfile':
+            return self.add_role_to_instance_profile(
+                params['InstanceProfileName'],
+                params['RoleName'])
+
+        elif action == 'CreateInstanceProfile':
+            return self.create_instance_profile(
+                params['InstanceProfileName'],
+                path=params.get('Path'))
+
+        elif action == 'CreateRole':
+            return self.create_role(
+                params['RoleName'],
+                json.loads(params['AssumeRolePolicyDocument']),
+                path=params.get('Path'))
+
+        elif action == 'GetRolePolicy':
+            return self.get_role_policy(
+                params['RoleName'],
+                params['PolicyName'])
+
+        elif action == 'ListInstanceProfiles':
+            if list_marker != 'InstanceProfiles':
+                raise ValueError
+
+            return self.list_instance_profiles(
+                path_prefix=params.get('PathPrefix'),
+                marker=params.get('Marker'),
+                max_items=params.get('MaxItems'))
+
+        elif action == 'ListRolePolicies':
+            if list_marker != 'PolicyNames':
+                raise ValueError
+
+            return self.list_role_policies(
+                params['RoleName'],
+                marker=params.get('Marker'),
+                max_items=params.get('MaxItems'))
+
+        elif action == 'ListRoles':
+            if list_marker != 'Roles':
+                raise ValueError
+
+            return self.list_roles(
+                path_prefix=params.get('PathPrefix'),
+                marker=params.get('Marker'),
+                max_items=params.get('MaxItems'))
+
+        elif action == 'PutRolePolicy':
+            # boto apparently doesn't make any attempt to
+            # JSON-encode the role policy for you!
+            return self.put_role_policy(
+                params['RoleName'],
+                params['PolicyName'],
+                params['PolicyDocument'])
+
+        else:
+            raise ValueError
+
+    # instance profiles
+
+    def add_role_to_instance_profile(self, instance_profile_name, role_name):
+        self._check_instance_profile_exists(instance_profile_name)
+
+        profile_data = self.mock_iam_instance_profiles[instance_profile_name]
+
+        if profile_data['role_name'] is not None:
+            raise boto.exception.BotoServerError(
+                409, 'Conflict', boto=err_xml(
+                    ('Cannot exceed quota for'
+                     ' InstanceSessionsPerInstanceProfile: 1'),
+                     code='LimitExceeded'))
+
+        self._check_role_exists(role_name)
+
+        profile_data['role_name'] = role_name
+
+        # response is empty
+        return self._wrap_result('add_role_to_instance_profile')
+
+    def create_instance_profile(self, instance_profile_name, path=None):
+        self._check_path(path)
+        self._check_instance_profile_does_not_exist(instance_profile_name)
+
+        self.mock_iam_instance_profiles[instance_profile_name] = dict(
+            create_date=to_iso8601(datetime.utcnow()),
+            path=(path or self.DEFAULT_PATH),
+            role_name=None,
+        )
+
+        return self._wrap_result(
+            'create_instance_profile',
+            {'instance_profile': self._describe_instance_profile(
+                instance_profile_name)})
+
+    def list_instance_profiles(self, path_prefix=None, marker=None,
+                               max_items=None):
+
+        self._check_path(path_prefix, field_name='pathPrefix')
+        path_prefix = path_prefix or '/'
+
+        profile_names = sorted(
+            name for name, data in self.mock_iam_instance_profiles.items()
+            if data['path'].startswith('path_prefix'))
+
+        result = self._paginate(profile_names, 'instance_profile',
+                                marker=marker, max_items=max_items)
+
+        return self._wrap_result('list_instance_profiles', result)
+
+    def _check_instance_profile_exists(self, instance_profile_name):
+        if instance_profile_name not in self.mock_iam_instance_profiles:
+            raise boto.exception.BotoServerError(
+                404, 'Not Found', body=err_xml(
+                    ('Instance Profile %s cannot be found.' %
+                     instance_profile_name), code='NoSuchEntity'))
+
+    def _check_instance_profile_does_not_exist(self, instance_profile_name):
+        if instance_profile_name in self.mock_iam_instance_profiles:
+            raise boto.exception.BotoServerError(
+                409, 'Conflict', body=err_xml(
+                    ('Instance Profile %s already exists.' %
+                     instance_profile_name), code='EntityAlreadyExists'))
+
+    def _describe_instance_profile(self, instance_profile_name):
+        """Format the given instance profile for an API response."""
+        profile_data = self.mock_iam_instance_profiles[instance_profile_name]
+
+        if profile_data['role_name'] is None:
+            roles = {}
+        else:
+            roles = {'member': self._describe_role(profile_data['role_name'])}
+
+        return dict(
+            create_date=profile_data['create_date'],
+            instance_profile_name=instance_profile_name,
+            path=profile_data['path'],
+            roles=roles)
+
+    # roles
+
+    def create_role(self, role_name, assume_role_policy_document, path=None):
+        # real boto has a default for assume_role_policy_document; not
+        # supporting this for now. It also allows assume_role_policy_document
+        # to be a string, which we don't.
+
+        self._check_path(path)
+        self._check_role_does_not_exist(role_name)
+
+        # there's no validation of assume_role_policy_document; not entirely
+        # sure what the rules are
+
+        self.mock_iam_roles[role_name] = dict(
+            assume_role_policy_document=quote(json.dumps(
+                assume_role_policy_document)),
+            create_date=to_iso8601(datetime.utcnow()),
+            path=(path or self.DEFAULT_PATH),
+            policy_names=[],
+        )
+
+        result = dict(role=self._describe_role(role_name))
+
+        return self._wrap_result('create_role', result)
+
+    def list_roles(self, path_prefix=None, marker=None, max_items=None):
+        self._check_path(path_prefix, field_name='pathPrefix')
+        path_prefix = path_prefix or '/'
+
+        # find all matching profiles
+        role_names = sorted(
+            name for name, data in self.mock_iam_roles.items()
+            if data['path'].startswith('path_prefix'))
+
+        result = self._paginate(role_names, 'roles',
+                                marker=marker, max_items=max_items)
+
+        return self._wrap_result('list_roles', result)
+
+    def _check_role_exists(self, role_name):
+        if role_name not in self.mock_iam_roles:
+            raise boto.exception.BotoServerError(
+                404, 'Not Found', body=err_xml(
+                    ('The role with name %s cannot be found.' %
+                     role_name), code='NoSuchEntity'))
+
+    def _check_role_does_not_exist(self, role_name):
+        if role_name in self.mock_iam_roles:
+            raise boto.exception.BotoServerError(
+                409, 'Conflict', body=err_xml(
+                    ('Role with name %s already exists.' %
+                     role_name), code='EntityAlreadyExists'))
+
+    def _describe_role(self, role_name):
+        """Format the given instance profile for an API response."""
+        role_data = self.mock_iam_roles[role_name]
+
+        # the IAM API doesn't include policy names when describing roles
+
+        return dict(
+            assume_role_policy_document=(
+                role_data['assume_role_policy_document']),
+            create_date=role_data['create_date'],
+            role_name=role_name,
+            path=role_data['path']
+        )
+
+    # role policies
+
+    def get_role_policy(self, role_name, policy_name):
+        self._check_role_exists(role_name)
+        self._check_role_policy_exists(policy_name)
+
+        result = dict(policy_document=self._describe_role_policy(policy_name))
+
+        return self._wrap_result('get_role_policy', result)
+
+    def list_role_policies(self, role_name, marker, max_items):
+
+        policy_names = [
+            name for name, data in sorted(self.mock_iam_role_policies.items())
+            if data['role_name'] == role_name]
+
+        result = self._paginate(policy_names, 'policy_names',
+                                marker=marker, max_items=max_items)
+
+        return self._wrap_result('list_role_policies', result)
+
+    def put_role_policy(self, role_name, policy_name, policy_document):
+        self._check_role_exists(role_name)
+
+        # PutRolePolicy will happily overwrite existing roles
+        self.mock_iam_role_policies[policy_name] = dict(
+            policy_document=quote(policy_document),
+            role_name=role_name)
+
+        return self._wrap_result('put_role_policy')
+
+    def _check_role_policy_exists(self, policy_name, role_name):
+        if (policy_name not in self.mock_iam_role_policies[policy_name] or
+            self.mock_iam_role_policies[policy_name]['role_name'] != role_name):
+
+            # the IAM API really does raise this error when the role policy
+            # exists but has a different role name
+            raise boto.exception.BotoServerError(
+                404, 'Not Found', body=err_xml(
+                    ('The role policy with name %s cannot be found.' %
+                     role_name), code='NoSuchEntity'))
+
+    def _describe_role_policy(self, policy_name):
+        policy_data = self.mock_iam_role_policies[policy_name]
+
+        return dict(
+            policy_document=policy_data['policy_document'],
+            policy_name=policy_name,
+            role_name=policy_data['role_name'],
+        )
+
+    # other utilities
+
+    def _check_path(self, path=None, field_name='path'):
+        if path is None or (path.startswith('/') and path.endswith('/')):
+            return
+
+        raise boto.exception.BotoServerError(
+            400, 'Bad Request', body=err_xml(
+                'The specified value for %s is invalid. It must begin and'
+                ' end with / and contain only alphanumeric characters and/or'
+                ' / characters.' % field_name))
+
+    def _paginate(self, items, name, marker=None, max_items=None):
+        """Given a list of items, return a dictionary mapping
+        *names* to a slice of items, with additional keys
+        'is_truncated' and, if 'is_truncated' is true, 'marker'.
+        """
+        max_items = max_items or self.DEFAULT_MAX_ITEMS
+
+        start = 0
+        if marker:
+            start = int(marker)
+
+        end = start + max_items
+
+        result = {name: items[start:end]}
+
+        result['is_truncated'] = end < len(items)
+        if result['is_truncated']:
+            result['marker'] = str(end)
+
+        return result
+
+    def _wrap_result(self, prefix, result=None):
+        """Wrap result in two additional dictionaries (these result from boto's
+        decoding of the XML response)."""
+        if result is None:
+            result_dict = {}
+        else:
+            result_dict = {prefix + '_result': result}
+
+       # could add response_metadata to result_dict, but we don't use it
+
+        return {prefix + '_response': result_dict}

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1026,7 +1026,10 @@ class MockIAMConnection(object):
             name for name, data in self.mock_iam_instance_profiles.items()
             if data['path'].startswith(path_prefix))
 
-        result = self._paginate(profile_names, 'instance_profile',
+        profiles = [self._describe_instance_profile(name)
+                    for name in profile_names]
+
+        result = self._paginate(profiles, 'instance_profiles',
                                 marker=marker, max_items=max_items)
 
         return self._wrap_result('list_instance_profiles', result)
@@ -1139,8 +1142,7 @@ class MockIAMConnection(object):
 
         return self._wrap_result('get_role_policy', result)
 
-    def list_role_policies(self, role_name, marker, max_items):
-
+    def list_role_policies(self, role_name, marker=None, max_items=None):
         policy_names = [
             name for name, data in sorted(self.mock_iam_role_policies.items())
             if data['role_name'] == role_name]
@@ -1153,7 +1155,7 @@ class MockIAMConnection(object):
     def put_role_policy(self, role_name, policy_name, policy_document):
         self._check_role_exists(role_name)
 
-        # PutRolePolicy will happily overwrite existing roles
+        # PutRolePolicy will happily overwrite existing role policies
         self.mock_iam_role_policies[policy_name] = dict(
             policy_document=quote(policy_document),
             role_name=role_name)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -667,6 +667,14 @@ class IAMTestCase(MockEMRAndS3TestCase):
 
         self.assertEqual(job_flow.jobflowrole, 'EMR_DefaultRole')
 
+    def test_deprecated_job_flow_role_option(self):
+        with logger_disabled('mrjob.emr'):
+            job_flow = self.run_and_get_job_flow(
+                '--iam-job-flow-role', 'EMR_DefaultRole')
+            self.assertTrue(boto.connect_iam.called)
+
+            self.assertEqual(job_flow.jobflowrole, 'EMR_DefaultRole')
+
     def test_iam_service_role_option(self):
         job_flow = self.run_and_get_job_flow(
             '--iam-service-role', 'EMR_EC2_DefaultRole')

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -595,7 +595,7 @@ class VisibleToAllUsersTestCase(MockEMRAndS3TestCase):
         self.assertTrue(job_flow.visibletoallusers, 'true')
 
 
-class IAMJobFlowRoleTestCase(MockEMRAndS3TestCase):
+class IAMInstanceProfileTestCase(MockEMRAndS3TestCase):
 
     def run_and_get_job_flow(self, *args):
         stdin = StringIO('foo\nbar\n')
@@ -612,8 +612,8 @@ class IAMJobFlowRoleTestCase(MockEMRAndS3TestCase):
         job_flow = self.run_and_get_job_flow()
         self.assertEqual(job_flow.iamjobflowrole, None)
 
-    def test_iamjobflowrole(self):
-        job_flow = self.run_and_get_job_flow('--iam-job-flow-role=EMRDefaultRole')
+    def test_iam_instance_profile(self):
+        job_flow = self.run_and_get_job_flow('--iam-instance-profile=EMRDefaultRole')
         self.assertEqual(job_flow.iamjobflowrole, 'EMRDefaultRole')
 
 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1,0 +1,65 @@
+import json
+try:
+    from unittest2 import TestCase
+    TestCase  # pyflakes
+except ImportError:
+    from unittest import TestCase
+
+from mrjob.iam import MRJOB_SERVICE_ROLE
+from mrjob.iam import MRJOB_SERVICE_ROLE_POLICY
+from mrjob.iam import _unwrap_response
+from mrjob.iam import yield_instance_profiles_with_policies
+from mrjob.iam import yield_roles_with_policies
+from mrjob.iam import yield_policies_for_role
+
+from tests.mockboto import MockIAMConnection
+
+# IAM stuff is mostly tested by test_emr.py, but we don't test what happens if
+# there are already enough IAM objects to cause pagination
+
+class PaginationTestCase(TestCase):
+
+    def test_many_instance_profiles(self):
+        conn = MockIAMConnection()
+        max_items = conn.DEFAULT_MAX_ITEMS
+
+        for i in range(2 * max_items):
+            conn.create_instance_profile('ip-%03d' % i)
+
+        instance_profiles_page = _unwrap_response(
+            conn.list_instance_profiles())['instance_profiles']
+        self.assertEqual(len(instance_profiles_page), max_items)
+
+        instance_profiles = list(yield_instance_profiles_with_policies(conn))
+        self.assertEqual(len(instance_profiles), 2 * max_items)
+
+    def test_many_roles(self):
+        conn = MockIAMConnection()
+        max_items = conn.DEFAULT_MAX_ITEMS
+
+        for i in range(2 * max_items):
+            conn.create_role('r-%03d' % i, MRJOB_SERVICE_ROLE)
+
+        roles_page = _unwrap_response(
+            conn.list_roles())['roles']
+        self.assertEqual(len(roles_page), max_items)
+
+        roles = list(yield_roles_with_policies(conn))
+        self.assertEqual(len(roles), 2 * max_items)
+
+    def test_many_role_policies(self):
+        conn = MockIAMConnection()
+        max_items = conn.DEFAULT_MAX_ITEMS
+
+        conn.create_role('r', MRJOB_SERVICE_ROLE)
+
+        for i in range(2 * max_items):
+            conn.put_role_policy('r', 'rp-%03d' % i,
+                                 json.dumps(MRJOB_SERVICE_ROLE_POLICY))
+
+        policies_page = _unwrap_response(
+            conn.list_role_policies('r'))['policy_names']
+        self.assertEqual(len(policies_page), max_items)
+
+        policies = list(yield_policies_for_role(conn, 'r'))
+        self.assertEqual(len(policies), 2 * max_items)


### PR DESCRIPTION
This fixes #999, which prevents mrjob from working for new AWS accounts. It's similar to automatic bucket creation; mrjob only creates IAM objects as needed, and once it's created them, they can be reused.

Also added an `iam_service_role` option and renamed the `iam_job_flow_role` option to `iam_instance_profile` because it's not just out-of-date, it's actually incorrect (IAM instance profiles are different from IAM roles). `iam_job_flow_role` still works; it's just deprecated.


