### PR TITLE
Fallback IAM role/profile

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1570,6 +1570,7 @@ class EMRJobRunner(MRJobRunner):
         # keep track of when we launched our job
         self._emr_job_start = time.time()
 
+    # TODO: break this method up; it's too big to write tests for
     def _wait_for_job_to_complete(self):
         """Wait for the job to complete, and raise an exception if
         the job failed.

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1392,7 +1392,7 @@ class EMRJobRunner(MRJobRunner):
             return (self._opts['iam_instance_profile'] or
                     get_or_create_mrjob_instance_profile(self.make_iam_conn()))
         except boto.exception.BotoServerError as ex:
-            if ex.code != 'AccessDenied':
+            if ex.status != 403:
                 raise
             log.warning(
                 "Can't access IAM API, trying default instance profile: %s" %
@@ -1404,7 +1404,7 @@ class EMRJobRunner(MRJobRunner):
             return (self._opts['iam_service_role'] or
                     get_or_create_mrjob_service_role(self.make_iam_conn()))
         except boto.exception.BotoServerError as ex:
-            if ex.code != 'AccessDenied':
+            if ex.status != 403:
                 raise
             log.warning(
                 "Can't access IAM API, trying default service role: %s" %

--- a/mrjob/iam.py
+++ b/mrjob/iam.py
@@ -116,6 +116,16 @@ MRJOB_INSTANCE_PROFILE_POLICY = {
     }]
 }
 
+# if we can't create or find our own service role, use the one
+# created by the AWS console and CLI
+FALLBACK_SERVICE_ROLE = 'EMR_DefaultRole'
+
+# if we can't create or find our own instance profile, use the one
+# created by the AWS console and CLI
+FALLBACK_INSTANCE_PROFILE = 'EMR_EC2_DefaultRole'
+
+
+
 log = getLogger(__name__)
 
 


### PR DESCRIPTION
This implements #1008.

Basically, if someone uses mrjob for the first time, and they have full IAM access, mrjob can just create the service role and instance profile for them.

However, if they're don't have full access to IAM, this approach won't work. In this case, the best we can do is hope they (or someone on their account) has followed [Amazon's instructions on how to create these](http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-iam-roles-creatingroles.html), and just go ahead and try to use them. If this fails (because they haven't been created after all), we give them a URL to show to their admin.

This is against the `v0.4.x` branch because it's going to go into `v0.4.5`, which will be a handful of IAM fixes plus some deprecation warnings. As soon as I merge this request, I'll merge `v0.4.x` into `master` (which currently targets `v0.5.0`).
