### PR TITLE
use correct format for step args

### DIFF
--- a/mrjob/tools/emr/job_flow_pool.py
+++ b/mrjob/tools/emr/job_flow_pool.py
@@ -26,8 +26,8 @@ from optparse import OptionGroup
 from optparse import OptionParser
 
 from mrjob.emr import EMRJobRunner
-from mrjob.emr import est_time_to_hour
 from mrjob.job import MRJob
+from mrjob.pool import est_time_to_hour
 from mrjob.util import scrape_options_into_new_groups
 from mrjob.util import strip_microseconds
 

--- a/mrjob/tools/emr/terminate_idle_job_flows.py
+++ b/mrjob/tools/emr/terminate_idle_job_flows.py
@@ -268,10 +268,10 @@ def is_cluster_non_streaming(steps):
     for step in steps:
         for arg in step.config.args:
             # This is hadoop streaming
-            if arg == '-mapper':
+            if arg.value == '-mapper':
                 return False
             # This is a debug jar associated with hadoop streaming
-            if DEBUG_JAR_RE.match(arg):
+            if DEBUG_JAR_RE.match(arg.value):
                 return False
     else:
         # job has at least one step, and none are streaming steps

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -895,7 +895,7 @@ class MockEmrConnection(object):
 
         for step in steps:
             step_config = MockEmrObject(
-                args=step.args(),
+                args=[MockEmrObject(value=a) for a in step.args()],
                 jar=step.jar(),
                 mainclass=step.main_class())
             # there's also a "properties" field, but boto doesn't handle it
@@ -943,8 +943,8 @@ class MockEmrConnection(object):
         and looking for an -output argument."""
         # parse in reverse order, in case there are multiple -output args
         for i, arg in reversed(list(enumerate(step_args[:-1]))):
-            if arg == '-output':
-                return step_args[i + 1]
+            if arg.value == '-output':
+                return step_args[i + 1].value
         else:
             return None
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3347,7 +3347,7 @@ class JarStepTestCase(MockEMRAndS3TestCase):
             self.assertEqual(jar_step.config.jar,
                              runner._upload_mgr.uri(fake_jar))
 
-            jar_args = jar_step.config.args
+            jar_args = [a.value for a in jar_step.config.args]
             self.assertEqual(len(jar_args), 3)
             self.assertEqual(jar_args[0], 'stuff')
 
@@ -3359,7 +3359,7 @@ class JarStepTestCase(MockEMRAndS3TestCase):
             # check output of jar is input of next step
             jar_output_arg = jar_args[2]
 
-            streaming_args = streaming_step.config.args
+            streaming_args = [a.value for a in streaming_step.config.args]
             streaming_input_arg = streaming_args[
                 streaming_args.index('-input') + 1]
             self.assertEqual(jar_output_arg, streaming_input_arg)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -336,8 +336,8 @@ class EMRJobRunnerEndToEndTestCase(MockEMRAndS3TestCase):
             emr_conn = runner.make_emr_conn()
             steps = list(_yield_all_steps(emr_conn, runner.get_cluster_id()))
 
-            step_0_args = steps[0].config.args
-            step_1_args = steps[1].config.args
+            step_0_args = [a.value for a in steps[0].config.args]
+            step_1_args = [a.value for a in steps[1].config.args]
 
             self.assertIn('-inputformat', step_0_args)
             self.assertNotIn('-outputformat', step_0_args)

--- a/tests/tools/emr/test_terminate_idle_job_flows.py
+++ b/tests/tools/emr/test_terminate_idle_job_flows.py
@@ -69,7 +69,7 @@ class JobFlowTerminationTestCase(MockEMRAndS3TestCase):
             return MockEmrObject(
                 config=MockEmrObject(
                     actiononfailure=action_on_failure,
-                    args=list(args),
+                    args=[MockEmrObject(value=a) for a in args],
                     jar=jar,
                 ),
                 status=MockEmrObject(


### PR DESCRIPTION
For some reason, `boto` wraps arguments to steps, which are, [according to the API docs](http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_HadoopStepConfig.html), strings, in objects; the actual string is in the `value` field.

When fixing #876, I paid too close attention to the API docs, and not close enough attention to boto. This fixes incorrect usage of step args in `terminate_idle_job_flows` and updates the tests (see comment at bottom of #876) for the crash.

This also fixes an `ImportError` on the deprecated `job_flow_pool` tool, which was incorrectly importing a function from `mrjob.emr`.