### PR TITLE
set visible_to_all_users to True by default

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -236,14 +236,22 @@ Job flow creation and configuration
 
 .. mrjob-opt::
     :config: visible_to_all_users
-    :switch: --visible-to-all-users
+    :switch: --visible-to-all-users, --no-visible-to-all-users
     :type: boolean
     :set: emr
-    :default: ``False``
+    :default: ``True``
 
-    If ``True``, EMR job flows will be visible to all IAM users. If ``False``,
-    the job flow will only be visible to the IAM user that created it. This parameter
-    can be overridden by :mrjob-opt:`emr_api_params` with key ``VisibleToAllUsers``.
+    If true (the default) EMR job flows will be visible to all IAM users.
+    Otherwise, the job flow will only be visible to the IAM user that created
+    it.
+
+    .. warning::
+
+        You should almost certainly not set this to ``False`` if you are
+        :ref:`pooling-job-flows` with other users; other users will
+        not be able to reuse your job flows, and
+        :py:mod:`~mrjob.tools.emr.terminate_idle_job_flows` won't be
+        able to shut them down when they become idle.
 
     .. versionadded:: 0.4.1
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -425,7 +425,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'ssh_bind_ports': list(range(40001, 40841)),
             'ssh_tunnel_to_job_tracker': False,
             'ssh_tunnel_is_open': False,
-            'visible_to_all_users': False,
+            'visible_to_all_users': True,
         })
 
     def _fix_ec2_instance_opts(self):
@@ -1359,21 +1359,13 @@ class EMRJobRunner(MRJobRunner):
         if self._opts['additional_emr_info']:
             args['additional_info'] = self._opts['additional_emr_info']
 
-        if (self._opts['visible_to_all_users'] and
-            'VisibleToAllUsers' not in self._opts['emr_api_params']):  # noqa
+        args['visible_to_all_users'] = self._opts['visible_to_all_users']
 
-            self._opts['emr_api_params']['VisibleToAllUsers'] = (
-                'true' if self._opts['visible_to_all_users'] else 'false')
+        args['job_flow_role'] = self._instance_profile()
+        args['service_role'] = self._service_role()
 
         if self._opts['emr_api_params']:
             args['api_params'] = self._opts['emr_api_params']
-
-        # instance profile and service role are required for accounts
-        # created after April 6, 2015, and will eventually be required
-        # for all accounts
-        api_params = args.setdefault('api_params', {})
-        api_params['JobFlowRole'] = self._instance_profile()
-        api_params['ServiceRole'] = self._service_role()
 
         if steps:
             args['steps'] = steps

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1359,13 +1359,19 @@ class EMRJobRunner(MRJobRunner):
         if self._opts['additional_emr_info']:
             args['additional_info'] = self._opts['additional_emr_info']
 
-        args['visible_to_all_users'] = self._opts['visible_to_all_users']
+        # boto's connect_emr() has keyword args for these, but they override
+        # emr_api_params, which is not what we want.
+        api_params = {}
 
-        args['job_flow_role'] = self._instance_profile()
-        args['service_role'] = self._service_role()
+        api_params['VisibleToAllUsers'] = self._opts['visible_to_all_users']
+
+        api_params['JobFlowRole'] = self._instance_profile()
+        api_params['ServiceRole'] = self._service_role()
 
         if self._opts['emr_api_params']:
-            args['api_params'] = self._opts['emr_api_params']
+            api_params.update(self._opts['emr_api_params'])
+
+        args['api_params'] = api_params
 
         if steps:
             args['steps'] = steps

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1363,7 +1363,8 @@ class EMRJobRunner(MRJobRunner):
         # emr_api_params, which is not what we want.
         api_params = {}
 
-        api_params['VisibleToAllUsers'] = self._opts['visible_to_all_users']
+        api_params['VisibleToAllUsers'] = bool(
+            self._opts['visible_to_all_users'])
 
         api_params['JobFlowRole'] = self._instance_profile()
         api_params['ServiceRole'] = self._service_role()

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -610,15 +610,17 @@ def add_emr_opts(opt_group):
         opt_group.add_option(
             '--visible-to-all-users', dest='visible_to_all_users',
             default=None, action='store_true',
-            help='Whether the job flow is visible to all IAM users of the AWS'
-                 ' account associated with the job flow. If this value is set'
-                 ' to True, all IAM users of that AWS account can view and'
-                 ' (if they have the proper policy permissions set) manage'
-                 ' the job flow. If it is set to False, only the IAM user'
-                 ' that created the job flow can view and manage it.'
-                 ' This option can be overridden by'
-                 ' --emr-api-param VisibleToAllUsers=true|false.'
+            help='Make your job flow is visible to all IAM users on the same'
+                 ' AWS account (the default).'
         ),
+
+        opt_group.add_option(
+            '--no-visible-to-all-users', dest='visible_to_all_users',
+            default=None, action='store_true',
+            help='Hide your job flow from other IAM users on the same AWS'
+                 ' account.'
+        ),
+
     ]
 
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -616,7 +616,7 @@ def add_emr_opts(opt_group):
 
         opt_group.add_option(
             '--no-visible-to-all-users', dest='visible_to_all_users',
-            default=None, action='store_true',
+            default=None, action='store_false',
             help='Hide your job flow from other IAM users on the same AWS'
                  ' account.'
         ),

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ try:
             'ujson': ['ujson'],
         },
         'install_requires': [
+            'boto>=2.35.0',
             'PyYAML',
             'filechunkio',
         ],
@@ -41,16 +42,6 @@ try:
         # unittest2 is a backport of unittest from Python 2.7
         if sys.version_info < (2, 7):
             setuptools_kwargs['tests_require'].append('unittest2')
-
-    # boto
-    if sys.version_info < (3, 0):
-        # Officially, the 0.4.x series of mrjob supports boto back to v2.2.0
-        setuptools_kwargs['install_requires'].append('boto>=2.2.0')
-    else:
-        # boto didn't support Python 3 until v2.32.1. Since Python 3 support
-        # is new as of mrjob v0.4.5, there's no backward compatibility issue,
-        # so we might as well require the latest version of boto.
-        setuptools_kwargs['install_requires'].append('boto>=2.38.0')
 
 except ImportError:
     from distutils.core import setup

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -618,7 +618,8 @@ class MockEmrConnection(object):
         if api_params:
             job_flow.api_params = api_params
             if 'VisibleToAllUsers' in api_params:
-                job_flow.visibletoallusers = api_params['VisibleToAllUsers']
+                job_flow.visibletoallusers = str(bool(
+                    api_params['VisibleToAllUsers'])).lower()
             if 'JobFlowRole' in api_params:
                 job_flow.jobflowrole = api_params['JobFlowRole']
             if 'ServiceRole' in api_params:

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -600,7 +600,7 @@ class MockEmrConnection(object):
             state='STARTING',
             steps=[],
             api_params={},
-            visibletoallusers='false',  # can only be set with api_params
+            visibletoallusers='false',
         )
 
         if slave_instance_type is not None:
@@ -618,8 +618,8 @@ class MockEmrConnection(object):
         if api_params:
             job_flow.api_params = api_params
             if 'VisibleToAllUsers' in api_params:
-                job_flow.visibletoallusers = str(bool(
-                    api_params['VisibleToAllUsers'])).lower()
+                job_flow.visibletoallusers = str(
+                    api_params['VisibleToAllUsers']).lower()
             if 'JobFlowRole' in api_params:
                 job_flow.jobflowrole = api_params['JobFlowRole']
             if 'ServiceRole' in api_params:

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -613,7 +613,18 @@ class VisibleToAllUsersTestCase(MockEMRAndS3TestCase):
 
     def test_no_visible(self):
         job_flow = self.run_and_get_job_flow('--no-visible-to-all-users')
-        self.assertTrue(job_flow.visibletoallusers, 'false')
+        self.assertEqual(job_flow.visibletoallusers, 'false')
+
+    def test_force_to_bool(self):
+        UGLY_MRJOB_CONF = {'runners': {'emr': {
+            'check_emr_status_every': 0.00,
+            's3_sync_wait_time': 0.00,
+            'visible_to_all_users': 1,
+        }}}
+
+        with mrjob_conf_patcher(UGLY_MRJOB_CONF):
+            job_flow = self.run_and_get_job_flow()
+            self.assertEqual(job_flow.visibletoallusers, 'true')
 
 
 class IAMTestCase(MockEMRAndS3TestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -609,11 +609,11 @@ class VisibleToAllUsersTestCase(MockEMRAndS3TestCase):
 
     def test_defaults(self):
         job_flow = self.run_and_get_job_flow()
-        self.assertEqual(job_flow.visibletoallusers, 'false')
+        self.assertEqual(job_flow.visibletoallusers, 'true')
 
-    def test_visible(self):
-        job_flow = self.run_and_get_job_flow('--visible-to-all-users')
-        self.assertTrue(job_flow.visibletoallusers, 'true')
+    def test_no_visible(self):
+        job_flow = self.run_and_get_job_flow('--no-visible-to-all-users')
+        self.assertTrue(job_flow.visibletoallusers, 'false')
 
 
 class IAMTestCase(MockEMRAndS3TestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -616,15 +616,20 @@ class VisibleToAllUsersTestCase(MockEMRAndS3TestCase):
         self.assertEqual(job_flow.visibletoallusers, 'false')
 
     def test_force_to_bool(self):
-        UGLY_MRJOB_CONF = {'runners': {'emr': {
+        # make sure mockboto doesn't always convert to bool
+        api_param_job_flow = self.run_and_get_job_flow(
+            '--emr-api-param', 'VisibleToAllUsers=1')
+        self.assertEqual(api_param_job_flow.visibletoallusers, '1')
+
+        VISIBLE_MRJOB_CONF = {'runners': {'emr': {
             'check_emr_status_every': 0.00,
             's3_sync_wait_time': 0.00,
-            'visible_to_all_users': 1,
+            'visible_to_all_users': 1,  # should be True
         }}}
 
-        with mrjob_conf_patcher(UGLY_MRJOB_CONF):
-            job_flow = self.run_and_get_job_flow()
-            self.assertEqual(job_flow.visibletoallusers, 'true')
+        with mrjob_conf_patcher(VISIBLE_MRJOB_CONF):
+            visible_job_flow = self.run_and_get_job_flow()
+            self.assertEqual(visible_job_flow.visibletoallusers, 'true')
 
 
 class IAMTestCase(MockEMRAndS3TestCase):


### PR DESCRIPTION
The long-awaited change to visible_to_all_users (see #930).

This also bumps the version for boto (see #980), which is part of the plan for v0.5.0. I was hoping to use `run_jobflow()`'s new `visible_to_all_users` keyword, but this would keep the `emr_api_params` option from overriding `VisibleToAllUsers` as suggested by the mrjob documentation (boto sort of broke my `api_params` patch).
