### PR TITLE
use managed IAM policies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,9 @@
-v0.4.5, 2015-??-?? -- ???
+v0.4.5, 2015-??-?? -- IAM Fortified
  * runners:
    * EMR:
      * aws_security_token for temporary credentials (#1003)
+     * Use AWS managed policies when creating IAM objects (#1026)
+     * Fall back to default role/instance profile when no IAM access (#1008)
  * more efficient decoding of bz2 files
 
 v0.4.4, 2015-04-21 -- EMRgency!

--- a/mrjob/iam.py
+++ b/mrjob/iam.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
 # Copyright 2015 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,7 +51,35 @@ MRJOB_SERVICE_ROLE = {
     }]
 }
 
+# Role to wrap in an instance profile
+MRJOB_INSTANCE_PROFILE_ROLE = {
+    "Version": "2008-10-17",
+    "Statement": [{
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "ec2.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+    }]
+}
+
+# the built-in, managed policy to attach to MRJOB_SERVICE_ROLE
+EMR_SERVICE_ROLE_POLICY = 'AmazonElasticMapReduceRole'
+
+# the built-in, managed policy to attach to MRJOB_INSTANCE_PROFILE_ROLE
+EMR_INSTANCE_PROFILE_POLICY = 'AmazonElasticMapReduceforEC2Role'
+
+# if we can't create or find our own service role, use the one
+# created by the AWS console and CLI
+FALLBACK_SERVICE_ROLE = 'EMR_DefaultRole'
+
+# if we can't create or find our own instance profile, use the one
+# created by the AWS console and CLI
+FALLBACK_INSTANCE_PROFILE = 'EMR_EC2_DefaultRole'
+
 # policy to add to MRJOB_SERVICE_ROLE
+# Deprecated in v0.4.5, will be removed in v0.5.0
 MRJOB_SERVICE_ROLE_POLICY = {
     "Version": "2012-10-17",
     "Statement": [{
@@ -84,19 +111,6 @@ MRJOB_SERVICE_ROLE_POLICY = {
     }]
 }
 
-# Role to wrap in an instance profile
-MRJOB_INSTANCE_PROFILE_ROLE = {
-    "Version": "2008-10-17",
-    "Statement": [{
-        "Sid": "",
-        "Effect": "Allow",
-        "Principal": {
-            "Service": "ec2.amazonaws.com"
-        },
-        "Action": "sts:AssumeRole"
-    }]
-}
-
 # policy to attach to MRJOB_INSTANCE_PROFILE_ROLE
 MRJOB_INSTANCE_PROFILE_POLICY = {
     "Statement": [{
@@ -115,14 +129,6 @@ MRJOB_INSTANCE_PROFILE_POLICY = {
         "Resource": ["*"]
     }]
 }
-
-# if we can't create or find our own service role, use the one
-# created by the AWS console and CLI
-FALLBACK_SERVICE_ROLE = 'EMR_DefaultRole'
-
-# if we can't create or find our own instance profile, use the one
-# created by the AWS console and CLI
-FALLBACK_INSTANCE_PROFILE = 'EMR_EC2_DefaultRole'
 
 
 

--- a/mrjob/iam.py
+++ b/mrjob/iam.py
@@ -65,10 +65,12 @@ MRJOB_INSTANCE_PROFILE_ROLE = {
 }
 
 # the built-in, managed policy to attach to MRJOB_SERVICE_ROLE
-EMR_SERVICE_ROLE_POLICY = 'AmazonElasticMapReduceRole'
+EMR_SERVICE_ROLE_POLICY_ARN = (
+    'arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole')
 
 # the built-in, managed policy to attach to MRJOB_INSTANCE_PROFILE_ROLE
-EMR_INSTANCE_PROFILE_POLICY = 'AmazonElasticMapReduceforEC2Role'
+EMR_INSTANCE_PROFILE_POLICY_ARN = (
+    'arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role')
 
 # if we can't create or find our own service role, use the one
 # created by the AWS console and CLI
@@ -77,58 +79,6 @@ FALLBACK_SERVICE_ROLE = 'EMR_DefaultRole'
 # if we can't create or find our own instance profile, use the one
 # created by the AWS console and CLI
 FALLBACK_INSTANCE_PROFILE = 'EMR_EC2_DefaultRole'
-
-# policy to add to MRJOB_SERVICE_ROLE
-# Deprecated in v0.4.5, will be removed in v0.5.0
-MRJOB_SERVICE_ROLE_POLICY = {
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Action": [
-            "ec2:AuthorizeSecurityGroupIngress",
-            "ec2:CancelSpotInstanceRequests",
-            "ec2:CreateSecurityGroup",
-            "ec2:CreateTags",
-            "ec2:Describe*",
-            "ec2:DeleteTags",
-            "ec2:ModifyImageAttribute",
-            "ec2:ModifyInstanceAttribute",
-            "ec2:RequestSpotInstances",
-            "ec2:RunInstances",
-            "ec2:TerminateInstances",
-            "iam:PassRole",
-            "iam:ListRolePolicies",
-            "iam:GetRole",
-            "iam:GetRolePolicy",
-            "iam:ListInstanceProfiles",
-            "s3:Get*",
-            "s3:List*",
-            "s3:CreateBucket",
-            "sdb:BatchPutAttributes",
-            "sdb:Select"
-        ],
-        "Effect": "Allow",
-        "Resource": "*"
-    }]
-}
-
-# policy to attach to MRJOB_INSTANCE_PROFILE_ROLE
-MRJOB_INSTANCE_PROFILE_POLICY = {
-    "Statement": [{
-        "Action": [
-            "cloudwatch:*",
-            "dynamodb:*",
-            "ec2:Describe*",
-            "elasticmapreduce:Describe*",
-            "rds:Describe*",
-            "s3:*",
-            "sdb:*",
-            "sns:*",
-            "sqs:*"
-        ],
-        "Effect": "Allow",
-        "Resource": ["*"]
-    }]
-}
 
 
 
@@ -182,123 +132,51 @@ def _get_responses(conn, action, params, *args, **kwargs):
             return
 
 
-def yield_instance_profiles_with_policies(conn):
-    """Yield (instance_proile_name, (role_document, [policy_documents])).
-
-    This works just like yield_roles_with_policies(), except it
-    gives the instance profile's name rather than the role name
-    (instance profiles are just thin wrappers for roles).
-    """
-    # could support path_prefix here, but mrjob isn't using it
-    resps = _get_responses(conn, 'ListInstanceProfiles', {},
-                           list_marker='InstanceProfiles')
-
-    for resp in resps:
-        for profile_data in resp['instance_profiles']:
-            profile_name = profile_data['instance_profile_name']
-
-            if profile_data['roles']:
-                # doesn't look like boto can handle two list markers, hence
-                # the extra "member" layer
-                role_data = profile_data['roles']['member']
-                _, role_with_policies = _get_role_with_policies(
-                    conn, role_data)
-            else:
-                role_with_policies = None
-
-            yield (profile_name, role_with_policies)
-
-
-def yield_roles_with_policies(conn, path=None):
-    """Yield (role_name, (role_document, [policy_documents])).
-
-    path is an exact path to match.
-    """
-    # could support path_prefix here, but mrjob isn't using it, and EMR
-    # role policies apparently have to have a path of / anyways
-
-    resps = _get_responses(conn, 'ListRoles', {}, list_marker='Roles')
-
-    for resp in resps:
-        for role_data in resp['roles']:
-            if path and role_data['path'] != path:
-                continue
-
-            yield _get_role_with_policies(conn, role_data)
-
-
-def _get_role_with_policies(conn, role_data):
-    """Returns (role_name, (role, policies))."""
-    role_name = role_data['role_name']
-    role = _unquote_json(role_data['assume_role_policy_document'])
-
-    policies = [policy for policy_name, policy in
-                yield_policies_for_role(conn, role_name)]
-
-    return (role_name, (role, policies))
-
-
-def yield_policies_for_role(conn, role_name):
-    """Given a role name, yield (policy_name, policy_document)
-
-    conn should be a boto.iam.IAMConnection
-    """
-    resps = _get_responses(conn,
-                           'ListRolePolicies',
-                           {'RoleName': role_name},
-                           list_marker='PolicyNames')
-
-    for resp in resps:
-        policy_names = resp['policy_names']
-
-        for policy_name in policy_names:
-            resp = _get_response(conn,
-                                 'GetRolePolicy',
-                                 {'RoleName': role_name,
-                                  'PolicyName': policy_name})
-
-            policy = _unquote_json(resp['policy_document'])
-            yield (policy_name, policy)
-
-
-def role_with_policies_matches(rp1, rp2):
-    role1, policies1 = rp1
-    role2, policies2 = rp2
-
-    # JSON-encode to allow sorting in Python 3
-    def dumps(x):
-        return json.dumps(x, sort_keys=True)
-
-    # Could make this a bit more lenient. For example, it doesn't look
-    # like the ordering of lists in any of these documents matters. For
-    # now, I'm just making mrjob's defaults the same as the ones created
-    # by awscli
-    return (role1 == role2 and
-            sorted(dumps(p1) for p1 in policies1) ==
-            sorted(dumps(p2) for p2 in policies2))
-
-
 def get_or_create_mrjob_service_role(conn):
-    target_role_with_policies = (
-        MRJOB_SERVICE_ROLE, [MRJOB_SERVICE_ROLE_POLICY])
-
     # As of 2015-04-20, it looks like EMR won't accept roles with a path
     # other than '/' (the default). Looks like what's happening is that EMR
     # forgets to include the path in the ARN.
     #
-    # This doesn't affect instance profiles.
-    for role_name, role_with_policies in (
-            yield_roles_with_policies(conn, path='/')):
-        if role_with_policies_matches(role_with_policies,
-                                      target_role_with_policies):
+    # This doesn't affect instance profiles
+    for role_name, role in _yield_roles(conn):
+        if role != MRJOB_SERVICE_ROLE:
+            continue
+
+        policy_arns = list(_yield_attached_role_policies(conn, role_name))
+        if policy_arns == [EMR_SERVICE_ROLE_POLICY_ARN]:
             return role_name
 
-    role_name = _create_mrjob_role_with_policies(
-        conn, *target_role_with_policies)
+    role_name = _create_mrjob_role_with_attached_policy(
+        conn, MRJOB_SERVICE_ROLE, EMR_SERVICE_ROLE_POLICY_ARN)
 
     log.info('Auto-created service role %s' % role_name)
 
     return role_name
+
+
+def _yield_roles(conn):
+    """Yield (role_name, role_document)."""
+    resps = _get_responses(conn, 'ListRoles', {}, list_marker='Roles')
+
+    for resp in resps:
+        for role_data in resp['roles']:
+            role_name = role_data['role_name']
+            role = _unquote_json(role_data['assume_role_policy_document'])
+
+            yield (role_name, role)
+
+
+def _yield_attached_role_policies(conn, role_name):
+    """Yield the ARNs for policies attached to the given role."""
+    # allowing for multiple responses might be overkill, as currently
+    # (2015-05-29) only two policies are allowed per role.
+    resps = _get_responses(conn, 'ListAttachedRolePolicies',
+                           {'RoleName': role_name},
+                           list_marker='AttachedPolicies')
+
+    for resp in resps:
+        for policy_data in resp['attached_policies']:
+            yield policy_data['policy_arn']
 
 
 def get_or_create_mrjob_instance_profile(conn):
@@ -324,6 +202,194 @@ def get_or_create_mrjob_instance_profile(conn):
     log.info('Auto-created instance profile %s' % name)
 
     return name
+
+
+def _create_mrjob_role_with_attached_policy(conn, role, policy_arn):
+    # create role
+    role_name = 'mrjob-' + random_identifier()
+
+    _get_response(conn, 'CreateRole', {
+        'AssumeRolePolicyDocument': json.dumps(role),
+        'RoleName': role_name})
+
+    _get_response(conn, 'AttachRolePolicy', {
+        'PolicyArn': policy_arn,
+        'RoleName': role_name})
+
+    return role_name
+
+
+# DEPRECATED STUFF
+
+# all this is deprecated as of v0.4.5, to be removed in v0.5.0
+
+# v0.4.4 used built-in role policies, but the built-in managed ones
+# are a better idea. See #1026
+
+# policy to add to MRJOB_SERVICE_ROLE
+MRJOB_SERVICE_ROLE_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Action": [
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:CancelSpotInstanceRequests",
+            "ec2:CreateSecurityGroup",
+            "ec2:CreateTags",
+            "ec2:Describe*",
+            "ec2:DeleteTags",
+            "ec2:ModifyImageAttribute",
+            "ec2:ModifyInstanceAttribute",
+            "ec2:RequestSpotInstances",
+            "ec2:RunInstances",
+            "ec2:TerminateInstances",
+            "iam:PassRole",
+            "iam:ListRolePolicies",
+            "iam:GetRole",
+            "iam:GetRolePolicy",
+            "iam:ListInstanceProfiles",
+            "s3:Get*",
+            "s3:List*",
+            "s3:CreateBucket",
+            "sdb:BatchPutAttributes",
+            "sdb:Select"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+    }]
+}
+
+# policy to attach to MRJOB_INSTANCE_PROFILE_ROLE
+MRJOB_INSTANCE_PROFILE_POLICY = {
+    "Statement": [{
+        "Action": [
+            "cloudwatch:*",
+            "dynamodb:*",
+            "ec2:Describe*",
+            "elasticmapreduce:Describe*",
+            "rds:Describe*",
+            "s3:*",
+            "sdb:*",
+            "sns:*",
+            "sqs:*"
+        ],
+        "Effect": "Allow",
+        "Resource": ["*"]
+    }]
+}
+
+
+def yield_roles_with_policies(conn, path=None):
+    """Yield (role_name, (role_document, [policy_documents])).
+
+    path is an exact path to match.
+    """
+    log.warning('yield_roles_with_policies() is deprecated'
+                ' and will be removed in v0.5.0')
+
+    # could support path_prefix here, but mrjob isn't using it, and EMR
+    # role policies apparently have to have a path of / anyways
+
+    resps = _get_responses(conn, 'ListRoles', {}, list_marker='Roles')
+
+    for resp in resps:
+        for role_data in resp['roles']:
+            if path and role_data['path'] != path:
+                continue
+
+            yield _get_role_with_policies(conn, role_data)
+
+
+def yield_policies_for_role(conn, role_name):
+    """Given a role name, yield (policy_name, policy_document)
+
+    conn should be a boto.iam.IAMConnection
+    """
+    log.warning('yield_policies_for_role() is deprecated'
+                ' and will be removed in v0.5.0')
+
+    resps = _get_responses(conn,
+                           'ListRolePolicies',
+                           {'RoleName': role_name},
+                           list_marker='PolicyNames')
+
+    for resp in resps:
+        policy_names = resp['policy_names']
+
+        for policy_name in policy_names:
+            resp = _get_response(conn,
+                                 'GetRolePolicy',
+                                 {'RoleName': role_name,
+                                  'PolicyName': policy_name})
+
+            policy = _unquote_json(resp['policy_document'])
+            yield (policy_name, policy)
+
+
+def yield_instance_profiles_with_policies(conn):
+    """Yield (instance_proile_name, (role_document, [policy_documents])).
+
+    This works just like yield_roles_with_policies(), except it
+    gives the instance profile's name rather than the role name
+    (instance profiles are just thin wrappers for roles).
+    """
+    log.warning('yield_instance_profiles_with_policies() is deprecated'
+                ' and will be removed in v0.5.0')
+
+
+    # could support path_prefix here, but mrjob isn't using it
+    resps = _get_responses(conn, 'ListInstanceProfiles', {},
+                           list_marker='InstanceProfiles')
+
+    for resp in resps:
+        for profile_data in resp['instance_profiles']:
+            profile_name = profile_data['instance_profile_name']
+
+            if profile_data['roles']:
+                # doesn't look like boto can handle two list markers, hence
+                # the extra "member" layer
+                role_data = profile_data['roles']['member']
+                _, role_with_policies = _get_role_with_policies(
+                    conn, role_data)
+            else:
+                role_with_policies = None
+
+            yield (profile_name, role_with_policies)
+
+
+
+
+def _get_role_with_policies(conn, role_data):
+    """Returns (role_name, (role, policies))."""
+    role_name = role_data['role_name']
+    role = _unquote_json(role_data['assume_role_policy_document'])
+
+    policies = [policy for policy_name, policy in
+                yield_policies_for_role(conn, role_name)]
+
+    return (role_name, (role, policies))
+
+
+def role_with_policies_matches(rp1, rp2):
+    log.warning('role_with_policies_matches() is deprecated'
+                ' and will be removed in v0.5.0')
+
+    role1, policies1 = rp1
+    role2, policies2 = rp2
+
+    # JSON-encode to allow sorting in Python 3
+    def dumps(x):
+        return json.dumps(x, sort_keys=True)
+
+    # Could make this a bit more lenient. For example, it doesn't look
+    # like the ordering of lists in any of these documents matters. For
+    # now, I'm just making mrjob's defaults the same as the ones created
+    # by awscli
+    return (role1 == role2 and
+            sorted(dumps(p1) for p1 in policies1) ==
+            sorted(dumps(p2) for p2 in policies2))
+
+
+
 
 
 def _create_mrjob_role_with_policies(conn, role, policies):

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -892,7 +892,8 @@ class MockIAMConnection(object):
                  debug=0, https_connection_factory=None, path='/',
                  security_token=None, validate_certs=True, profile_name=None,
                  mock_iam_instance_profiles=None, mock_iam_roles=None,
-                 mock_iam_role_policies=None):
+                 mock_iam_role_policies=None,
+                 mock_iam_role_attached_policies=None):
         """Mock out connection to IAM.
 
         mock_iam_instance_profiles maps profile name to a dictionary containing:
@@ -909,14 +910,19 @@ class MockIAMConnection(object):
             policy_document -- JSON-then-URI-encoded policy doc
             role_name -- name of single role for this policy (always defined)
 
-        We don't currently support role IDs or ARNs because our code doesn't
-        use them.
+        mock_iam_role_attached_policies maps role to a list of ARNs for
+        attached (managed) policies.
+
+        We don't track which managed policies exist or what their contents are.
+        We also don't support role IDs.
         """
         self.mock_iam_instance_profiles = combine_values(
             {}, mock_iam_instance_profiles)
         self.mock_iam_roles = combine_values({}, mock_iam_roles)
         self.mock_iam_role_policies = combine_values(
             {}, mock_iam_role_policies)
+        self.mock_iam_role_attached_policies = combine_values(
+            {}, mock_iam_role_attached_policies)
 
     def get_response(self, action, params, path='/', parent=None,
                      verb='POST', list_marker='Set'):
@@ -927,6 +933,10 @@ class MockIAMConnection(object):
             return self.add_role_to_instance_profile(
                 params['InstanceProfileName'],
                 params['RoleName'])
+
+        elif action == 'AttachRolePolicy':
+            return self._attach_role_policy(params['RoleName'],
+                                            params['PolicyArn'])
 
         elif action == 'CreateInstanceProfile':
             return self.create_instance_profile(
@@ -943,6 +953,12 @@ class MockIAMConnection(object):
             return self.get_role_policy(
                 params['RoleName'],
                 params['PolicyName'])
+
+        elif action == 'ListAttachedRolePolicies':
+            if list_marker != 'AttachedPolicies':
+                raise ValueError
+
+            return self._list_attached_role_policies(params['RoleName'])
 
         elif action == 'ListInstanceProfiles':
             if list_marker != 'InstanceProfiles':
@@ -978,6 +994,7 @@ class MockIAMConnection(object):
                 params['RoleName'],
                 params['PolicyName'],
                 params['PolicyDocument'])
+
 
         else:
             raise NotImplementedError(
@@ -1135,7 +1152,7 @@ class MockIAMConnection(object):
             path=role_data['path']
         )
 
-    # role policies
+    # (inline) role policies
 
     def get_role_policy(self, role_name, policy_name):
         self._check_role_exists(role_name)
@@ -1184,6 +1201,28 @@ class MockIAMConnection(object):
             policy_name=policy_name,
             role_name=policy_data['role_name'],
         )
+
+    # attached (managed) role policies
+
+    # boto does not yet have methods for these
+
+    def _attach_role_policy(self, role_name, policy_arn):
+        self._check_role_exists(role_name)
+
+        arns = self.mock_iam_role_attached_policies.setdefault(role_name, [])
+        if policy_arn not in arns:
+            arns.append(policy_arn)
+
+        return self._wrap_result('attach_role_policy')
+
+    def _list_attached_role_policies(self, role_name):
+        self._check_role_exists(role_name)
+
+        arns = self.mock_iam_role_attached_policies.get(role_name, [])
+
+        return self._wrap_result('list_attached_role_policies',
+                                 {'attached_policies': [
+                                     {'policy_arn': arn} for arn in arns]})
 
     # other utilities
 

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -980,7 +980,8 @@ class MockIAMConnection(object):
                 params['PolicyDocument'])
 
         else:
-            raise ValueError
+            raise NotImplementedError(
+                'mockboto does not implement the %s API call' % action)
 
     # instance profiles
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -145,6 +145,8 @@ class MockEMRAndS3TestCase(FastEMRTestCase):
         kwargs['mock_iam_instance_profiles'] = self.mock_iam_instance_profiles
         kwargs['mock_iam_roles'] = self.mock_iam_roles
         kwargs['mock_iam_role_policies'] = self.mock_iam_role_policies
+        kwargs['mock_iam_role_attached_policies'] = (
+            self.mock_iam_role_attached_policies)
         return MockIAMConnection(*args, **kwargs)
 
     def setUp(self):
@@ -153,6 +155,7 @@ class MockEMRAndS3TestCase(FastEMRTestCase):
         self.mock_emr_job_flows = {}
         self.mock_emr_output = {}
         self.mock_iam_instance_profiles = {}
+        self.mock_iam_role_attached_policies = {}
         self.mock_iam_role_policies = {}
         self.mock_iam_roles = {}
         self.mock_s3_fs = {}
@@ -641,14 +644,16 @@ class IAMTestCase(MockEMRAndS3TestCase):
         self.assertTrue(instance_profile_name.startswith('mrjob-'))
         self.assertIn(instance_profile_name, self.mock_iam_instance_profiles)
         self.assertIn(instance_profile_name, self.mock_iam_roles)
-        self.assertIn(instance_profile_name, self.mock_iam_role_policies)
+        self.assertIn(instance_profile_name,
+                      self.mock_iam_role_attached_policies)
 
         # check service_role
         service_role_name = job_flow.servicerole
         self.assertIsNotNone(service_role_name)
         self.assertTrue(service_role_name.startswith('mrjob-'))
         self.assertIn(service_role_name, self.mock_iam_roles)
-        self.assertIn(service_role_name, self.mock_iam_role_policies)
+        self.assertIn(service_role_name,
+                      self.mock_iam_role_attached_policies)
 
         # instance_profile and service_role should be distinct
         self.assertNotEqual(instance_profile_name, service_role_name)


### PR DESCRIPTION
This implements #1026.

Basically, we're working a little harder than we need to to set up IAM for EMR. We *do* need to create roles and an instance profile, but instead of creating policies, we can simply "attach" ones already in AWS. This is not only simpler, it's better because these "managed" policies are versioned and will be automatically updated to track changes in EMR.

Apparently (based on email conversations with a senior manager on the EMR team), the AWS web interface and CLI are going to work this way soon as well. Once they do, mrjob will be able to find and use the role/profile they create rather than auto-creating its own.

Hand-tested this in addition to updating the unit tests.