### PR TITLE
emr_tags and other fixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,8 +15,11 @@ v0.4.5, 2015-07-28 -- DescribeJobFlows begone
  * EMR tools:
    * added switches for AWS connection options etc. (#1087)
    * mrboss is available from command line tool: mrjob boss [args]
-   * terminate_idle_job_flows less prone to race condition (#910)
-   * job flows stuck in STARTING state now considered long-running, not idle
+   * terminate_idle_job_flows:
+     * less prone to race condition (#910)
+     * prints results to stdout in dry_run mode (#1102)
+     * job flows stuck in STARTING state no longer considered idle
+   * report_long_jobs reports job flows stuck in STARTING state
    * collect_emr_stats and job_flow_pool are deprecated
  * more efficient decoding of bz2 files
  * mrjob.retry.RetryWrapper raises exception when out of tries (#1093)

--- a/mrjob/_boto_emr.py
+++ b/mrjob/_boto_emr.py
@@ -13,13 +13,43 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Code from boto 2.35.0 to support "cluster" EMR API calls"""
+"""Code from boto 2.35.0 to support "cluster" EMR API calls and tags"""
 import boto.utils
 from boto.emr.emrobject import EmrObject
 from boto.resultset import ResultSet
 
 
 # from boto/emr/connection.py (these are EMRConnection methods in boto)
+def add_tags(emr_conn, resource_id, tags):
+    """
+    Create new metadata tags for the specified resource id.
+
+    :type resource_id: str
+    :param resource_id: The cluster id
+
+    :type tags: dict
+    :param tags: A dictionary containing the name/value pairs.
+                 If you want to create only a tag name, the
+                 value for that tag should be the empty string
+                 (e.g. '') or None.
+    """
+    params = {
+        'ResourceId': resource_id,
+    }
+    params.update(_build_tag_list(tags))
+    return emr_conn.get_status('AddTags', params, verb='POST')
+
+
+def _build_tag_list(tags):
+    params = {}
+    for i, key_value in enumerate(sorted(tags.items()), start=1):
+        key, value = key_value
+        current_prefix = 'Tags.member.%s' % i
+        params['%s.Key' % current_prefix] = key
+        if value:
+            params['%s.Value' % current_prefix] = value
+    return params
+
 
 def describe_cluster(emr_conn, cluster_id):
     """

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1600,7 +1600,7 @@ class EMRJobRunner(MRJobRunner):
         if tags:
             log.info('Setting EMR tags: %s' % ', '.join(
                 '%s=%s' % (tag, value) for tag, value in tags.items()))
-            emr_conn.add_tags(self._cluster_id, tags)
+            _boto_emr.add_tags(emr_conn, self._cluster_id, tags)
 
     # TODO: break this method up; it's too big to write tests for
     def _wait_for_job_to_complete(self):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1335,7 +1335,7 @@ class EMRJobRunner(MRJobRunner):
         tags = self._opts['emr_tags']
         if tags:
             log.info('Setting EMR tags: %s' % ', '.join(
-                '%s=%s' % (tag, value) for tag, value in tags.items()))
+                '%s=%s' % (tag, value or '') for tag, value in tags.items()))
             _boto_emr.add_tags(emr_conn, emr_job_flow_id, tags)
 
         return emr_job_flow_id

--- a/mrjob/tools/emr/terminate_idle_job_flows.py
+++ b/mrjob/tools/emr/terminate_idle_job_flows.py
@@ -351,7 +351,9 @@ def terminate_and_notify(runner, cluster_id, cluster_name, num_steps,
         strip_microseconds(time_to_end_of_hour))
 
     did_terminate = False
-    if not dry_run:
+    if dry_run:
+        did_terminate = True
+    else:
         status = attempt_to_acquire_lock(
             runner.make_s3_conn(),
             runner._lock_uri(cluster_id, num_steps),

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -851,16 +851,14 @@ class MockEmrConnection(object):
                     code='InvalidRequestException'))
 
         for key, value in sorted(tags.items()):
+            value = value or ''
+
             for tag_obj in cluster.tags:
                 if tag_obj.key == key:
-                    if value:
-                        tag_obj.value == value
-                    elif hasattr(tag_obj.value):
-                        del tag_obj.value
-                    break
+                    tag_obj.value == value
             else:
                 cluster.tags.append(MockEmrObject(
-                    key=key, value=(value or None)))
+                    key=key, value=value))
 
         return True
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3584,14 +3584,14 @@ class EMRTagsTestCase(MockEMRAndS3TestCase):
             MockEmrObject(key='tag_two', value='bar'),
         ])
 
-    def test_empty_tag_value(self):
+    def test_blank_tag_value(self):
         cluster = self.run_and_get_cluster('--emr-tag', 'tag_one=foo',
                                            '--emr-tag', 'tag_two=')
 
         # tags should be in alphabetical order by key
         self.assertEqual(cluster.tags, [
             MockEmrObject(key='tag_one', value='foo'),
-            MockEmrObject(key='tag_two'),
+            MockEmrObject(key='tag_two', value=''),
         ])
 
     def test_tag_values_can_be_none(self):
@@ -3600,7 +3600,7 @@ class EMRTagsTestCase(MockEMRAndS3TestCase):
 
         mock_cluster = self.mock_emr_clusters[cluster_id]
         self.assertEqual(mock_cluster.tags, [
-            MockEmrObject(key='tag_one'),
+            MockEmrObject(key='tag_one', value=''),
         ])
 
     def test_persistent_cluster(self):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3594,6 +3594,15 @@ class EMRTagsTestCase(MockEMRAndS3TestCase):
             MockEmrObject(key='tag_two'),
         ])
 
+    def test_tag_values_can_be_none(self):
+        runner = EMRJobRunner(conf_paths=[], emr_tags={'tag_one': None})
+        cluster_id = runner.make_persistent_cluster()
+
+        mock_cluster = self.mock_emr_clusters[cluster_id]
+        self.assertEqual(mock_cluster.tags, [
+            MockEmrObject(key='tag_one'),
+        ])
+
     def test_persistent_cluster(self):
         args = ['--emr-tag', 'tag_one=foo',
                 '--emr-tag', 'tag_two=bar']

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3555,19 +3555,24 @@ class EMRTagsTestCase(MockEMRAndS3TestCase):
                             {'tag_one': 'foo', 'tag_two': 'bar'})
 
     def test_emr_tags_get_created(self):
-        # use a Mock object for the 'add_tags' method in MockEmrConnection and
-        # add a __name__ attribute to it, in oder to avoid problems with
-        # mrjob's retry machinery
-        emr_add_tags_mock = Mock()
-        emr_add_tags_mock.__name__ = 'add_tags'
-        with patch.object(MockEmrConnection, 'add_tags', emr_add_tags_mock):
-            cluster = self.run_and_get_cluster('--emr-tag', 'tag_one=foo',
-                                               '--emr-tag', 'tag_two=bar')
+        cluster = self.run_and_get_cluster('--emr-tag', 'tag_one=foo',
+                                           '--emr-tag', 'tag_two=bar')
 
-            # assert that 'add_tags' was called once with the proper parameters
-            self.assertEqual(emr_add_tags_mock.call_count, 1)
-            emr_add_tags_mock.assert_called_with(
-                cluster.id, {'tag_one': 'foo', 'tag_two': 'bar'})
+        # tags should be in alphabetical order by key
+        self.assertEqual(cluster.tags, [
+            MockEmrObject(key='tag_one', value='foo'),
+            MockEmrObject(key='tag_two', value='bar'),
+        ])
+
+    def test_empty_tag_value(self):
+        cluster = self.run_and_get_cluster('--emr-tag', 'tag_one=foo',
+                                           '--emr-tag', 'tag_two=')
+
+        # tags should be in alphabetical order by key
+        self.assertEqual(cluster.tags, [
+            MockEmrObject(key='tag_one', value='foo'),
+            MockEmrObject(key='tag_two'),
+        ])
 
     def test_command_line_overrides_config(self):
         EMR_TAGS_MRJOB_CONF = {'runners': {'emr': {

--- a/tests/tools/emr/test_terminate_idle_job_flows.py
+++ b/tests/tools/emr/test_terminate_idle_job_flows.py
@@ -712,9 +712,13 @@ class JobFlowTerminationTestCase(MockEMRAndS3TestCase):
         self.maybe_terminate_quietly(
             stdout=stdout, max_hours_idle=0.01, dry_run=True)
 
+        # dry_run doesn't actually try to lock
+        expected_stdout_lines = self.EXPECTED_STDOUT_LINES + [
+            'Terminated job flow j-IDLE_AND_LOCKED (IDLE_AND_LOCKED);'
+            ' was idle for 2:00:00, 1:00:00 to end of hour']
 
         self.assertEqual(set(stdout.getvalue().splitlines()),
-                         set(self.EXPECTED_STDOUT_LINES))
+                         set(expected_stdout_lines))
 
         # shouldn't *actually* terminate clusters
         self.assertEqual(self.ids_of_terminated_clusters(), [])

--- a/tests/tools/emr/test_terminate_idle_job_flows.py
+++ b/tests/tools/emr/test_terminate_idle_job_flows.py
@@ -670,18 +670,51 @@ class JobFlowTerminationTestCase(MockEMRAndS3TestCase):
             stdout=stdout, max_hours_idle=0.01, quiet=True)
         self.assertEqual(stdout.getvalue(), '')
 
+
+    EXPECTED_STDOUT_LINES = [
+        'Terminated job flow j-POOLED (POOLED);'
+        ' was idle for 0:50:00, 0:05:00 to end of hour',
+        'Terminated job flow j-PENDING_BUT_IDLE (PENDING_BUT_IDLE);'
+        ' was pending for 2:50:00, 1:00:00 to end of hour',
+        'Terminated job flow j-DEBUG_ONLY (DEBUG_ONLY);'
+        ' was idle for 2:00:00, 1:00:00 to end of hour',
+        'Terminated job flow j-DONE_AND_IDLE (DONE_AND_IDLE);'
+        ' was idle for 2:00:00, 1:00:00 to end of hour',
+        'Terminated job flow j-IDLE_AND_EXPIRED (IDLE_AND_EXPIRED);'
+        ' was idle for 2:00:00, 1:00:00 to end of hour',
+        'Terminated job flow j-IDLE_AND_FAILED (IDLE_AND_FAILED);'
+        ' was idle for 3:00:00, 1:00:00 to end of hour',
+        'Terminated job flow j-HADOOP_DEBUGGING (HADOOP_DEBUGGING);'
+        ' was idle for 2:00:00, 1:00:00 to end of hour',
+    ]
+
     def test_its_not_very_quiet(self):
         stdout = StringIO()
         self.maybe_terminate_quietly(
             stdout=stdout, max_hours_idle=0.01)
-        output = u"""Terminated job flow j-POOLED (POOLED); was idle for 0:50:00, 0:05:00 to end of hour
-Terminated job flow j-PENDING_BUT_IDLE (PENDING_BUT_IDLE); was pending for 2:50:00, 1:00:00 to end of hour
-Terminated job flow j-DEBUG_ONLY (DEBUG_ONLY); was idle for 2:00:00, 1:00:00 to end of hour
-Terminated job flow j-DONE_AND_IDLE (DONE_AND_IDLE); was idle for 2:00:00, 1:00:00 to end of hour
-Terminated job flow j-IDLE_AND_EXPIRED (IDLE_AND_EXPIRED); was idle for 2:00:00, 1:00:00 to end of hour
-Terminated job flow j-IDLE_AND_FAILED (IDLE_AND_FAILED); was idle for 3:00:00, 1:00:00 to end of hour
-Terminated job flow j-HADOOP_DEBUGGING (HADOOP_DEBUGGING); was idle for 2:00:00, 1:00:00 to end of hour
-"""
-        self.assertItemsEqual(
-            stdout.getvalue().splitlines(),
-            output.splitlines())
+
+        self.assertEqual(set(stdout.getvalue().splitlines()),
+                         set(self.EXPECTED_STDOUT_LINES))
+
+        # should have actually terminated clusters
+        self.assertEqual(self.ids_of_terminated_clusters(), [
+            'j-DEBUG_ONLY',
+            'j-DONE_AND_IDLE',
+            'j-HADOOP_DEBUGGING',
+            'j-IDLE_AND_EXPIRED',
+            'j-IDLE_AND_FAILED',
+            'j-PENDING_BUT_IDLE',
+            'j-POOLED',
+        ])
+
+    def test_dry_run(self):
+        stdout = StringIO()
+        self.maybe_terminate_quietly(
+            stdout=stdout, max_hours_idle=0.01, dry_run=True)
+
+
+        self.assertEqual(set(stdout.getvalue().splitlines()),
+                         set(self.EXPECTED_STDOUT_LINES))
+
+        # shouldn't *actually* terminate clusters
+        self.assertEqual(self.ids_of_terminated_clusters(), [])


### PR DESCRIPTION
Noticed that although `create-job-flows` has an `--emr-tag` switch, tags weren't actually added. Turns out the tag code was added in the wrong place, so that it wouldn't run for persistent job flows. The existing tests for `emr_tags` used mocks directly, not mockboto, so I needed to add that (see #1096).

Also noticed that the `add_tags()` method isn't actually available in the ancient version of boto we're supporting, so added a shim for that.

Unrelated, I noticed that if you run `terminate-idle-job-flows` in dry-run mode, it doesn't actually print out information about which job flows it would terminate. Fixed that (see #1102).