### PR TITLE
rename is_mapper_or_reducer() to is_task()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 v0.5.0, 2015-??-?? -- ???
  * requires boto 2.35.0 or newer (#980)
  * jobs:
+   * is_mapper_or_reducer() renamed to is_task() (#1072)
    * mr() no longer takes positional arguments (#814)
    * removed jar() (use mrjob.step.JarStep)
    * removed testing methods parse_counters() and parse_output()

--- a/docs/job.rst
+++ b/docs/job.rst
@@ -80,7 +80,7 @@ configuration options.
 .. automethod:: MRJob.add_passthrough_option
 .. automethod:: MRJob.add_file_option
 .. automethod:: MRJob.load_options
-.. automethod:: MRJob.is_mapper_or_reducer
+.. automethod:: MRJob.is_task
 
 .. autoattribute:: MRJob.OPTION_CLASS
 

--- a/mrjob/examples/mr_postfix_bounce/mr_postfix_bounce.py
+++ b/mrjob/examples/mr_postfix_bounce/mr_postfix_bounce.py
@@ -140,7 +140,7 @@ class MRPostfixBounce(MRJob):
 
     def load_options(self, args):
         super(MRPostfixBounce, self).load_options(args=args)
-        if self.is_mapper_or_reducer():
+        if self.is_task():
             with open(self.options.bounce_processing_rules) as bounce_rules_f:
                 self.bounce_processing_rules = json.load(bounce_rules_f)
 

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -827,8 +827,8 @@ class MRJob(MRJobLauncher):
     def all_option_groups(self):
         return super(MRJob, self).all_option_groups() + (self.mux_opt_group,)
 
-    def is_mapper_or_reducer(self):
-        """True if this is a mapper/reducer.
+    def is_task(self):
+        """True if this is a mapper, combiner, or reducer.
 
         This is mostly useful inside :py:meth:`load_options`, to disable
         loading options when we aren't running inside Hadoop Streaming.

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -318,13 +318,19 @@ class MRJobLauncher(object):
                 self.runner_opt_group, self.hadoop_emr_opt_group,
                 self.emr_opt_group, self.hadoop_opts_opt_group)
 
-    def is_mapper_or_reducer(self):
-        """True if this is a mapper/reducer.
+    def is_task(self):
+        """True if this is a mapper, combiner, or reducer.
 
         This is mostly useful inside :py:meth:`load_options`, to disable
         loading options when we aren't running inside Hadoop Streaming.
         """
         return False
+
+    def is_mapper_or_reducer(self):
+        """The old name for :py:meth:`is_task`. Going away in v0.6.0"""
+        log.warning('is_mapper_or_reducer() has been renamed to is_task().'
+                    ' This alias will be removed in v0.6.0')
+        return self.is_task()
 
     def add_passthrough_option(self, *args, **kwargs):
         """Function to create options which both the job runner

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -829,14 +829,19 @@ class PartitionerTestCase(TestCase):
                          'org.apache.hadoop.mapreduce.Partitioner')
 
 
-class IsMapperOrReducerTestCase(TestCase):
+class IsTaskTestCase(TestCase):
 
-    def test_is_mapper_or_reducer(self):
-        self.assertEqual(MRJob().is_mapper_or_reducer(), False)
-        self.assertEqual(MRJob(['--mapper']).is_mapper_or_reducer(), True)
-        self.assertEqual(MRJob(['--reducer']).is_mapper_or_reducer(), True)
-        self.assertEqual(MRJob(['--combiner']).is_mapper_or_reducer(), True)
-        self.assertEqual(MRJob(['--steps']).is_mapper_or_reducer(), False)
+    def test_is_task(self):
+        self.assertEqual(MRJob().is_task(), False)
+        self.assertEqual(MRJob(['--mapper']).is_task(), True)
+        self.assertEqual(MRJob(['--reducer']).is_task(), True)
+        self.assertEqual(MRJob(['--combiner']).is_task(), True)
+        self.assertEqual(MRJob(['--steps']).is_task(), False)
+
+    def test_deprecated_alias(self):
+        with logger_disabled('mrjob.launch'):
+            self.assertEqual(MRJob().is_mapper_or_reducer(), False)
+            self.assertEqual(MRJob(['--mapper']).is_mapper_or_reducer(), True)
 
 
 class StepNumTestCase(TestCase):


### PR DESCRIPTION
`is_task()` is shorter and more correct (it's `True` for combiners too). Fixes #1072.