### PR TITLE
Add support for applying metadata tags to the EMR cluster right after its creation

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -173,6 +173,39 @@ Job flow creation and configuration
     ``us-west-1.elasticmapreduce.amazonaws.com``).
 
 .. mrjob-opt::
+    :config: emr_tags
+    :switch: --emr-tag
+    :type: :ref:`dict <data-type-plain-dict>`
+    :set: emr
+    :default: ``{}``
+
+    Metadata tags to apply to the EMR cluster after creating a
+    job flow. See `Tagging Amazon EMR Clusters`_ for more information
+    on applying metadata tags to EMR clusters.
+
+    .. _`Tagging Amazon EMR Clusters`:
+        http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-tags.html
+
+    Tag names and values are strings. On the command line, to set a tag
+    use ``--emr-tag KEY=VALUE``:
+
+    .. code-block:: sh
+
+        --emr-tag team=development
+
+    In the config file, ``emr_tags`` is a dict:
+
+    .. code-block:: yaml
+
+        runners:
+          emr:
+            emr_tags:
+              team: development
+              project: mrjob
+
+    .. versionadded:: 0.5.0
+
+.. mrjob-opt::
     :config: hadoop_streaming_jar_on_emr
     :switch: --hadoop-streaming-jar-on-emr
     :type: :ref:`string <data-type-string>`

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -345,6 +345,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         'emr_endpoint',
         'emr_job_flow_id',
         'emr_job_flow_pool_name',
+        'emr_tags',
         'enable_emr_debugging',
         'hadoop_streaming_jar_on_emr',
         'hadoop_version',
@@ -381,7 +382,8 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         's3_log_uri': combine_paths,
         's3_scratch_uri': combine_paths,
         'ssh_bin': combine_cmds,
-        'emr_api_params': combine_dicts
+        'emr_api_params': combine_dicts,
+        'emr_tags': combine_dicts
     })
 
     def __init__(self, alias, opts, conf_path):
@@ -1561,6 +1563,14 @@ class EMRJobRunner(MRJobRunner):
 
         # keep track of when we launched our job
         self._emr_job_start = time.time()
+
+        # set EMR tags for the job, if any
+        tags = self._opts['emr_tags']
+        if tags:
+            log.info('Setting EMR tags: %s' %
+                ', '.join('%s=%s' % (tag, value) for tag, value in tags.items())
+            )
+            emr_conn.add_tags(self._emr_job_flow_id, tags)
 
     # TODO: break this method up; it's too big to write tests for
     def _wait_for_job_to_complete(self):

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -468,6 +468,15 @@ class MRJobLauncher(object):
         for param in self.options.no_emr_api_params:
             self.options.emr_api_params[param] = None
 
+        # emr_tags
+        emr_tags_err = (
+            'emr-tag argument "%s" is not of the form KEY=VALUE')
+
+        self.options.emr_tags = parse_key_value_list(
+            self.options.emr_tags,
+            emr_tags_err,
+            self.option_parser.error)
+
         def parse_commas(cleanup_str):
             cleanup_error = ('cleanup option %s is not one of ' +
                              ', '.join(CLEANUP_CHOICES))

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -621,6 +621,14 @@ def add_emr_opts(opt_group):
                  ' account.'
         ),
 
+        opt_group.add_option(
+            '--emr-tag', dest='emr_tags',
+            default=[], action='append',
+            help='Metadata tags to apply to the EMR cluster; '
+                 'should take the form KEY=VALUE. You can use --emr-tag '
+                 'multiple times.'
+        ),
+
     ]
 
 

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -858,6 +858,12 @@ class MockEmrConnection(object):
             job_flow.state = 'COMPLETED'
             job_flow.reason = 'Steps Completed'
 
+    def add_tags(self, resource_id, tags):
+        """Simulate successful creation of new metadata tags for the specified
+        resource id.
+        """
+        return bool(resource_id and tags)
+
 
 class MockEmrObject(object):
     """Mock out boto.emr.EmrObject. This is just a generic object that you


### PR DESCRIPTION
This has been asked in https://groups.google.com/forum/#!msg/mrjob/bLGuo4rssds/eWZfKZrSTKQJ.

The third comment in the thread suggests using a **bootstrap action** script in order to have the tags applied. However, I found that solution too cumbersome for something that should be simple to achieve.

Maybe this feature can make it into the 0.5.0 release?

Cheers!