### PR TITLE
Add missing tool switches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 .tox
 .coverage
 *,cover
+j-*

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ v0.4.5, 2015-??-?? -- IAM Fortified
      * aws_security_token for temporary credentials (#1003)
      * Use AWS managed policies when creating IAM objects (#1026)
      * Fall back to default role/instance profile when no IAM access (#1008)
+   * EMR tools:
+     * added switches for options formerly only available from mrjob.conf
+     * mrboss is available from command line tool: mrjob boss [args]
+     * job_flow_pool is deprecated
  * more efficient decoding of bz2 files
 
 v0.4.4, 2015-04-21 -- EMRgency!

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,7 +7,7 @@ v0.4.5, 2015-??-?? -- IAM Fortified
    * EMR tools:
      * added switches for options formerly only available from mrjob.conf
      * mrboss is available from command line tool: mrjob boss [args]
-     * job_flow_pool is deprecated
+     * collect_emr_stats and job_flow_pool are deprecated
  * more efficient decoding of bz2 files
 
 v0.4.4, 2015-04-21 -- EMRgency!

--- a/mrjob/cmd.py
+++ b/mrjob/cmd.py
@@ -69,6 +69,12 @@ def audit_usage(args):
     main(args)
 
 
+@command('boss', 'Run a command on every node of a cluster.')
+def mrboss(args):
+    from mrjob.tools.emr.mrboss import main
+    main(args)
+
+
 @command('collect-emr-active-stats', 'Collect EMR stats from active jobflows')
 def collect_emr_stats(args):
     from mrjob.tools.emr.collect_emr_stats import main

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -37,6 +37,7 @@ from mrjob.options import add_hadoop_shared_opts
 from mrjob.options import add_protocol_opts
 from mrjob.options import add_runner_opts
 from mrjob.options import alphabetize_options
+from mrjob.options import parse_emr_api_params
 from mrjob.options import print_help_for_groups
 from mrjob.parse import parse_key_value_list
 from mrjob.parse import parse_port_range_list
@@ -431,7 +432,6 @@ class MRJobLauncher(object):
 
         # parse custom options here to avoid setting a custom Option subclass
         # and confusing users
-
         if self.options.ssh_bind_ports:
             try:
                 ports = parse_port_range_list(self.options.ssh_bind_ports)
@@ -452,17 +452,8 @@ class MRJobLauncher(object):
                                                     self.option_parser.error)
 
         # emr_api_params
-        emr_api_err = (
-            'emr-api-params argument "%s" is not of the form KEY=VALUE')
-
-        self.options.emr_api_params = parse_key_value_list(
-            self.options.emr_api_params,
-            emr_api_err,
-            self.option_parser.error)
-
-        # no_emr_api_params just exists to modify emr_api_params
-        for param in self.options.no_emr_api_params:
-            self.options.emr_api_params[param] = None
+        self.options.emr_api_params = parse_emr_api_params(
+            self.options, self.option_parser)
 
         def parse_commas(cleanup_str):
             cleanup_error = ('cleanup option %s is not one of ' +

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -430,6 +430,8 @@ class MRJobLauncher(object):
 
         self._process_args(args)
 
+        # TODO: break this out into separate function
+
         # parse custom options here to avoid setting a custom Option subclass
         # and confusing users
         if self.options.ssh_bind_ports:

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -36,6 +36,7 @@ from mrjob.options import add_hadoop_emr_opts
 from mrjob.options import add_hadoop_shared_opts
 from mrjob.options import add_protocol_opts
 from mrjob.options import add_runner_opts
+from mrjob.options import alphabetize_options
 from mrjob.options import print_help_for_groups
 from mrjob.parse import parse_key_value_list
 from mrjob.parse import parse_port_range_list
@@ -96,6 +97,9 @@ class MRJobLauncher(object):
                                           option_class=self.OPTION_CLASS,
                                           add_help_option=False)
         self.configure_options()
+
+        for opt_group in self.all_option_groups():
+            alphabetize_options(opt_group)
 
         # don't pass None to parse_args unless we're actually running
         # the MRJob script

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -37,11 +37,8 @@ from mrjob.options import add_hadoop_shared_opts
 from mrjob.options import add_protocol_opts
 from mrjob.options import add_runner_opts
 from mrjob.options import alphabetize_options
-from mrjob.options import parse_emr_api_params
+from mrjob.options import fix_custom_options
 from mrjob.options import print_help_for_groups
-from mrjob.parse import parse_key_value_list
-from mrjob.parse import parse_port_range_list
-from mrjob.runner import CLEANUP_CHOICES
 from mrjob.util import log_to_null
 from mrjob.util import log_to_stream
 from mrjob.util import parse_and_save_options
@@ -430,62 +427,7 @@ class MRJobLauncher(object):
 
         self._process_args(args)
 
-        # TODO: break this out into separate function
-
-        # parse custom options here to avoid setting a custom Option subclass
-        # and confusing users
-        if self.options.ssh_bind_ports:
-            try:
-                ports = parse_port_range_list(self.options.ssh_bind_ports)
-            except ValueError as e:
-                self.option_parser.error('invalid port range list "%s": \n%s' %
-                                         (self.options.ssh_bind_ports,
-                                          e.args[0]))
-            self.options.ssh_bind_ports = ports
-
-        cmdenv_err = 'cmdenv argument "%s" is not of the form KEY=VALUE'
-        self.options.cmdenv = parse_key_value_list(self.options.cmdenv,
-                                                   cmdenv_err,
-                                                   self.option_parser.error)
-
-        jobconf_err = 'jobconf argument "%s" is not of the form KEY=VALUE'
-        self.options.jobconf = parse_key_value_list(self.options.jobconf,
-                                                    jobconf_err,
-                                                    self.option_parser.error)
-
-        # emr_api_params
-        self.options.emr_api_params = parse_emr_api_params(
-            self.options, self.option_parser)
-
-        # emr_tags
-        emr_tags_err = (
-            'emr-tag argument "%s" is not of the form KEY=VALUE')
-
-        self.options.emr_tags = parse_key_value_list(
-            self.options.emr_tags,
-            emr_tags_err,
-            self.option_parser.error)
-
-        def parse_commas(cleanup_str):
-            cleanup_error = ('cleanup option %s is not one of ' +
-                             ', '.join(CLEANUP_CHOICES))
-            new_cleanup_options = []
-            for choice in cleanup_str.split(','):
-                if choice in CLEANUP_CHOICES:
-                    new_cleanup_options.append(choice)
-                else:
-                    self.option_parser.error(cleanup_error % choice)
-            if ('NONE' in new_cleanup_options and
-                    len(set(new_cleanup_options)) > 1):
-                self.option_parser.error(
-                    'Cannot clean up both nothing and something!')
-            return new_cleanup_options
-
-        if self.options.cleanup is not None:
-            self.options.cleanup = parse_commas(self.options.cleanup)
-        if self.options.cleanup_on_failure is not None:
-            self.options.cleanup_on_failure = parse_commas(
-                self.options.cleanup_on_failure)
+        fix_custom_options(self.options, self.option_parser)
 
     def job_runner_kwargs(self):
         """Keyword arguments used to create runners when

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -369,65 +369,9 @@ def add_emr_launch_opts(opt_group):
             help='A JSON string for selecting additional features on EMR'),
 
         opt_group.add_option(
-            '--ami-version', dest='ami_version', default=None,
-            help=('AMI Version to use, e.g. "2.4.11" (default "latest").')),
-
-        opt_group.add_option(
             '--aws-availability-zone', dest='aws_availability_zone',
             default=None,
             help='Availability zone to run the job flow on'),
-
-        opt_group.add_option(
-            '--bootstrap', dest='bootstrap', action='append',
-            help=('A shell command to set up libraries etc. before any steps'
-                  ' (e.g. "sudo apt-get -qy install python3"). You may'
-                  ' interpolate files available via URL or locally with Hadoop'
-                  ' Distributed Cache syntax ("sudo dpkg -i foo.deb#")')),
-
-        opt_group.add_option(
-            '--bootstrap-action', dest='bootstrap_actions', action='append',
-            default=[],
-            help=('Raw bootstrap action scripts to run before any of the other'
-                  ' bootstrap steps. You can use --bootstrap-action more than'
-                  ' once. Local scripts will be automatically uploaded to S3.'
-                  ' To add arguments, just use quotes: "foo.sh arg1 arg2"')),
-
-        opt_group.add_option(
-            '--bootstrap-cmd', dest='bootstrap_cmds', action='append',
-            default=[],
-            help=('Commands to run on the master node to set up libraries,'
-                  ' etc. You can use --bootstrap-cmd more than once. Use'
-                  ' mrjob.conf to specify arguments as a list to be run'
-                  ' directly.')),
-
-        opt_group.add_option(
-            '--bootstrap-file', dest='bootstrap_files', action='append',
-            default=[],
-            help=('File to upload to the master node before running'
-                  ' bootstrap_cmds (for example, debian packages). These will'
-                  ' be made public on S3 due to a limitation of the bootstrap'
-                  ' feature. You can use --bootstrap-file more than once.')),
-
-        opt_group.add_option(
-            '--bootstrap-python-package', dest='bootstrap_python_packages',
-            action='append', default=[],
-            help=('Path to a Python module to install on EMR. These should be'
-                  ' standard python module tarballs where you can cd into a'
-                  ' subdirectory and run ``sudo python setup.py install``. You'
-                  ' can use --bootstrap-python-package more than once.')),
-
-        opt_group.add_option(
-            '--bootstrap-script', dest='bootstrap_scripts', action='append',
-            default=[],
-            help=('Script to upload and then run on the master node (a'
-                  ' combination of bootstrap_cmds and bootstrap_files). These'
-                  ' are run after the command from bootstrap_cmds. You can use'
-                  ' --bootstrap-script more than once.')),
-
-        opt_group.add_option(
-            '--disable-emr-debugging', dest='enable_emr_debugging',
-            action='store_false',
-            help='Disable storage of Hadoop logs in SimpleDB'),
 
         opt_group.add_option(
             '--ec2-instance-type', dest='ec2_instance_type', default=None,
@@ -440,49 +384,6 @@ def add_emr_launch_opts(opt_group):
             '--ec2-key-pair', dest='ec2_key_pair', default=None,
             help='Name of the SSH key pair you set up for EMR'),
 
-        # EMR instance types
-        opt_group.add_option(
-            '--ec2-core-instance-type', '--ec2-slave-instance-type',
-            dest='ec2_core_instance_type', default=None,
-            help='Type of EC2 instance for core (or "slave") nodes only'),
-
-        opt_group.add_option(
-            '--ec2-master-instance-type', dest='ec2_master_instance_type',
-            default=None,
-            help='Type of EC2 instance for master node only'),
-
-        opt_group.add_option(
-            '--ec2-task-instance-type', dest='ec2_task_instance_type',
-            default=None,
-            help='Type of EC2 instance for task nodes only'),
-
-        # EMR instance bid prices
-        opt_group.add_option(
-            '--ec2-core-instance-bid-price',
-            dest='ec2_core_instance_bid_price', default=None,
-            help=(
-                'Bid price to specify for core (or "slave") nodes when'
-                ' setting them up as EC2 spot instances (you probably only'
-                ' want to set a bid price for task instances).')
-        ),
-
-        opt_group.add_option(
-            '--ec2-master-instance-bid-price',
-            dest='ec2_master_instance_bid_price', default=None,
-            help=(
-                'Bid price to specify for the master node when setting it up '
-                'as an EC2 spot instance (you probably only want to set '
-                'a bid price for task instances).')
-        ),
-
-        opt_group.add_option(
-            '--ec2-task-instance-bid-price',
-            dest='ec2_task_instance_bid_price', default=None,
-            help=(
-                'Bid price to specify for task nodes when '
-                'setting them up as EC2 spot instances.')
-        ),
-
         opt_group.add_option(
             '--emr-api-param', dest='emr_api_params',
             default=[], action='append',
@@ -494,11 +395,6 @@ def add_emr_launch_opts(opt_group):
         opt_group.add_option(
             '--emr-job-flow-id', dest='emr_job_flow_id', default=None,
             help='ID of an existing EMR job flow to use'),
-
-        opt_group.add_option(
-            '--enable-emr-debugging', dest='enable_emr_debugging',
-            default=None, action='store_true',
-            help='Enable storage of Hadoop logs in SimpleDB'),
 
         opt_group.add_option(
             '--hadoop-streaming-jar-on-emr',
@@ -540,27 +436,6 @@ def add_emr_launch_opts(opt_group):
             '--no-pool-emr-job-flows', dest='pool_emr_job_flows',
             action='store_false',
             help="Don't try to run our job on a pooled job flow."),
-
-        opt_group.add_option(
-            '--num-ec2-instances', dest='num_ec2_instances', default=None,
-            type='int',
-            help='Total number of EC2 instances to launch '),
-
-        # NB: EMR instance counts are only applicable for slave/core and
-        # task, since a master count > 1 causes the EMR API to return the
-        # ValidationError "A master instance group must specify a single
-        # instance".
-        opt_group.add_option(
-            '--num-ec2-core-instances', dest='num_ec2_core_instances',
-            default=None, type='int',
-            help=('Number of EC2 instances to start as core (or "slave") '
-                  'nodes. Incompatible with --num-ec2-instances.')),
-
-        opt_group.add_option(
-            '--num-ec2-task-instances', dest='num_ec2_task_instances',
-            default=None, type='int',
-            help=('Number of EC2 instances to start as task '
-                  'nodes. Incompatible with --num-ec2-instances.')),
 
         opt_group.add_option(
             '--pool-emr-job-flows', dest='pool_emr_job_flows',
@@ -626,6 +501,145 @@ def add_emr_launch_opts(opt_group):
                  ' that created the job flow can view and manage it.'
                  ' This option can be overridden by'
                  ' --emr-api-param VisibleToAllUsers=true|false.'
+        ),
+    ] + add_emr_bootstrap_opts(opt_group) + add_emr_instance_opts(opt_group)
+
+
+def add_emr_bootstrap_opts(opt_group):
+    """Add options having to do with bootstrapping (other than
+    :mrjob-opt:`bootstrap_mrjob`, which is shared with other runners)."""
+    return [
+
+        opt_group.add_option(
+            '--bootstrap', dest='bootstrap', action='append',
+            help=('A shell command to set up libraries etc. before any steps'
+                  ' (e.g. "sudo apt-get -qy install python3"). You may'
+                  ' interpolate files available via URL or locally with Hadoop'
+                  ' Distributed Cache syntax ("sudo dpkg -i foo.deb#")')),
+
+        opt_group.add_option(
+            '--bootstrap-action', dest='bootstrap_actions', action='append',
+            default=[],
+            help=('Raw bootstrap action scripts to run before any of the other'
+                  ' bootstrap steps. You can use --bootstrap-action more than'
+                  ' once. Local scripts will be automatically uploaded to S3.'
+                  ' To add arguments, just use quotes: "foo.sh arg1 arg2"')),
+
+        opt_group.add_option(
+            '--bootstrap-cmd', dest='bootstrap_cmds', action='append',
+            default=[],
+            help=('Commands to run on the master node to set up libraries,'
+                  ' etc. You can use --bootstrap-cmd more than once. Use'
+                  ' mrjob.conf to specify arguments as a list to be run'
+                  ' directly.')),
+
+        opt_group.add_option(
+            '--bootstrap-file', dest='bootstrap_files', action='append',
+            default=[],
+            help=('File to upload to the master node before running'
+                  ' bootstrap_cmds (for example, debian packages). These will'
+                  ' be made public on S3 due to a limitation of the bootstrap'
+                  ' feature. You can use --bootstrap-file more than once.')),
+
+        opt_group.add_option(
+            '--bootstrap-python-package', dest='bootstrap_python_packages',
+            action='append', default=[],
+            help=('Path to a Python module to install on EMR. These should be'
+                  ' standard python module tarballs where you can cd into a'
+                  ' subdirectory and run ``sudo python setup.py install``. You'
+                  ' can use --bootstrap-python-package more than once.')),
+
+        opt_group.add_option(
+            '--bootstrap-script', dest='bootstrap_scripts', action='append',
+            default=[],
+            help=('Script to upload and then run on the master node (a'
+                  ' combination of bootstrap_cmds and bootstrap_files). These'
+                  ' are run after the command from bootstrap_cmds. You can use'
+                  ' --bootstrap-script more than once.')),
+
+        opt_group.add_option(
+            '--disable-emr-debugging', dest='enable_emr_debugging',
+            action='store_false',
+            help='Disable storage of Hadoop logs in SimpleDB'),
+
+        opt_group.add_option(
+            '--enable-emr-debugging', dest='enable_emr_debugging',
+            default=None, action='store_true',
+            help='Enable storage of Hadoop logs in SimpleDB'),
+    ]
+
+
+def add_emr_instance_opts(opt_group):
+    """Add options having to do with instance creation"""
+    return [
+        # AMI
+        opt_group.add_option(
+            '--ami-version', dest='ami_version', default=None,
+            help=('AMI Version to use, e.g. "2.4.11" (default "latest").')),
+
+        # instance types
+        opt_group.add_option(
+            '--ec2-core-instance-type', '--ec2-slave-instance-type',
+            dest='ec2_core_instance_type', default=None,
+            help='Type of EC2 instance for core (or "slave") nodes only'),
+
+        opt_group.add_option(
+            '--ec2-master-instance-type', dest='ec2_master_instance_type',
+            default=None,
+            help='Type of EC2 instance for master node only'),
+
+        opt_group.add_option(
+            '--ec2-task-instance-type', dest='ec2_task_instance_type',
+            default=None,
+            help='Type of EC2 instance for task nodes only'),
+
+        # instance number
+        opt_group.add_option(
+            '--num-ec2-instances', dest='num_ec2_instances', default=None,
+            type='int',
+            help='Total number of EC2 instances to launch '),
+
+        # NB: EMR instance counts are only applicable for slave/core and
+        # task, since a master count > 1 causes the EMR API to return the
+        # ValidationError "A master instance group must specify a single
+        # instance".
+        opt_group.add_option(
+            '--num-ec2-core-instances', dest='num_ec2_core_instances',
+            default=None, type='int',
+            help=('Number of EC2 instances to start as core (or "slave") '
+                  'nodes. Incompatible with --num-ec2-instances.')),
+
+        opt_group.add_option(
+            '--num-ec2-task-instances', dest='num_ec2_task_instances',
+            default=None, type='int',
+            help=('Number of EC2 instances to start as task '
+                  'nodes. Incompatible with --num-ec2-instances.')),
+
+        # bid price
+        opt_group.add_option(
+            '--ec2-core-instance-bid-price',
+            dest='ec2_core_instance_bid_price', default=None,
+            help=(
+                'Bid price to specify for core (or "slave") nodes when'
+                ' setting them up as EC2 spot instances (you probably only'
+                ' want to set a bid price for task instances).')
+        ),
+
+        opt_group.add_option(
+            '--ec2-master-instance-bid-price',
+            dest='ec2_master_instance_bid_price', default=None,
+            help=(
+                'Bid price to specify for the master node when setting it up '
+                'as an EC2 spot instance (you probably only want to set '
+                'a bid price for task instances).')
+        ),
+
+        opt_group.add_option(
+            '--ec2-task-instance-bid-price',
+            dest='ec2_task_instance_bid_price', default=None,
+            help=(
+                'Bid price to specify for task nodes when '
+                'setting them up as EC2 spot instances.')
         ),
     ]
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -286,7 +286,7 @@ def add_emr_opts(opt_group):
     """Options for ``emr`` runner"""
     return (add_emr_connect_opts(opt_group) +
             add_emr_launch_opts(opt_group) +
-            add_emr_monitor_opts(opt_group))
+            add_emr_run_opts(opt_group))
 
 
 def add_emr_connect_opts(opt_group):
@@ -310,7 +310,7 @@ def add_emr_connect_opts(opt_group):
     ]
 
 
-def add_emr_monitor_opts(opt_group):
+def add_emr_run_opts(opt_group):
     """Options for monitoring a running job on EMR."""
     return [
         opt_group.add_option(

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -634,3 +634,7 @@ def print_help_for_groups(*args):
     option_parser = OptionParser(usage=SUPPRESS_USAGE, add_help_option=False)
     option_parser.option_groups = args
     option_parser.print_help()
+
+
+def alphabetize_options(opt_group):
+    opt_group.option_list.sort(key=lambda opt: opt.dest)

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -391,13 +391,6 @@ def add_emr_launch_opts(opt_group):
             help='Availability zone to run the job flow on'),
 
         opt_group.add_option(
-            '--ec2-instance-type', dest='ec2_instance_type', default=None,
-            help=('Type of EC2 instance(s) to launch (e.g. m1.small,'
-                  ' c1.xlarge, m2.xlarge). See'
-                  ' http://aws.amazon.com/ec2/instance-types/ for the full'
-                  ' list.')),
-
-        opt_group.add_option(
             '--ec2-key-pair', dest='ec2_key_pair', default=None,
             help='Name of the SSH key pair you set up for EMR'),
 
@@ -582,6 +575,13 @@ def add_emr_instance_opts(opt_group):
             '--ec2-core-instance-type', '--ec2-slave-instance-type',
             dest='ec2_core_instance_type', default=None,
             help='Type of EC2 instance for core (or "slave") nodes only'),
+
+        opt_group.add_option(
+            '--ec2-instance-type', dest='ec2_instance_type', default=None,
+            help=('Type of EC2 instance(s) to launch (e.g. m1.small,'
+                  ' c1.xlarge, m2.xlarge). See'
+                  ' http://aws.amazon.com/ec2/instance-types/ for the full'
+                  ' list.')),
 
         opt_group.add_option(
             '--ec2-master-instance-type', dest='ec2_master_instance_type',

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -407,7 +407,7 @@ def add_emr_launch_opts(opt_group):
             default=[], action='append',
             help='Metadata tags to apply to the EMR cluster; '
                  'should take the form KEY=VALUE. You can use --emr-tag '
-                 'multiple times.'
+                 'multiple times.'),
 
         opt_group.add_option(
             '--iam-instance-profile', dest='iam_instance_profile',

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -21,15 +21,25 @@ Usage::
 Options::
 
   -h, --help            show this help message and exit
-  -v, --verbose         print more messages to stderr
-  -q, --quiet           Don't log status messages; just print the report.
-  -c CONF_PATH, --conf-path=CONF_PATH
+  --aws-region=AWS_REGION
+                        Region to connect to S3 and EMR on (e.g. us-west-1).
+  -c CONF_PATHS, --conf-path=CONF_PATHS
                         Path to alternate mrjob.conf file to read from
   --no-conf             Don't load mrjob.conf even if it's available
+  --emr-endpoint=EMR_ENDPOINT
+                        Optional host to connect to when communicating with S3
+                        (e.g. us-west-1.elasticmapreduce.amazonaws.com).
+                        Default is to infer this from aws_region.
   --max-days-ago=MAX_DAYS_AGO
                         Max number of days ago to look at jobs. By default, we
                         go back as far as EMR supports (currently about 2
                         months)
+  -q, --quiet           Don't print anything to stderr
+  --s3-endpoint=S3_ENDPOINT
+                        Host to connect to when communicating with S3 (e.g. s3
+                        -us-west-1.amazonaws.com). Default is to infer this
+                        from region (see --aws-region).
+  -v, --verbose         print more messages to stderr
 """
 from datetime import datetime
 from datetime import timedelta
@@ -42,6 +52,7 @@ from mrjob.emr import describe_all_job_flows
 from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
 from mrjob.options import add_emr_connect_opts
+from mrjob.options import alphabetize_options
 from mrjob.parse import JOB_NAME_RE
 from mrjob.parse import STEP_NAME_RE
 from mrjob.parse import iso8601_to_datetime
@@ -85,6 +96,8 @@ def make_option_parser():
 
     add_basic_opts(option_parser)
     add_emr_connect_opts(option_parser)
+
+    alphabetize_options(option_parser)
 
     return option_parser
 

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -41,6 +41,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.emr import describe_all_job_flows
 from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
+from mrjob.options import add_emr_connect_opts
 from mrjob.parse import JOB_NAME_RE
 from mrjob.parse import STEP_NAME_RE
 from mrjob.parse import iso8601_to_datetime
@@ -83,6 +84,7 @@ def make_option_parser():
               ' as far as EMR supports (currently about 2 months)'))
 
     add_basic_opts(option_parser)
+    add_emr_connect_opts(option_parser)
 
     return option_parser
 

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -75,7 +75,7 @@ def main(args):
 
     log.info('getting job flow history...')
     job_flows = get_job_flows(
-        options.conf_paths, options.max_days_ago, now=now)
+        max_days_ago=options.max_days_ago, now=now, **runner_kwargs(options))
 
     log.info('compiling job flow stats...')
     stats = job_flows_to_stats(job_flows, now=now)
@@ -100,6 +100,14 @@ def make_option_parser():
     alphabetize_options(option_parser)
 
     return option_parser
+
+
+def runner_kwargs(options):
+    kwargs = options.__dict__.copy()
+    for unused_arg in ('quiet', 'verbose', 'max_days_ago'):
+        del kwargs[unused_arg]
+
+    return kwargs
 
 
 def job_flows_to_stats(job_flows, now=None):
@@ -556,7 +564,7 @@ def subdivide_interval_by_hour(start, end):
     return hour_to_secs
 
 
-def get_job_flows(conf_paths, max_days_ago=None, now=None):
+def get_job_flows(max_days_ago=None, now=None, **runner_kwargs):
     """Get relevant job flow information from EMR.
 
     :param str conf_path: Alternate path to read :py:mod:`mrjob.conf` from, or
@@ -569,7 +577,7 @@ def get_job_flows(conf_paths, max_days_ago=None, now=None):
     if now is None:
         now = datetime.utcnow()
 
-    emr_conn = EMRJobRunner(conf_paths=conf_paths).make_emr_conn()
+    emr_conn = EMRJobRunner(**runner_kwargs).make_emr_conn()
 
     # if --max-days-ago is set, only look at recent jobs
     created_after = None

--- a/mrjob/tools/emr/collect_emr_stats.py
+++ b/mrjob/tools/emr/collect_emr_stats.py
@@ -21,18 +21,28 @@
 
 Usage::
 
-    mrjob collect-emr-stats > report
+    mrjob collect-emr-active-stats > report
     python -m mrjob.tools.emr.collect_emr_stats > report
 
 Options::
 
-  -h, --help            Show this help message and exit
-  -v, --verbose         Print more messages to stderr
-  -q, --quiet           Don't log status messages; just print the report.
-  -c CONF_PATH, --conf-path=CONF_PATH
+  -h, --help            show this help message and exit
+  --aws-region=AWS_REGION
+                        Region to connect to S3 and EMR on (e.g. us-west-1).
+  -c CONF_PATHS, --conf-path=CONF_PATHS
                         Path to alternate mrjob.conf file to read from
-  -p, --pretty-print    Pretty print the collected stats.
   --no-conf             Don't load mrjob.conf even if it's available
+  --emr-endpoint=EMR_ENDPOINT
+                        Optional host to connect to when communicating with S3
+                        (e.g. us-west-1.elasticmapreduce.amazonaws.com).
+                        Default is to infer this from aws_region.
+  -p, --pretty-print    Pretty print the collected stats
+  -q, --quiet           Don't print anything to stderr
+  --s3-endpoint=S3_ENDPOINT
+                        Host to connect to when communicating with S3 (e.g. s3
+                        -us-west-1.amazonaws.com). Default is to infer this
+                        from region (see --aws-region).
+  -v, --verbose         print more messages to stderr
 """
 
 from datetime import datetime
@@ -50,6 +60,7 @@ from mrjob.emr import describe_all_job_flows
 from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
 from mrjob.options import add_emr_connect_opts
+from mrjob.options import alphabetize_options
 
 log = getLogger(__name__)
 
@@ -71,6 +82,7 @@ def main(args):
         help=('Pretty print the collected stats'))
     add_basic_opts(option_parser)
     add_emr_connect_opts(option_parser)
+    alphabetize_options(option_parser)
 
     options, args = option_parser.parse_args(args)
     if args:

--- a/mrjob/tools/emr/collect_emr_stats.py
+++ b/mrjob/tools/emr/collect_emr_stats.py
@@ -49,6 +49,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.emr import describe_all_job_flows
 from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
+from mrjob.options import add_emr_connect_opts
 
 log = getLogger(__name__)
 
@@ -69,6 +70,7 @@ def main(args):
         action="store_true", dest="pretty_print", default=False,
         help=('Pretty print the collected stats'))
     add_basic_opts(option_parser)
+    add_emr_connect_opts(option_parser)
 
     options, args = option_parser.parse_args(args)
     if args:

--- a/mrjob/tools/emr/collect_emr_stats.py
+++ b/mrjob/tools/emr/collect_emr_stats.py
@@ -21,28 +21,18 @@
 
 Usage::
 
-    mrjob collect-emr-active-stats > report
+    mrjob collect-emr-stats > report
     python -m mrjob.tools.emr.collect_emr_stats > report
 
 Options::
 
-  -h, --help            show this help message and exit
-  --aws-region=AWS_REGION
-                        Region to connect to S3 and EMR on (e.g. us-west-1).
-  -c CONF_PATHS, --conf-path=CONF_PATHS
+  -h, --help            Show this help message and exit
+  -v, --verbose         Print more messages to stderr
+  -q, --quiet           Don't log status messages; just print the report.
+  -c CONF_PATH, --conf-path=CONF_PATH
                         Path to alternate mrjob.conf file to read from
+  -p, --pretty-print    Pretty print the collected stats.
   --no-conf             Don't load mrjob.conf even if it's available
-  --emr-endpoint=EMR_ENDPOINT
-                        Optional host to connect to when communicating with S3
-                        (e.g. us-west-1.elasticmapreduce.amazonaws.com).
-                        Default is to infer this from aws_region.
-  -p, --pretty-print    Pretty print the collected stats
-  -q, --quiet           Don't print anything to stderr
-  --s3-endpoint=S3_ENDPOINT
-                        Host to connect to when communicating with S3 (e.g. s3
-                        -us-west-1.amazonaws.com). Default is to infer this
-                        from region (see --aws-region).
-  -v, --verbose         print more messages to stderr
 """
 
 from datetime import datetime
@@ -59,8 +49,6 @@ from mrjob.emr import EMRJobRunner
 from mrjob.emr import describe_all_job_flows
 from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
-from mrjob.options import add_emr_connect_opts
-from mrjob.options import alphabetize_options
 
 log = getLogger(__name__)
 
@@ -81,8 +69,6 @@ def main(args):
         action="store_true", dest="pretty_print", default=False,
         help=('Pretty print the collected stats'))
     add_basic_opts(option_parser)
-    add_emr_connect_opts(option_parser)
-    alphabetize_options(option_parser)
 
     options, args = option_parser.parse_args(args)
     if args:

--- a/mrjob/tools/emr/collect_emr_stats.py
+++ b/mrjob/tools/emr/collect_emr_stats.py
@@ -19,6 +19,8 @@
     number of Amazon EC2 instances used to execute these jobflows.
     The instance counts are not separated by instance type.
 
+    .. deprecated:: 0.4.5
+
 Usage::
 
     mrjob collect-emr-stats > report
@@ -50,7 +52,7 @@ from mrjob.emr import describe_all_job_flows
 from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
 
-log = getLogger(__name__)
+log = getLogger('mrjob.tools.emr.collect_emr_stats')
 
 
 def main(args):
@@ -75,6 +77,10 @@ def main(args):
         option_parser.error('takes no arguments')
 
     MRJob.set_up_logging(quiet=options.quiet, verbose=options.verbose)
+
+    log.warning(
+        'collect_emr_stats is deprecated and will be removed in v0.5.0')
+
     log.info('collecting EMR active jobflows...')
     job_flows = collect_active_job_flows(options.conf_paths)
     log.info('compiling stats from collected jobflows...')

--- a/mrjob/tools/emr/create_job_flow.py
+++ b/mrjob/tools/emr/create_job_flow.py
@@ -196,7 +196,6 @@ Options::
                         --emr-api-param VisibleToAllUsers=true|false.
 """
 from optparse import OptionParser
-from optparse import OptionGroup
 
 from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob

--- a/mrjob/tools/emr/create_job_flow.py
+++ b/mrjob/tools/emr/create_job_flow.py
@@ -11,17 +11,189 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Create a persistent EMR job flow, using bootstrap scripts and other
-configs from :py:mod:`mrjob.conf`, and print the job flow ID to stdout.
+"""Create a persistent EMR job flow to run jobs in, and print its ID to stdout.
+
+.. warning::
+
+    Do not run this without mrjob.tools.emr.terminate_idle_job_flows in
+    your crontab; job flows left idle can quickly become expensive!
 
 Usage::
 
     mrjob create-job-flow
     python -m mrjob.tools.emr.create_job_flow
 
-**WARNING**: do not run this without having
-:py:mod:`mrjob.tools.emr.terminate_idle_job_flows` in your crontab; job flows
-left idle can quickly become expensive!
+Options::
+
+  -h, --help            show this help message and exit
+  --additional-emr-info=ADDITIONAL_EMR_INFO
+                        A JSON string for selecting additional features on EMR
+  --ami-version=AMI_VERSION
+                        AMI Version to use, e.g. "2.4.11" (default "latest").
+  --aws-availability-zone=AWS_AVAILABILITY_ZONE
+                        Availability zone to run the job flow on
+  --aws-region=AWS_REGION
+                        Region to connect to S3 and EMR on (e.g. us-west-1).
+  --bootstrap=BOOTSTRAP
+                        A shell command to set up libraries etc. before any
+                        steps (e.g. "sudo apt-get -qy install python3"). You
+                        may interpolate files available via URL or locally
+                        with Hadoop Distributed Cache syntax ("sudo dpkg -i
+                        foo.deb#")
+  --bootstrap-action=BOOTSTRAP_ACTIONS
+                        Raw bootstrap action scripts to run before any of the
+                        other bootstrap steps. You can use --bootstrap-action
+                        more than once. Local scripts will be automatically
+                        uploaded to S3. To add arguments, just use quotes:
+                        "foo.sh arg1 arg2"
+  --bootstrap-cmd=BOOTSTRAP_CMDS
+                        Commands to run on the master node to set up
+                        libraries, etc. You can use --bootstrap-cmd more than
+                        once. Use mrjob.conf to specify arguments as a list to
+                        be run directly.
+  --bootstrap-file=BOOTSTRAP_FILES
+                        File to upload to the master node before running
+                        bootstrap_cmds (for example, debian packages). These
+                        will be made public on S3 due to a limitation of the
+                        bootstrap feature. You can use --bootstrap-file more
+                        than once.
+  --bootstrap-mrjob     Automatically tar up the mrjob library and install it
+                        when we run the mrjob. This is the default. Use --no-
+                        bootstrap-mrjob if you've already installed mrjob on
+                        your Hadoop cluster.
+  --no-bootstrap-mrjob  Don't automatically tar up the mrjob library and
+                        install it when we run this job. Use this if you've
+                        already installed mrjob on your Hadoop cluster.
+  --bootstrap-python-package=BOOTSTRAP_PYTHON_PACKAGES
+                        Path to a Python module to install on EMR. These
+                        should be standard python module tarballs where you
+                        can cd into a subdirectory and run ``sudo python
+                        setup.py install``. You can use --bootstrap-python-
+                        package more than once.
+  --bootstrap-script=BOOTSTRAP_SCRIPTS
+                        Script to upload and then run on the master node (a
+                        combination of bootstrap_cmds and bootstrap_files).
+                        These are run after the command from bootstrap_cmds.
+                        You can use --bootstrap-script more than once.
+  -c CONF_PATHS, --conf-path=CONF_PATHS
+                        Path to alternate mrjob.conf file to read from
+  --no-conf             Don't load mrjob.conf even if it's available
+  --ec2-core-instance-bid-price=EC2_CORE_INSTANCE_BID_PRICE
+                        Bid price to specify for core (or "slave") nodes when
+                        setting them up as EC2 spot instances (you probably
+                        only want to set a bid price for task instances).
+  --ec2-core-instance-type=EC2_CORE_INSTANCE_TYPE, --ec2-slave-instance-type=EC2_CORE_INSTANCE_TYPE
+                        Type of EC2 instance for core (or "slave") nodes only
+  --ec2-instance-type=EC2_INSTANCE_TYPE
+                        Type of EC2 instance(s) to launch (e.g. m1.small,
+                        c1.xlarge, m2.xlarge). See http://aws.amazon.com/ec2
+                        /instance-types/ for the full list.
+  --ec2-key-pair=EC2_KEY_PAIR
+                        Name of the SSH key pair you set up for EMR
+  --ec2-master-instance-bid-price=EC2_MASTER_INSTANCE_BID_PRICE
+                        Bid price to specify for the master node when setting
+                        it up as an EC2 spot instance (you probably only want
+                        to set a bid price for task instances).
+  --ec2-master-instance-type=EC2_MASTER_INSTANCE_TYPE
+                        Type of EC2 instance for master node only
+  --ec2-task-instance-bid-price=EC2_TASK_INSTANCE_BID_PRICE
+                        Bid price to specify for task nodes when setting them
+                        up as EC2 spot instances.
+  --ec2-task-instance-type=EC2_TASK_INSTANCE_TYPE
+                        Type of EC2 instance for task nodes only
+  --emr-api-param=EMR_API_PARAMS
+                        Additional parameters to pass directly to the EMR API
+                        when creating a cluster. Should take the form
+                        KEY=VALUE. You can use --emr-api-param multiple times.
+  --emr-endpoint=EMR_ENDPOINT
+                        Optional host to connect to when communicating with S3
+                        (e.g. us-west-1.elasticmapreduce.amazonaws.com).
+                        Default is to infer this from aws_region.
+  --emr-job-flow-id=EMR_JOB_FLOW_ID
+                        ID of an existing EMR job flow to use
+  --pool-name=EMR_JOB_FLOW_POOL_NAME
+                        Specify a pool name to join. Set to "default" if not
+                        specified.
+  --disable-emr-debugging
+                        Disable storage of Hadoop logs in SimpleDB
+  --enable-emr-debugging
+                        Enable storage of Hadoop logs in SimpleDB
+  --hadoop-streaming-jar-on-emr=HADOOP_STREAMING_JAR_ON_EMR
+                        Local path of the hadoop streaming jar on the EMR
+                        node. Rarely necessary.
+  --iam-instance-profile=IAM_INSTANCE_PROFILE
+                        EC2 instance profile to use for the EMR cluster - see
+                        "Configure IAM Roles for Amazon EMR" in AWS docs
+  --iam-job-flow-role=IAM_JOB_FLOW_ROLE
+                        Deprecated alias for --iam-instance-profile
+  --iam-service-role=IAM_SERVICE_ROLE
+                        IAM Job flow role to use for the EMR cluster - see
+                        "Configure IAM Roles for Amazon EMR" in AWS docs
+  --label=LABEL         custom prefix for job name, to help us identify the
+                        job
+  --max-hours-idle=MAX_HOURS_IDLE
+                        If we create a persistent job flow, have it
+                        automatically terminate itself after it's been idle
+                        this many hours.
+  --mins-to-end-of-hour=MINS_TO_END_OF_HOUR
+                        If --max-hours-idle is set, control how close to the
+                        end of an EC2 billing hour the job flow can
+                        automatically terminate itself (default is 5 minutes).
+  --no-emr-api-param=NO_EMR_API_PARAMS
+                        Parameters to be unset when calling EMR API. You can
+                        use --no-emr-api-param multiple times.
+  --num-ec2-core-instances=NUM_EC2_CORE_INSTANCES
+                        Number of EC2 instances to start as core (or "slave")
+                        nodes. Incompatible with --num-ec2-instances.
+  --num-ec2-instances=NUM_EC2_INSTANCES
+                        Total number of EC2 instances to launch
+  --num-ec2-task-instances=NUM_EC2_TASK_INSTANCES
+                        Number of EC2 instances to start as task nodes.
+                        Incompatible with --num-ec2-instances.
+  --owner=OWNER         custom username to use, to help us identify who ran
+                        the job
+  --no-pool-emr-job-flows
+                        Don't try to run our job on a pooled job flow.
+  --pool-emr-job-flows  Add to an existing job flow or create a new one that
+                        does not terminate when the job completes. Overrides
+                        other job flow-related options including EC2 instance
+                        configuration. Joins pool "default" if
+                        emr_job_flow_pool_name is not specified. WARNING: do
+                        not run this without
+                        mrjob.tools.emr.terminate_idle_job_flows in your
+                        crontab; job flows left idle can quickly become
+                        expensive!
+  --pool-wait-minutes=POOL_WAIT_MINUTES
+                        Wait for a number of minutes for a job flow to finish
+                        if a job finishes, pick up their job flow. Otherwise
+                        create a new one. (default 0)
+  -q, --quiet           Don't print anything to stderr
+  --s3-endpoint=S3_ENDPOINT
+                        Host to connect to when communicating with S3 (e.g. s3
+                        -us-west-1.amazonaws.com). Default is to infer this
+                        from region (see --aws-region).
+  --s3-log-uri=S3_LOG_URI
+                        URI on S3 to write logs into
+  --s3-scratch-uri=S3_SCRATCH_URI
+                        URI on S3 to use as our temp directory.
+  --s3-sync-wait-time=S3_SYNC_WAIT_TIME
+                        How long to wait for S3 to reach eventual consistency.
+                        This is typically less than a second (zero in us-west)
+                        but the default is 5.0 to be safe.
+  --s3-upload-part-size=S3_UPLOAD_PART_SIZE
+                        Upload files to S3 in parts no bigger than this many
+                        megabytes. Default is 100 MiB. Set to 0 to disable
+                        multipart uploading entirely.
+  -v, --verbose         print more messages to stderr
+  --visible-to-all-users
+                        Whether the job flow is visible to all IAM users of
+                        the AWS account associated with the job flow. If this
+                        value is set to True, all IAM users of that AWS
+                        account can view and (if they have the proper policy
+                        permissions set) manage the job flow. If it is set to
+                        False, only the IAM user that created the job flow can
+                        view and manage it. This option can be overridden by
+                        --emr-api-param VisibleToAllUsers=true|false.
 """
 from optparse import OptionParser
 from optparse import OptionGroup
@@ -31,6 +203,7 @@ from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
 from mrjob.options import add_emr_connect_opts
 from mrjob.options import add_emr_launch_opts
+from mrjob.options import alphabetize_options
 from mrjob.util import scrape_options_into_new_groups
 
 
@@ -65,7 +238,8 @@ def runner_kwargs(cl_args=None):
 def make_option_parser():
     usage = '%prog [options]'
     description = (
-        'Create a persistent EMR job flow to run jobs in. WARNING: do not run'
+        'Create a persistent EMR job flow to run jobs in, and print its ID to'
+        ' stdout. WARNING: Do not run'
         ' this without mrjob.tools.emr.terminate_idle_job_flows in your'
         ' crontab; job flows left idle can quickly become expensive!')
     option_parser = OptionParser(usage=usage, description=description)
@@ -81,6 +255,8 @@ def make_option_parser():
     })
     add_emr_connect_opts(option_parser)
     add_emr_launch_opts(option_parser)
+
+    alphabetize_options(option_parser)
 
     return option_parser
 

--- a/mrjob/tools/emr/create_job_flow.py
+++ b/mrjob/tools/emr/create_job_flow.py
@@ -28,6 +28,9 @@ from optparse import OptionGroup
 
 from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
+from mrjob.options import add_basic_opts
+from mrjob.options import add_emr_connect_opts
+from mrjob.options import add_emr_launch_opts
 from mrjob.util import scrape_options_into_new_groups
 
 
@@ -67,68 +70,18 @@ def make_option_parser():
         ' crontab; job flows left idle can quickly become expensive!')
     option_parser = OptionParser(usage=usage, description=description)
 
-    def make_option_group(halp):
-        g = OptionGroup(option_parser, halp)
-        option_parser.add_option_group(g)
-        return g
-
-    runner_group = make_option_group('Running the entire job')
-    hadoop_emr_opt_group = make_option_group(
-        'Running on Hadoop or EMR (these apply when you set -r hadoop or -r'
-        ' emr)')
-    emr_opt_group = make_option_group(
-        'Running on Amazon Elastic MapReduce (these apply when you set -r'
-        ' emr)')
-
-    assignments = {
-        runner_group: (
+    add_basic_opts(option_parser)
+    # these aren't nicely broken down, just scrape specific options
+    scrape_options_into_new_groups(MRJob().all_option_groups(), {
+        option_parser: (
             'bootstrap_mrjob',
-            'conf_paths',
-            'quiet',
-            'verbose'
-        ),
-        hadoop_emr_opt_group: (
             'label',
             'owner',
         ),
-        emr_opt_group: (
-            'additional_emr_info',
-            'ami_version',
-            'aws_availability_zone',
-            'aws_region',
-            'bootstrap_actions',
-            'bootstrap_cmds',
-            'bootstrap_files',
-            'bootstrap_python_packages',
-            'ec2_core_instance_bid_price',
-            'ec2_core_instance_type',
-            'ec2_instance_type',
-            'ec2_key_pair',
-            'ec2_master_instance_bid_price',
-            'ec2_master_instance_type',
-            'ec2_task_instance_bid_price',
-            'ec2_task_instance_type',
-            'emr_endpoint',
-            'emr_job_flow_pool_name',
-            'enable_emr_debugging',
-            'hadoop_version',
-            'max_hours_idle',
-            'mins_to_end_of_hour',
-            'num_ec2_core_instances',
-            'num_ec2_instances',
-            'num_ec2_task_instances',
-            'pool_emr_job_flows',
-            's3_endpoint',
-            's3_log_uri',
-            's3_scratch_uri',
-            's3_sync_wait_time',
-        ),
-    }
+    })
+    add_emr_connect_opts(option_parser)
+    add_emr_launch_opts(option_parser)
 
-    # Scrape options from MRJob and index them by dest
-    mr_job = MRJob()
-    job_option_groups = mr_job.all_option_groups()
-    scrape_options_into_new_groups(job_option_groups, assignments)
     return option_parser
 
 

--- a/mrjob/tools/emr/create_job_flow.py
+++ b/mrjob/tools/emr/create_job_flow.py
@@ -195,6 +195,7 @@ from mrjob.options import add_emr_connect_opts
 from mrjob.options import add_emr_launch_opts
 from mrjob.options import alphabetize_options
 from mrjob.options import parse_emr_api_params
+from mrjob.parse import parse_key_value_list
 from mrjob.util import scrape_options_into_new_groups
 
 
@@ -215,6 +216,11 @@ def runner_kwargs(cl_args=None):
     options, args = option_parser.parse_args(cl_args)
     # fake custom emr_api_params option
     options.emr_api_params = parse_emr_api_params(options, option_parser)
+
+    options.emr_tags = parse_key_value_list(
+        options.emr_tags,
+        'emr-tag argument "%s" is not of the form KEY=VALUE',
+        option_parser.error)
 
     if args:
         option_parser.error('takes no arguments')

--- a/mrjob/tools/emr/create_job_flow.py
+++ b/mrjob/tools/emr/create_job_flow.py
@@ -109,8 +109,6 @@ Options::
                         Optional host to connect to when communicating with S3
                         (e.g. us-west-1.elasticmapreduce.amazonaws.com).
                         Default is to infer this from aws_region.
-  --emr-job-flow-id=EMR_JOB_FLOW_ID
-                        ID of an existing EMR job flow to use
   --pool-name=EMR_JOB_FLOW_POOL_NAME
                         Specify a pool name to join. Set to "default" if not
                         specified.
@@ -118,9 +116,6 @@ Options::
                         Disable storage of Hadoop logs in SimpleDB
   --enable-emr-debugging
                         Enable storage of Hadoop logs in SimpleDB
-  --hadoop-streaming-jar-on-emr=HADOOP_STREAMING_JAR_ON_EMR
-                        Local path of the hadoop streaming jar on the EMR
-                        node. Rarely necessary.
   --iam-instance-profile=IAM_INSTANCE_PROFILE
                         EC2 instance profile to use for the EMR cluster - see
                         "Configure IAM Roles for Amazon EMR" in AWS docs
@@ -163,10 +158,6 @@ Options::
                         mrjob.tools.emr.terminate_idle_job_flows in your
                         crontab; job flows left idle can quickly become
                         expensive!
-  --pool-wait-minutes=POOL_WAIT_MINUTES
-                        Wait for a number of minutes for a job flow to finish
-                        if a job finishes, pick up their job flow. Otherwise
-                        create a new one. (default 0)
   -q, --quiet           Don't print anything to stderr
   --s3-endpoint=S3_ENDPOINT
                         Host to connect to when communicating with S3 (e.g. s3
@@ -203,6 +194,7 @@ from mrjob.options import add_basic_opts
 from mrjob.options import add_emr_connect_opts
 from mrjob.options import add_emr_launch_opts
 from mrjob.options import alphabetize_options
+from mrjob.options import parse_emr_api_params
 from mrjob.util import scrape_options_into_new_groups
 
 
@@ -221,6 +213,8 @@ def runner_kwargs(cl_args=None):
     # parser command-line args
     option_parser = make_option_parser()
     options, args = option_parser.parse_args(cl_args)
+    # fake custom emr_api_params option
+    options.emr_api_params = parse_emr_api_params(options, option_parser)
 
     if args:
         option_parser.error('takes no arguments')
@@ -229,8 +223,11 @@ def runner_kwargs(cl_args=None):
 
     # create the persistent job
     kwargs = options.__dict__.copy()
+
     del kwargs['quiet']
     del kwargs['verbose']
+    del kwargs['no_emr_api_params']
+
     return kwargs
 
 

--- a/mrjob/tools/emr/create_job_flow.py
+++ b/mrjob/tools/emr/create_job_flow.py
@@ -194,7 +194,7 @@ from mrjob.options import add_basic_opts
 from mrjob.options import add_emr_connect_opts
 from mrjob.options import add_emr_launch_opts
 from mrjob.options import alphabetize_options
-from mrjob.options import parse_emr_api_params
+from mrjob.options import fix_custom_options
 from mrjob.parse import parse_key_value_list
 from mrjob.util import scrape_options_into_new_groups
 
@@ -214,13 +214,9 @@ def runner_kwargs(cl_args=None):
     # parser command-line args
     option_parser = make_option_parser()
     options, args = option_parser.parse_args(cl_args)
-    # fake custom emr_api_params option
-    options.emr_api_params = parse_emr_api_params(options, option_parser)
 
-    options.emr_tags = parse_key_value_list(
-        options.emr_tags,
-        'emr-tag argument "%s" is not of the form KEY=VALUE',
-        option_parser.error)
+    # fix emr_api_params and emr_tags
+    fix_custom_options(options, option_parser)
 
     if args:
         option_parser.error('takes no arguments')

--- a/mrjob/tools/emr/fetch_logs.py
+++ b/mrjob/tools/emr/fetch_logs.py
@@ -24,18 +24,34 @@ Usage::
 
 Options::
 
-  -a, --cat             Cat log files MRJob finds relevant
+  -h, --help            show this help message and exit
+  --aws-region=AWS_REGION
+                        Region to connect to S3 and EMR on (e.g. us-west-1).
   -A, --cat-all         Cat all log files to JOB_FLOW_ID/
-  -c CONF_PATH, --conf-path=CONF_PATH
+  -a, --cat             Cat log files MRJob finds relevant
+  -c CONF_PATHS, --conf-path=CONF_PATHS
                         Path to alternate mrjob.conf file to read from
-  --counters            Show counters from the job flow
+  --no-conf             Don't load mrjob.conf even if it's available
   --ec2-key-pair-file=EC2_KEY_PAIR_FILE
                         Path to file containing SSH key for EMR
-  -h, --help            show this help message and exit
-  -l, --list            List log files MRJob finds relevant
+  --emr-endpoint=EMR_ENDPOINT
+                        Optional host to connect to when communicating with S3
+                        (e.g. us-west-1.elasticmapreduce.amazonaws.com).
+                        Default is to infer this from aws_region.
+  -f, --find-failure    Search the logs for information about why the job
+                        failed
+  --counters            Show counters from the job flow
   -L, --list-all        List all log files
-  --no-conf             Don't load mrjob.conf even if it's available
+  -l, --list            List log files MRJob finds relevant
   -q, --quiet           Don't print anything to stderr
+  --s3-endpoint=S3_ENDPOINT
+                        Host to connect to when communicating with S3 (e.g. s3
+                        -us-west-1.amazonaws.com). Default is to infer this
+                        from region (see --aws-region).
+  --s3-sync-wait-time=S3_SYNC_WAIT_TIME
+                        How long to wait for S3 to reach eventual consistency.
+                        This is typically less than a second (zero in us-west)
+                        but the default is 5.0 to be safe.
   -s STEP_NUM, --step-num=STEP_NUM
                         Limit results to a single step. To be used with --list
                         and --cat.
@@ -52,6 +68,9 @@ from mrjob.logparsers import TASK_ATTEMPT_LOGS
 from mrjob.logparsers import STEP_LOGS
 from mrjob.logparsers import JOB_LOGS
 from mrjob.logparsers import NODE_LOGS
+from mrjob.options import add_basic_opts
+from mrjob.options import add_emr_connect_opts
+from mrjob.options import alphabetize_options
 from mrjob.util import scrape_options_into_new_groups
 
 
@@ -172,6 +191,8 @@ def make_option_parser():
     scrape_options_into_new_groups(MRJob().all_option_groups(), {
         option_parser: ('ec2_key_pair_file', 's3_sync_wait_time')
     })
+
+    alphabetize_options(option_parser)
 
     return option_parser
 

--- a/mrjob/tools/emr/fetch_logs.py
+++ b/mrjob/tools/emr/fetch_logs.py
@@ -137,6 +137,8 @@ def make_option_parser():
 
     option_parser = OptionParser(usage=usage, description=description)
 
+    add_basic_opts(option_parser)
+
     option_parser.add_option('-f', '--find-failure', dest='find_failure',
                              action='store_true', default=False,
                              help=('Search the logs for information about why'
@@ -165,17 +167,12 @@ def make_option_parser():
                              action='store_true', default=False,
                              help='Show counters from the job flow')
 
-    assignments = {
-        option_parser: ('conf_paths', 'quiet', 'verbose',
-                        'ec2_key_pair_file', 's3_sync_wait_time')
-    }
+    add_emr_connect_opts(option_parser)
 
-    mr_job = MRJob()
-    job_option_groups = (mr_job.option_parser, mr_job.mux_opt_group,
-                         mr_job.proto_opt_group, mr_job.runner_opt_group,
-                         mr_job.hadoop_emr_opt_group, mr_job.emr_opt_group,
-                         mr_job.hadoop_opts_opt_group)
-    scrape_options_into_new_groups(job_option_groups, assignments)
+    scrape_options_into_new_groups(MRJob().all_option_groups(), {
+        option_parser: ('ec2_key_pair_file', 's3_sync_wait_time')
+    })
+
     return option_parser
 
 

--- a/mrjob/tools/emr/fetch_logs.py
+++ b/mrjob/tools/emr/fetch_logs.py
@@ -52,6 +52,8 @@ Options::
                         How long to wait for S3 to reach eventual consistency.
                         This is typically less than a second (zero in us-west)
                         but the default is 5.0 to be safe.
+  --ssh-bin=SSH_BIN     Name/path of ssh binary. Arguments are allowed (e.g.
+                        --ssh-bin 'ssh -v')
   -s STEP_NUM, --step-num=STEP_NUM
                         Limit results to a single step. To be used with --list
                         and --cat.
@@ -189,7 +191,7 @@ def make_option_parser():
     add_emr_connect_opts(option_parser)
 
     scrape_options_into_new_groups(MRJob().all_option_groups(), {
-        option_parser: ('ec2_key_pair_file', 's3_sync_wait_time')
+        option_parser: ('ec2_key_pair_file', 's3_sync_wait_time', 'ssh_bin')
     })
 
     alphabetize_options(option_parser)

--- a/mrjob/tools/emr/job_flow_pool.py
+++ b/mrjob/tools/emr/job_flow_pool.py
@@ -17,14 +17,120 @@ running a job with the specified options.
 Usage::
 
     python -m mrjob.tools.emr.job_flow_pool
+
+Options::
+
+  -h, --help            show this help message and exit
+  --ami-version=AMI_VERSION
+                        AMI Version to use, e.g. "2.4.11" (default "latest").
+  --aws-region=AWS_REGION
+                        Region to connect to S3 and EMR on (e.g. us-west-1).
+  --bootstrap=BOOTSTRAP
+                        A shell command to set up libraries etc. before any
+                        steps (e.g. "sudo apt-get -qy install python3"). You
+                        may interpolate files available via URL or locally
+                        with Hadoop Distributed Cache syntax ("sudo dpkg -i
+                        foo.deb#")
+  --bootstrap-action=BOOTSTRAP_ACTIONS
+                        Raw bootstrap action scripts to run before any of the
+                        other bootstrap steps. You can use --bootstrap-action
+                        more than once. Local scripts will be automatically
+                        uploaded to S3. To add arguments, just use quotes:
+                        "foo.sh arg1 arg2"
+  --bootstrap-cmd=BOOTSTRAP_CMDS
+                        Commands to run on the master node to set up
+                        libraries, etc. You can use --bootstrap-cmd more than
+                        once. Use mrjob.conf to specify arguments as a list to
+                        be run directly.
+  --bootstrap-file=BOOTSTRAP_FILES
+                        File to upload to the master node before running
+                        bootstrap_cmds (for example, debian packages). These
+                        will be made public on S3 due to a limitation of the
+                        bootstrap feature. You can use --bootstrap-file more
+                        than once.
+  --bootstrap-mrjob     Automatically tar up the mrjob library and install it
+                        when we run the mrjob. This is the default. Use --no-
+                        bootstrap-mrjob if you've already installed mrjob on
+                        your Hadoop cluster.
+  --no-bootstrap-mrjob  Don't automatically tar up the mrjob library and
+                        install it when we run this job. Use this if you've
+                        already installed mrjob on your Hadoop cluster.
+  --bootstrap-python-package=BOOTSTRAP_PYTHON_PACKAGES
+                        Path to a Python module to install on EMR. These
+                        should be standard python module tarballs where you
+                        can cd into a subdirectory and run ``sudo python
+                        setup.py install``. You can use --bootstrap-python-
+                        package more than once.
+  --bootstrap-script=BOOTSTRAP_SCRIPTS
+                        Script to upload and then run on the master node (a
+                        combination of bootstrap_cmds and bootstrap_files).
+                        These are run after the command from bootstrap_cmds.
+                        You can use --bootstrap-script more than once.
+  -c CONF_PATHS, --conf-path=CONF_PATHS
+                        Path to alternate mrjob.conf file to read from
+  --no-conf             Don't load mrjob.conf even if it's available
+  --ec2-core-instance-bid-price=EC2_CORE_INSTANCE_BID_PRICE
+                        Bid price to specify for core (or "slave") nodes when
+                        setting them up as EC2 spot instances (you probably
+                        only want to set a bid price for task instances).
+  --ec2-core-instance-type=EC2_CORE_INSTANCE_TYPE, --ec2-slave-instance-type=EC2_CORE_INSTANCE_TYPE
+                        Type of EC2 instance for core (or "slave") nodes only
+  --ec2-master-instance-bid-price=EC2_MASTER_INSTANCE_BID_PRICE
+                        Bid price to specify for the master node when setting
+                        it up as an EC2 spot instance (you probably only want
+                        to set a bid price for task instances).
+  --ec2-master-instance-type=EC2_MASTER_INSTANCE_TYPE
+                        Type of EC2 instance for master node only
+  --ec2-task-instance-bid-price=EC2_TASK_INSTANCE_BID_PRICE
+                        Bid price to specify for task nodes when setting them
+                        up as EC2 spot instances.
+  --ec2-task-instance-type=EC2_TASK_INSTANCE_TYPE
+                        Type of EC2 instance for task nodes only
+  --emr-endpoint=EMR_ENDPOINT
+                        Optional host to connect to when communicating with S3
+                        (e.g. us-west-1.elasticmapreduce.amazonaws.com).
+                        Default is to infer this from aws_region.
+  --pool-name=EMR_JOB_FLOW_POOL_NAME
+                        Specify a pool name to join. Set to "default" if not
+                        specified.
+  --disable-emr-debugging
+                        Disable storage of Hadoop logs in SimpleDB
+  --enable-emr-debugging
+                        Enable storage of Hadoop logs in SimpleDB
+  -f, --find            Find a job flow matching the pool name, bootstrap
+                        configuration, and instance number/type as specified
+                        on the command line and in the configuration files
+  -a, --all             List all available job flows without filtering by
+                        configuration
+  --num-ec2-core-instances=NUM_EC2_CORE_INSTANCES
+                        Number of EC2 instances to start as core (or "slave")
+                        nodes. Incompatible with --num-ec2-instances.
+  --num-ec2-instances=NUM_EC2_INSTANCES
+                        Total number of EC2 instances to launch
+  --num-ec2-task-instances=NUM_EC2_TASK_INSTANCES
+                        Number of EC2 instances to start as task nodes.
+                        Incompatible with --num-ec2-instances.
+  -q, --quiet           Don't print anything to stderr
+  --s3-endpoint=S3_ENDPOINT
+                        Host to connect to when communicating with S3 (e.g. s3
+                        -us-west-1.amazonaws.com). Default is to infer this
+                        from region (see --aws-region).
+  -t JOB_FLOW_ID, --terminate=JOB_FLOW_ID
+                        Terminate all job flows in the given pool (defaults to
+                        pool "default")
+  -v, --verbose         print more messages to stderr
 """
 from optparse import OptionError
-from optparse import OptionGroup
 from optparse import OptionParser
 
 from mrjob.emr import EMRJobRunner
 from mrjob.emr import est_time_to_hour
 from mrjob.job import MRJob
+from mrjob.options import add_basic_opts
+from mrjob.options import add_emr_connect_opts
+from mrjob.options import add_emr_bootstrap_opts
+from mrjob.options import add_emr_instance_opts
+from mrjob.options import alphabetize_options
 from mrjob.util import scrape_options_into_new_groups
 from mrjob.util import strip_microseconds
 
@@ -112,6 +218,8 @@ def main():
 
     MRJob.set_up_logging(quiet=options.quiet, verbose=options.verbose)
 
+    log.warning('job_flow_pool is deprecated and is going away in v0.5.0')
+
     with EMRJobRunner(**runner_kwargs(options)) as runner:
         perform_actions(options, runner)
 
@@ -123,45 +231,6 @@ def make_option_parser():
         ' running a job with the specified options.')
     option_parser = OptionParser(usage=usage, description=description)
 
-    def make_option_group(halp):
-        g = OptionGroup(option_parser, halp)
-        option_parser.add_option_group(g)
-        return g
-
-    ec2_opt_group = make_option_group('EC2 instance configuration')
-    hadoop_opt_group = make_option_group('Hadoop configuration')
-    job_opt_group = make_option_group('Job flow configuration')
-
-    assignments = {
-        option_parser: (
-            'conf_paths',
-            'emr_job_flow_pool_name',
-            'quiet',
-            'verbose',
-        ),
-        ec2_opt_group: (
-            'aws_availability_zone',
-            'ec2_instance_type',
-            'ec2_key_pair',
-            'ec2_key_pair_file',
-            'ec2_master_instance_type',
-            'ec2_core_instance_type',
-            'emr_endpoint',
-            'num_ec2_instances',
-        ),
-        hadoop_opt_group: (
-            'hadoop_version',
-            'label',
-            'owner',
-        ),
-        job_opt_group: (
-            'bootstrap_actions',
-            'bootstrap_cmds',
-            'bootstrap_files',
-            'bootstrap_mrjob',
-            'bootstrap_python_packages',
-        ),
-    }
 
     option_parser.add_option('-a', '--all', action='store_true',
                              default=False, dest='list_all',
@@ -179,9 +248,19 @@ def make_option_parser():
                              help=('Terminate all job flows in the given pool'
                                    ' (defaults to pool "default")'))
 
-    # Scrape options from MRJob and index them by dest
-    mr_job = MRJob()
-    scrape_options_into_new_groups(mr_job.all_option_groups(), assignments)
+    add_basic_opts(option_parser)
+    add_emr_connect_opts(option_parser)
+    add_emr_instance_opts(option_parser)
+    add_emr_bootstrap_opts(option_parser)
+
+    scrape_options_into_new_groups(MRJob().all_option_groups(), {
+        option_parser: (
+            'bootstrap_mrjob',
+            'emr_job_flow_pool_name',
+        ),
+    })
+
+    alphabetize_options(option_parser)
     return option_parser
 
 

--- a/mrjob/tools/emr/job_flow_pool.py
+++ b/mrjob/tools/emr/job_flow_pool.py
@@ -120,6 +120,7 @@ Options::
                         pool "default")
   -v, --verbose         print more messages to stderr
 """
+from logging import getLogger
 from optparse import OptionError
 from optparse import OptionParser
 
@@ -133,6 +134,9 @@ from mrjob.options import add_emr_instance_opts
 from mrjob.options import alphabetize_options
 from mrjob.util import scrape_options_into_new_groups
 from mrjob.util import strip_microseconds
+
+
+log = getLogger('mrjob.emr.tools.job_flow_pool')
 
 
 def get_pools(emr_conn):

--- a/mrjob/tools/emr/job_flow_pool.py
+++ b/mrjob/tools/emr/job_flow_pool.py
@@ -17,126 +17,16 @@ running a job with the specified options.
 Usage::
 
     python -m mrjob.tools.emr.job_flow_pool
-
-Options::
-
-  -h, --help            show this help message and exit
-  --ami-version=AMI_VERSION
-                        AMI Version to use, e.g. "2.4.11" (default "latest").
-  --aws-region=AWS_REGION
-                        Region to connect to S3 and EMR on (e.g. us-west-1).
-  --bootstrap=BOOTSTRAP
-                        A shell command to set up libraries etc. before any
-                        steps (e.g. "sudo apt-get -qy install python3"). You
-                        may interpolate files available via URL or locally
-                        with Hadoop Distributed Cache syntax ("sudo dpkg -i
-                        foo.deb#")
-  --bootstrap-action=BOOTSTRAP_ACTIONS
-                        Raw bootstrap action scripts to run before any of the
-                        other bootstrap steps. You can use --bootstrap-action
-                        more than once. Local scripts will be automatically
-                        uploaded to S3. To add arguments, just use quotes:
-                        "foo.sh arg1 arg2"
-  --bootstrap-cmd=BOOTSTRAP_CMDS
-                        Commands to run on the master node to set up
-                        libraries, etc. You can use --bootstrap-cmd more than
-                        once. Use mrjob.conf to specify arguments as a list to
-                        be run directly.
-  --bootstrap-file=BOOTSTRAP_FILES
-                        File to upload to the master node before running
-                        bootstrap_cmds (for example, debian packages). These
-                        will be made public on S3 due to a limitation of the
-                        bootstrap feature. You can use --bootstrap-file more
-                        than once.
-  --bootstrap-mrjob     Automatically tar up the mrjob library and install it
-                        when we run the mrjob. This is the default. Use --no-
-                        bootstrap-mrjob if you've already installed mrjob on
-                        your Hadoop cluster.
-  --no-bootstrap-mrjob  Don't automatically tar up the mrjob library and
-                        install it when we run this job. Use this if you've
-                        already installed mrjob on your Hadoop cluster.
-  --bootstrap-python-package=BOOTSTRAP_PYTHON_PACKAGES
-                        Path to a Python module to install on EMR. These
-                        should be standard python module tarballs where you
-                        can cd into a subdirectory and run ``sudo python
-                        setup.py install``. You can use --bootstrap-python-
-                        package more than once.
-  --bootstrap-script=BOOTSTRAP_SCRIPTS
-                        Script to upload and then run on the master node (a
-                        combination of bootstrap_cmds and bootstrap_files).
-                        These are run after the command from bootstrap_cmds.
-                        You can use --bootstrap-script more than once.
-  -c CONF_PATHS, --conf-path=CONF_PATHS
-                        Path to alternate mrjob.conf file to read from
-  --no-conf             Don't load mrjob.conf even if it's available
-  --ec2-core-instance-bid-price=EC2_CORE_INSTANCE_BID_PRICE
-                        Bid price to specify for core (or "slave") nodes when
-                        setting them up as EC2 spot instances (you probably
-                        only want to set a bid price for task instances).
-  --ec2-core-instance-type=EC2_CORE_INSTANCE_TYPE, --ec2-slave-instance-type=EC2_CORE_INSTANCE_TYPE
-                        Type of EC2 instance for core (or "slave") nodes only
-  --ec2-master-instance-bid-price=EC2_MASTER_INSTANCE_BID_PRICE
-                        Bid price to specify for the master node when setting
-                        it up as an EC2 spot instance (you probably only want
-                        to set a bid price for task instances).
-  --ec2-master-instance-type=EC2_MASTER_INSTANCE_TYPE
-                        Type of EC2 instance for master node only
-  --ec2-task-instance-bid-price=EC2_TASK_INSTANCE_BID_PRICE
-                        Bid price to specify for task nodes when setting them
-                        up as EC2 spot instances.
-  --ec2-task-instance-type=EC2_TASK_INSTANCE_TYPE
-                        Type of EC2 instance for task nodes only
-  --emr-endpoint=EMR_ENDPOINT
-                        Optional host to connect to when communicating with S3
-                        (e.g. us-west-1.elasticmapreduce.amazonaws.com).
-                        Default is to infer this from aws_region.
-  --pool-name=EMR_JOB_FLOW_POOL_NAME
-                        Specify a pool name to join. Set to "default" if not
-                        specified.
-  --disable-emr-debugging
-                        Disable storage of Hadoop logs in SimpleDB
-  --enable-emr-debugging
-                        Enable storage of Hadoop logs in SimpleDB
-  -f, --find            Find a job flow matching the pool name, bootstrap
-                        configuration, and instance number/type as specified
-                        on the command line and in the configuration files
-  -a, --all             List all available job flows without filtering by
-                        configuration
-  --num-ec2-core-instances=NUM_EC2_CORE_INSTANCES
-                        Number of EC2 instances to start as core (or "slave")
-                        nodes. Incompatible with --num-ec2-instances.
-  --num-ec2-instances=NUM_EC2_INSTANCES
-                        Total number of EC2 instances to launch
-  --num-ec2-task-instances=NUM_EC2_TASK_INSTANCES
-                        Number of EC2 instances to start as task nodes.
-                        Incompatible with --num-ec2-instances.
-  -q, --quiet           Don't print anything to stderr
-  --s3-endpoint=S3_ENDPOINT
-                        Host to connect to when communicating with S3 (e.g. s3
-                        -us-west-1.amazonaws.com). Default is to infer this
-                        from region (see --aws-region).
-  -t JOB_FLOW_ID, --terminate=JOB_FLOW_ID
-                        Terminate all job flows in the given pool (defaults to
-                        pool "default")
-  -v, --verbose         print more messages to stderr
 """
-from logging import getLogger
 from optparse import OptionError
+from optparse import OptionGroup
 from optparse import OptionParser
 
 from mrjob.emr import EMRJobRunner
 from mrjob.emr import est_time_to_hour
 from mrjob.job import MRJob
-from mrjob.options import add_basic_opts
-from mrjob.options import add_emr_connect_opts
-from mrjob.options import add_emr_bootstrap_opts
-from mrjob.options import add_emr_instance_opts
-from mrjob.options import alphabetize_options
 from mrjob.util import scrape_options_into_new_groups
 from mrjob.util import strip_microseconds
-
-
-log = getLogger('mrjob.emr.tools.job_flow_pool')
 
 
 def get_pools(emr_conn):
@@ -222,8 +112,6 @@ def main():
 
     MRJob.set_up_logging(quiet=options.quiet, verbose=options.verbose)
 
-    log.warning('job_flow_pool is deprecated and is going away in v0.5.0')
-
     with EMRJobRunner(**runner_kwargs(options)) as runner:
         perform_actions(options, runner)
 
@@ -235,6 +123,45 @@ def make_option_parser():
         ' running a job with the specified options.')
     option_parser = OptionParser(usage=usage, description=description)
 
+    def make_option_group(halp):
+        g = OptionGroup(option_parser, halp)
+        option_parser.add_option_group(g)
+        return g
+
+    ec2_opt_group = make_option_group('EC2 instance configuration')
+    hadoop_opt_group = make_option_group('Hadoop configuration')
+    job_opt_group = make_option_group('Job flow configuration')
+
+    assignments = {
+        option_parser: (
+            'conf_paths',
+            'emr_job_flow_pool_name',
+            'quiet',
+            'verbose',
+        ),
+        ec2_opt_group: (
+            'aws_availability_zone',
+            'ec2_instance_type',
+            'ec2_key_pair',
+            'ec2_key_pair_file',
+            'ec2_master_instance_type',
+            'ec2_core_instance_type',
+            'emr_endpoint',
+            'num_ec2_instances',
+        ),
+        hadoop_opt_group: (
+            'hadoop_version',
+            'label',
+            'owner',
+        ),
+        job_opt_group: (
+            'bootstrap_actions',
+            'bootstrap_cmds',
+            'bootstrap_files',
+            'bootstrap_mrjob',
+            'bootstrap_python_packages',
+        ),
+    }
 
     option_parser.add_option('-a', '--all', action='store_true',
                              default=False, dest='list_all',
@@ -252,19 +179,9 @@ def make_option_parser():
                              help=('Terminate all job flows in the given pool'
                                    ' (defaults to pool "default")'))
 
-    add_basic_opts(option_parser)
-    add_emr_connect_opts(option_parser)
-    add_emr_instance_opts(option_parser)
-    add_emr_bootstrap_opts(option_parser)
-
-    scrape_options_into_new_groups(MRJob().all_option_groups(), {
-        option_parser: (
-            'bootstrap_mrjob',
-            'emr_job_flow_pool_name',
-        ),
-    })
-
-    alphabetize_options(option_parser)
+    # Scrape options from MRJob and index them by dest
+    mr_job = MRJob()
+    scrape_options_into_new_groups(mr_job.all_option_groups(), assignments)
     return option_parser
 
 

--- a/mrjob/tools/emr/job_flow_pool.py
+++ b/mrjob/tools/emr/job_flow_pool.py
@@ -14,10 +14,13 @@
 """Inspect available job flow pools or identify job flows suitable for
 running a job with the specified options.
 
+.. deprecated:: 0.4.5
+
 Usage::
 
     python -m mrjob.tools.emr.job_flow_pool
 """
+from logging import getLogger
 from optparse import OptionError
 from optparse import OptionGroup
 from optparse import OptionParser
@@ -27,6 +30,8 @@ from mrjob.emr import est_time_to_hour
 from mrjob.job import MRJob
 from mrjob.util import scrape_options_into_new_groups
 from mrjob.util import strip_microseconds
+
+log = getLogger('mrjob.tools.emr.job_flow_pool')
 
 
 def get_pools(emr_conn):
@@ -111,6 +116,8 @@ def main():
         option_parser.error('This tool takes no arguments.')
 
     MRJob.set_up_logging(quiet=options.quiet, verbose=options.verbose)
+
+    log.warning('job_flow_pool is deprecated and will be removed in v0.5.0')
 
     with EMRJobRunner(**runner_kwargs(options)) as runner:
         perform_actions(options, runner)

--- a/mrjob/tools/emr/mrboss.py
+++ b/mrjob/tools/emr/mrboss.py
@@ -11,22 +11,37 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Run a command on the master and all slaves. Store stdout and stderr for
+"""Run a command on every node of a cluster. Store stdout and stderr for
 results in OUTPUT_DIR.
 
 Usage::
 
     python -m mrjob.tools.emr.mrboss JOB_FLOW_ID [options] "command string"
+    mrjob boss JOB_FLOW_ID [options] "command string"
 
 Options::
 
-  -c CONF_PATH, --conf-path=CONF_PATH
+  -h, --help            show this help message and exit
+  --aws-region=AWS_REGION
+                        Region to connect to S3 and EMR on (e.g. us-west-1).
+  -c CONF_PATHS, --conf-path=CONF_PATHS
+                        Path to alternate mrjob.conf file to read from
+  --no-conf             Don't load mrjob.conf even if it's available
   --ec2-key-pair-file=EC2_KEY_PAIR_FILE
                         Path to file containing SSH key for EMR
-  -h, --help            show this help message and exit
-  --no-conf             Don't load mrjob.conf even if it's available
-  -o, --output-dir      Specify an output directory (default: JOB_FLOW_ID)
+  --emr-endpoint=EMR_ENDPOINT
+                        Optional host to connect to when communicating with S3
+                        (e.g. us-west-1.elasticmapreduce.amazonaws.com).
+                        Default is to infer this from aws_region.
+  -o OUTPUT_DIR, --output-dir=OUTPUT_DIR
+                        Specify an output directory (default: JOB_FLOW_ID)
   -q, --quiet           Don't print anything to stderr
+  --s3-endpoint=S3_ENDPOINT
+                        Host to connect to when communicating with S3 (e.g. s3
+                        -us-west-1.amazonaws.com). Default is to infer this
+                        from region (see --aws-region).
+  --ssh-bin=SSH_BIN     Name/path of ssh binary. Arguments are allowed (e.g.
+                        --ssh-bin 'ssh -v')
   -v, --verbose         print more messages to stderr
 """
 from optparse import OptionParser
@@ -35,32 +50,32 @@ import sys
 
 from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
+from mrjob.options import add_basic_opts
+from mrjob.options import add_emr_connect_opts
+from mrjob.options import alphabetize_options
 from mrjob.ssh import ssh_run_with_recursion
 from mrjob.util import scrape_options_into_new_groups
 from mrjob.util import shlex_split
 
 
-def main():
+def main(cl_args=None):
     usage = 'usage: %prog JOB_FLOW_ID OUTPUT_DIR [options] "command string"'
     description = ('Run a command on the master and all slaves of an EMR job'
                    ' flow. Store stdout and stderr for results in OUTPUT_DIR.')
 
     option_parser = OptionParser(usage=usage, description=description)
-
-    assignments = {
-        option_parser: ('conf_paths', 'quiet', 'verbose',
-                        'ec2_key_pair_file')
-    }
-
     option_parser.add_option('-o', '--output-dir', dest='output_dir',
                              default=None,
                              help="Specify an output directory (default:"
                              " JOB_FLOW_ID)")
+    add_basic_opts(option_parser)
+    add_emr_connect_opts(option_parser)
+    scrape_options_into_new_groups(MRJob().all_option_groups(), {
+        option_parser: ('ec2_key_pair_file', 'ssh_bin'),
+    })
+    alphabetize_options(option_parser)
 
-    mr_job = MRJob()
-    scrape_options_into_new_groups(mr_job.all_option_groups(), assignments)
-
-    options, args = option_parser.parse_args()
+    options, args = option_parser.parse_args(cl_args)
 
     MRJob.set_up_logging(quiet=options.quiet, verbose=options.verbose)
 
@@ -90,7 +105,6 @@ def run_on_all_nodes(runner, output_dir, cmd_args, print_stderr=True):
     You should probably have run :py:meth:`_enable_slave_ssh_access()` on the
     runner before calling this function.
     """
-
     master_addr = runner._address_of_master()
     addresses = [master_addr]
     if runner._opts['num_ec2_instances'] > 1:

--- a/mrjob/tools/emr/s3_tmpwatch.py
+++ b/mrjob/tools/emr/s3_tmpwatch.py
@@ -83,13 +83,13 @@ def main(cl_args=None):
 
     for path in args[1:]:
         s3_cleanup(path, time_old,
-                   conf_paths=options.conf_paths,
-                   dry_run=options.test)
+                   dry_run=options.text,
+                   **runner_kwargs(options))
 
 
-def s3_cleanup(glob_path, time_old, options):
+def s3_cleanup(glob_path, time_old, dry_run=False, **runner_kwargs):
     """Delete all files older than *time_old* in *path*."""
-    runner = EMRJobRunner(**runner_kwargs(options))
+    runner = EMRJobRunner(**runner_kwargs)
     s3_conn = runner.make_s3_conn()
 
     log.info('Deleting all files in %s that are older than %s' %
@@ -105,7 +105,7 @@ def s3_cleanup(glob_path, time_old, options):
             if age > time_old:
                 # Delete it
                 log.info('Deleting %s; is %s old' % (key.name, age))
-                if not options.test:
+                if not dry_run:
                     key.delete()
 
 

--- a/mrjob/tools/emr/s3_tmpwatch.py
+++ b/mrjob/tools/emr/s3_tmpwatch.py
@@ -31,14 +31,19 @@ Usage::
 Options::
 
   -h, --help            show this help message and exit
-  -v, --verbose         Print more messages
-  -q, --quiet           Report only fatal errors.
-  -c CONF_PATH, --conf-path=CONF_PATH
+  --aws-region=AWS_REGION
+                        Region to connect to S3 and EMR on (e.g. us-west-1).
+  -c CONF_PATHS, --conf-path=CONF_PATHS
                         Path to alternate mrjob.conf file to read from
   --no-conf             Don't load mrjob.conf even if it's available
+  -q, --quiet           Don't print anything to stderr
+  --s3-endpoint=S3_ENDPOINT
+                        Host to connect to when communicating with S3 (e.g. s3
+                        -us-west-1.amazonaws.com). Default is to infer this
+                        from region (see --aws-region).
   -t, --test            Don't actually delete any files; just log that we
                         would
-
+  -v, --verbose         print more messages to stderr
 """
 from datetime import datetime
 from datetime import timedelta
@@ -56,7 +61,9 @@ from mrjob.emr import iso8601_to_datetime
 from mrjob.fs.s3 import _get_bucket
 from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
+from mrjob.options import alphabetize_options
 from mrjob.parse import parse_s3_uri
+from mrjob.util import scrape_options_into_new_groups
 
 
 log = logging.getLogger(__name__)
@@ -80,12 +87,9 @@ def main(cl_args=None):
                    dry_run=options.test)
 
 
-def s3_cleanup(glob_path, time_old, dry_run=False, conf_paths=None):
-    """Delete all files older than *time_old* in *path*.
-       If *dry_run* is ``True``, then just log the files that need to be
-       deleted without actually deleting them
-       """
-    runner = EMRJobRunner(conf_paths=conf_paths)
+def s3_cleanup(glob_path, time_old, options):
+    """Delete all files older than *time_old* in *path*."""
+    runner = EMRJobRunner(**runner_kwargs(options))
     s3_conn = runner.make_s3_conn()
 
     log.info('Deleting all files in %s that are older than %s' %
@@ -101,8 +105,17 @@ def s3_cleanup(glob_path, time_old, dry_run=False, conf_paths=None):
             if age > time_old:
                 # Delete it
                 log.info('Deleting %s; is %s old' % (key.name, age))
-                if not dry_run:
+                if not options.test:
                     key.delete()
+
+
+def runner_kwargs(options):
+    """Options to pass to the EMRJobRunner."""
+    kwargs = options.__dict__.copy()
+    for unused_arg in ('quiet', 'verbose', 'test'):
+        del kwargs[unused_arg]
+
+    return kwargs
 
 
 def process_time(time):
@@ -134,6 +147,11 @@ def make_option_parser():
         help="Don't actually delete any files; just log that we would")
 
     add_basic_opts(option_parser)
+    scrape_options_into_new_groups(MRJob().all_option_groups(), {
+        option_parser: ('aws_region', 's3_endpoint'),
+    })
+
+    alphabetize_options(option_parser)
 
     return option_parser
 

--- a/mrjob/tools/emr/terminate_job_flow.py
+++ b/mrjob/tools/emr/terminate_job_flow.py
@@ -23,12 +23,23 @@ Terminate an existing EMR job flow.
 Options::
 
   -h, --help            show this help message and exit
-  -v, --verbose         print more messages to stderr
-  -q, --quiet           don't print anything
-  -c CONF_PATH, --conf-path=CONF_PATH
+  --aws-region=AWS_REGION
+                        Region to connect to S3 and EMR on (e.g. us-west-1).
+  -c CONF_PATHS, --conf-path=CONF_PATHS
                         Path to alternate mrjob.conf file to read from
   --no-conf             Don't load mrjob.conf even if it's available
-
+  --emr-endpoint=EMR_ENDPOINT
+                        Optional host to connect to when communicating with S3
+                        (e.g. us-west-1.elasticmapreduce.amazonaws.com).
+                        Default is to infer this from aws_region.
+  -q, --quiet           Don't print anything to stderr
+  --s3-endpoint=S3_ENDPOINT
+                        Host to connect to when communicating with S3 (e.g. s3
+                        -us-west-1.amazonaws.com). Default is to infer this
+                        from region (see --aws-region).
+  -t, --test            Don't actually delete any files; just log that we
+                        would
+  -v, --verbose         print more messages to stderr
 """
 import logging
 from optparse import OptionParser
@@ -36,6 +47,8 @@ from optparse import OptionParser
 from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
 from mrjob.options import add_basic_opts
+from mrjob.options import add_emr_connect_opts
+from mrjob.options import alphabetize_options
 
 log = logging.getLogger(__name__)
 
@@ -52,7 +65,7 @@ def main(cl_args=None):
     MRJob.set_up_logging(quiet=options.quiet, verbose=options.verbose)
 
     # create the persistent job
-    runner = EMRJobRunner(conf_paths=options.conf_paths)
+    runner = EMRJobRunner(**runner_kwargs(options))
     log.debug('Terminating job flow %s' % emr_job_flow_id)
     runner.make_emr_conn().terminate_jobflow(emr_job_flow_id)
     log.info('Terminated job flow %s' % emr_job_flow_id)
@@ -70,8 +83,19 @@ def make_option_parser():
         help="Don't actually delete any files; just log that we would")
 
     add_basic_opts(option_parser)
+    add_emr_connect_opts(option_parser)
+    alphabetize_options(option_parser)
 
     return option_parser
+
+
+def runner_kwargs(options):
+    kwargs = options.__dict__.copy()
+    for unused_arg in ('quiet', 'verbose', 'test'):
+        del kwargs[unused_arg]
+
+    return kwargs
+
 
 
 if __name__ == '__main__':

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -87,7 +87,7 @@ class InlineMRJobRunnerEndToEndTestCase(SandboxedTestCase):
 
     def test_missing_input(self):
         runner = InlineMRJobRunner(input_paths=['/some/bogus/file/path'])
-        self.assertRaises(runner._run)
+        self.assertRaises(Exception, runner._run)
 
 
 class InlineMRJobRunnerCmdenvTest(EmptyMrjobConfTestCase):

--- a/tests/tools/emr/test_create_job_flow.py
+++ b/tests/tools/emr/test_create_job_flow.py
@@ -20,6 +20,8 @@ from tests.tools.emr import ToolTestCase
 
 class JobFlowInspectionTestCase(ToolTestCase):
 
+    maxDiff = None
+
     def test_runner_kwargs(self):
         self.monkey_patch_argv('--quiet')
         self.assertEqual(
@@ -28,11 +30,13 @@ class JobFlowInspectionTestCase(ToolTestCase):
              'ami_version': None,
              'aws_availability_zone': None,
              'aws_region': None,
+             'bootstrap': None,
              'bootstrap_actions': [],
              'bootstrap_cmds': [],
              'bootstrap_files': [],
              'bootstrap_mrjob': None,
              'bootstrap_python_packages': [],
+             'bootstrap_scripts': [],
              'conf_paths': None,
              'ec2_core_instance_bid_price': None,
              'ec2_core_instance_type': None,
@@ -42,10 +46,13 @@ class JobFlowInspectionTestCase(ToolTestCase):
              'ec2_master_instance_type': None,
              'ec2_task_instance_bid_price': None,
              'ec2_task_instance_type': None,
+             'emr_api_params': {},
              'emr_endpoint': None,
              'emr_job_flow_pool_name': None,
              'enable_emr_debugging': None,
-             'hadoop_version': None,
+             'iam_instance_profile': None,
+             'iam_job_flow_role': None,
+             'iam_service_role': None,
              'label': None,
              'mins_to_end_of_hour': None,
              'max_hours_idle': None,
@@ -57,7 +64,10 @@ class JobFlowInspectionTestCase(ToolTestCase):
              's3_endpoint': None,
              's3_log_uri': None,
              's3_scratch_uri': None,
-             's3_sync_wait_time': None})
+             's3_sync_wait_time': None,
+             's3_upload_part_size': None,
+             'visible_to_all_users': None,
+             })
 
     def test_create_job_flow(self):
         self.add_mock_s3_data({'walrus': {}})

--- a/tests/tools/emr/test_create_job_flow.py
+++ b/tests/tools/emr/test_create_job_flow.py
@@ -49,6 +49,7 @@ class JobFlowInspectionTestCase(ToolTestCase):
              'emr_api_params': {},
              'emr_endpoint': None,
              'emr_job_flow_pool_name': None,
+             'emr_tags': {},
              'enable_emr_debugging': None,
              'iam_instance_profile': None,
              'iam_job_flow_role': None,

--- a/tests/tools/emr/test_fetch_logs.py
+++ b/tests/tools/emr/test_fetch_logs.py
@@ -44,6 +44,8 @@ def make_args(step_num=1, list_relevant=False, list_all=False,
 
 class LogFetchingTestCase(ToolTestCase):
 
+    maxDiff = None
+
     def setUp(self):
         super(LogFetchingTestCase, self).setUp()
 
@@ -59,10 +61,16 @@ class LogFetchingTestCase(ToolTestCase):
         self.monkey_patch_argv('--quiet', 'j-MOCKJOBFLOW0')
         self.assertEqual(
             runner_kwargs(parse_args(make_option_parser())),
-            {'conf_paths': None,
-             'ec2_key_pair_file': None,
-             's3_sync_wait_time': None,
-             'emr_job_flow_id': 'j-MOCKJOBFLOW0'})
+            {
+                'aws_region': None,
+                'conf_paths': None,
+                'ec2_key_pair_file': None,
+                'emr_endpoint': None,
+                'emr_job_flow_id': 'j-MOCKJOBFLOW0',
+                's3_endpoint': None,
+                's3_sync_wait_time': None,
+                'ssh_bin': None,
+            })
 
     def test_find_failure(self):
         self.make_job_flow()

--- a/tests/tools/emr/test_job_flow_pool.py
+++ b/tests/tools/emr/test_job_flow_pool.py
@@ -25,8 +25,6 @@ from tests.tools.emr import ToolTestCase
 
 class PoolingToolTestCase(ToolTestCase):
 
-    maxDiff = None
-
     def test_bad_args(self):
         self.monkey_patch_argv('bad_arg')
         self.assertRaises(OptionError, parse_args, make_option_parser())
@@ -35,32 +33,24 @@ class PoolingToolTestCase(ToolTestCase):
         self.monkey_patch_argv('--verbose')
         self.assertEqual(
             runner_kwargs(parse_args(make_option_parser())),
-            {
-                'ami_version': None,
-                'aws_region': None,
-                'bootstrap': None,
-                'bootstrap_actions': [],
-                'bootstrap_cmds': [],
-                'bootstrap_files': [],
-                'bootstrap_mrjob': None,
-                'bootstrap_python_packages': [],
-                'bootstrap_scripts': [],
-                'conf_paths': None,
-                'ec2_core_instance_bid_price': None,
-                'ec2_core_instance_type': None,
-                'ec2_instance_type': None,
-                'ec2_master_instance_bid_price': None,
-                'ec2_master_instance_type': None,
-                'ec2_task_instance_bid_price': None,
-                'ec2_task_instance_type': None,
-                'emr_endpoint': None,
-                'emr_job_flow_pool_name': None,
-                'enable_emr_debugging': None,
-                'num_ec2_core_instances': None,
-                'num_ec2_instances': None,
-                'num_ec2_task_instances': None,
-                's3_endpoint': None,
-             })
+            {'aws_availability_zone': None,
+             'bootstrap_actions': [],
+             'bootstrap_cmds': [],
+             'bootstrap_files': [],
+             'bootstrap_mrjob': None,
+             'bootstrap_python_packages': [],
+             'conf_paths': None,
+             'ec2_core_instance_type': None,
+             'ec2_instance_type': None,
+             'ec2_key_pair': None,
+             'ec2_key_pair_file': None,
+             'ec2_master_instance_type': None,
+             'emr_endpoint': None,
+             'emr_job_flow_pool_name': None,
+             'hadoop_version': None,
+             'label': None,
+             'num_ec2_instances': None,
+             'owner': None})
 
     def test_list_job_flows(self):
         self.make_job_flow(pool_emr_job_flows=True)

--- a/tests/tools/emr/test_job_flow_pool.py
+++ b/tests/tools/emr/test_job_flow_pool.py
@@ -25,6 +25,8 @@ from tests.tools.emr import ToolTestCase
 
 class PoolingToolTestCase(ToolTestCase):
 
+    maxDiff = None
+
     def test_bad_args(self):
         self.monkey_patch_argv('bad_arg')
         self.assertRaises(OptionError, parse_args, make_option_parser())
@@ -33,24 +35,32 @@ class PoolingToolTestCase(ToolTestCase):
         self.monkey_patch_argv('--verbose')
         self.assertEqual(
             runner_kwargs(parse_args(make_option_parser())),
-            {'aws_availability_zone': None,
-             'bootstrap_actions': [],
-             'bootstrap_cmds': [],
-             'bootstrap_files': [],
-             'bootstrap_mrjob': None,
-             'bootstrap_python_packages': [],
-             'conf_paths': None,
-             'ec2_core_instance_type': None,
-             'ec2_instance_type': None,
-             'ec2_key_pair': None,
-             'ec2_key_pair_file': None,
-             'ec2_master_instance_type': None,
-             'emr_endpoint': None,
-             'emr_job_flow_pool_name': None,
-             'hadoop_version': None,
-             'label': None,
-             'num_ec2_instances': None,
-             'owner': None})
+            {
+                'ami_version': None,
+                'aws_region': None,
+                'bootstrap': None,
+                'bootstrap_actions': [],
+                'bootstrap_cmds': [],
+                'bootstrap_files': [],
+                'bootstrap_mrjob': None,
+                'bootstrap_python_packages': [],
+                'bootstrap_scripts': [],
+                'conf_paths': None,
+                'ec2_core_instance_bid_price': None,
+                'ec2_core_instance_type': None,
+                'ec2_instance_type': None,
+                'ec2_master_instance_bid_price': None,
+                'ec2_master_instance_type': None,
+                'ec2_task_instance_bid_price': None,
+                'ec2_task_instance_type': None,
+                'emr_endpoint': None,
+                'emr_job_flow_pool_name': None,
+                'enable_emr_debugging': None,
+                'num_ec2_core_instances': None,
+                'num_ec2_instances': None,
+                'num_ec2_task_instances': None,
+                's3_endpoint': None,
+             })
 
     def test_list_job_flows(self):
         self.make_job_flow(pool_emr_job_flows=True)

--- a/tests/tools/emr/test_mrboss.py
+++ b/tests/tools/emr/test_mrboss.py
@@ -1,4 +1,3 @@
-
 # Copyright 2011 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Someone pointed out on in the Google Group that one of the new IAM options wasn't available in the `create-job-flow` tool (see #1087). Looked over the tools, and found that a lot of options were missing; I think we were mostly expecting people to load options from conf files.

This should add all relevant options to each tool in a way that's somewhat future-proof.

I also stopped using option groups in the tools, and alphabetized (see #1089) command-line switches by their destination throughout (including for mrjobs themselves).

Also added the `mrboss` tool to the `mrjob` command line tool as `mrjob boss`. Deprecated the `job_flow_pool` tool because it's never been part of the `mrjob` command line tool and doesn't seem to do anything particularly useful.

