### PR TITLE
load pool_wait_minutes from mrjob.conf

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,7 @@ v0.5.0, 2015-??-?? -- ???
        * connect to each S3 bucket on appropriate endpoint (#1028)
        * create/select temp bucket in same region as EMR jobs (#687)
      * added iam_endpoint option (#1067)
+     * pool_wait_minutes can now be loaded from mrjob.conf (#1070)
      * SSH tunnel now works on 3.x AMIs (#1013)
        * renamed ssh_tunnel_to_job_tracker option to ssh_tunnel
      * removed s3_conn args from methods in EMRJobRunner and S3Filesystem

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -368,6 +368,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'num_ec2_core_instances': 0,
             'num_ec2_instances': 1,
             'num_ec2_task_instances': 0,
+            'pool_wait_minutes': 0,
             's3_sync_wait_time': 5.0,
             's3_upload_part_size': 100,  # 100 MB
             'sh_bin': ['/bin/sh', '-ex'],

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -345,11 +345,11 @@ def add_emr_run_opts(opt_group):
                   " tracker/resource manager")),
 
         opt_group.add_option(
-            '--pool-wait-minutes', dest='pool_wait_minutes', default=0,
+            '--pool-wait-minutes', dest='pool_wait_minutes', default=None,
             type='int',
             help=('Wait for a number of minutes for a job flow to finish'
                   ' if a job finishes, pick up their job flow. Otherwise'
-                  ' create a new one. (default 0)')),
+                  " create a new one. (0, the default, means don't wait)")),
 
         opt_group.add_option(
             '--ssh-bin', dest='ssh_bin', default=None,

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2938,6 +2938,28 @@ class JobWaitTestCase(MockBotoTestCase):
         self.assertEqual(self.sleep_counter, 2)
 
 
+class PoolWaitMinutesOptionTestCase(MockBotoTestCase):
+
+    MRJOB_CONF_CONTENTS = {'runners': {'emr': {
+        'check_emr_status_every': 0.00,
+        's3_sync_wait_time': 0.00,
+        'pool_wait_minutes': 11,
+    }}}
+
+    def test_default_pool_wait_minutes(self):
+        runner = self.make_runner('--no-conf')
+        self.assertEqual(runner._opts['pool_wait_minutes'], 0)
+
+    def test_pool_wait_minutes_from_mrjob_conf(self):
+        # tests issue #1070
+        runner = self.make_runner()
+        self.assertEqual(runner._opts['pool_wait_minutes'], 11)
+
+    def test_pool_wait_minutes_from_command_line(self):
+        runner = self.make_runner('--pool-wait-minutes', '12')
+        self.assertEqual(runner._opts['pool_wait_minutes'], 12)
+
+
 class BuildStreamingStepTestCase(MockBotoTestCase):
 
     def setUp(self):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2940,20 +2940,21 @@ class JobWaitTestCase(MockBotoTestCase):
 
 class PoolWaitMinutesOptionTestCase(MockBotoTestCase):
 
-    MRJOB_CONF_CONTENTS = {'runners': {'emr': {
-        'check_emr_status_every': 0.00,
-        's3_sync_wait_time': 0.00,
-        'pool_wait_minutes': 11,
-    }}}
-
     def test_default_pool_wait_minutes(self):
         runner = self.make_runner('--no-conf')
         self.assertEqual(runner._opts['pool_wait_minutes'], 0)
 
     def test_pool_wait_minutes_from_mrjob_conf(self):
         # tests issue #1070
-        runner = self.make_runner()
-        self.assertEqual(runner._opts['pool_wait_minutes'], 11)
+        MRJOB_CONF_WITH_POOL_WAIT_MINUTES = {'runners': {'emr': {
+            'check_emr_status_every': 0.00,
+            's3_sync_wait_time': 0.00,
+            'pool_wait_minutes': 11,
+        }}}
+
+        with mrjob_conf_patcher(MRJOB_CONF_WITH_POOL_WAIT_MINUTES):
+            runner = self.make_runner()
+            self.assertEqual(runner._opts['pool_wait_minutes'], 11)
 
     def test_pool_wait_minutes_from_command_line(self):
         runner = self.make_runner('--pool-wait-minutes', '12')


### PR DESCRIPTION
Fixes a bug where we were specifying the default value in the option rather than in the runner, so that "default" always overrode mrjob.conf (see #1070)