### PR TITLE
chunks to lines

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,6 @@
 v0.5.0, 2015-??-?? -- ???
- * renamed mrjob.util.buffer_iterator_to_line_iterator() to yield_lines()
- * yield_lines() no longer appends a newline to data (#819)
+ * renamed mrjob.util.buffer_iterator_to_line_iterator() to to_lines()
+ * to_lines() no longer appends a newline to data (#819)
  * mrjob.util.gunzip_stream() now yields chunks, not lines
 
 v0.4.5, 2015-??-?? -- IAM Fortified

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
 v0.5.0, 2015-??-?? -- ???
+ * renamed mrjob.util.buffer_iterator_to_line_iterator() to yield_lines()
+ * yield_lines() no longer appends a newline to data (#819)
+ * mrjob.util.gunzip_stream() now yields chunks, not lines
 
 v0.4.5, 2015-??-?? -- IAM Fortified
  * runners:

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -63,6 +63,16 @@ def bash_wrap(cmd_str):
     return "bash -c '%s'" % cmd_str.replace("'", "'\\''")
 
 
+def buffer_iterator_to_line_iterator(chunks):
+    """Alias for :py:func:`to_lines()`. Will be removed in v0.6.0.
+
+    .. deprecated:: 0.5.0
+    """
+    log.warning('buffer_iterator_to_line_iterator() has been renamed to'
+                ' to_lines(). This alias will be removed in v0.6.0')
+    return to_lines(chunks)
+
+
 def bunzip2_stream(fileobj, bufsize=1024):
     """Decompress gzipped data on the fly.
 
@@ -685,9 +695,6 @@ def to_lines(chunks):
 
     if leftovers:
         yield b''.join(leftovers)
-
-#: Deprecated alias for :py:func:`to_lines`, will be removed in v0.6.0
-buffer_iterator_to_line_iterator = to_lines
 
 
 def unarchive(archive_path, dest):

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -88,7 +88,7 @@ def buffer_iterator_to_line_iterator(iterator):
             if leftovers:
                 leftovers.append(chunk[start:end])
                 yield b''.join(leftovers)
-                del leftovers[:]  # clear out the leftovers list
+                leftovers = []
             else:
                 yield chunk[start:end]
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3084,7 +3084,7 @@ class TestCatFallback(MockEMRAndS3TestCase):
         runner = EMRJobRunner(s3_scratch_uri='s3://walrus/tmp',
                               conf_paths=[])
 
-        self.assertEqual(list(runner.cat('s3://walrus/one')), [b'one_text\n'])
+        self.assertEqual(list(runner.cat('s3://walrus/one')), [b'one_text'])
 
     def test_ssh_cat(self):
         runner = EMRJobRunner(conf_paths=[])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -60,19 +60,33 @@ class BufferIteratorToLineIteratorTestCase(TestCase):
             [b'The quick\n', b'brown fox\n', b'jumped over\n', b'the lazy\n',
              b'dogs.\n'])
 
-    def test_add_trailing_newline(self):
+    def test_empty_chunks(self):
+        self.assertEqual(
+            list(buffer_iterator_to_line_iterator(chunk for chunk in
+                                                  [b'',
+                                                   b'The quick\nbrown fox\nju',
+                                                   b'', b'', b'',
+                                                   b'mped over\nthe lazy\ndog',
+                                                   b'',
+                                                   b's.\n',
+                                                   b''])),
+            [b'The quick\n', b'brown fox\n', b'jumped over\n', b'the lazy\n',
+             b'dogs.\n'])
+
+    def test_no_trailing_newline(self):
         self.assertEqual(
             list(buffer_iterator_to_line_iterator(chunk for chunk in
                                                   [b'Alouette,\ngentille',
                                                    b' Alouette.'])),
-            [b'Alouette,\n', b'gentille Alouette.\n'])
+            [b'Alouette,\n', b'gentille Alouette.'])
 
     def test_long_lines(self):
         super_long_line = b'a' * 10000 + b'\n' + b'b' * 1000 + b'\nlast\n'
         self.assertEqual(
             list(buffer_iterator_to_line_iterator(
                 chunk for chunk in
-                (super_long_line[0+i:1024+i] for i in range(0, len(super_long_line), 1024)))),
+                (super_long_line[0+i:1024+i]
+                 for i in range(0, len(super_long_line), 1024)))),
             [b'a' * 10000 + b'\n', b'b' * 1000 + b'\n', b'last\n'])
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -38,23 +38,23 @@ from mrjob.util import safeeval
 from mrjob.util import scrape_options_into_new_groups
 from mrjob.util import tar_and_gzip
 from mrjob.util import unarchive
-from mrjob.util import yield_lines
+from mrjob.util import to_lines
 
 from tests.py2 import TestCase
 from tests.quiet import logger_disabled
 from tests.sandbox import random_seed
 
 
-class BufferIteratorToLineIteratorTestCase(TestCase):
+class ToLinesTestCase(TestCase):
 
     def test_empty(self):
         self.assertEqual(
-            list(yield_lines(_ for _ in ())),
+            list(to_lines(_ for _ in ())),
             [])
 
     def test_buffered_lines(self):
         self.assertEqual(
-            list(yield_lines(chunk for chunk in
+            list(to_lines(chunk for chunk in
                              [b'The quick\nbrown fox\nju',
                               b'mped over\nthe lazy\ndog',
                               b's.\n'])),
@@ -63,7 +63,7 @@ class BufferIteratorToLineIteratorTestCase(TestCase):
 
     def test_empty_chunks(self):
         self.assertEqual(
-            list(yield_lines(chunk for chunk in
+            list(to_lines(chunk for chunk in
                              [b'',
                               b'The quick\nbrown fox\nju',
                               b'', b'', b'',
@@ -76,7 +76,7 @@ class BufferIteratorToLineIteratorTestCase(TestCase):
 
     def test_no_trailing_newline(self):
         self.assertEqual(
-            list(yield_lines(chunk for chunk in
+            list(to_lines(chunk for chunk in
                              [b'Alouette,\ngentille',
                               b' Alouette.'])),
             [b'Alouette,\n', b'gentille Alouette.'])
@@ -84,14 +84,14 @@ class BufferIteratorToLineIteratorTestCase(TestCase):
     def test_long_lines(self):
         super_long_line = b'a' * 10000 + b'\n' + b'b' * 1000 + b'\nlast\n'
         self.assertEqual(
-            list(yield_lines(
+            list(to_lines(
                 chunk for chunk in
                 (super_long_line[0+i:1024+i]
                  for i in range(0, len(super_long_line), 1024)))),
             [b'a' * 10000 + b'\n', b'b' * 1000 + b'\n', b'last\n'])
 
     def test_old_alias(self):
-        self.assertEqual(buffer_iterator_to_line_iterator, yield_lines)
+        self.assertEqual(buffer_iterator_to_line_iterator, to_lines)
 
 
 class CmdLineTestCase(TestCase):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-# Copyright 2009-2013 Yelp and Contributors
+# Copyright 2009-2015 Yelp and Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ from mrjob.util import safeeval
 from mrjob.util import scrape_options_into_new_groups
 from mrjob.util import tar_and_gzip
 from mrjob.util import unarchive
+from mrjob.util import yield_lines
 
 from tests.py2 import TestCase
 from tests.quiet import logger_disabled
@@ -48,48 +49,49 @@ class BufferIteratorToLineIteratorTestCase(TestCase):
 
     def test_empty(self):
         self.assertEqual(
-            list(buffer_iterator_to_line_iterator(_ for _ in ())),
+            list(yield_lines(_ for _ in ())),
             [])
 
     def test_buffered_lines(self):
         self.assertEqual(
-            list(buffer_iterator_to_line_iterator(chunk for chunk in
-                                                  [b'The quick\nbrown fox\nju',
-                                                   b'mped over\nthe lazy\ndog',
-                                                   b's.\n'])),
+            list(yield_lines(chunk for chunk in
+                             [b'The quick\nbrown fox\nju',
+                              b'mped over\nthe lazy\ndog',
+                              b's.\n'])),
             [b'The quick\n', b'brown fox\n', b'jumped over\n', b'the lazy\n',
              b'dogs.\n'])
 
     def test_empty_chunks(self):
         self.assertEqual(
-            list(buffer_iterator_to_line_iterator(chunk for chunk in
-                                                  [b'',
-                                                   b'The quick\nbrown fox\nju',
-                                                   b'', b'', b'',
-                                                   b'mped over\nthe lazy\ndog',
-                                                   b'',
-                                                   b's.\n',
-                                                   b''])),
+            list(yield_lines(chunk for chunk in
+                             [b'',
+                              b'The quick\nbrown fox\nju',
+                              b'', b'', b'',
+                              b'mped over\nthe lazy\ndog',
+                              b'',
+                              b's.\n',
+                              b''])),
             [b'The quick\n', b'brown fox\n', b'jumped over\n', b'the lazy\n',
              b'dogs.\n'])
 
     def test_no_trailing_newline(self):
         self.assertEqual(
-            list(buffer_iterator_to_line_iterator(chunk for chunk in
-                                                  [b'Alouette,\ngentille',
-                                                   b' Alouette.'])),
+            list(yield_lines(chunk for chunk in
+                             [b'Alouette,\ngentille',
+                              b' Alouette.'])),
             [b'Alouette,\n', b'gentille Alouette.'])
 
     def test_long_lines(self):
         super_long_line = b'a' * 10000 + b'\n' + b'b' * 1000 + b'\nlast\n'
         self.assertEqual(
-            list(buffer_iterator_to_line_iterator(
+            list(yield_lines(
                 chunk for chunk in
                 (super_long_line[0+i:1024+i]
                  for i in range(0, len(super_long_line), 1024)))),
             [b'a' * 10000 + b'\n', b'b' * 1000 + b'\n', b'last\n'])
 
-
+    def test_old_alias(self):
+        self.assertEqual(buffer_iterator_to_line_iterator, yield_lines)
 
 
 class CmdLineTestCase(TestCase):


### PR DESCRIPTION
In anticipation of supporting non-line-based protocols (see #715), mrjob is undergoing a transition from generators that yield lines to generators that can yield data in arbitrary chunks of bytes. When you want lines, you can wrap said chunk iterators through `mrjob.util.to_lines()`

(`to_lines()` was formerly named `buffer_iterator_to_line_iterator()`, which is more clear, but awkward to use as a wrapper function. The old name will still work until v0.6.0.)

`to_lines()` used to add a trailing newline if the last chunk didn't have one; it now leaves the data unmolested (see #819).

This also lets `mrjob.util.gunzip_stream()` just yield chunks of data rather than lines, as promised in its docstring.

I updated the implementation `to_lines()` to try to be more efficient: instead of appending to a `bytes`, we maintain a list of chunks, and `join()` them when we're ready to yield a line. Using `tests.test_util.ReadFileTestCase.test_large_bz2_file()` as a benchmark, I determined that... the old and new implementations are just about equally fast. I still believe it's probably a bit better for the cases I care about, but can't prove it yet.
