### PR TITLE
"job key", not "job name"

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -68,7 +68,7 @@ Options available to hadoop and emr runners
     :set: all
     :default: script's module name, or ``no_script``
 
-    Description of this job to use as the part of its name.
+    Alternate label for the job
 
 .. mrjob-opt::
     :config: owner
@@ -77,7 +77,7 @@ Options available to hadoop and emr runners
     :set: all
     :default: :py:func:`getpass.getuser`, or ``no_user`` if that fails
 
-    Who is running this job. Used solely to set the job name.
+    Who is running this job (if different from the current user)
 
 .. mrjob-opt::
     :config: partitioner

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -263,7 +263,7 @@ def make_lock_uri(s3_tmp_uri, emr_job_flow_id, step_num):
     return s3_tmp_uri + 'locks/' + emr_job_flow_id + '/' + str(step_num)
 
 
-def _lock_acquire_step_1(s3_conn, lock_uri, job_name, mins_to_expiration=None):
+def _lock_acquire_step_1(s3_conn, lock_uri, job_key, mins_to_expiration=None):
     bucket_name, key_prefix = parse_s3_uri(lock_uri)
     bucket = _get_bucket(s3_conn, bucket_name)
     key = bucket.get_key(key_prefix)
@@ -280,26 +280,26 @@ def _lock_acquire_step_1(s3_conn, lock_uri, job_name, mins_to_expiration=None):
 
     if key is None or key_expired:
         key = bucket.new_key(key_prefix)
-        key.set_contents_from_string(job_name.encode('utf_8'))
+        key.set_contents_from_string(job_key.encode('utf_8'))
         return key
     else:
         return None
 
 
-def _lock_acquire_step_2(key, job_name):
+def _lock_acquire_step_2(key, job_key):
     key_value = key.get_contents_as_string()
-    return (key_value == job_name.encode('utf_8'))
+    return (key_value == job_key.encode('utf_8'))
 
 
-def attempt_to_acquire_lock(s3_conn, lock_uri, sync_wait_time, job_name,
+def attempt_to_acquire_lock(s3_conn, lock_uri, sync_wait_time, job_key,
                             mins_to_expiration=None):
     """Returns True if this session successfully took ownership of the lock
     specified by ``lock_uri``.
     """
-    key = _lock_acquire_step_1(s3_conn, lock_uri, job_name, mins_to_expiration)
+    key = _lock_acquire_step_1(s3_conn, lock_uri, job_key, mins_to_expiration)
     if key is not None:
         time.sleep(sync_wait_time)
-        success = _lock_acquire_step_2(key, job_name)
+        success = _lock_acquire_step_2(key, job_key)
         if success:
             return True
 
@@ -579,7 +579,7 @@ class EMRJobRunner(MRJobRunner):
         self._fix_s3_scratch_and_log_uri_opts()
 
         # pick a tmp dir based on the job name
-        self._s3_tmp_uri = self._opts['s3_scratch_uri'] + self._job_name + '/'
+        self._s3_tmp_uri = self._opts['s3_scratch_uri'] + self._job_key + '/'
 
         # pick/validate output dir
         if self._output_dir:
@@ -782,7 +782,7 @@ class EMRJobRunner(MRJobRunner):
 
     @property
     def _ssh_key_name(self):
-        return self._job_name + '.pem'
+        return self._job_key + '.pem'
 
     @property
     def fs(self):
@@ -1249,10 +1249,10 @@ class EMRJobRunner(MRJobRunner):
 
         emr_conn = self.make_emr_conn()
         log.debug('Calling run_jobflow(%r, %r, %s)' % (
-            self._job_name, self._opts['s3_log_uri'],
+            self._job_key, self._opts['s3_log_uri'],
             ', '.join('%s=%r' % (k, v) for k, v in args.items())))
         emr_job_flow_id = emr_conn.run_jobflow(
-            self._job_name, self._opts['s3_log_uri'], **args)
+            self._job_key, self._opts['s3_log_uri'], **args)
 
          # keep track of when we started our job
         self._emr_job_start = time.time()
@@ -1434,7 +1434,7 @@ class EMRJobRunner(MRJobRunner):
     def _build_streaming_step(self, step_num):
         streaming_step_kwargs = {
             'name': '%s: Step %d of %d' % (
-                self._job_name, step_num + 1, self._num_steps()),
+                self._job_key, step_num + 1, self._num_steps()),
             'input': self._step_input_uris(step_num),
             'output': self._step_output_uri(step_num),
             'jar': self._get_streaming_jar(),
@@ -1481,7 +1481,7 @@ class EMRJobRunner(MRJobRunner):
 
         return boto.emr.JarStep(
             name='%s: Step %d of %d' % (
-                self._job_name, step_num + 1, self._num_steps()),
+                self._job_key, step_num + 1, self._num_steps()),
             jar=jar,
             main_class=step['main_class'],
             step_args=step_args,
@@ -1599,7 +1599,7 @@ class EMRJobRunner(MRJobRunner):
                     latest_lg_step_num += 1
 
                 # ignore steps belonging to other jobs
-                if not step.name.startswith(self._job_name):
+                if not step.name.startswith(self._job_key):
                     continue
 
                 step_nums.append(i + 1)
@@ -1723,7 +1723,7 @@ class EMRJobRunner(MRJobRunner):
         else:
             # put intermediate data in HDFS
             return ['hdfs:///tmp/mrjob/%s/step-output/%s/' % (
-                self._job_name, step_num)]
+                self._job_key, step_num)]
 
     def _step_output_uri(self, step_num):
         if step_num == len(self._get_steps()) - 1:
@@ -1731,7 +1731,7 @@ class EMRJobRunner(MRJobRunner):
         else:
             # put intermediate data in HDFS
             return 'hdfs:///tmp/mrjob/%s/step-output/%s/' % (
-                self._job_name, step_num + 1)
+                self._job_key, step_num + 1)
 
     ### LOG FETCHING/PARSING ###
 
@@ -2450,7 +2450,7 @@ class EMRJobRunner(MRJobRunner):
                 job_flow = sorted_tagged_job_flows[-1]
                 status = attempt_to_acquire_lock(
                     s3_conn, self._lock_uri(job_flow),
-                    self._opts['s3_sync_wait_time'], self._job_name)
+                    self._opts['s3_sync_wait_time'], self._job_key)
                 if status:
                     return sorted_tagged_job_flows[-1]
                 else:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -578,7 +578,7 @@ class EMRJobRunner(MRJobRunner):
 
         self._fix_s3_scratch_and_log_uri_opts()
 
-        # pick a tmp dir based on the job name
+        # use job key to make a unique tmp dir
         self._s3_tmp_uri = self._opts['s3_scratch_uri'] + self._job_key + '/'
 
         # pick/validate output dir

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -181,7 +181,7 @@ class HadoopJobRunner(MRJobRunner):
 
         self._hdfs_tmp_dir = fully_qualify_hdfs_path(
             posixpath.join(
-                self._opts['hdfs_scratch_dir'], self._job_name))
+                self._opts['hdfs_scratch_dir'], self._job_key))
 
         # Keep track of local files to upload to HDFS. We'll add them
         # to this manager just before we need them.

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -517,7 +517,6 @@ class MRJobLauncher(object):
             'input_paths': self.args,
             'interpreter': self.options.interpreter,
             'jobconf': self.jobconf(),
-            'job_name': self.options.job_name,
             'mr_job_script': self._script_path,
             'label': self.options.label,
             'output_dir': self.options.output_dir,

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -230,12 +230,11 @@ def add_hadoop_emr_opts(opt_group):
 
         opt_group.add_option(
             '--label', dest='label', default=None,
-            help='custom prefix for job name, to help us identify the job'),
+            help='alternate label for the job, to help us identify it'),
 
         opt_group.add_option(
             '--owner', dest='owner', default=None,
-            help='custom username to use, to help us identify who ran the'
-            ' job'),
+            help='user who ran the job (if different from the current user)'),
 
         opt_group.add_option(
             '--partitioner', dest='partitioner', default=None,

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -123,12 +123,6 @@ def add_runner_opts(opt_group, default_runner='local'):
             help=('Non-python command to run your script, e.g. "ruby".')),
 
         opt_group.add_option(
-            '--job-name', dest='job_name', default=None,
-            help='Specify the job name manually instead of asking mrjob for '
-                 'a unique name. Use this option if you want to give the job '
-                 'a descriptive name.'),
-
-        opt_group.add_option(
             '--no-bootstrap-mrjob', dest='bootstrap_mrjob',
             action='store_false', default=None,
             help=("Don't automatically tar up the mrjob library and install it"

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -38,7 +38,7 @@ except ImportError:
 HADOOP_STREAMING_JAR_RE = re.compile(
     r'^hadoop.*streaming.*(?<!-sources)\.jar$')
 
-# match an mrjob job name (these are used to name EMR job flows)
+# match an mrjob job key (these are used to name EMR job flows)
 JOB_NAME_RE = re.compile(r'^(.*)\.(.*)\.(\d+)\.(\d+)\.(\d+)$')
 
 # match an mrjob step name (these are used to name steps in EMR)

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -39,7 +39,7 @@ HADOOP_STREAMING_JAR_RE = re.compile(
     r'^hadoop.*streaming.*(?<!-sources)\.jar$')
 
 # match an mrjob job key (these are used to name EMR job flows)
-JOB_NAME_RE = re.compile(r'^(.*)\.(.*)\.(\d+)\.(\d+)\.(\d+)$')
+JOB_KEY_RE = re.compile(r'^(.*)\.(.*)\.(\d+)\.(\d+)\.(\d+)$')
 
 # match an mrjob step name (these are used to name steps in EMR)
 STEP_NAME_RE = re.compile(

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -328,7 +328,7 @@ class MRJobRunner(object):
             self._working_dir_mgr.add('file', self._script_path)
 
         # give this job a unique name
-        self._job_name = self._make_unique_job_name(
+        self._job_key = self._make_unique_job_key(
             label=self._opts['label'], owner=self._opts['owner'])
 
         # we'll create the wrapper script later
@@ -602,11 +602,11 @@ class MRJobRunner(object):
         """Get options set for this runner, as a dict."""
         return copy.deepcopy(self._opts)
 
-    def get_job_name(self):
+    def get_job_key(self):
         """Get the unique name for the job run by this runner.
         This has the format ``label.owner.date.time.microseconds``
         """
-        return self._job_name
+        return self._job_key
 
     def get_output_dir(self):
         """Find the directory containing the job output. If the job hasn't
@@ -644,7 +644,7 @@ class MRJobRunner(object):
         """Create a tmp directory on the local filesystem that will be
         cleaned up by self.cleanup()"""
         if not self._local_tmp_dir:
-            path = os.path.join(self._opts['base_tmp_dir'], self._job_name)
+            path = os.path.join(self._opts['base_tmp_dir'], self._job_key)
             log.info('creating tmp directory %s' % path)
             if os.path.isdir(path):
                 shutil.rmtree(path)
@@ -653,7 +653,7 @@ class MRJobRunner(object):
 
         return self._local_tmp_dir
 
-    def _make_unique_job_name(self, label=None, owner=None):
+    def _make_unique_job_key(self, label=None, owner=None):
         """Come up with a useful unique ID for this job.
 
         We use this to choose the output directory, etc. for the job.
@@ -1004,7 +1004,7 @@ class MRJobRunner(object):
         # and then release the lock by closing the file descriptor.
         # File descriptors 10 and higher are used internally by the shell,
         # so 9 is as out-of-the-way as we can get.
-        writeln('exec 9>/tmp/wrapper.lock.%s' % self._job_name)
+        writeln('exec 9>/tmp/wrapper.lock.%s' % self._job_key)
         # would use flock(1), but it's not always available
         writeln("%s -c 'import fcntl; fcntl.flock(9, fcntl.LOCK_EX)'" %
                 cmd_line(self._python_bin()))

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -603,10 +603,19 @@ class MRJobRunner(object):
         return copy.deepcopy(self._opts)
 
     def get_job_key(self):
-        """Get the unique name for the job run by this runner.
+        """Get the unique key for the job run by this runner.
         This has the format ``label.owner.date.time.microseconds``
         """
         return self._job_key
+
+    def get_job_name(self):
+        """Alias for :py:meth:`get_job_key`. Will be removed in v0.6.0.
+
+        .. deprecated:: 0.5.0
+        """
+        log.warn('get_job_name() has been renamed to get_job_key().'
+                 ' get_job_name() will be removed in v0.6.0')
+        return self.get_job_key()
 
     def get_output_dir(self):
         """Find the directory containing the job output. If the job hasn't

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -93,6 +93,7 @@ class RunnerOptionStore(OptionStore):
     ALLOWED_KEYS = OptionStore.ALLOWED_KEYS.union(set([
         'base_tmp_dir',
         'bootstrap_mrjob',
+        'check_input_paths',
         'cleanup',
         'cleanup_on_failure',
         'cmdenv',
@@ -101,7 +102,6 @@ class RunnerOptionStore(OptionStore):
         'hadoop_version',
         'interpreter',
         'jobconf',
-        'job_name',
         'label',
         'owner',
         'python_archives',
@@ -115,7 +115,6 @@ class RunnerOptionStore(OptionStore):
         'strict_protocols',
         'upload_archives',
         'upload_files',
-        'check_input_paths',
     ]))
 
     COMBINERS = combine_dicts(OptionStore.COMBINERS, {

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -461,7 +461,7 @@ class SimMRJobRunner(MRJobRunner):
         # translate them at the very end.
         j = {}
 
-        j['mapreduce.job.id'] = self._job_name
+        j['mapreduce.job.id'] = self._job_key
         j['mapreduce.task.output.dir'] = self._output_dir
         j['mapreduce.job.local.dir'] = working_dir
         # archives and files for jobconf
@@ -490,10 +490,10 @@ class SimMRJobRunner(MRJobRunner):
 
         # task and attempt IDs
         j['mapreduce.task.id'] = 'task_%s_%s_%05d%d' % (
-            self._job_name, step_type.lower(), step_num, task_num)
+            self._job_key, step_type.lower(), step_num, task_num)
         # (we only have one attempt)
         j['mapreduce.task.attempt.id'] = 'attempt_%s_%s_%05d%d_0' % (
-            self._job_name, step_type.lower(), step_num, task_num)
+            self._job_key, step_type.lower(), step_num, task_num)
 
         # not actually sure what's correct for combiners here. It'll definitely
         # be true if we're just using pipes to simulate a combiner though

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -166,7 +166,7 @@ def job_flows_to_stats(job_flows, now=None):
                         start_to_nih[start] += nih
             s[key] = start_to_nih
 
-    # break down by label ("job name") and owner ("user")
+    # break out by label (usually script name) and owner (usually current user)
     for key in ('label', 'owner'):
         for nih_type in ('nih_used', 'nih_billed', 'nih_bbnu'):
             key_to_nih = {}

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -43,7 +43,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.emr import describe_all_job_flows
 from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
-from mrjob.parse import JOB_NAME_RE
+from mrjob.parse import JOB_KEY_RE
 from mrjob.parse import STEP_NAME_RE
 from mrjob.parse import iso8601_to_datetime
 from mrjob.util import strip_microseconds
@@ -303,7 +303,7 @@ def job_flow_to_basic_summary(job_flow, now=None):
         if len(args) == 2 and args[0].startswith('pool-'):
             jf['pool'] = args[1]
 
-    m = JOB_NAME_RE.match(getattr(job_flow, 'name', ''))
+    m = JOB_KEY_RE.match(getattr(job_flow, 'name', ''))
     if m:
         jf['label'], jf['owner'] = m.group(1), m.group(2)
     else:

--- a/mrjob/tools/emr/terminate_idle_job_flows.py
+++ b/mrjob/tools/emr/terminate_idle_job_flows.py
@@ -322,7 +322,7 @@ def terminate_and_notify(runner, to_terminate, dry_run=False,
                 runner._lock_uri(jf),
                 runner._opts['s3_sync_wait_time'],
                 '%s (%s)' % (msg,
-                             runner._make_unique_job_name(label='terminate')),
+                             runner._make_unique_job_key(label='terminate')),
                 mins_to_expiration=max_mins_locked,
             )
             if status:

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1728,10 +1728,10 @@ class CounterFetchingTestCase(MockEMRAndS3TestCase):
     def test_zero_log_generating_steps(self):
         mock_steps = [
             MockEmrObject(jar='x.jar',
-                          name=self.runner._job_name,
+                          name=self.runner._job_key,
                           state='COMPLETED'),
             MockEmrObject(jar='x.jar',
-                          name=self.runner._job_name,
+                          name=self.runner._job_key,
                           state='COMPLETED'),
         ]
         mock_jobflow = MockEmrObject(state='COMPLETED',
@@ -1744,16 +1744,16 @@ class CounterFetchingTestCase(MockEMRAndS3TestCase):
     def test_interleaved_log_generating_steps(self):
         mock_steps = [
             MockEmrObject(jar='x.jar',
-                          name=self.runner._job_name,
+                          name=self.runner._job_key,
                           state='COMPLETED'),
             MockEmrObject(jar='hadoop.streaming.jar',
-                          name=self.runner._job_name,
+                          name=self.runner._job_key,
                           state='COMPLETED'),
             MockEmrObject(jar='x.jar',
-                          name=self.runner._job_name,
+                          name=self.runner._job_key,
                           state='COMPLETED'),
             MockEmrObject(jar='hadoop.streaming.jar',
-                          name=self.runner._job_name,
+                          name=self.runner._job_key,
                           state='COMPLETED'),
         ]
         mock_jobflow = MockEmrObject(state='COMPLETED',
@@ -3277,9 +3277,9 @@ class JobWaitTestCase(MockEMRAndS3TestCase):
         self.jobs = []
         self.future_jobs = []
 
-    def add_job_flow(self, job_names, job_list):
+    def add_job_flow(self, job_keys, job_list):
         """Puts a fake job flow into a list of jobs for testing."""
-        for name in job_names:
+        for name in job_keys:
             jf = Mock()
             jf.state = 'WAITING'
             jf.jobflowid = name

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -38,7 +38,7 @@ from mrjob.emr import filechunkio
 from mrjob.emr import _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH
 from mrjob.emr import _lock_acquire_step_1
 from mrjob.emr import _lock_acquire_step_2
-from mrjob.parse import JOB_NAME_RE
+from mrjob.parse import JOB_KEY_RE
 from mrjob.parse import parse_s3_uri
 from mrjob.pool import pool_hash_and_name
 from mrjob.py2 import PY2
@@ -315,7 +315,7 @@ class EMRJobRunnerEndToEndTestCase(MockEMRAndS3TestCase):
             emr_conn = runner.make_emr_conn()
             job_flow = emr_conn.describe_jobflow(runner.get_emr_job_flow_id())
             self.assertEqual(job_flow.state, 'COMPLETED')
-            name_match = JOB_NAME_RE.match(job_flow.name)
+            name_match = JOB_KEY_RE.match(job_flow.name)
             self.assertEqual(name_match.group(1), 'mr_hadoop_format_job')
             self.assertEqual(name_match.group(2), getpass.getuser())
 

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -301,15 +301,15 @@ class SimRunnerJobConfTestCase(SandboxedTestCase):
         self.assertEqual(
             sorted(results['mapreduce.job.cache.local.files'].split(',')),
             sorted(expected_local_files))
-        self.assertEqual(results['mapreduce.job.id'], runner._job_name)
+        self.assertEqual(results['mapreduce.job.id'], runner._job_key)
 
         self.assertEqual(results['mapreduce.map.input.file'], input_path)
         self.assertEqual(results['mapreduce.map.input.length'], '4')
         self.assertEqual(results['mapreduce.map.input.start'], '0')
         self.assertEqual(results['mapreduce.task.attempt.id'],
-                       'attempt_%s_mapper_000000_0' % runner._job_name)
+                       'attempt_%s_mapper_000000_0' % runner._job_key)
         self.assertEqual(results['mapreduce.task.id'],
-                       'task_%s_mapper_000000' % runner._job_name)
+                       'task_%s_mapper_000000' % runner._job_key)
         self.assertEqual(results['mapreduce.task.ismap'], 'true')
         self.assertEqual(results['mapreduce.task.output.dir'],
                          runner._output_dir)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -27,7 +27,7 @@ from subprocess import CalledProcessError
 
 from mrjob.inline import InlineMRJobRunner
 from mrjob.local import LocalMRJobRunner
-from mrjob.parse import JOB_NAME_RE
+from mrjob.parse import JOB_KEY_RE
 from mrjob.py2 import PY2
 from mrjob.py2 import StringIO
 from mrjob.runner import MRJobRunner
@@ -125,7 +125,7 @@ class TestJobName(TestCase):
 
     def test_empty(self):
         runner = InlineMRJobRunner(conf_paths=[])
-        match = JOB_NAME_RE.match(runner.get_job_key())
+        match = JOB_KEY_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'no_script')
         self.assertEqual(match.group(2), getpass.getuser())
@@ -133,14 +133,14 @@ class TestJobName(TestCase):
     def test_empty_no_user(self):
         self.getuser_should_fail = True
         runner = InlineMRJobRunner(conf_paths=[])
-        match = JOB_NAME_RE.match(runner.get_job_key())
+        match = JOB_KEY_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'no_script')
         self.assertEqual(match.group(2), 'no_user')
 
     def test_auto_label(self):
         runner = MRTwoStepJob(['--no-conf']).make_runner()
-        match = JOB_NAME_RE.match(runner.get_job_key())
+        match = JOB_KEY_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'mr_two_step_job')
         self.assertEqual(match.group(2), getpass.getuser())
@@ -148,7 +148,7 @@ class TestJobName(TestCase):
     def test_auto_owner(self):
         os.environ['USER'] = 'mcp'
         runner = InlineMRJobRunner(conf_paths=[])
-        match = JOB_NAME_RE.match(runner.get_job_key())
+        match = JOB_KEY_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'no_script')
         self.assertEqual(match.group(2), 'mcp')
@@ -158,7 +158,7 @@ class TestJobName(TestCase):
 
         os.environ['USER'] = 'mcp'
         runner = MRTwoStepJob(['--no-conf']).make_runner()
-        match = JOB_NAME_RE.match(runner.get_job_key())
+        match = JOB_KEY_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'mr_two_step_job')
         self.assertEqual(match.group(2), 'mcp')
@@ -173,7 +173,7 @@ class TestJobName(TestCase):
     def test_owner_and_label_switches(self):
         runner_opts = ['--no-conf', '--owner=ads', '--label=ads_chain']
         runner = MRTwoStepJob(runner_opts).make_runner()
-        match = JOB_NAME_RE.match(runner.get_job_key())
+        match = JOB_KEY_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'ads_chain')
         self.assertEqual(match.group(2), 'ads')
@@ -181,7 +181,7 @@ class TestJobName(TestCase):
     def test_owner_and_label_kwargs(self):
         runner = InlineMRJobRunner(conf_paths=[],
                                    owner='ads', label='ads_chain')
-        match = JOB_NAME_RE.match(runner.get_job_key())
+        match = JOB_KEY_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'ads_chain')
         self.assertEqual(match.group(2), 'ads')

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -125,7 +125,7 @@ class TestJobName(TestCase):
 
     def test_empty(self):
         runner = InlineMRJobRunner(conf_paths=[])
-        match = JOB_NAME_RE.match(runner.get_job_name())
+        match = JOB_NAME_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'no_script')
         self.assertEqual(match.group(2), getpass.getuser())
@@ -133,14 +133,14 @@ class TestJobName(TestCase):
     def test_empty_no_user(self):
         self.getuser_should_fail = True
         runner = InlineMRJobRunner(conf_paths=[])
-        match = JOB_NAME_RE.match(runner.get_job_name())
+        match = JOB_NAME_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'no_script')
         self.assertEqual(match.group(2), 'no_user')
 
     def test_auto_label(self):
         runner = MRTwoStepJob(['--no-conf']).make_runner()
-        match = JOB_NAME_RE.match(runner.get_job_name())
+        match = JOB_NAME_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'mr_two_step_job')
         self.assertEqual(match.group(2), getpass.getuser())
@@ -148,7 +148,7 @@ class TestJobName(TestCase):
     def test_auto_owner(self):
         os.environ['USER'] = 'mcp'
         runner = InlineMRJobRunner(conf_paths=[])
-        match = JOB_NAME_RE.match(runner.get_job_name())
+        match = JOB_NAME_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'no_script')
         self.assertEqual(match.group(2), 'mcp')
@@ -158,7 +158,7 @@ class TestJobName(TestCase):
 
         os.environ['USER'] = 'mcp'
         runner = MRTwoStepJob(['--no-conf']).make_runner()
-        match = JOB_NAME_RE.match(runner.get_job_name())
+        match = JOB_NAME_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'mr_two_step_job')
         self.assertEqual(match.group(2), 'mcp')
@@ -173,7 +173,7 @@ class TestJobName(TestCase):
     def test_owner_and_label_switches(self):
         runner_opts = ['--no-conf', '--owner=ads', '--label=ads_chain']
         runner = MRTwoStepJob(runner_opts).make_runner()
-        match = JOB_NAME_RE.match(runner.get_job_name())
+        match = JOB_NAME_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'ads_chain')
         self.assertEqual(match.group(2), 'ads')
@@ -181,7 +181,7 @@ class TestJobName(TestCase):
     def test_owner_and_label_kwargs(self):
         runner = InlineMRJobRunner(conf_paths=[],
                                    owner='ads', label='ads_chain')
-        match = JOB_NAME_RE.match(runner.get_job_name())
+        match = JOB_NAME_RE.match(runner.get_job_key())
 
         self.assertEqual(match.group(1), 'ads_chain')
         self.assertEqual(match.group(2), 'ads')

--- a/tests/tools/emr/test_audit_usage.py
+++ b/tests/tools/emr/test_audit_usage.py
@@ -624,7 +624,7 @@ class JobFlowToFullSummaryTestCase(TestCase):
         })
 
     def test_pooled_job_flow(self):
-        # same as test case above with different job names
+        # same as test case above with different job keys
         job_flow = MockEmrObject(
             bootstrapactions=[
                 MockEmrObject(args=[]),


### PR DESCRIPTION
mrjob selects a unique key for each job, which is used for selecting temp directories and "locking" for job flow pooling. Because it contains script and user name, it can also be used to audit usage.

This changes the name of the unique key from "job name" (which is easily confused with Hadoop's job names) to "job key". It also removes code which appeared to allow you to set this key manually, but actually does nothing.

See #982 for why this matters.

