### PR TITLE
handle step IDs in step log paths

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1750,7 +1750,11 @@ class EMRJobRunner(MRJobRunner):
 
     def ls_step_logs_ssh(self, step_nums, cluster_step_ids):
         # step nums are 1-indexed
-        step_ids = [cluster_step_ids[step_num - 1] for step_num in step_nums]
+        if step_nums is None:
+            step_ids = None
+        else:
+            step_ids = [cluster_step_ids[step_num - 1]
+                        for step_num in step_nums]
 
         self._enable_slave_ssh_access()
         return self._enforce_path_regexp(
@@ -1796,8 +1800,12 @@ class EMRJobRunner(MRJobRunner):
                                          filters=dict(step_num=step_nums))
 
     def ls_step_logs_s3(self, step_nums, cluster_step_ids):
-        # step nums are 1-indexed
-        step_ids = [cluster_step_ids[step_num - 1] for step_num in step_nums]
+        if step_nums is None:
+            step_ids = None
+        else:
+            # step nums are 1-indexed
+            step_ids = [cluster_step_ids[step_num - 1]
+                        for step_num in step_nums]
 
         return self._enforce_path_regexp(self._ls_s3_logs('steps/'),
                                          EMR_STEP_LOG_URI_RE,

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -79,7 +79,7 @@ from mrjob.iam import get_or_create_mrjob_instance_profile
 from mrjob.iam import get_or_create_mrjob_service_role
 from mrjob.logparsers import EMR_JOB_LOG_URI_RE
 from mrjob.logparsers import NODE_LOG_URI_RE
-from mrjob.logparsers import STEP_LOG_URI_RE
+from mrjob.logparsers import EMR_STEP_LOG_URI_RE
 from mrjob.logparsers import TASK_ATTEMPTS_LOG_URI_RE
 from mrjob.logparsers import best_error_from_logs
 from mrjob.logparsers import scan_for_counters_in_files
@@ -1769,7 +1769,7 @@ class EMRJobRunner(MRJobRunner):
         self._enable_slave_ssh_access()
         return self._enforce_path_regexp(
             self._ls_ssh_logs('steps/'),
-            STEP_LOG_URI_RE,
+            EMR_STEP_LOG_URI_RE,
             filters=dict(step_id=step_ids))
 
     def ls_job_logs_ssh(self, step_nums):
@@ -1813,7 +1813,7 @@ class EMRJobRunner(MRJobRunner):
         step_ids = self._step_nums_to_ids(step_nums)
 
         return self._enforce_path_regexp(self._ls_s3_logs('steps/'),
-                                         STEP_LOG_URI_RE,
+                                         EMR_STEP_LOG_URI_RE,
                                          filters=dict(step_id=step_ids))
 
     def ls_job_logs_s3(self, step_nums):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1686,9 +1686,11 @@ class EMRJobRunner(MRJobRunner):
 
         filters maps from regexp group to a list of thing to match
         """
-        filters = dict((group_name, set(str(v) for v in values))
-                       for group_name, values in (filters or {}).items()
-                       if values)
+        # convert filters to a map from group_name to sets of strings
+        str_set_filters = {}
+        for group_name, values in (filters or {}).items():
+            if values:
+                str_set_filters[group_name] = set(str(v) for v in values)
 
         for path in paths:
             m = regexp.match(path)
@@ -1696,7 +1698,7 @@ class EMRJobRunner(MRJobRunner):
                 continue
 
             if any(m.group(group_name) not in values
-                   for group_name, values in filters.items()):
+                   for group_name, values in str_set_filters.items()):
                 continue
 
             yield path

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1754,7 +1754,8 @@ class EMRJobRunner(MRJobRunner):
             step_ids = None
         else:
             step_ids = [cluster_step_ids[step_num - 1]
-                        for step_num in step_nums]
+                        for step_num in step_nums
+                        if step_num <= len(cluster_step_ids)]
 
         self._enable_slave_ssh_access()
         return self._enforce_path_regexp(
@@ -1805,7 +1806,8 @@ class EMRJobRunner(MRJobRunner):
         else:
             # step nums are 1-indexed
             step_ids = [cluster_step_ids[step_num - 1]
-                        for step_num in step_nums]
+                        for step_num in step_nums
+                        if step_num <= len(cluster_step_ids)]
 
         return self._enforce_path_regexp(self._ls_s3_logs('steps/'),
                                          EMR_STEP_LOG_URI_RE,

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -37,7 +37,7 @@ from mrjob.fs.hadoop import HadoopFilesystem
 from mrjob.fs.local import LocalFilesystem
 from mrjob.fs.composite import CompositeFilesystem
 from mrjob.logparsers import TASK_ATTEMPTS_LOG_URI_RE
-from mrjob.logparsers import STEP_LOG_URI_RE
+from mrjob.logparsers import HADOOP_STEP_LOG_URI_RE
 from mrjob.logparsers import HADOOP_JOB_LOG_URI_RE
 from mrjob.logparsers import scan_for_counters_in_files
 from mrjob.logparsers import best_error_from_logs
@@ -570,7 +570,7 @@ class HadoopJobRunner(MRJobRunner):
                                                       TASK_ATTEMPTS_LOG_URI_RE,
                                                       step_nums)
         step_logs = self._enforce_path_regexp(self._ls_logs('steps/'),
-                                              STEP_LOG_URI_RE,
+                                              HADOOP_STEP_LOG_URI_RE,
                                               step_nums)
         job_logs = self._enforce_path_regexp(self._ls_logs('history/'),
                                              HADOOP_JOB_LOG_URI_RE,

--- a/mrjob/logparsers.py
+++ b/mrjob/logparsers.py
@@ -35,7 +35,7 @@ NODE_LOGS = 'NODE_LOGS'
 TASK_ATTEMPTS_LOG_URI_RE = re.compile(
     r'^.*/attempt_'                 # attempt_
     r'(?P<timestamp>\d+)_'          # 201203222119_
-    r'(?P<step_num>\d+)_'           # 0001_
+    r'0*(?P<step_num>\d+)_'         # 0001_
     r'(?P<node_type>\w)_'           # m_
     r'(?P<node_num>\d+)_'           # 000000_
     r'(?P<attempt_num>\d+)/'        # 3/
@@ -50,14 +50,15 @@ STEP_LOG_URI_RE = re.compile(
 EMR_JOB_LOG_URI_RE = re.compile(
     r'^.*?'     # sometimes there is a number at the beginning, and the
                 # containing directory can be almost anything.
-    r'job_(?P<timestamp>\d+)_(?P<step_num>\d+)'  # oh look, meaningful data!
+    r'job_(?P<timestamp>\d+)_0*(?P<step_num>\d+)'  # oh look, meaningful data!
     r'([_-]\d+)?'  # sometimes there is a number here.
     r'[_-]hadoop[_-]streamjob(\d+).jar'
     r'(-[A-Za-z0-9-]+\.jhist)?' # this happens on YARN
     r'$')
 # TODO: should update this too, or possibly merge with EMR_JOB_LOG_URI_RE
 HADOOP_JOB_LOG_URI_RE = re.compile(
-    r'^.*?/job_(?P<timestamp>\d+)_(?P<step_num>\d+)_(?P<mystery_string_1>\d+)'
+    r'^.*?/job_(?P<timestamp>\d+)_0*(?P<step_num>\d+)'
+    r'_(?P<mystery_string_1>\d+)'
     r'_(?P<user>.*?)_streamjob(?P<mystery_string_2>\d+).jar$')
 
 # regex for matching slave log URIs

--- a/mrjob/logparsers.py
+++ b/mrjob/logparsers.py
@@ -43,7 +43,11 @@ TASK_ATTEMPTS_LOG_URI_RE = re.compile(
 
 # regex for matching step log URIs
 STEP_LOG_URI_RE = re.compile(
-    r'^.*/(?P<step_id>s-[A-Z][0-9]+)/(?P<stream>syslog|stderr)$')
+    r'^.*/(?P<step_num>\d+)/(?P<stream>syslog|stderr)$')
+
+# EMR uses step IDs rather than step numbers (see #1117)
+EMR_STEP_LOG_URI_RE = re.compile(
+    r'^.*/(?P<step_id>s-[A-Z0-9]+)/(?P<stream>syslog|stderr)$')
 
 # regex for matching job log URIs. There is some variety in how these are
 # formatted, so this expression is pretty general.
@@ -102,10 +106,11 @@ def _sorted_task_attempts(logs):
             info['node_num']))
 
 
+# TODO: this is wrong, and doesn't work on Hadoop
 def _sorted_steps(logs):
     return _filter_sort(
         logs,
-        [STEP_LOG_URI_RE],
+        [EMR_STEP_LOG_URI_RE],
         lambda info: (info['step_id'], info['stream'] == 'stderr'))
 
 

--- a/mrjob/logparsers.py
+++ b/mrjob/logparsers.py
@@ -125,7 +125,8 @@ def _sorted_steps_emr(logs, cluster_step_ids):
     return _filter_sort(
         logs,
         [EMR_STEP_LOG_URI_RE],
-        lambda info: (cluster_step_ids.index(info['step_id']),
+        lambda info: (cluster_step_ids.index(info['step_id'])
+                      if info['step_id'] in cluster_step_ids else -1,
                       info['stream'] == 'stderr'))
 
 

--- a/mrjob/logparsers.py
+++ b/mrjob/logparsers.py
@@ -43,7 +43,7 @@ TASK_ATTEMPTS_LOG_URI_RE = re.compile(
 
 # regex for matching step log URIs
 STEP_LOG_URI_RE = re.compile(
-    r'^.*/(?P<step_num>\d+)/(?P<stream>syslog|stderr)$')
+    r'^.*/(?P<step_id>s-[A-Z][0-9]+)/(?P<stream>syslog|stderr)$')
 
 # regex for matching job log URIs. There is some variety in how these are
 # formatted, so this expression is pretty general.
@@ -105,7 +105,7 @@ def _sorted_steps(logs):
     return _filter_sort(
         logs,
         [STEP_LOG_URI_RE],
-        lambda info: (info['step_num'], info['stream'] == 'stderr'))
+        lambda info: (info['step_id'], info['stream'] == 'stderr'))
 
 
 def _sorted_jobs(logs):

--- a/mrjob/logparsers.py
+++ b/mrjob/logparsers.py
@@ -39,15 +39,15 @@ TASK_ATTEMPTS_LOG_URI_RE = re.compile(
     r'(?P<node_type>\w)_'           # m_
     r'(?P<node_num>\d+)_'           # 000000_
     r'(?P<attempt_num>\d+)/'        # 3/
-    r'(?P<stream>stderr|syslog)$')  # stderr
+    r'(?P<stream>stderr|syslog)(\.gz)?$')  # stderr
 
 # regex for matching step log URIs
 HADOOP_STEP_LOG_URI_RE = re.compile(
-    r'^.*/(?P<step_num>\d+)/(?P<stream>syslog|stderr)$')
+    r'^.*/(?P<step_num>\d+)/(?P<stream>syslog|stderr)(\.gz)?$')
 
 # EMR uses step IDs rather than step numbers (see #1117)
 EMR_STEP_LOG_URI_RE = re.compile(
-    r'^.*/(?P<step_id>s-[A-Z0-9]+)/(?P<stream>syslog|stderr)$')
+    r'^.*/(?P<step_id>s-[A-Z0-9]+)/(?P<stream>syslog|stderr)(\.gz)?$')
 
 # regex for matching job log URIs. There is some variety in how these are
 # formatted, so this expression is pretty general.

--- a/mrjob/tools/emr/fetch_logs.py
+++ b/mrjob/tools/emr/fetch_logs.py
@@ -222,10 +222,12 @@ def _prettyprint_relevant(log_type_to_uri_list):
 
 
 def list_relevant(runner, step_nums):
+    cluster_step_ids = runner._step_ids_for_cluster()
+
     try:
         logs = {
             TASK_ATTEMPT_LOGS: runner.ls_task_attempt_logs_ssh(step_nums),
-            STEP_LOGS: runner.ls_step_logs_ssh(step_nums),
+            STEP_LOGS: runner.ls_step_logs_ssh(step_nums, cluster_step_ids),
             JOB_LOGS: runner.ls_job_logs_ssh(step_nums),
             NODE_LOGS: runner.ls_node_logs_ssh(),
         }
@@ -233,7 +235,7 @@ def list_relevant(runner, step_nums):
     except LogFetchError:
         logs = {
             TASK_ATTEMPT_LOGS: runner.ls_task_attempt_logs_s3(step_nums),
-            STEP_LOGS: runner.ls_step_logs_s3(step_nums),
+            STEP_LOGS: runner.ls_step_logs_s3(step_nums, cluster_step_ids),
             JOB_LOGS: runner.ls_job_logs_s3(step_nums),
             NODE_LOGS: runner.ls_node_logs_s3(),
         }

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1138,12 +1138,8 @@ class FindProbableCauseOfFailureTestCase(MockBotoTestCase):
         self.runner._s3_job_log_uri = BUCKET_URI + LOG_DIR
 
         # need this to make step mapping work
-        self.runner._cluster_id = 'j-FAKE'
-        self.runner._list_steps_for_cluster = Mock(
-            return_value=[MockEmrObject(id='s-ONE'),
-                          MockEmrObject(id='s-TWO'),
-                          MockEmrObject(id='s-THREE'),
-                          MockEmrObject(id='s-FOUR')])
+        self.runner._step_ids_for_cluster = Mock(
+            return_value=['s-ONE', 's-TWO', 's-THREE', 's-FOUR'])
 
     def cleanup_runner(self):
         self.runner.cleanup()

--- a/tests/test_logparsers.py
+++ b/tests/test_logparsers.py
@@ -21,13 +21,13 @@ from tests.py2 import TestCase
 class URIRegexTestCase(TestCase):
 
     def test_emr_job_re_on_2_x_ami(self):
-        uri = 'ssh://ec2-52-88-7-250.us-west-2.compute.amazonaws.com/mnt/var/log/hadoop/history/done/version-1/ip-172-31-29-201.us-west-2.compute.internal_1441062912502_/2015/08/31/000000/job_201508312315_0001_1441062985499_hadoop_streamjob1474198573915234945.jar'
+        uri = 'ssh://ec2-52-88-7-250.us-west-2.compute.amazonaws.com/mnt/var/log/hadoop/history/done/version-1/ip-172-31-29-201.us-west-2.compute.internal_1441062912502_/2015/08/31/000000/job_201508312315_0011_1441062985499_hadoop_streamjob1474198573915234945.jar'
         m = EMR_JOB_LOG_URI_RE.match(uri)
         self.assertTrue(m)
-        self.assertEqual(m.group('step_num'), '0001')
+        self.assertEqual(m.group('step_num'), '11')
 
     def test_emr_job_re_on_3_x_ami(self):
-        uri = 'ssh://ec2-52-24-131-73.us-west-2.compute.amazonaws.com/mnt/var/log/hadoop/history/2015/08/31/000000/job_1441057410014_0001-1441057493406-hadoop-streamjob6928722756977481487.jar-1441057604210-2-1-SUCCEEDED-default-1441057523674.jhist'  # noqa
+        uri = 'ssh://ec2-52-24-131-73.us-west-2.compute.amazonaws.com/mnt/var/log/hadoop/history/2015/08/31/000000/job_1441057410014_0011-1441057493406-hadoop-streamjob6928722756977481487.jar-1441057604210-2-1-SUCCEEDED-default-1441057523674.jhist'  # noqa
         m = EMR_JOB_LOG_URI_RE.match(uri)
         self.assertTrue(m)
-        self.assertEqual(m.group('step_num'), '0001')
+        self.assertEqual(m.group('step_num'), '11')


### PR DESCRIPTION
This fixes #1117.

In brief: log paths for step logs used to use numbers (`1`, `2`, etc.) but now use randomly-assigned step IDs (`s-AAAAAAAA`). This means we need an extra mapping, both to ignore steps that don't matter for our job, and to sort steps in the proper order so that we can find the earliest failure.

