### PR TITLE
update IAM code to use "new" boto methods

### DIFF
--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1052,7 +1052,8 @@ class MockIAMConnection(object):
 
     def create_role(self, role_name, assume_role_policy_document, path=None):
         # real boto has a default for assume_role_policy_document; not
-        # supporting this for now        self._check_path(path)
+        # supporting this for now
+        self._check_path(path)
         self._check_role_does_not_exist(role_name)
 
         # there's no validation of assume_role_policy_document; not entirely

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -924,12 +924,12 @@ class MockIAMConnection(object):
                  mock_iam_role_attached_policies=None):
         """Mock out connection to IAM.
 
-        mock_iam_instance_profiles maps profile name to a dictionary containing:
+        mock_iam_instance_profiles maps profile name to a dict containing:
             create_date -- ISO creation datetime
             path -- IAM path
             role_name -- name of single role for this instance profile, or None
 
-        mock_iam_roles maps role name to a dictionary containing:
+        mock_iam_roles maps role name to a dict containing:
             assume_role_policy_document -- a JSON-then-URI-encoded policy doc
             create_date -- ISO creation datetime
             path -- IAM path

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -681,7 +681,6 @@ class IAMTestCase(MockEMRAndS3TestCase):
         self.assertEqual(job_flow2.jobflowrole, instance_profile_name)
         self.assertEqual(job_flow2.servicerole, service_role_name)
 
-
     def test_iam_instance_profile_option(self):
         job_flow = self.run_and_get_job_flow(
             '--iam-instance-profile', 'EMR_EC2_DefaultRole')

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -147,7 +147,6 @@ class MockEMRAndS3TestCase(FastEMRTestCase):
     def _mock_boto_connect_iam(self, *args, **kwargs):
         kwargs['mock_iam_instance_profiles'] = self.mock_iam_instance_profiles
         kwargs['mock_iam_roles'] = self.mock_iam_roles
-        kwargs['mock_iam_role_policies'] = self.mock_iam_role_policies
         kwargs['mock_iam_role_attached_policies'] = (
             self.mock_iam_role_attached_policies)
         return MockIAMConnection(*args, **kwargs)
@@ -159,7 +158,6 @@ class MockEMRAndS3TestCase(FastEMRTestCase):
         self.mock_emr_output = {}
         self.mock_iam_instance_profiles = {}
         self.mock_iam_role_attached_policies = {}
-        self.mock_iam_role_policies = {}
         self.mock_iam_roles = {}
         self.mock_s3_fs = {}
 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
+
 from mrjob.iam import MRJOB_SERVICE_ROLE
 from mrjob.iam import _unwrap_response
 from mrjob.iam import _yield_instance_profiles
@@ -45,10 +47,9 @@ class PaginationTestCase(TestCase):
         max_items = conn.DEFAULT_MAX_ITEMS
 
         for i in range(2 * max_items):
-            conn.create_role('r-%03d' % i, MRJOB_SERVICE_ROLE)
+            conn.create_role('r-%03d' % i, json.dumps(MRJOB_SERVICE_ROLE))
 
-        roles_page = _unwrap_response(
-            conn.list_roles())['roles']
+        roles_page = _unwrap_response(conn.list_roles())['roles']
         self.assertEqual(len(roles_page), max_items)
 
         roles = list(_yield_roles(conn))


### PR DESCRIPTION
Now that we're on boto 2.35.0, boto's `IAMConnection` has methods for most of the IAM API calls we need. This pull request uses those methods instead of setting up calls manually with `IAMConnection.get_response()`. (Fixes #1062)

This also removes a lot of test code for inline (as opposed to "attached") role policies, which we haven't used since v0.4.5.