### PR TITLE
Write as binary mode when outputting setup-wrapper.sh.

### DIFF
--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -917,9 +917,9 @@ class MRJobRunner(object):
         for line in contents:
             log.debug('WRAPPER: ' + line.rstrip('\n'))
 
-        with open(path, 'w') as f:
+        with open(path, 'wb') as f:
             for line in contents:
-                f.write(line)
+                f.write(line.encode('utf-8'))
 
         self._setup_wrapper_script_path = path
         self._working_dir_mgr.add('file', self._setup_wrapper_script_path)


### PR DESCRIPTION
This is so setup-wrapper.sh has correct UNIX line endings for AWS EMR. 
Python will write \r\n on Windows when encountering a \n when writing using text mode, which causes jobs to not start on EMR.