### PR TITLE
Fetching counters via SSH from 3.x AMIs

### DIFF
--- a/mrjob/logparsers.py
+++ b/mrjob/logparsers.py
@@ -55,6 +55,7 @@ EMR_JOB_LOG_URI_RE = re.compile(
     r'[_-]hadoop[_-]streamjob(\d+).jar'
     r'(-[A-Za-z0-9-]+\.jhist)?' # this happens on YARN
     r'$')
+# TODO: should update this too, or possibly merge with EMR_JOB_LOG_URI_RE
 HADOOP_JOB_LOG_URI_RE = re.compile(
     r'^.*?/job_(?P<timestamp>\d+)_(?P<step_num>\d+)_(?P<mystery_string_1>\d+)'
     r'_(?P<user>.*?)_streamjob(?P<mystery_string_2>\d+).jar$')

--- a/mrjob/logparsers.py
+++ b/mrjob/logparsers.py
@@ -51,8 +51,10 @@ EMR_JOB_LOG_URI_RE = re.compile(
     r'^.*?'     # sometimes there is a number at the beginning, and the
                 # containing directory can be almost anything.
     r'job_(?P<timestamp>\d+)_(?P<step_num>\d+)'  # oh look, meaningful data!
-    r'(_\d+)?'  # sometimes there is a number here.
-    r'_hadoop_streamjob(\d+).jar$')
+    r'([_-]\d+)?'  # sometimes there is a number here.
+    r'[_-]hadoop[_-]streamjob(\d+).jar'
+    r'(-[A-Za-z0-9-]+\.jhist)?' # this happens on YARN
+    r'$')
 HADOOP_JOB_LOG_URI_RE = re.compile(
     r'^.*?/job_(?P<timestamp>\d+)_(?P<step_num>\d+)_(?P<mystery_string_1>\d+)'
     r'_(?P<user>.*?)_streamjob(?P<mystery_string_2>\d+).jar$')

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1336,6 +1336,7 @@ class CounterFetchingTestCase(MockBotoTestCase):
         super(CounterFetchingTestCase, self).setUp()
         self.add_mock_s3_data({'walrus': {}})
         kwargs = {
+            'ami_version': '2.4.9',  # counters have different format in 3.x
             'conf_paths': [],
             's3_tmp_dir': 's3://walrus/',
             's3_sync_wait_time': 0}

--- a/tests/test_logparsers.py
+++ b/tests/test_logparsers.py
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+# Copyright 2015 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mrjob.logparsers import EMR_JOB_LOG_URI_RE
+
+
+from tests.py2 import TestCase
+
+
+class URIRegexTestCase(TestCase):
+
+    def test_emr_job_re_on_2_x_ami(self):
+        uri = 'ssh://ec2-52-88-7-250.us-west-2.compute.amazonaws.com/mnt/var/log/hadoop/history/done/version-1/ip-172-31-29-201.us-west-2.compute.internal_1441062912502_/2015/08/31/000000/job_201508312315_0001_1441062985499_hadoop_streamjob1474198573915234945.jar'
+        m = EMR_JOB_LOG_URI_RE.match(uri)
+        self.assertTrue(m)
+        self.assertEqual(m.group('step_num'), '0001')
+
+    def test_emr_job_re_on_3_x_ami(self):
+        uri = 'ssh://ec2-52-24-131-73.us-west-2.compute.amazonaws.com/mnt/var/log/hadoop/history/2015/08/31/000000/job_1441057410014_0001-1441057493406-hadoop-streamjob6928722756977481487.jar-1441057604210-2-1-SUCCEEDED-default-1441057523674.jhist'  # noqa
+        m = EMR_JOB_LOG_URI_RE.match(uri)
+        self.assertTrue(m)
+        self.assertEqual(m.group('step_num'), '0001')

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -307,6 +307,8 @@ class CounterTestCase(TestCase):
 
         b'" .')
 
+    TEST_COUNTERS_2_0 = b'{"type":"TASK_FINISHED","event":{"org.apache.hadoop.mapreduce.jobhistory.TaskFinished":{"taskid":"task_1441057410014_0001_r_000000","taskType":"REDUCE","finishTime":1441057603495,"status":"SUCCEEDED","counters":{"name":"COUNTERS","groups":[{"name":"org.apache.hadoop.mapreduce.FileSystemCounter","displayName":"File System Counters","counts":[{"name":"FILE_BYTES_READ","displayName":"FILE: Number of bytes read","value":83},{"name":"FILE_BYTES_WRITTEN","displayName":"FILE: Number of bytes written","value":103064}]},{"name":"org.apache.hadoop.mapreduce.lib.output.FileOutputFormatCounter","displayName":"File Output Format Counters ","counts":[{"name":"BYTES_WRITTEN","displayName":"Bytes Written","value":34}]}]},"successfulAttemptId":"attempt_1441057410014_0001_r_000000_0"}}}'  # noqa
+
     def test_find_counters_0_18_explicit(self):
         counters, step_num = parse_hadoop_counters_from_line(
             self.TEST_COUNTERS_0_18, hadoop_version='0.18')
@@ -323,6 +325,21 @@ class CounterTestCase(TestCase):
 
         self.assertIn('reducer time (processing): 2.51', counters['profile'])
         self.assertEqual(step_num, 3)
+
+    def test_find_counters_2_0_explicit(self):
+        counters, step_num = parse_hadoop_counters_from_line(
+            self.TEST_COUNTERS_2_0, hadoop_version='2.4.0')
+
+        self.assertEqual(step_num, 1)
+        self.assertEqual(counters, {
+            'File System Counters': {
+                'FILE: Number of bytes read': 83,
+                'FILE: Number of bytes written': 103064,
+            },
+            'File Output Format Counters ': {
+                'Bytes Written': 34,
+            }
+        })
 
     def test_find_weird_counters_0_20(self):
         counter_bits = [


### PR DESCRIPTION
This is part of very slow progress towards getting log fetching/parsing working on the "new" (3.x) AMIs (see #888). This specifically makes it possible to fetch and parse counters via SSH. Hand-tested this, and added some tests for the regexes involved. Basically it boils down to a different filename, and a new, JSON-based format for counters.

Apologies for moving so slowly; the log parsing code is not super good (@irskep, the original author, confirms this ;) ) and I hadn't really taken the time to familiarize myself with it until now.

Also, to make matters worse, mrjob currently can't fetch step logs at all, thanks to EMR now using step IDs rather than step numbers in log paths (see #1117). Will fix that next.
