### PR TITLE
iam_endpoint option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ v0.5.0, 2015-??-?? -- ???
    * All runners:
      * removed IS_SUCCESSFUL cleanup option (use ALL)
    * EMR:
+     * added iam_endpoint option (#1067)
      * removed iam_job_flow_role option (use iam_instance_profile)
      * removed get_s3_folder_keys()
  * removed mrjob.compat.get_jobconf_value() (use jobconf_from_env())

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -217,6 +217,18 @@ Job flow creation and configuration
     necessary to set this by hand.
 
 .. mrjob-opt::
+    :config: iam_endpoint
+    :switch: --iam-endpoint
+    :type: :ref:`string <data-type-string>`
+    :set: emr
+    :default: (automatic)
+
+    Force mrjob to connect to IAM on this endpoint (e.g.
+    ``iam.us-gov.amazonaws.com``).
+
+    Mostly exists as a workaround for network issues.
+
+.. mrjob-opt::
     :config: iam_instance_profile
     :switch: --iam-instance-profile
     :type: :ref:`string <data-type-string>`

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -316,6 +316,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         'hadoop_streaming_jar_on_emr',
         'hadoop_version',
         'iam_instance_profile',
+        'iam_endpoint',
         'iam_service_role',
         'max_hours_idle',
         'mins_to_end_of_hour',
@@ -2608,7 +2609,9 @@ class EMRJobRunner(MRJobRunner):
         if boto is None:
             raise ImportError('You must install boto to connect to IAM')
 
-        log.debug('creating IAM connection')
+        host = self._opts['iam_endpoint'] or 'iam.amazonaws.com'
+
+        log.debug('creating IAM connection to %s' % host)
 
         # boto 2.2.0's IamConnection doesn't support security_token,
         # so only include it if set
@@ -2619,5 +2622,6 @@ class EMRJobRunner(MRJobRunner):
         raw_iam_conn = boto.connect_iam(
             aws_access_key_id=self._aws_access_key_id,
             aws_secret_access_key=self._aws_secret_access_key,
+            host=host,
             **kwargs)
         return wrap_aws_conn(raw_iam_conn)

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -444,6 +444,11 @@ def add_emr_opts(opt_group):
                   ' Rarely necessary.')),
 
         opt_group.add_option(
+            '--iam-endpoint', dest='iam_endpoint', default=None,
+            help=('Force mrjob to connect to IAM on this endpoint'
+                  ' (e.g. iam.us-gov.amazonaws.com)')),
+
+        opt_group.add_option(
             '--iam-instance-profile', dest='iam_instance_profile',
             default=None,
             help=('EC2 instance profile to use for the EMR cluster - see'

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -953,6 +953,8 @@ class MockIAMConnection(object):
         self.mock_iam_role_attached_policies = combine_values(
             {}, mock_iam_role_attached_policies)
 
+        self.host = host
+
     def get_response(self, action, params, path='/', parent=None,
                      verb='POST', list_marker='Set'):
         # mrjob.iam currently only calls get_response(), to support old

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -38,6 +38,7 @@ from mrjob.emr import filechunkio
 from mrjob.emr import _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH
 from mrjob.emr import _lock_acquire_step_1
 from mrjob.emr import _lock_acquire_step_2
+from mrjob.job import MRJob
 from mrjob.parse import JOB_KEY_RE
 from mrjob.parse import parse_s3_uri
 from mrjob.pool import pool_hash_and_name
@@ -3868,3 +3869,26 @@ class EMRTagsTestCase(MockEMRAndS3TestCase):
                     {'tag_one': 'foo',
                      'tag_two': 'qwerty',
                      'tag_three': 'bar'})
+
+
+class IAMEndpointTestCase(MockEMRAndS3TestCase):
+
+    def test_default(self):
+        runner = EMRJobRunner()
+
+        iam_conn = runner.make_iam_conn()
+        self.assertEqual(iam_conn.host, 'iam.amazonaws.com')
+
+    def test_explicit_iam_endpoint(self):
+        runner = EMRJobRunner(iam_endpoint='iam.us-gov.amazonaws.com')
+
+        iam_conn = runner.make_iam_conn()
+        self.assertEqual(iam_conn.host, 'iam.us-gov.amazonaws.com')
+
+    def test_iam_endpoint_option(self):
+        mr_job = MRJob(
+            ['-r', 'emr', '--iam-endpoint', 'iam.us-gov.amazonaws.com'])
+
+        with mr_job.make_runner() as runner:
+            iam_conn = runner.make_iam_conn()
+            self.assertEqual(iam_conn.host, 'iam.us-gov.amazonaws.com')


### PR DESCRIPTION
For consistency creates an `iam_endpoint` option, analogous to `emr_endpoint` and `s3_endpoint`. (Fixes #1067)

Under normal circumstances, IAM only has a single endpoint, so this mostly exists to support China/GovCloud, or to help people work around weird network issues.