### PR TITLE
Fix resource warnings in tests

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -990,6 +990,10 @@ class EMRJobRunner(MRJobRunner):
             if ssh_proc.returncode is None:
                 self._ssh_proc = ssh_proc
                 break
+            else:
+                ssh_proc.stdin.close()
+                ssh_proc.stdout.close()
+                ssh_proc.stderr.close()
 
         if not self._ssh_proc:
             log.warning('Failed to open ssh tunnel to job tracker')
@@ -1037,6 +1041,11 @@ class EMRJobRunner(MRJobRunner):
             if self._ssh_proc.returncode is None:
                 log.info('Killing our SSH tunnel (pid %d)' %
                          self._ssh_proc.pid)
+
+                self._ssh_proc.stdin.close()
+                self._ssh_proc.stdout.close()
+                self._ssh_proc.stderr.close()
+
                 try:
                     os.kill(self._ssh_proc.pid, signal.SIGKILL)
                     self._ssh_proc = None

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -179,6 +179,9 @@ class HadoopFilesystem(Filesystem):
             for line in cat_proc.stderr:
                 log.error('STDERR: ' + line)
 
+            cat_proc.stdout.close()
+            cat_proc.stderr.close()
+
             returncode = cat_proc.wait()
 
             if returncode != 0:

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -318,6 +318,9 @@ class HadoopJobRunner(MRJobRunner):
                 for line in step_proc.stdout:
                     log.error('STDOUT: ' + to_string(line.strip(b'\n')))
 
+                step_proc.stdout.close()
+                step_proc.stderr.close()
+
                 returncode = step_proc.wait()
             else:
                 # we have PTYs

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -241,8 +241,9 @@ class LocalMRJobRunner(SimMRJobRunner):
             proc.stderr, step_num=step_num)
         tb_lines = find_python_traceback(stderr_lines)
 
-        proc.stdin.close()
-        proc.stdout.close()
+        # proc.stdout isn't always defined
+        if proc.stdout:
+            proc.stdout.close()
         proc.stderr.close()
 
         returncode = proc.wait()

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -235,11 +235,17 @@ class LocalMRJobRunner(SimMRJobRunner):
 
     def _wait_for_process(self, proc_dict, step_num):
         # handle counters, status msgs, and other stuff on stderr
+        proc = proc_dict['proc']
+
         stderr_lines = self._process_stderr_from_script(
-            proc_dict['proc'].stderr, step_num=step_num)
+            proc.stderr, step_num=step_num)
         tb_lines = find_python_traceback(stderr_lines)
 
-        returncode = proc_dict['proc'].wait()
+        proc.stdin.close()
+        proc.stdout.close()
+        proc.stderr.close()
+
+        returncode = proc.wait()
 
         if returncode != 0:
             self.print_counters([step_num + 1])


### PR DESCRIPTION
This makes our code much more careful about closing files we've opened, especially pipes to subprocesses.