### PR TITLE
python_bin and interpreter options

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -201,7 +201,8 @@ Job execution context
     :default: ``None``
 
     Interpreter to launch your script with (e.g. ``'ruby'``). Change this if
-    you're using a language other than Python.
+    you're using a language other than Python. This will also be used to
+    query the script about steps unless you set :mrjob-opt:`steps_interpreter`.
 
 .. mrjob-opt::
     :config: python_bin
@@ -211,8 +212,11 @@ Job execution context
     :default: (automatic)
 
     Name/path of alternate Python binary for wrapper scripts and
-    mappers/reducers. This defaults to ``'python'`` if you're in Python 2
-    and ``'python3'`` if you're in Python 3.
+    mappers/reducers (e.g. ``'python -v'``). This defaults to ``'python'`` if
+    you're in Python 2 and ``'python3'`` if you're in Python 3.
+
+    Unlike :mrjob-opt:`interpreter`, this does not affect the binary used to
+    query the job about its steps (use :mrjob-opt:`steps_python_bin`).
 
 .. mrjob-opt::
     :config: setup
@@ -297,21 +301,18 @@ Job execution context
     :default: current Python interpreter
 
     Name/path of alternate (non-Python) binary to use to query the job about
-    its steps. Defaults to :mrjob-opt:`interpreter`, if set.
+    its steps.
 
 .. mrjob-opt::
     :config: steps_python_bin
     :switch: --steps-python-bin
     :type: :ref:`command <data-type-command>`
     :set: all
-    :default: current Python interpreter
+    :default: (current Python interpreter)
 
     Name/path of alternate python binary to use to query the job about its
-    steps. Rarely needed. Defaults to ``sys.executable`` (the current Python
-    interpreter).
-
-    Unlike :mrjob-opt:`steps_interpreter`, this is unaffected by changes to
-    :mrjob-opt:`python_bin`.
+    steps. Rarely needed. If not set, we use ``sys.executable`` (the current
+    Python interpreter).
 
 .. mrjob-opt::
     :config: strict_protocols

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -200,9 +200,15 @@ Job execution context
     :set: all
     :default: ``None``
 
-    Interpreter to launch your script with (e.g. ``'ruby'``). Change this if
-    you're using a language other than Python. This will also be used to
-    query the script about steps unless you set :mrjob-opt:`steps_interpreter`.
+    Non-Python command to launch your script with (e.g. ``'ruby'``).
+    This will also be used to query the script about steps unless you set
+    :mrjob-opt:`steps_interpreter`.
+
+    If you want to use an alternate Python command to run the job, use
+    :mrjob-opt:`python_bin`.
+
+    This takes precedence over :mrjob-opt:`python_bin` and
+    :mrjob-opt:`steps_python_bin`.
 
 .. mrjob-opt::
     :config: python_bin
@@ -214,6 +220,12 @@ Job execution context
     Name/path of alternate Python binary for wrapper scripts and
     mappers/reducers (e.g. ``'python -v'``). This defaults to ``'python'`` if
     you're in Python 2 and ``'python3'`` if you're in Python 3.
+
+    This option also affects which Python binary is used for file locking in
+    :mrjob-opt:`setup` scripts, so it might be useful to set even if you're
+    using a non-Python :mrjob-opt:`interpreter`. It's also used by
+    :py:class:`~mrjob.emr.EMRJobRunner` to compile mrjob after bootstrapping it
+    (see :mrjob-opt:`bootstrap_mrjob`).
 
     Unlike :mrjob-opt:`interpreter`, this does not affect the binary used to
     query the job about its steps (use :mrjob-opt:`steps_python_bin`).
@@ -300,8 +312,13 @@ Job execution context
     :set: all
     :default: current Python interpreter
 
-    Name/path of alternate (non-Python) binary to use to query the job about
-    its steps.
+    Alternate (non-Python) command to use to query the job about
+    its steps. Usually it's good enough to set :mrjob-opt:`interpreter`.
+
+    If you want to use an alternate Python command to get the job's steps,
+    use :mrjob-opt:`steps_python_bin`.
+
+    This takes precedence over :mrjob-opt:`steps_python_bin`.
 
 .. mrjob-opt::
     :config: steps_python_bin

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -39,10 +39,12 @@ options related to file uploading.
     :switch: --bootstrap-mrjob, --no-bootstrap-mrjob
     :type: boolean
     :set: all
-    :default: ``True``
+    :default: (automatic)
 
     Should we automatically tar up the mrjob library and install it when we run
-    job?  Set this to ``False`` if you've already installed ``mrjob`` on your
+    job? By default, we do unless :mrjob:`interpreter` is set.
+
+    Set this to ``False`` if you've already installed ``mrjob`` on your
     Hadoop cluster or install it by some other method.
 
 .. mrjob-opt::

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -1,3 +1,4 @@
+================================
 Options available to all runners
 ================================
 
@@ -19,7 +20,7 @@ initialized programmatically.
 .. _configs-making-files-available:
 
 Making files available to tasks
--------------------------------
+===============================
 
 Most jobs have dependencies of some sort - Python packages, Debian packages,
 data files, etc. This section covers options available to all runners that
@@ -90,7 +91,7 @@ options related to file uploading.
     :envvar:`PYTHONPATH`.
 
 Temp files and cleanup
-----------------------
+======================
 
 .. mrjob-opt::
     :config: base_tmp_dir
@@ -170,7 +171,7 @@ Temp files and cleanup
     conjunction with ``--output-dir`` to store output only in HDFS or S3.
 
 Job execution context
----------------------
+=====================
 
 .. mrjob-opt::
     :config: cmdenv
@@ -197,21 +198,21 @@ Job execution context
     :switch: --interpreter
     :type: :ref:`string <data-type-string>`
     :set: all
-    :default: value of :mrjob-opt:`python_bin` (``'python'``)
+    :default: ``None``
 
-    Interpreter to launch your script with. Defaults to the value of
-    **python_bin**, which is deprecated. Change this if you're using a
-    language besides Python 2.6-2.7.
+    Interpreter to launch your script with (e.g. ``'ruby'``). Change this if
+    you're using a language other than Python.
 
 .. mrjob-opt::
     :config: python_bin
     :switch: --python-bin
     :type: :ref:`command <data-type-command>`
     :set: all
-    :default: ``'python'``
+    :default: (automatic)
 
-    Deprecated (use :mrjob-opt:`interpreter` instead). Name/path of alternate
-    Python binary for wrapper scripts and mappers/reducers.
+    Name/path of alternate Python binary for wrapper scripts and
+    mappers/reducers. This defaults to ``'python'`` if you're in Python 2
+    and ``'python3'`` if you're in Python 3.
 
 .. mrjob-opt::
     :config: setup
@@ -289,6 +290,16 @@ Job execution context
     an error, use ``'sh -e'``.
 
 .. mrjob-opt::
+    :config: steps_interpreter
+    :switch: --steps-interpreter
+    :type: :ref:`command <data-type-command>`
+    :set: all
+    :default: current Python interpreter
+
+    Name/path of alternate (non-Python) binary to use to query the job about
+    its steps. Defaults to :mrjob-opt:`interpreter`, if set.
+
+.. mrjob-opt::
     :config: steps_python_bin
     :switch: --steps-python-bin
     :type: :ref:`command <data-type-command>`
@@ -298,6 +309,9 @@ Job execution context
     Name/path of alternate python binary to use to query the job about its
     steps. Rarely needed. Defaults to ``sys.executable`` (the current Python
     interpreter).
+
+    Unlike :mrjob-opt:`steps_interpreter`, this is unaffected by changes to
+    :mrjob-opt:`python_bin`.
 
 .. mrjob-opt::
     :config: strict_protocols
@@ -314,7 +328,7 @@ Job execution context
         "Loose" protocols are going away in v0.6.0.
 
 Other
------
+=====
 
 .. mrjob-opt::
     :config: conf_paths
@@ -350,7 +364,7 @@ Other
 
 
 Options ignored by the local and inline runners
------------------------------------------------
+===============================================
 
 These options are ignored because they require a real instance of Hadoop:
 
@@ -362,7 +376,7 @@ These options are ignored because they require a real instance of Hadoop:
 
 
 Options ignored by the inline runner
-------------------------------------
+====================================
 
 These options are ignored because the ``inline`` runner does not invoke the job
 as a subprocess:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2040,7 +2040,7 @@ class EMRJobRunner(MRJobRunner):
                 "__mrjob_PYTHON_LIB=$(%s -c "
                 "'from distutils.sysconfig import get_python_lib;"
                 " print(get_python_lib())')" %
-                cmd_line(self._opts['python_bin'])])
+                cmd_line(self._python_bin())])
             # un-tar mrjob.tar.gz
             mrjob_bootstrap.append(
                 ['sudo tar xfz ', path_dict, ' -C $__mrjob_PYTHON_LIB'])
@@ -2050,7 +2050,7 @@ class EMRJobRunner(MRJobRunner):
             # sh_bin were 'sh -e')
             mrjob_bootstrap.append(
                 ['sudo %s -m compileall -f $__mrjob_PYTHON_LIB/mrjob && true' %
-                 cmd_line(self._opts['python_bin'])])
+                 cmd_line(self._python_bin())])
 
         # we call the script b.py because there's a character limit on
         # bootstrap script names (or there was at one time, anyway)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -862,7 +862,7 @@ class EMRJobRunner(MRJobRunner):
         persistent -- set by make_persistent_job_flow()
         """
         # lazily create mrjob.tar.gz
-        if self._opts['bootstrap_mrjob']:
+        if self._bootstrap_mrjob():
             self._create_mrjob_tar_gz()
             self._bootstrap_dir_mgr.add('file', self._mrjob_tar_gz_path)
 
@@ -2023,12 +2023,12 @@ class EMRJobRunner(MRJobRunner):
         # Also don't bother if we're not bootstrapping
         if not (self._bootstrap or self._legacy_bootstrap or
                 self._opts['bootstrap_files'] or
-                self._opts['bootstrap_mrjob']):
+                self._bootstrap_mrjob()):
             return
 
         # create mrjob.tar.gz if we need it, and add commands to install it
         mrjob_bootstrap = []
-        if self._opts['bootstrap_mrjob']:
+        if self._bootstrap_mrjob():
             # _add_bootstrap_files_for_upload() should have done this
             assert self._mrjob_tar_gz_path
             path_dict = {
@@ -2500,10 +2500,10 @@ class EMRJobRunner(MRJobRunner):
             self._bootstrap,
             self._bootstrap_actions,
             self._opts['bootstrap_cmds'],
-            self._opts['bootstrap_mrjob'],
+            self._bootstrap_mrjob(),
         ]
 
-        if self._opts['bootstrap_mrjob']:
+        if self._bootstrap_mrjob():
             things_to_hash.append(mrjob.__version__)
 
         things_json = json.dumps(things_to_hash, sort_keys=True)

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -76,13 +76,6 @@ def _chain_procs(procs_args, **kwargs):
     return procs
 
 
-class LocalRunnerOptionStore(SimRunnerOptionStore):
-
-    def _default_python_bin(self, local=False):
-        return super(LocalRunnerOptionStore, self)._default_python_bin(
-            local=True)
-
-
 class LocalMRJobRunner(SimMRJobRunner):
     """Runs an :py:class:`~mrjob.job.MRJob` locally, for testing purposes.
     Invoked when you run your job with ``-r local``.
@@ -98,8 +91,6 @@ class LocalMRJobRunner(SimMRJobRunner):
 
     """
     alias = 'local'
-
-    OPTION_STORE_CLASS = LocalRunnerOptionStore
 
     def __init__(self, **kwargs):
         """Arguments to this constructor may also appear in :file:`mrjob.conf`
@@ -288,3 +279,7 @@ class LocalMRJobRunner(SimMRJobRunner):
             for line in parsed['other']:
                 log.error('STDERR: %s' % line.rstrip('\r\n'))
                 yield line
+
+    def _default_python_bin(self, local=False):
+        return super(LocalRunnerOptionStore, self)._default_python_bin(
+            local=True)

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -281,5 +281,5 @@ class LocalMRJobRunner(SimMRJobRunner):
                 yield line
 
     def _default_python_bin(self, local=False):
-        return super(LocalRunnerOptionStore, self)._default_python_bin(
+        return super(LocalMRJobRunner, self)._default_python_bin(
             local=True)

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -120,7 +120,7 @@ def add_runner_opts(opt_group, default_runner='local'):
 
         opt_group.add_option(
             '--interpreter', dest='interpreter', default=None,
-            help=("Interpreter to run your script, e.g. python or ruby.")),
+            help=('Non-python interpreter to run your script, e.g. "ruby".')),
 
         opt_group.add_option(
             '--job-name', dest='job_name', default=None,
@@ -155,9 +155,9 @@ def add_runner_opts(opt_group, default_runner='local'):
 
         opt_group.add_option(
             '--python-bin', dest='python_bin', default=None,
-            help=("Deprecated. Name/path of alternate python binary for"
-                  " wrapper script and Python mappers/reducers. You can"
-                  " include arguments, e.g. --python-bin 'python -v'")),
+            help=('Name/path of alternate python binary for Python'
+                  ' mappers/reducers. You can'
+                  ' include arguments, e.g. --python-bin "python -v"')),
 
         opt_group.add_option(
             '-r', '--runner', dest='runner', default=default_runner,
@@ -192,13 +192,13 @@ def add_runner_opts(opt_group, default_runner='local'):
 
         opt_group.add_option(
             '--steps-interpreter', dest='steps_interpreter', default=None,
-            help=("Name/path of alternate interpreter binary to use to query"
+            help=("Name/path of alternate (non-Python) binary to use to query"
                   " the job about its steps, if different from --interpreter."
                   " Rarely needed.")),
 
         opt_group.add_option(
             '--steps-python-bin', dest='steps_python_bin', default=None,
-            help=('Deprecated. Name/path of alternate python binary to use to'
+            help=('Name/path of alternate python binary to use to'
                   ' query the job about its steps, if different from the'
                   ' current Python interpreter. Rarely needed.')),
     ]

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -120,7 +120,7 @@ def add_runner_opts(opt_group, default_runner='local'):
 
         opt_group.add_option(
             '--interpreter', dest='interpreter', default=None,
-            help=('Non-python interpreter to run your script, e.g. "ruby".')),
+            help=('Non-python command to run your script, e.g. "ruby".')),
 
         opt_group.add_option(
             '--job-name', dest='job_name', default=None,
@@ -155,7 +155,7 @@ def add_runner_opts(opt_group, default_runner='local'):
 
         opt_group.add_option(
             '--python-bin', dest='python_bin', default=None,
-            help=('Name/path of alternate python binary for Python'
+            help=('Alternate python command for Python'
                   ' mappers/reducers. You can'
                   ' include arguments, e.g. --python-bin "python -v"')),
 
@@ -192,15 +192,14 @@ def add_runner_opts(opt_group, default_runner='local'):
 
         opt_group.add_option(
             '--steps-interpreter', dest='steps_interpreter', default=None,
-            help=("Name/path of alternate (non-Python) binary to use to query"
-                  " the job about its steps, if different from --interpreter."
-                  " Rarely needed.")),
+            help=("Non-Python command to use to query the job about its"
+                  " steps, if different from --interpreter.")),
 
         opt_group.add_option(
             '--steps-python-bin', dest='steps_python_bin', default=None,
-            help=('Name/path of alternate python binary to use to'
+            help=('Name/path of alternate python command to use to'
                   ' query the job about its steps, if different from the'
-                  ' current Python interpreter. Rarely needed.')),
+                  ' current Python interpreter.')),
     ]
 
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -736,12 +736,10 @@ class MRJobRunner(object):
         if steps:
             return (self._opts['steps_interpreter'] or
                     self._opts['interpreter'] or
-                    self._opts['steps_python_bin'] or
-                    self._default_python_bin(local=True))
+                    self._python_bin(steps=True))
         else:
             return (self._opts['interpreter'] or
-                    self._opts['python_bin'] or
-                    self._default_python_bin(local=False))
+                    self._python_bin())
 
     def _executable(self, steps=False):
         if steps:
@@ -749,6 +747,14 @@ class MRJobRunner(object):
         else:
             return self._interpreter() + [
                 self._working_dir_mgr.name('file', self._script_path)]
+
+    def _python_bin(self, steps=False):
+        if steps:
+            return (self._opts['steps_python_bin'] or
+                    self._default_python_bin(local=True))
+        else:
+            return (self._opts['python_bin'] or
+                    self._default_python_bin())
 
     def _default_python_bin(self, local=False):
         """The default python command. If local is true, try to use
@@ -1003,7 +1009,7 @@ class MRJobRunner(object):
         writeln('exec 9>/tmp/wrapper.lock.%s' % self._job_name)
         # would use flock(1), but it's not always available
         writeln("%s -c 'import fcntl; fcntl.flock(9, fcntl.LOCK_EX)'" %
-                cmd_line(self._opts['python_bin']))
+                cmd_line(self._python_bin()))
         writeln()
 
         writeln('# setup commands')

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -722,7 +722,7 @@ class MRJobRunner(object):
             if not self._script_path:
                 self._steps = []
             else:
-                args = (self._executable(True) + ['--steps'] +
+                args = (self.interpreter(True) + ['--steps'] +
                         self._mr_job_extra_args(local=True))
                 log.debug('> %s' % cmd_line(args))
                 # add . to PYTHONPATH (in case mrjob isn't actually installed)
@@ -765,7 +765,7 @@ class MRJobRunner(object):
         """Get the number of steps (calls :py:meth:`get_steps`)."""
         return len(self._get_steps())
 
-    def _executable(self, steps=False):
+    def interpreter(self, steps=False):
         # default behavior is to always use an interpreter. local, emr, and
         # hadoop runners check for executable script paths and prepend the
         # working_dir, discarding the interpreter if possible.
@@ -778,7 +778,7 @@ class MRJobRunner(object):
     def _script_args_for_step(self, step_num, mrc):
         assert self._script_path
 
-        args = self._executable() + [
+        args = self.interpreter() + [
             '--step-num=%d' % step_num,
             '--%s' % mrc,
         ] + self._mr_job_extra_args()

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -180,7 +180,6 @@ class RunnerOptionStore(OptionStore):
 
         return combine_dicts(super_opts, {
             'base_tmp_dir': tempfile.gettempdir(),
-            'bootstrap_mrjob': True,
             'check_input_paths': True,
             'cleanup': ['ALL'],
             'cleanup_on_failure': ['NONE'],
@@ -909,7 +908,7 @@ class MRJobRunner(object):
 
         setup = self._setup
 
-        if self._opts['bootstrap_mrjob'] and self.BOOTSTRAP_MRJOB_IN_SETUP:
+        if self._bootstrap_mrjob() and self.BOOTSTRAP_MRJOB_IN_SETUP:
             # patch setup to add mrjob.tar.gz to PYTYHONPATH
             mrjob_tar_gz = self._create_mrjob_tar_gz()
             path_dict = {'type': 'archive', 'name': None, 'path': mrjob_tar_gz}
@@ -1044,6 +1043,13 @@ class MRJobRunner(object):
         writeln('"$@"')
 
         return out
+
+    def _bootstrap_mrjob(self):
+        """Should we bootstrap mrjob?"""
+        if self._opts['bootstrap_mrjob'] is None:
+            return self._opts['interpreter'] is None
+        else:
+            return bool(self._opts['bootstrap_mrjob'])
 
     def _get_input_paths(self):
         """Get the paths to input files, dumping STDIN to a local

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -722,7 +722,7 @@ class MRJobRunner(object):
             if not self._script_path:
                 self._steps = []
             else:
-                args = (self.interpreter(True) + ['--steps'] +
+                args = (self._executable(True) + ['--steps'] +
                         self._mr_job_extra_args(local=True))
                 log.debug('> %s' % cmd_line(args))
                 # add . to PYTHONPATH (in case mrjob isn't actually installed)
@@ -765,7 +765,7 @@ class MRJobRunner(object):
         """Get the number of steps (calls :py:meth:`get_steps`)."""
         return len(self._get_steps())
 
-    def interpreter(self, steps=False):
+    def _executable(self, steps=False):
         # default behavior is to always use an interpreter. local, emr, and
         # hadoop runners check for executable script paths and prepend the
         # working_dir, discarding the interpreter if possible.
@@ -778,7 +778,7 @@ class MRJobRunner(object):
     def _script_args_for_step(self, step_num, mrc):
         assert self._script_path
 
-        args = self.interpreter() + [
+        args = self._executable() + [
             '--step-num=%d' % step_num,
             '--%s' % mrc,
         ] + self._mr_job_extra_args()

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -765,15 +765,18 @@ class MRJobRunner(object):
         """Get the number of steps (calls :py:meth:`get_steps`)."""
         return len(self._get_steps())
 
-    def _executable(self, steps=False):
-        # default behavior is to always use an interpreter. local, emr, and
-        # hadoop runners check for executable script paths and prepend the
-        # working_dir, discarding the interpreter if possible.
+    def _interpreter(self, steps=False):
         if steps:
-            return self._opts['steps_interpreter'] + [self._script_path]
+            return self._opts['steps_interpreter']
         else:
-            return (self._opts['interpreter'] +
-                    [self._working_dir_mgr.name('file', self._script_path)])
+            return self._opts['interpreter']
+
+    def _executable(self, steps=False):
+        if steps:
+            return self._interpreter(steps=True) + [self._script_path]
+        else:
+            return self._interpreter() + [
+                self._working_dir_mgr.name('file', self._script_path)]
 
     def _script_args_for_step(self, step_num, mrc):
         assert self._script_path

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -464,7 +464,7 @@ class LocalBootstrapMrjobTestCase(TestCase):
 
             with mr_job.make_runner() as runner:
                 # sanity check
-                self.assertEqual(runner.get_opts()['bootstrap_mrjob'], True)
+                self.assertEqual(runner._bootstrap_mrjob(), True)
                 local_tmp_dir = os.path.realpath(runner._get_local_tmp_dir())
 
                 runner.run()

--- a/tests/test_option_store.py
+++ b/tests/test_option_store.py
@@ -73,25 +73,6 @@ class TempdirTestCase(TestCase):
         return [os.path.join(self.tmp_dir, path) for path in paths]
 
 
-class RunnerOptionStoreTestCase(EmptyMrjobConfTestCase):
-
-    def _assert_interp(self, val, **kwargs):
-        opts = RunnerOptionStore('inline', kwargs, [])
-        self.assertEqual(opts['interpreter'], val)
-
-    def test_interpreter_fallback(self):
-        if PY2:
-            self._assert_interp(['python'])
-        else:
-            self._assert_interp(['python3'])
-
-    def test_interpreter_fallback_2(self):
-        self._assert_interp(['python', '-v'], python_bin=['python', '-v'])
-
-    def test_interpreter(self):
-        self._assert_interp(['ruby'], interpreter=['ruby'])
-
-
 class ConfigFilesTestCase(TempdirTestCase):
 
     def save_conf(self, name, conf):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -836,3 +836,24 @@ class InterpreterTestCase(TestCase):
                              steps_python_bin=['python', '-v'])
         self.assertEqual(runner._interpreter(), ['ruby'])
         self.assertEqual(runner._interpreter(steps=True), ['ruby'])
+
+
+class BootstrapMRJobTestCase(TestCase):
+    # this just tests _bootstrap_mrjob() (i.e. whether to bootstrap mrjob);
+    # actual testing of bootstrapping is in test_local
+
+    def test_default(self):
+        runner = MRJobRunner()
+        self.assertEqual(runner._bootstrap_mrjob(), True)
+
+    def test_no_bootstrap_mrjob(self):
+        runner = MRJobRunner(bootstrap_mrjob=False)
+        self.assertEqual(runner._bootstrap_mrjob(), False)
+
+    def test_interpreter(self):
+        runner = MRJobRunner(interpreter=['ruby'])
+        self.assertEqual(runner._bootstrap_mrjob(), False)
+
+    def test_bootstrap_mrjob_overrides_interpreter(self):
+        runner = MRJobRunner(interpreter=['ruby'], bootstrap_mrjob=True)
+        self.assertEqual(runner._bootstrap_mrjob(), True)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -28,6 +28,7 @@ from subprocess import CalledProcessError
 from mrjob.inline import InlineMRJobRunner
 from mrjob.local import LocalMRJobRunner
 from mrjob.parse import JOB_NAME_RE
+from mrjob.py2 import PY2
 from mrjob.py2 import StringIO
 from mrjob.runner import MRJobRunner
 from mrjob.util import log_to_stream
@@ -787,3 +788,51 @@ class ClosedRunnerTestCase(EmptyMrjobConfTestCase):
             # do nothing
             self.assertFalse(runner._closed)
         self.assertTrue(runner._closed)
+
+
+class InterpreterTestCase(TestCase):
+
+    def default_python_bin(self):
+        return ['python'] if PY2 else ['python3']
+
+    def test_default(self):
+        runner = MRJobRunner()
+        self.assertEqual(runner._interpreter(),
+                         self.default_python_bin())
+        self.assertEqual(runner._interpreter(steps=True),
+                         [sys.executable])
+
+    def test_python_bin(self):
+        runner = MRJobRunner(python_bin=['python', '-v'])
+        self.assertEqual(runner._interpreter(), ['python', '-v'])
+        self.assertEqual(runner._interpreter(steps=True), [sys.executable])
+
+    def test_steps_python_bin(self):
+        runner = MRJobRunner(steps_python_bin=['python', '-v'])
+        self.assertEqual(runner._interpreter(),
+                         self.default_python_bin())
+        self.assertEqual(runner._interpreter(steps=True), ['python', '-v'])
+
+    def test_interpreter(self):
+        runner = MRJobRunner(interpreter=['ruby'])
+        self.assertEqual(runner._interpreter(), ['ruby'])
+        self.assertEqual(runner._interpreter(steps=True), ['ruby'])
+
+    def test_steps_interpreter(self):
+        # including whether steps_interpreter overrides interpreter
+        runner = MRJobRunner(interpreter=['ruby', '-v'],
+                             steps_interpreter=['ruby'])
+        self.assertEqual(runner._interpreter(), ['ruby', '-v'])
+        self.assertEqual(runner._interpreter(steps=True), ['ruby'])
+
+    def test_interpreter_overrides_python_bin(self):
+        runner = MRJobRunner(interpreter=['ruby'],
+                             python_bin=['python', '-v'])
+        self.assertEqual(runner._interpreter(), ['ruby'])
+        self.assertEqual(runner._interpreter(steps=True), ['ruby'])
+
+    def test_interpreter_overrides_steps_python_bin(self):
+        runner = MRJobRunner(interpreter=['ruby'],
+                             steps_python_bin=['python', '-v'])
+        self.assertEqual(runner._interpreter(), ['ruby'])
+        self.assertEqual(runner._interpreter(steps=True), ['ruby'])


### PR DESCRIPTION
This change decouples `steps_python_bin` from `python_bin`, as requested in #1038.

This also explicitly un-deprecates the `python_bin` and `steps_python_bin` option, which we thought at one time would be superseded by the `interpreter` and `steps_interpreter` options, and makes explicit that these options are only meant for non-Python binaries (bet you didn't know you could write a job in bash!).

Part of the reason to decouple `python_bin` and `interpreter` is that they have different defaults. If we're not using Python, we probably want to use `interpreter` both to read steps from the job locally, and to run it remotely. Whereas, if we *are* using Python, you can't really beat `sys.executable` for running the job locally.

Since setting `interpreter` means you're not using Python, doing so now implicitly turns off bootstrapping of mrjob unless you set `bootstrap_mrjob` explicitly (see #1041).
