### PR TITLE
Install ujson on Python 2

### DIFF
--- a/docs/guides/emr-bootstrap-cookbook.rst
+++ b/docs/guides/emr-bootstrap-cookbook.rst
@@ -20,7 +20,7 @@ all these examples will work with :mrjob-opt:`setup` as well (yes, Hadoop
 tasks on EMR apparently have access to :command:`sudo`).
 
 
-.. _bootstrap-pip:
+.. _using-pip:
 
 Installing Python packages with pip
 -----------------------------------
@@ -64,7 +64,7 @@ Or a tarball:
 If you turned off :mrjob-opt:`bootstrap_mrjob` but still want :command:`pip`,
 the relevant package is ``python-pip``; see :ref:`bootstrap-system-packages`.
 
-.. _bootstrap-pip-py3:
+.. _using-pip-py3:
 
 on Python 3
 ^^^^^^^^^^^
@@ -97,7 +97,7 @@ This works with requirements files or tarballs too:
 
 If you want to install a Python package with C bindings (e.g. ``numpy``)
 you'll first need to compile Python from source. See
-:ref:`Installing ujson on Python 3 <bootstrap-ujson-py3>` for how this works.
+:ref:`Installing ujson on Python 3 <using-ujson-py3>` for how this works.
 
 
 Installing ujson
@@ -111,9 +111,9 @@ on Python 2
 
 On Python 2, mrjob automatically installs ``ujson`` for you. Done! (If you
 turned off :mrjob-opt:`bootstrap_mrjob`, the relevant Python package is
-``ujson``; see :ref:`bootstrap-pip`.)
+``ujson``; see :ref:`using-pip`.)
 
-.. _bootstrap-ujson-py3:
+.. _using-ujson-py3:
 
 on Python 3
 ^^^^^^^^^^^
@@ -199,7 +199,7 @@ and then go to ``http://aws.amazon.com/amazon-linux-ami/YYYY.MM-packages``
 
 Keep in mind that Amazon Linux has zero support for Python 3 outside
 the ``python34`` and ``python34-docs`` packages themselves;
-:ref:`install and use pip <bootstrap-pip-py3>` instead.
+:ref:`install and use pip <using-pip-py3>` instead.
 
 I don't know or care which AMI version I'm using
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -222,7 +222,7 @@ Installing Python from source
 -----------------------------
 
 We mostly covered this when we
-:ref:`installed ujson on Python 3 <bootstrap-ujson-py3>`, but here it
+:ref:`installed ujson on Python 3 <using-ujson-py3>`, but here it
 is, for reference:
 
 .. code-block:: yaml

--- a/docs/guides/emr-bootstrap-cookbook.rst
+++ b/docs/guides/emr-bootstrap-cookbook.rst
@@ -216,6 +216,8 @@ Here's a trick you can use to install, for example, ``python-pip`` on any AMI:
         bootstrap:
         - sudo apt-get install -y python-pip || sudo yum install -y python-pip
 
+.. _installing-python-from-source:
+
 Installing Python from source
 -----------------------------
 

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -427,9 +427,9 @@ and install another Python binary.
    :command:`pip` *or* ``ujson`` by default on Python 3.
 
    If you just need pure
-   Python packages, see :ref:`Installing pip on Python 3 <bootstrap-pip-py3>`.
+   Python packages, see :ref:`Installing pip on Python 3 <using-pip-py3>`.
    If you'd like ``ujson`` or other C packages as well, see
-   :ref:`Installing ujson on Python 3 <bootstrap-ujson-py3>`. (The latter
+   :ref:`Installing ujson on Python 3 <using-ujson-py3>`. (The latter
    will also support Python 3 on any AMI because it compiles Python from
    source.)
 
@@ -447,6 +447,8 @@ and install another Python binary.
     Paths of python modules tarballs to install on EMR. Pass
     ``pip install path/to/tarballs/*.tar.gz#`` to :mrjob-opt:`bootstrap`
     instead.
+
+    .. warning:: This option is not supported at all in Python 3.
 
 .. mrjob-opt::
     :config: bootstrap_scripts

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -448,7 +448,9 @@ and install another Python binary.
     ``pip install path/to/tarballs/*.tar.gz#`` to :mrjob-opt:`bootstrap`
     instead.
 
-    .. warning:: This option is not supported at all in Python 3.
+    In addition to being deprecated, this option only works in Python 2.
+    See :ref:`Installing packages with pip on Python 3 <using-pip-py3>`
+    to see how to do this on Python 3.
 
 .. mrjob-opt::
     :config: bootstrap_scripts

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -412,27 +412,26 @@ and install another Python binary.
    :switch: --bootstrap-python, --no-bootstrap-python
    :type: boolean
    :set: emr
-   :default: (automatic)
+   :default: ``True``
 
    Attempt to install a compatible version of Python at bootstrap time.
-   By default, this only triggers if same major version of Python
-   (e.g. 2 or 3) is not already available on your EMR AMI. In practice,
-   this means it always triggers by default for Python 3, and never for
-   Python 2.
 
-   This runs before other :mrjob-opt:`bootstrap` commands.
+   Python 2 is already installed on all AMIs, but if you're in Python 2,
+   this will also install :command:`pip` and the ``ujson`` library.
 
-   In Python 3, this option attempts to install Python 3.4 from a package
-   (``sudo yum install -y python34``).
+   In Python 3 this option attempts to install Python 3.4 from a package
+   (``sudo yum install -y python34``), which will work unless you've set
+   :mrjob-opt:`ami_version` to something earlier than 3.7.0.
 
-   Note that this will fail if you set :mrjob-opt:`ami_version` to something
-   earlier than 3.7.0. If you need to use an earlier AMI version with Python 3,
-   first set this option to false, and then use :mrjob-opt:`bootstrap` to
-   install Python 3; see :ref:`bootstrap-python-source`.
+   Unfortunately, there is not a simple, highly reliable way to install
+   :command:`pip` *or* ``ujson`` by default on Python 3.
 
-   Currently, this option does nothing in Python 2. In later versions of mrjob,
-   setting this to true might do more (e.g. installing the exact same version
-   of Python from source).
+   If you just need pure
+   Python packages, see :ref:`Installing pip on Python 3 <bootstrap-pip-py3>`.
+   If you'd like ``ujson`` or other C packages as well, see
+   :ref:`Installing ujson on Python 3 <bootstrap-ujson-py3>`. (The latter
+   will also support Python 3 on any AMI because it compiles Python from
+   source.)
 
    .. versionadded:: 0.5.0
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1884,29 +1884,28 @@ class EMRJobRunner(MRJobRunner):
 
         # bootstrap_python_packages
         if self._opts['bootstrap_python_packages']:
-            if not PY2:
-                raise Exception(
+            if PY2:
+                log.warning(
+                    "bootstrap_python_packages is deprecated since v0.4.2 and"
+                    " will be removed in v0.6.0. Consider using bootstrap"
+                    " instead.")
+
+                # this works on any AMI version
+                bootstrap.append(['sudo apt-get install -y python-pip || '
+                                  'sudo yum install -y python-pip'])
+
+                for path in self._opts['bootstrap_python_packages']:
+                    path_dict = parse_legacy_hash_path('file', path)
+                    # don't worry about inspecting the tarball; pip is smart
+                    # enough to deal with that
+                    bootstrap.append(['sudo pip install ', path_dict])
+
+            else:
+                log.warning(
                     'bootstrap_python_packages is deprecated and is not'
                     ' supported on Python 3. See'
                     ' https://pythonhosted.org/mrjob/guides/emr-bootstrap'
                     '-cookbook.html#using-pip for an alternative.')
-
-            # Rather than keeping mrjob in sync with AMI versions, just
-            # run whatever package manager works (until
-            # bootstrap_python_packages becomes obsolete, and we can
-            # rip this code out entirely)
-            bootstrap.append(['sudo apt-get install -y python-pip || '
-                              'sudo yum install -y python-pip'])
-            # Print a warning
-            log.warning(
-                "bootstrap_python_packages is deprecated since v0.4.2 and will"
-                " be removed in v0.6.0. Consider using bootstrap instead.")
-
-        for path in self._opts['bootstrap_python_packages']:
-            path_dict = parse_legacy_hash_path('file', path)
-            # don't worry about inspecting the tarball; pip is smart
-            # enough to deal with that
-            bootstrap.append(['sudo pip install ', path_dict])
 
         # setup_cmds
         if self._opts['bootstrap_cmds']:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1884,9 +1884,13 @@ class EMRJobRunner(MRJobRunner):
 
         # bootstrap_python_packages
         if self._opts['bootstrap_python_packages']:
-            # 1.x and 2.x AMIs use Debian (apt-get) and 3.x AMIs use
-            # Amazon Linux (yum). Who knows what 4.x AMIs will use?
-            #
+            if not PY2:
+                raise Exception(
+                    'bootstrap_python_packages is deprecated and is not'
+                    ' supported on Python 3. See'
+                    ' https://pythonhosted.org/mrjob/guides/emr-bootstrap'
+                    '-cookbook.html#using-pip for an alternative.')
+
             # Rather than keeping mrjob in sync with AMI versions, just
             # run whatever package manager works (until
             # bootstrap_python_packages becomes obsolete, and we can

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -356,6 +356,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         return combine_dicts(super_opts, {
             'ami_version': _DEFAULT_AMI_VERSION,
             'aws_region': _DEFAULT_AWS_REGION,
+            'bootstrap_python': True,
             'check_emr_status_every': 30,
             'cleanup_on_failure': ['JOB'],
             'ec2_core_instance_type': 'm1.medium',
@@ -1832,20 +1833,33 @@ class EMRJobRunner(MRJobRunner):
     def _bootstrap_python(self):
         """Return a (possibly empty) list of parsed commands (in the same
         format as returned by parse_setup_cmd())'"""
-        if PY2:
-            if self._opts['bootstrap_python']:
-                log.warning('bootstrap_python does nothing in Python 2')
-        # Python 3
-        elif (self._opts['bootstrap_python'] or
-            self._opts['bootstrap_python'] is None):
+        if not self._opts['bootstrap_python']:
+            return []
 
+        if PY2:
+            # Python 2 is already installed; install pip and ujson
+
+            # (We also install python-pip for bootstrap_python_packages,
+            # but there's no harm in running these commands twice, and
+            # bootstrap_python_packages is deprecated anyway.)
+            return [
+                ['sudo apt-get install -y python-pip || '
+                 'sudo yum install -y python-pip'],
+                ['sudo pip install --upgrade ujson'],
+            ]
+        else:
+            # the best we can do is install the Python 3.4 package
+            # (getting pip and ujson on Python 3 is much harder on EMR;
+            # see docs/guides/emr-bootstrap-cookbook.rst)
+
+            # we have to have at least on AMI 3.7.0
             if (self._opts['ami_version'] == 'latest' or
                 not version_gte(self._opts['ami_version'], '3.7.0')):
                 log.warning(
                     'bootstrapping Python 3 will probably not work on'
                     ' AMIs prior to 3.7.0. For an alternative, see:'
                     ' https://pythonhosted.org/mrjob/guides/emr-bootstrap'
-                    '-cookbook.html#upgrading-python-from-source')
+                    '-cookbook.html#installing-python-from-source')
 
             return [['sudo yum install -y python34']]
 


### PR DESCRIPTION
This enables the `bootstrap_python` option by default for all versions of Python. On Python 2, rather than installing Python 2 (which is already installed), it auto-installs `pip` and `ujson` for you (so that JSON serialization will magically be fast). See #1035.

Unfortunately, Amazon's support for Python 3 is really minimal, and installing `pip` is simpler than `ujson`. Left `bootstrap_python` as-is for Python 3, but added extensive documentation about what you need to do to get `pip` and/or `ujson`.

Also disabled `bootstrap_python_packages` on Python 3.
