### PR TITLE
SSH to resource tracker on 3.x AMIs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,8 @@ v0.5.0, 2015-??-?? -- ???
        * connect to each S3 bucket on appropriate endpoint (#1028)
        * create/select temp bucket in same region as EMR jobs (#687)
      * added iam_endpoint option (#1067)
+     * SSH tunnel now works on 3.x AMIs (#1013)
+       * renamed ssh_tunnel_to_job_tracker option to ssh_tunnel
      * removed s3_conn args from methods in EMRJobRunner and S3Filesystem
      * removed iam_job_flow_role option (use iam_instance_profile)
      * removed support for _$folder$ keys, which EMR no longer creates

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -791,16 +791,20 @@ SSH access and tunneling
     colons separate range endpoints.
 
 .. mrjob-opt::
-    :config: ssh_tunnel_to_job_tracker
-    :switch: --ssh-tunnel-to-job-tracker
+   :config: ssh_tunnel
+    :switch: --ssh-tunnel, --no-ssh-tunnel
     :type: boolean
     :set: emr
     :default: ``False``
 
-    If True, create an ssh tunnel to the job tracker and listen on a randomly
-    chosen port. This requires you to set :mrjob-opt:`ec2_key_pair` and
-    :mrjob-opt:`ec2_key_pair_file`. See :ref:`ssh-tunneling` for detailed
-    instructions.
+    If True, create an ssh tunnel to the job tracker/resource manager and
+    listen on a randomly chosen port. This requires you to set
+    :mrjob-opt:`ec2_key_pair` and :mrjob-opt:`ec2_key_pair_file`. See
+    :ref:`ssh-tunneling` for detailed instructions.
+
+    .. versionchanged:: 0.5.0
+
+       This option used to be named ``ssh_tunnel_to_job_tracker``.
 
 .. mrjob-opt::
     :config: ssh_tunnel_is_open

--- a/docs/guides/emr-quickstart.rst
+++ b/docs/guides/emr-quickstart.rst
@@ -47,7 +47,7 @@ fetch error logs quickly.
       emr:
         ec2_key_pair: EMR
         ec2_key_pair_file: /path/to/EMR.pem # ~/ and $ENV_VARS allowed here
-        ssh_tunnel_to_job_tracker: true
+        ssh_tunnel: true
 
 .. _running-an-emr-job:
 

--- a/mrjob.conf.example
+++ b/mrjob.conf.example
@@ -59,11 +59,11 @@ runners:
     # run Makefile.emr to compile C code (EMR has a different architecture,
     # so we can't just upload the .so files)
     - cd src-tree.tar.gz; make -f Makefile.emr
+    ssh_tunnel: true
     # generally, we run jobs on a Linux server separate from our desktop
     # machine. So the SSH tunnel needs to be open so a browser on our
     # desktop machine can connect to it.
     ssh_tunnel_is_open: true
-    ssh_tunnel_to_job_tracker: true
     # upload these particular files on the fly because they're different
     # between development and production
     upload_files: &upload_files

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -67,6 +67,9 @@ class OptionStore(dict):
 
         for k, v in sorted(opts.items()):
             if k in self.DEPRECATED_ALIASES:
+                if v is None:
+                    continue
+
                 aliased_opt = self.DEPRECATED_ALIASES[k]
 
                 log.warning('Deprecated option %s%s has been renamed to %s' % (

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -72,12 +72,16 @@ class OptionStore(dict):
 
                 aliased_opt = self.DEPRECATED_ALIASES[k]
 
-                log.warning('Deprecated option %s%s has been renamed to %s' % (
+                log.warning('Deprecated option %s%s has been renamed to %s'
+                            ' and will be removed in v0.6.0' % (
                     k, from_where, aliased_opt))
+
                 if opts.get(aliased_opt) is None:
                     results[aliased_opt] = v
+
             elif k in self.ALLOWED_KEYS:
                 results[k] = v
+
             else:
                 log.warning('Unexpected option %s%s' % (k, from_where))
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -327,8 +327,8 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         's3_upload_part_size',
         'ssh_bin',
         'ssh_bind_ports',
+        'ssh_tunnel',
         'ssh_tunnel_is_open',
-        'ssh_tunnel_to_job_tracker',
         'visible_to_all_users',
     ]))
 
@@ -349,6 +349,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
 
     DEPRECATED_ALIASES = combine_dicts(RunnerOptionStore.DEPRECATED_ALIASES, {
         's3_scratch_uri': 's3_tmp_dir',
+        'ssh_tunnel_to_job_tracker': 'ssh_tunnel',
     })
 
     def __init__(self, alias, opts, conf_paths):
@@ -382,7 +383,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'sh_bin': ['/bin/sh', '-ex'],
             'ssh_bin': ['ssh'],
             'ssh_bind_ports': list(range(40001, 40841)),
-            'ssh_tunnel_to_job_tracker': False,
+            'ssh_tunnel': False,
             'ssh_tunnel_is_open': False,
             'visible_to_all_users': True,
         })
@@ -1602,7 +1603,7 @@ class EMRJobRunner(MRJobRunner):
                 # once a step is running, it's safe to set up the ssh tunnel to
                 # the job tracker
                 job_host = getattr(cluster, 'masterpublicdnsname', None)
-                if job_host and self._opts['ssh_tunnel_to_job_tracker']:
+                if job_host and self._opts['ssh_tunnel']:
                     self._set_up_ssh_tunnel(job_host)
 
             # other states include STARTING and SHUTTING_DOWN

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -93,6 +93,7 @@ from mrjob.pool import _est_time_to_hour
 from mrjob.pool import _pool_hash_and_name
 from mrjob.py2 import PY2
 from mrjob.py2 import string_types
+from mrjob.py2 import to_string
 from mrjob.py2 import urlopen
 from mrjob.retry import RetryGoRound
 from mrjob.runner import MRJobRunner
@@ -119,8 +120,11 @@ JOB_TRACKER_RE = re.compile(r'(\d{1,3}\.\d{2})%')
 LOG_GENERATING_STEP_NAME_RE = HADOOP_STREAMING_JAR_RE
 
 # the port to tunnel to
-EMR_JOB_TRACKER_PORT = 9100
-EMR_JOB_TRACKER_PATH = '/jobtracker.jsp'
+#EMR_JOB_TRACKER_PORT = 9100
+#EMR_JOB_TRACKER_PATH = '/jobtracker.jsp'
+EMR_JOB_TRACKER_PORT = 9026
+EMR_JOB_TRACKER_PATH = '/cluster'
+
 
 MAX_SSH_RETRIES = 20
 
@@ -954,6 +958,7 @@ class EMRJobRunner(MRJobRunner):
             else:
                 ssh_proc.stdin.close()
                 ssh_proc.stdout.close()
+                print('ssh stderr: ' + to_string(ssh_proc.stderr.read()))
                 ssh_proc.stderr.close()
 
         if not self._ssh_proc:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1595,7 +1595,7 @@ class EMRJobRunner(MRJobRunner):
                             progress = _parse_progress_from_resource_manager(
                                 tunnel_html)
                             if progress is not None:
-                                log.info('  progress: %3.1d%%')
+                                log.info(' %5.1f%% complete' % progress)
                     finally:
                         tunnel_handle.close()
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -339,6 +339,12 @@ def add_emr_run_opts(opt_group):
                   ' Rarely necessary.')),
 
         opt_group.add_option(
+            '--no-ssh-tunnel', dest='ssh_tunnel',
+            default=None, action='store_false',
+            help=("Don't open an SSH tunnel to the Hadoop job"
+                  " tracker/resource manager")),
+
+        opt_group.add_option(
             '--pool-wait-minutes', dest='pool_wait_minutes', default=0,
             type='int',
             help=('Wait for a number of minutes for a job flow to finish'
@@ -358,6 +364,12 @@ def add_emr_run_opts(opt_group):
                   ' Defaults to 40001:40840.')),
 
         opt_group.add_option(
+            '--ssh-tunnel', dest='ssh_tunnel',
+            default=None, action='store_true',
+            help=('Open an SSH tunnel to the Hadoop job tracker/resource'
+                  ' manager')),
+
+        opt_group.add_option(
             '--ssh-tunnel-is-closed', dest='ssh_tunnel_is_open',
             default=None, action='store_false',
             help='Make ssh tunnel accessible from localhost only'),
@@ -371,7 +383,7 @@ def add_emr_run_opts(opt_group):
         opt_group.add_option(
             '--ssh-tunnel-to-job-tracker', dest='ssh_tunnel_to_job_tracker',
             default=None, action='store_true',
-            help='Open up an SSH tunnel to the Hadoop job tracker'),
+            help='Deprecated alias for --ssh-tunnel'),
     ]
 
 

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -586,8 +586,8 @@ def parse_hadoop_counters_from_line(line, hadoop_version=None):
 
 ### job tracker/resource manager ###
 
-_JOB_TRACKER_PERCENT_RE = re.compile(rb'\b(\d{1,3}\.\d{2})%')
-_RESOURCE_MANAGER_PERCENT_RE = re.compile(rb'style="width:(\d{1,3}.\d)%"')
+_JOB_TRACKER_PERCENT_RE = re.compile(br'\b(\d{1,3}\.\d{2})%')
+_RESOURCE_MANAGER_PERCENT_RE = re.compile(br'RUNNING.*:(\d{1,3}.\d)%"')
 
 def _parse_progress_from_job_tracker(html_bytes):
     """Pull (map_percent, reduce_percent) from job tracker HTML as floats,
@@ -598,6 +598,10 @@ def _parse_progress_from_job_tracker(html_bytes):
     else:
         return None, None
 
+
+# TODO: actual data is in an out-of-order JS data structure. Need to
+# parse pairs of (job_id, percent) and return percent from largest
+# (most recent) job ID.
 def _parse_progress_from_resource_manager(html_bytes):
     """Pull progress_precent from job tracker HTML, as a float, or return
     None."""

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -583,6 +583,31 @@ def parse_hadoop_counters_from_line(line, hadoop_version=None):
         counters[group][counter] += int(value)
     return counters, int(m.group('step_num'))
 
+
+### job tracker/resource manager ###
+
+_JOB_TRACKER_PERCENT_RE = re.compile(rb'\b(\d{1,3}\.\d{2})%')
+_RESOURCE_MANAGER_PERCENT_RE = re.compile(rb'style="width:(\d{1,3}.\d)%"')
+
+def _parse_progress_from_job_tracker(html_bytes):
+    """Pull (map_percent, reduce_percent) from job tracker HTML as floats,
+    or return (None, None)."""
+    matches = _JOB_TRACKER_PERCENT_RE.findall(html_bytes)
+    if len(matches) >= 2:
+        return float(matches[0]), float(matches[1])
+    else:
+        return None, None
+
+def _parse_progress_from_resource_manager(html_bytes):
+    """Pull progress_precent from job tracker HTML, as a float, or return
+    None."""
+    m = _RESOURCE_MANAGER_PERCENT_RE.search(html_bytes)
+    if m:
+        return float(m.group(1))
+    else:
+        return None
+
+
 ### AWS Date-time parsing ###
 
 # sometimes AWS gives us seconds as a decimal, which we can't parse

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -592,16 +592,9 @@ class ResourceManagerProgressTestCase(TestCase):
     def test_empty(self):
         self.assertEqual(_parse_progress_from_resource_manager(b''), None)
 
-    def test_on_html_snippet(self):
-        HTML = b"""
-            <span class="DataTables_sort_icon css_right ui-icon ui-icon-carat-2-n-s"></span></div></th></tr></thead>
-          <tbody role="alert" aria-live="polite" aria-relevant="all"><tr class="odd"><td class=" sorting_1"><a href="http://localhost:40344/cluster/app/application_1440199428349_0002">application_1440199428349_0002</a></td><td class="">hadoop</td><td class="">streamjob4113830892405300127.jar</td><td class="">MAPREDUCE</td><td class="">default</td><td class="">Fri, 21 Aug 2015 23:26:53 GMT</td><td class="">N/A</td><td class="">RUNNING</td><td class="">UNDEFINED</td><td class=""><br title="27.5"> <div class="ui-progressbar ui-widget ui-widget-content ui-corner-all" title="27.5%"> <div class="ui-progressbar-value ui-widget-header ui-corner-left" style="width:27.5%"> </div> </div></td><td class=""><a href="http://172.31.20.170:9046/proxy/application_1440199428349_0002/">ApplicationMaster</a></td></tr><tr class="even"><td class=
-        """
-        self.assertEqual(_parse_progress_from_resource_manager(HTML), 27.5)
-
     def test_on_javascript_snippet(self):
         # the actual data is in JavaScript at the bottom of the page
-        JS = """
+        JS = b"""
 <script type="text/javascript">
               var appsTableData=[
 ["<a href='/cluster/app/application_1440199050012_0002'>application_1440199050012_0002</a>","hadoop","streamjob4609242403924457306.jar","MAPREDUCE","default","1440199276424","1440199351438","FINISHED","SUCCEEDED","<br title='100.0'> <div class='ui-progressbar ui-widget ui-widget-content ui-corner-all' title='100.0%'> <div class='ui-progressbar-value ui-widget-header ui-corner-left' style='width:100.0%'> </div> </div>","<a href='http://172.31.23.88:9046/proxy/application_1440199050012_0002/jobhistory/job/job_1440199050012_0002'>History</a>"],
@@ -616,3 +609,4 @@ class ResourceManagerProgressTestCase(TestCase):
   </table>
 </html>
         """
+        self.assertEqual(_parse_progress_from_resource_manager(JS), 5.0)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -598,3 +598,21 @@ class ResourceManagerProgressTestCase(TestCase):
           <tbody role="alert" aria-live="polite" aria-relevant="all"><tr class="odd"><td class=" sorting_1"><a href="http://localhost:40344/cluster/app/application_1440199428349_0002">application_1440199428349_0002</a></td><td class="">hadoop</td><td class="">streamjob4113830892405300127.jar</td><td class="">MAPREDUCE</td><td class="">default</td><td class="">Fri, 21 Aug 2015 23:26:53 GMT</td><td class="">N/A</td><td class="">RUNNING</td><td class="">UNDEFINED</td><td class=""><br title="27.5"> <div class="ui-progressbar ui-widget ui-widget-content ui-corner-all" title="27.5%"> <div class="ui-progressbar-value ui-widget-header ui-corner-left" style="width:27.5%"> </div> </div></td><td class=""><a href="http://172.31.20.170:9046/proxy/application_1440199428349_0002/">ApplicationMaster</a></td></tr><tr class="even"><td class=
         """
         self.assertEqual(_parse_progress_from_resource_manager(HTML), 27.5)
+
+    def test_on_javascript_snippet(self):
+        # the actual data is in JavaScript at the bottom of the page
+        JS = """
+<script type="text/javascript">
+              var appsTableData=[
+["<a href='/cluster/app/application_1440199050012_0002'>application_1440199050012_0002</a>","hadoop","streamjob4609242403924457306.jar","MAPREDUCE","default","1440199276424","1440199351438","FINISHED","SUCCEEDED","<br title='100.0'> <div class='ui-progressbar ui-widget ui-widget-content ui-corner-all' title='100.0%'> <div class='ui-progressbar-value ui-widget-header ui-corner-left' style='width:100.0%'> </div> </div>","<a href='http://172.31.23.88:9046/proxy/application_1440199050012_0002/jobhistory/job/job_1440199050012_0002'>History</a>"],
+["<a href='/cluster/app/application_1440199050012_0003'>application_1440199050012_0003</a>","hadoop","streamjob1426116009682801380.jar","MAPREDUCE","default","1440205192909","0","RUNNING","UNDEFINED","<br title='5.0'> <div class='ui-progressbar ui-widget ui-widget-content ui-corner-all' title='5.0%'> <div class='ui-progressbar-value ui-widget-header ui-corner-left' style='width:5.0%'> </div> </div>","<a href='http://172.31.23.88:9046/proxy/application_1440199050012_0003/'>ApplicationMaster</a>"],
+["<a href='/cluster/app/application_1440199050012_0001'>application_1440199050012_0001</a>","hadoop","streamjob7935208784309830219.jar","MAPREDUCE","default","1440199122680","1440199195931","FINISHED","SUCCEEDED","<br title='100.0'> <div class='ui-progressbar ui-widget ui-widget-content ui-corner-all' title='100.0%'> <div class='ui-progressbar-value ui-widget-header ui-corner-left' style='width:100.0%'> </div> </div>","<a href='http://172.31.23.88:9046/proxy/application_1440199050012_0001/jobhistory/job/job_1440199050012_0001'>History</a>"]
+]
+            </script>
+            <tbody>
+            </tbody>
+          </table>
+    </tbody>
+  </table>
+</html>
+        """


### PR DESCRIPTION
This get the SSH tunneling behavior that we know and love working on the 3.x AMIs, fixing #1013. These AMIs use Hadoop 2 (a.k.a. YARN), which has a "resource manager" instead of a "job tracker". You can see job progress and download logs from the resource manager, but not get counters. 

We now opening up the tunnel to the correct port, show the correct URL to point the browser at (it has a different path), use "resource manager" or "job tracker" as appropriate in logging messages, and parse the HTML/JS accessible via the tunnel to show job progress. Also renamed `ssh_tunnel_to_job_tracker` to the shorter and more correct `ssh_tunnel` (the old option/switches still work, with a deprecation warning).

EMR has a tantalizing but ultimately unusable proxy to one of the "application servers" for a job (which do provide counters); see #1013 for discussion.

I found a *lot* of things I'd like to improve about SSH tunneling (see #1112, #1113, #1114, #1115), but for v0.5.0, I'm trying to focus on just getting mrjob's existing features to work with the newer AMIs.

There are tests for the parsers of job progress, but I mostly relied on extensive hand-testing for this change. `_wait_for_job_to_complete()` really needs to be broken up/rewritten (see #1114) before it's possible to write good unit tests for stuff like this, and that would delay the v0.5.0 release.



