### PR TITLE
Make the --hadoop-home command line option work

### DIFF
--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -270,6 +270,12 @@ def add_hadoop_opts(opt_group):
             help='hadoop binary. Defaults to $HADOOP_HOME/bin/hadoop'),
 
         opt_group.add_option(
+            '--hadoop-home', dest='hadoop_home',
+            default=None,
+            help='Alternative to setting the HADOOP_HOME environment variable.'),
+
+
+        opt_group.add_option(
             '--hdfs-scratch-dir', dest='hdfs_scratch_dir',
             default=None,
             help='Scratch space on HDFS (default is tmp/)'),


### PR DESCRIPTION
The `--hadoop-home` command line option was not working for me (using v0.4.4).

A simple fix to *mrjob/options.py* did the trick.

Best regards!