### PR TITLE
MockBoto test case

### DIFF
--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -28,10 +28,10 @@ from tests.mockboto import add_mock_s3_data
 from tests.py2 import Mock
 from tests.py2 import TestCase
 from tests.py2 import patch
-from tests.test_emr import MockEMRAndS3TestCase
+from tests.mockboto import MockBotoTestCase
 
 
-class S3FSTestCase(MockEMRAndS3TestCase):
+class S3FSTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(S3FSTestCase, self).setUp()
@@ -124,7 +124,7 @@ class S3FSTestCase(MockEMRAndS3TestCase):
         self.assertEqual(self.fs.path_exists('s3://walrus/data/foo'), False)
 
 
-class S3FSRegionTestCase(MockEMRAndS3TestCase):
+class S3FSRegionTestCase(MockBotoTestCase):
 
     def test_default_endpoint(self):
         fs = S3Filesystem()

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -88,6 +88,15 @@ class EmptyMrjobConfTestCase(TestCase):
             patcher.start()
             self.addCleanup(patcher.stop)
 
+    def start(self, patcher):
+        """Add the given patcher to this test case's cleanup actions,
+        then start it, and return the mock it returns. Example:
+
+        mock_turtle = self.start(patch('foo.bar.turtle'))
+        """
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
 
 class SandboxedTestCase(EmptyMrjobConfTestCase):
     """Patch mrjob.conf, create a temp directory, and save the environment for
@@ -133,15 +142,6 @@ class SandboxedTestCase(EmptyMrjobConfTestCase):
         """
         os.environ['PYTHONPATH'] = (
             mrjob_pythonpath() + ':' + os.environ.get('PYTHONPATH', ''))
-
-    def start(self, patcher):
-        """Add the given patcher to this test case's cleanup actions,
-        then start it, and return the mock it returns. Example:
-
-        mock_turtle = self.start(patch('foo.bar.turtle'))
-        """
-        self.addCleanup(patcher.stop)
-        return patcher.start()
 
 
 def mrjob_pythonpath():

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -15,8 +15,6 @@
 """Tests for EMRJobRunner"""
 import copy
 import getpass
-import itertools
-import logging
 import os
 import os.path
 import posixpath
@@ -50,14 +48,11 @@ from mrjob.util import bash_wrap
 from mrjob.util import log_to_stream
 from mrjob.util import tar_and_gzip
 
+from tests.mockboto import MockBotoTestCase
 from tests.mockboto import DEFAULT_MAX_JOB_FLOWS_RETURNED
 from tests.mockboto import MockEmrConnection
 from tests.mockboto import MockEmrObject
-from tests.mockboto import MockIAMConnection
-from tests.mockboto import MockS3Connection
-from tests.mockboto import add_mock_s3_data
 from tests.mockboto import to_iso8601
-from tests.mockssh import create_mock_ssh_script
 from tests.mockssh import mock_ssh_dir
 from tests.mockssh import mock_ssh_file
 from tests.mr_hadoop_format_job import MRHadoopFormatJob
@@ -72,7 +67,6 @@ from tests.py2 import patch
 from tests.py2 import skipIf
 from tests.quiet import logger_disabled
 from tests.quiet import no_handlers_for_logger
-from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_conf_patcher
 from tests.sandbox import patch_fs_s3
 
@@ -92,162 +86,7 @@ else:
     PYTHON_BIN = 'python3'
 
 
-class MockEMRAndS3TestCase(SandboxedTestCase):
-
-    MAX_SIMULATION_STEPS = 100
-
-    @classmethod
-    def setUpClass(cls):
-        # we don't care what's in this file, just want mrjob to stop creating
-        # and deleting a complicated archive.
-        cls.fake_mrjob_tgz_path = tempfile.mkstemp(
-            prefix='fake_mrjob_', suffix='.tar.gz')[1]
-
-    @classmethod
-    def tearDownClass(cls):
-        if os.path.exists(cls.fake_mrjob_tgz_path):
-            os.remove(cls.fake_mrjob_tgz_path)
-
-    def setUp(self):
-        # patch boto
-        self.mock_emr_failures = {}
-        self.mock_emr_job_flows = {}
-        self.mock_emr_output = {}
-        self.mock_iam_instance_profiles = {}
-        self.mock_iam_role_attached_policies = {}
-        self.mock_iam_roles = {}
-        self.mock_s3_fs = {}
-
-        self.simulation_iterator = itertools.repeat(
-            None, self.MAX_SIMULATION_STEPS)
-
-        p_s3 = patch.object(boto, 'connect_s3', self._mock_boto_connect_s3)
-        self.addCleanup(p_s3.stop)
-        p_s3.start()
-
-        p_iam = patch.object(boto, 'connect_iam', self._mock_boto_connect_iam)
-        self.addCleanup(p_iam.stop)
-        p_iam.start()
-
-        p_emr = patch.object(
-            boto.emr.connection, 'EmrConnection',
-            self._mock_boto_emr_EmrConnection)
-        self.addCleanup(p_emr.stop)
-        p_emr.start()
-
-        super(MockEMRAndS3TestCase, self).setUp()
-
-        # patch slow things
-        def fake_create_mrjob_tar_gz(mocked_self, *args, **kwargs):
-            mocked_self._mrjob_tar_gz_path = self.fake_mrjob_tgz_path
-            return self.fake_mrjob_tgz_path
-
-        self.start(patch.object(
-            EMRJobRunner, '_create_mrjob_tar_gz',
-            fake_create_mrjob_tar_gz))
-
-        self.start(patch.object(
-            EMRJobRunner, '_wait_for_s3_eventual_consistency'))
-
-        self.start(patch.object(
-            EMRJobRunner, '_wait_for_job_flow_termination'))
-
-        self.start(patch.object(time, 'sleep'))
-
-    def add_mock_s3_data(self, data, time_modified=None, location=None):
-        """Update self.mock_s3_fs with a map from bucket name
-        to key name to data."""
-        add_mock_s3_data(self.mock_s3_fs, data, time_modified, location)
-
-    def prepare_runner_for_ssh(self, runner, num_slaves=0):
-        # TODO: Refactor this abomination of a test harness
-
-        # Set up environment variables
-        os.environ['MOCK_SSH_VERIFY_KEY_FILE'] = 'true'
-
-        # Create temporary directories and add them to MOCK_SSH_ROOTS
-        master_ssh_root = tempfile.mkdtemp(prefix='master_ssh_root.')
-        os.environ['MOCK_SSH_ROOTS'] = 'testmaster=%s' % master_ssh_root
-        mock_ssh_dir('testmaster', SSH_LOG_ROOT + '/history')
-
-        if not hasattr(self, 'slave_ssh_roots'):
-            self.slave_ssh_roots = []
-
-        self.addCleanup(self.teardown_ssh, master_ssh_root)
-
-        # Make the fake binary
-        os.mkdir(os.path.join(master_ssh_root, 'bin'))
-        self.ssh_bin = os.path.join(master_ssh_root, 'bin', 'ssh')
-        create_mock_ssh_script(self.ssh_bin)
-
-        # Make a fake keyfile so that the 'file exists' requirements are
-        # satsified
-        self.keyfile_path = os.path.join(master_ssh_root, 'key.pem')
-        with open(self.keyfile_path, 'w') as f:
-            f.write('I AM DEFINITELY AN SSH KEY FILE')
-
-        # Tell the runner to use the fake binary
-        runner._opts['ssh_bin'] = [self.ssh_bin]
-        # Inject master node hostname so it doesn't try to 'emr --describe' it
-        runner._address = 'testmaster'
-        # Also pretend to have an SSH key pair file
-        runner._opts['ec2_key_pair_file'] = self.keyfile_path
-
-        # re-initialize fs
-        runner._fs = None
-        runner._ssh_fs = None
-        runner._s3_fs = None
-        #runner.fs
-
-    def add_slave(self):
-        """Add a mocked slave to the cluster. Caller is responsible for setting
-        runner._opts['num_ec2_instances'] to the correct number.
-        """
-        slave_num = len(self.slave_ssh_roots)
-        new_dir = tempfile.mkdtemp(prefix='slave_%d_ssh_root.' % slave_num)
-        self.slave_ssh_roots.append(new_dir)
-        os.environ['MOCK_SSH_ROOTS'] += (':testmaster!testslave%d=%s'
-                                         % (slave_num, new_dir))
-
-    def teardown_ssh(self, master_ssh_root):
-        shutil.rmtree(master_ssh_root)
-        for path in self.slave_ssh_roots:
-            shutil.rmtree(path)
-
-    def run_and_get_job_flow(self, *args):
-        # set up a job flow without caring about what the job is or what its
-        # inputs are.
-        stdin = BytesIO(b'foo\nbar\n')
-        mr_job = MRTwoStepJob(
-            ['-r', 'emr', '-v'] + list(args))
-        mr_job.sandbox(stdin=stdin)
-
-        with mr_job.make_runner() as runner:
-            runner.run()
-            emr_conn = runner.make_emr_conn()
-            return emr_conn.describe_jobflow(runner.get_emr_job_flow_id())
-
-    def _mock_boto_connect_s3(self, *args, **kwargs):
-        kwargs['mock_s3_fs'] = self.mock_s3_fs
-        return MockS3Connection(*args, **kwargs)
-
-    def _mock_boto_emr_EmrConnection(self, *args, **kwargs):
-        kwargs['mock_s3_fs'] = self.mock_s3_fs
-        kwargs['mock_emr_job_flows'] = self.mock_emr_job_flows
-        kwargs['mock_emr_failures'] = self.mock_emr_failures
-        kwargs['mock_emr_output'] = self.mock_emr_output
-        kwargs['simulation_iterator'] = self.simulation_iterator
-        return MockEmrConnection(*args, **kwargs)
-
-    def _mock_boto_connect_iam(self, *args, **kwargs):
-        kwargs['mock_iam_instance_profiles'] = self.mock_iam_instance_profiles
-        kwargs['mock_iam_roles'] = self.mock_iam_roles
-        kwargs['mock_iam_role_attached_policies'] = (
-            self.mock_iam_role_attached_policies)
-        return MockIAMConnection(*args, **kwargs)
-
-
-class EMRJobRunnerEndToEndTestCase(MockEMRAndS3TestCase):
+class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
 
     MRJOB_CONF_CONTENTS = {'runners': {'emr': {
         'check_emr_status_every': 0.00,
@@ -488,7 +327,7 @@ class EMRJobRunnerEndToEndTestCase(MockEMRAndS3TestCase):
             runner._wait_for_job_flow_termination()
 
 
-class ExistingJobFlowTestCase(MockEMRAndS3TestCase):
+class ExistingJobFlowTestCase(MockBotoTestCase):
 
     def test_attach_to_existing_job_flow(self):
         emr_conn = EMRJobRunner(conf_paths=[]).make_emr_conn()
@@ -560,7 +399,7 @@ class ExistingJobFlowTestCase(MockEMRAndS3TestCase):
         self.assertEqual(job_flow.state, 'WAITING')
 
 
-class VisibleToAllUsersTestCase(MockEMRAndS3TestCase):
+class VisibleToAllUsersTestCase(MockBotoTestCase):
 
     def test_defaults(self):
         job_flow = self.run_and_get_job_flow()
@@ -587,7 +426,7 @@ class VisibleToAllUsersTestCase(MockEMRAndS3TestCase):
             self.assertEqual(visible_job_flow.visibletoallusers, 'true')
 
 
-class IAMTestCase(MockEMRAndS3TestCase):
+class IAMTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(IAMTestCase, self).setUp()
@@ -678,7 +517,7 @@ class IAMTestCase(MockEMRAndS3TestCase):
         self.assertEqual(job_flow.servicerole, 'EMR_DefaultRole')
 
 
-class EMRAPIParamsTestCase(MockEMRAndS3TestCase):
+class EMRAPIParamsTestCase(MockBotoTestCase):
 
     def test_param_set(self):
         job_flow = self.run_and_get_job_flow('--emr-api-param', 'Test.API=a', '--emr-api-param', 'Test.API2=b')
@@ -755,7 +594,7 @@ class EMRAPIParamsTestCase(MockEMRAndS3TestCase):
                      'Name': 'eaten_by_a_whale'})
 
 
-class AMIAndHadoopVersionTestCase(MockEMRAndS3TestCase):
+class AMIAndHadoopVersionTestCase(MockBotoTestCase):
 
     def test_defaults(self):
         with logger_disabled('mrjob.emr'):
@@ -825,7 +664,7 @@ class AMIAndHadoopVersionTestCase(MockEMRAndS3TestCase):
                               '--hadoop-version', '0.20.205')
 
 
-class AvailabilityZoneTestCase(MockEMRAndS3TestCase):
+class AvailabilityZoneTestCase(MockBotoTestCase):
 
     MRJOB_CONF_CONTENTS = {'runners': {'emr': {
         'check_emr_status_every': 0.00,
@@ -858,7 +697,7 @@ class AvailabilityZoneTestCase(MockEMRAndS3TestCase):
             self.assertEqual(flow.steps[0].name, 'Setup Hadoop Debugging')
 
 
-class RegionTestCase(MockEMRAndS3TestCase):
+class RegionTestCase(MockBotoTestCase):
 
     def test_default(self):
         runner = EMRJobRunner()
@@ -873,7 +712,7 @@ class RegionTestCase(MockEMRAndS3TestCase):
         self.assertEqual(runner._opts['aws_region'], 'us-west-2')
 
 
-class ScratchBucketTestCase(MockEMRAndS3TestCase):
+class ScratchBucketTestCase(MockBotoTestCase):
 
     def assert_new_scratch_bucket(self, location, **runner_kwargs):
         """Assert that if we create an EMRJobRunner with the given keyword
@@ -954,7 +793,7 @@ class ScratchBucketTestCase(MockEMRAndS3TestCase):
         self.assertEqual(runner._opts['aws_region'], 'us-west-1')
 
 
-class DescribeAllJobFlowsTestCase(MockEMRAndS3TestCase):
+class DescribeAllJobFlowsTestCase(MockBotoTestCase):
 
     def test_can_get_more_job_flows_than_limit(self):
         now = datetime.utcnow()
@@ -1018,7 +857,7 @@ class DescribeAllJobFlowsTestCase(MockEMRAndS3TestCase):
                          ['j-LONGRUNNING', 'j-THREEWEEKSAGO'])
 
 
-class EC2InstanceGroupTestCase(MockEMRAndS3TestCase):
+class EC2InstanceGroupTestCase(MockBotoTestCase):
 
     def _test_instance_groups(self, opts, **expected):
         """Run a job with the given option dictionary, and check for
@@ -1406,7 +1245,7 @@ def make_input_uri_line(input_uri):
             " Opening '%s' for reading\n" % input_uri).encode('utf_8')
 
 
-class FindProbableCauseOfFailureTestCase(MockEMRAndS3TestCase):
+class FindProbableCauseOfFailureTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(FindProbableCauseOfFailureTestCase, self).setUp()
@@ -1609,7 +1448,7 @@ class FindProbableCauseOfFailureTestCase(MockEMRAndS3TestCase):
                          None)
 
 
-class CounterFetchingTestCase(MockEMRAndS3TestCase):
+class CounterFetchingTestCase(MockBotoTestCase):
 
     COUNTER_LINE = (
         b'Job JOBID="job_201106092314_0001" FINISH_TIME="1307662284564"'
@@ -1709,7 +1548,7 @@ class CounterFetchingTestCase(MockEMRAndS3TestCase):
         self.runner._fetch_counters_s3.assert_called_with([1, 2], False)
 
 
-class LogFetchingFallbackTestCase(MockEMRAndS3TestCase):
+class LogFetchingFallbackTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(LogFetchingFallbackTestCase, self).setUp()
@@ -1792,7 +1631,7 @@ class LogFetchingFallbackTestCase(MockEMRAndS3TestCase):
                          'attempt_201007271720_0002_m_000126_0/stderr')
 
 
-class TestEMREndpoints(MockEMRAndS3TestCase):
+class TestEMREndpoints(MockBotoTestCase):
 
     def test_default_region(self):
         runner = EMRJobRunner(conf_paths=[])
@@ -1876,7 +1715,7 @@ class TestEMREndpoints(MockEMRAndS3TestCase):
                          'elasticmapreduce.us-west-1.amazonaws.com')
 
 
-class TestS3Ls(MockEMRAndS3TestCase):
+class TestS3Ls(MockBotoTestCase):
 
     def test_s3_ls(self):
         self.add_mock_s3_data(
@@ -1906,7 +1745,7 @@ class TestS3Ls(MockEMRAndS3TestCase):
         self.assertRaises(Exception, set, runner._s3_ls('s3://lolcat/'))
 
 
-class TestSSHLs(MockEMRAndS3TestCase):
+class TestSSHLs(MockBotoTestCase):
 
     def setUp(self):
         super(TestSSHLs, self).setUp()
@@ -1967,7 +1806,7 @@ class TestNoBoto(TestCase):
         self.assertRaises(ImportError, EMRJobRunner, conf_paths=[])
 
 
-class TestMasterBootstrapScript(MockEMRAndS3TestCase):
+class TestMasterBootstrapScript(MockBotoTestCase):
 
     def setUp(self):
         super(TestMasterBootstrapScript, self).setUp()
@@ -2195,7 +2034,7 @@ class TestMasterBootstrapScript(MockEMRAndS3TestCase):
         self.assertTrue(runner.path_exists(actions[1].path))
 
 
-class EMRNoMapperTest(MockEMRAndS3TestCase):
+class EMRNoMapperTest(MockBotoTestCase):
 
     def setUp(self):
         super(EMRNoMapperTest, self).setUp()
@@ -2243,7 +2082,7 @@ class EMRNoMapperTest(MockEMRAndS3TestCase):
                          [(1, 'qux'), (2, 'bar'), (2, 'foo'), (5, None)])
 
 
-class PoolMatchingTestCase(MockEMRAndS3TestCase):
+class PoolMatchingTestCase(MockBotoTestCase):
 
     def make_pooled_job_flow(self, name=None, minutes_ago=0, **kwargs):
         """Returns ``(runner, job_flow_id)``. Set minutes_ago to set
@@ -2825,7 +2664,7 @@ class PoolMatchingTestCase(MockEMRAndS3TestCase):
         self.assertJoins(job_flow_id, ['-r', 'emr', '--pool-emr-job-flows'])
 
 
-class PoolingDisablingTestCase(MockEMRAndS3TestCase):
+class PoolingDisablingTestCase(MockBotoTestCase):
 
     MRJOB_CONF_CONTENTS = {'runners': {'emr': {
         'check_emr_status_every': 0.00,
@@ -2846,7 +2685,7 @@ class PoolingDisablingTestCase(MockEMRAndS3TestCase):
             self.assertEqual(jf.keepjobflowalivewhennosteps, 'false')
 
 
-class S3LockTestCase(MockEMRAndS3TestCase):
+class S3LockTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(S3LockTestCase, self).setUp()
@@ -2905,7 +2744,7 @@ class S3LockTestCase(MockEMRAndS3TestCase):
         self.assertFalse(_lock_acquire_step_2(key, 'jf1'), 'Lock should fail')
 
 
-class MaxHoursIdleTestCase(MockEMRAndS3TestCase):
+class MaxHoursIdleTestCase(MockBotoTestCase):
 
     def assertRanIdleTimeoutScriptWith(self, runner, args):
         emr_conn = runner.make_emr_conn()
@@ -2988,7 +2827,7 @@ class MaxHoursIdleTestCase(MockEMRAndS3TestCase):
     def test_bootstrap_script_is_actually_installed(self):
         self.assertTrue(os.path.exists(_MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH))
 
-class TestCatFallback(MockEMRAndS3TestCase):
+class TestCatFallback(MockBotoTestCase):
 
     def test_s3_cat(self):
         self.add_mock_s3_data(
@@ -3025,7 +2864,7 @@ class TestCatFallback(MockEMRAndS3TestCase):
             [error_message])
 
 
-class CleanUpJobTestCase(MockEMRAndS3TestCase):
+class CleanUpJobTestCase(MockBotoTestCase):
 
     @contextmanager
     def _test_mode(self, mode):
@@ -3138,7 +2977,7 @@ class CleanUpJobTestCase(MockEMRAndS3TestCase):
                 self.assertTrue(m().terminate_jobflow.called)
 
 
-class JobWaitTestCase(MockEMRAndS3TestCase):
+class JobWaitTestCase(MockBotoTestCase):
 
     # A list of job ids that hold booleans of whether or not the job can
     # acquire a lock. Helps simulate mrjob.emr.attempt_to_acquire_lock.
@@ -3242,7 +3081,7 @@ class JobWaitTestCase(MockEMRAndS3TestCase):
         self.assertEqual(self.sleep_counter, 2)
 
 
-class BuildStreamingStepTestCase(MockEMRAndS3TestCase):
+class BuildStreamingStepTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(BuildStreamingStepTestCase, self).setUp()
@@ -3387,7 +3226,7 @@ class BuildStreamingStepTestCase(MockEMRAndS3TestCase):
         )
 
 
-class JarStepTestCase(MockEMRAndS3TestCase):
+class JarStepTestCase(MockBotoTestCase):
 
     MRJOB_CONF_CONTENTS = {'runners': {'emr': {
         'check_emr_status_every': 0.00,
@@ -3484,7 +3323,7 @@ class JarStepTestCase(MockEMRAndS3TestCase):
             self.assertEqual(jar_output_arg, streaming_input_arg)
 
 
-class ActionOnFailureTestCase(MockEMRAndS3TestCase):
+class ActionOnFailureTestCase(MockBotoTestCase):
 
     def test_default(self):
         runner = EMRJobRunner()
@@ -3515,7 +3354,7 @@ class ActionOnFailureTestCase(MockEMRAndS3TestCase):
             self.assertEqual(runner._action_on_failure, 'CONTINUE')
 
 
-class MultiPartUploadTestCase(MockEMRAndS3TestCase):
+class MultiPartUploadTestCase(MockBotoTestCase):
 
     PART_SIZE_IN_MB = 50.0 / 1024 / 1024
     TEST_BUCKET = 'walrus'
@@ -3600,7 +3439,7 @@ class MultiPartUploadTestCase(MockEMRAndS3TestCase):
             self.assertTrue(s3_key.mock_multipart_upload_was_cancelled())
 
 
-class SecurityTokenTestCase(MockEMRAndS3TestCase):
+class SecurityTokenTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(SecurityTokenTestCase, self).setUp()
@@ -3645,7 +3484,7 @@ class SecurityTokenTestCase(MockEMRAndS3TestCase):
         self.assert_conns_use_security_token(runner, 'meow')
 
 
-class BootstrapPythonTestCase(MockEMRAndS3TestCase):
+class BootstrapPythonTestCase(MockBotoTestCase):
 
     def test_default(self):
         mr_job = MRTwoStepJob(['-r', 'emr'])
@@ -3725,7 +3564,7 @@ class BootstrapPythonTestCase(MockEMRAndS3TestCase):
                     [['sudo yum install-python-already'], ['true']])
 
 
-class EMRTagsTestCase(MockEMRAndS3TestCase):
+class EMRTagsTestCase(MockBotoTestCase):
     def test_emr_tags_option_dict(self):
         job = MRWordCount([
             '-r', 'emr',
@@ -3772,7 +3611,7 @@ class EMRTagsTestCase(MockEMRAndS3TestCase):
                      'tag_three': 'bar'})
 
 
-class IAMEndpointTestCase(MockEMRAndS3TestCase):
+class IAMEndpointTestCase(MockBotoTestCase):
 
     def test_default(self):
         runner = EMRJobRunner()

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -280,16 +280,16 @@ class StreamingArgsTestCase(EmptyMrjobConfTestCase):
         self.runner._add_job_files_for_upload()
 
         self.runner._hadoop_version='0.20.204'
-        self.simple_patch(self.runner, '_new_upload_args',
-                          return_value=['new_upload_args'])
-        self.simple_patch(self.runner, '_old_upload_args',
-                          return_value=['old_upload_args'])
-        self.simple_patch(self.runner, '_hadoop_args_for_step',
-                          return_value=['hadoop_args_for_step'])
-        self.simple_patch(self.runner, '_hdfs_step_input_files',
-                          return_value=['hdfs_step_input_files'])
-        self.simple_patch(self.runner, '_hdfs_step_output_dir',
-                          return_value='hdfs_step_output_dir')
+        self.start(patch.object(self.runner, '_new_upload_args',
+                                return_value=['new_upload_args']))
+        self.start(patch.object(self.runner, '_old_upload_args',
+                                return_value=['old_upload_args']))
+        self.start(patch.object(self.runner, '_hadoop_args_for_step',
+                                return_value=['hadoop_args_for_step']))
+        self.start(patch.object(self.runner, '_hdfs_step_input_files',
+                                return_value=['hdfs_step_input_files']))
+        self.start(patch.object(self.runner, '_hdfs_step_output_dir',
+                                return_value='hdfs_step_output_dir'))
         self.runner._script_path = 'my_job.py'
 
         self._new_basic_args = [
@@ -304,12 +304,6 @@ class StreamingArgsTestCase(EmptyMrjobConfTestCase):
              '-input', 'hdfs_step_input_files',
              '-output', 'hdfs_step_output_dir',
              'old_upload_args']
-
-    def simple_patch(self, obj, attr, side_effect=None, return_value=None):
-        patcher = patch.object(obj, attr, side_effect=side_effect,
-                               return_value=return_value)
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
     def _assert_streaming_step(self, step, args):
         self.runner._steps = [step]

--- a/tests/tools/emr/__init__.py
+++ b/tests/tools/emr/__init__.py
@@ -20,10 +20,10 @@ from mrjob.py2 import StringIO
 
 from tests.py2 import mock_stdout_or_stderr
 from tests.py2 import patch
-from tests.test_emr import MockEMRAndS3TestCase
+from tests.mockboto import MockBotoTestCase
 
 
-class ToolTestCase(MockEMRAndS3TestCase):
+class ToolTestCase(MockBotoTestCase):
 
     def monkey_patch_argv(self, *args):
         p = patch('sys.argv', [sys.argv[0]] + list(args))

--- a/tests/tools/emr/test_mrboss.py
+++ b/tests/tools/emr/test_mrboss.py
@@ -20,12 +20,12 @@ import tempfile
 from mrjob.emr import EMRJobRunner
 from mrjob.tools.emr.mrboss import run_on_all_nodes
 from tests.mockssh import mock_ssh_file
-from tests.test_emr import MockEMRAndS3TestCase
+from tests.mockboto import MockBotoTestCase
 from tests.test_emr import BUCKET_URI
 from tests.test_emr import LOG_DIR
 
 
-class MRBossTestCase(MockEMRAndS3TestCase):
+class MRBossTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(MRBossTestCase, self).setUp()

--- a/tests/tools/emr/test_report_long_jobs.py
+++ b/tests/tools/emr/test_report_long_jobs.py
@@ -23,7 +23,7 @@ from mrjob.tools.emr.report_long_jobs import main
 
 from tests.mockboto import MockEmrObject
 from tests.py2 import TestCase
-from tests.test_emr import MockEMRAndS3TestCase
+from tests.mockboto import MockBotoTestCase
 
 JOB_FLOWS = [
     MockEmrObject(
@@ -144,7 +144,7 @@ JOB_FLOWS = [
 JOB_FLOWS_BY_ID = dict((jf.jobflowid, jf) for jf in JOB_FLOWS)
 
 
-class ReportLongJobsTestCase(MockEMRAndS3TestCase):
+class ReportLongJobsTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(ReportLongJobsTestCase, self).setUp()

--- a/tests/tools/emr/test_s3_tmpwatch.py
+++ b/tests/tools/emr/test_s3_tmpwatch.py
@@ -28,10 +28,10 @@ from mrjob.emr import EMRJobRunner
 from mrjob.parse import parse_s3_uri
 from mrjob.tools.emr.s3_tmpwatch import s3_cleanup
 from tests.mockboto import MockKey
-from tests.test_emr import MockEMRAndS3TestCase
+from tests.mockboto import MockBotoTestCase
 
 
-class S3TmpWatchTestCase(MockEMRAndS3TestCase):
+class S3TmpWatchTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(S3TmpWatchTestCase, self).setUp()

--- a/tests/tools/emr/test_terminate_idle_job_flows.py
+++ b/tests/tools/emr/test_terminate_idle_job_flows.py
@@ -33,10 +33,10 @@ from tests.mockboto import MockEmrObject
 from tests.mockboto import to_iso8601
 from tests.mockboto import MockEmrConnection
 from tests.mockboto import MockS3Connection
-from tests.test_emr import MockEMRAndS3TestCase
+from tests.mockboto import MockBotoTestCase
 
 
-class JobFlowInspectionTestCase(MockEMRAndS3TestCase):
+class JobFlowInspectionTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(JobFlowInspectionTestCase, self).setUp()


### PR DESCRIPTION
Rename `MockEMRAndS3TestCase` (an awkward and incorrect name) to `MockBotoTestCase` and move it to `tests.mockboto`.

Also clean out some unnecessary test case classes and test methods.