### PR TITLE
version-agnostic local mode

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -5,21 +5,31 @@ Since mrjob is geared toward Hadoop, there are a few Hadoop-specific options.
 However, due to the difference between the different runners, the Hadoop
 platform, and Elastic MapReduce, they are not all available for all runners.
 
-Options available to local, hadoop, and emr runners
----------------------------------------------------
 
-These options are both used by Hadoop and simulated by the ``local`` runner to
-some degree.
+Options specific to the local and inline runners
+------------------------------------------------
 
 .. mrjob-opt::
     :config: hadoop_version
     :switch: --hadoop-version
     :type: :ref:`string <data-type-string>`
     :set: emr
-    :default: inferred from environment/AWS
+    :default: ``None``
 
-    Set the version of Hadoop to simulate in the ``local`` or ``inline``
-    runner.
+    Set the version of Hadoop to simulate (this currently only matters for
+    :mrjob-opt:`jobconf`).
+
+    If you don't set this, the ``local`` and
+    ``inline`` runners will run in a version-agnostic mode, where anytime
+    the runner sets a simulated jobconf variable, it'll use *every* possible
+    name for it (e.g. ``user.name`` *and* ``mapreduce.job.user.name``).
+
+
+Options available to local, hadoop, and emr runners
+---------------------------------------------------
+
+These options are both used by Hadoop and simulated by the ``local``
+and ``inline`` runners to some degree.
 
 .. mrjob-opt::
     :config: jobconf
@@ -32,6 +42,7 @@ some degree.
     property name to value.  Equivalent to passing ``['-jobconf',
     'KEY1=VALUE1', '-jobconf', 'KEY2=VALUE2', ...]`` to
     :mrjob-opt:`hadoop_extra_args`.
+
 
 Options available to hadoop and emr runners
 -------------------------------------------

--- a/mrjob/compat.py
+++ b/mrjob/compat.py
@@ -655,6 +655,12 @@ def translate_jobconf(variable, version):
         return variable
 
 
+def get_all_jobconf_variants(variable):
+    """Get all known variants of the given jobconf variable."""
+    return sorted(
+        set([variable] + list(_JOBCONF_MAP.get(variable, {}).values())))
+
+
 def supports_combiners_in_hadoop_streaming(version):
     """Return ``True`` if this version of Hadoop Streaming supports combiners
     (i.e. >= 0.20.203), otherwise False.

--- a/mrjob/compat.py
+++ b/mrjob/compat.py
@@ -729,3 +729,15 @@ def add_translated_jobconf_for_hadoop_version(jobconf, hadoop_version):
 
     translated_jobconf.update(jobconf)
     return translated_jobconf
+
+
+def add_translated_jobconf_for_all_versions(jobconf):
+    """Update *jobconf* to include all possible variants of each
+    configuration name."""
+    translated_jobconf = {}
+
+    for var, value in jobconf.items():
+        for translated_var in translate_jobconf_for_all_versions(key):
+            translated_jobconf[translated_var] = value
+
+    return translated_jobconf

--- a/mrjob/compat.py
+++ b/mrjob/compat.py
@@ -717,29 +717,43 @@ def translate_jobconf_dict(jobconf, hadoop_version=None):
 
 def supports_combiners_in_hadoop_streaming(version):
     """Return ``True`` if this version of Hadoop Streaming supports combiners
-    (i.e. >= 0.20.203), otherwise False.
+    (i.e. >= 0.20.203), otherwise ``False``.
+
+    If version is empty, returns ``True``
     """
-    return version_gte(version, '0.20')
+    if not version:
+        return True
+    else:
+        return version_gte(version, '0.20')
 
 
 def supports_new_distributed_cache_options(version):
     """Use ``-files`` and ``-archives`` instead of ``-cacheFile`` and
-    ``-cacheArchive``
+    ``-cacheArchive``. If version is empty, returns ``True``
     """
-    # Although Hadoop 0.20 supports these options, that support is buggy:
-    # https://issues.apache.org/jira/browse/MAPREDUCE-2361
-    # https://issues.apache.org/jira/browse/HADOOP-6334
-    # The bug was fixed in Hadoop 0.20.203.0:
-    # http://hadoop.apache.org/common/docs/r0.20.203.0/releasenotes.html
-    return version_gte(version, '0.20.203')
+    if not version:
+        return True
+    else:
+        # Although Hadoop 0.20 supports these options, that support is buggy:
+        # https://issues.apache.org/jira/browse/MAPREDUCE-2361
+        # https://issues.apache.org/jira/browse/HADOOP-6334
+        # The bug was fixed in Hadoop 0.20.203.0:
+        # http://hadoop.apache.org/common/docs/r0.20.203.0/releasenotes.html
+        return version_gte(version, '0.20.203')
 
 
 def uses_020_counters(version):
+    """Does this version of Hadoop log counters the same way as Hadoop 0.20?"""
+    # TODO: YARN has a different counter style anyway; this probably belongs
+    # in log parsing code.
     return version_gte(version, '0.20')
 
 
 def uses_generic_jobconf(version):
-    """Use ``-D`` instead of ``-jobconf``"""
+    """Use ``-D`` instead of ``-jobconf``. Defaults to ``True`` if
+    *version* is empty."""
+    if not version:
+        return True
     return version_gte(version, '0.20')
 
 

--- a/mrjob/compat.py
+++ b/mrjob/compat.py
@@ -655,8 +655,9 @@ def translate_jobconf(variable, version):
         return variable
 
 
-def get_all_jobconf_variants(variable):
-    """Get all known variants of the given jobconf variable."""
+def translate_jobconf_for_all_versions(variable):
+    """Get all known variants of the given jobconf variable.
+    Unlike :py:func:`translate_jobconf`, returns a list."""
     return sorted(
         set([variable] + list(_JOBCONF_MAP.get(variable, {}).values())))
 

--- a/mrjob/compat.py
+++ b/mrjob/compat.py
@@ -620,14 +620,20 @@ def jobconf_from_dict(jobconf, name, default=None):
     return default
 
 
-def _map_version(version_map, version):
-    """Look up value in the given dictionary which maps versions
-    (as strings) to the value for that version and later.
+def map_version(version, version_map):
+    """Allows you to look up something by version (e.g. which jobconf variable
+    to use), specifying only the versions where that value changed.
 
-    For efficiency, version_map can also be a list of tuples of
-    (LooseVersion(version_as_string), value), with oldest versions first.
+    *version* is a string
 
-    If there are no matches, use the value for the earliest version.
+    *version_map* is a map from version (as a string) that a value changed
+    to the new value.
+
+    For efficiency, *version_map* can also be a list of tuples of
+    ``(LooseVersion(version_as_string), value)``, with oldest versions first.
+
+    If *version* is less than any version in *version_map*, use the value for
+    the earliest version in *version_map*.
     """
     if not version_map:
         raise ValueError
@@ -650,7 +656,7 @@ def translate_jobconf(variable, version):
     a variable we recognize, leave as-is.
     """
     if variable in _JOBCONF_MAP:
-        return _map_version(_JOBCONF_MAP[variable], version)
+        return map_version(version, _JOBCONF_MAP[variable])
     else:
         return variable
 

--- a/mrjob/compat.py
+++ b/mrjob/compat.py
@@ -674,47 +674,9 @@ def translate_jobconf_for_all_versions(variable):
         set([variable] + list(_JOBCONF_MAP.get(variable, {}).values())))
 
 
-def supports_combiners_in_hadoop_streaming(version):
-    """Return ``True`` if this version of Hadoop Streaming supports combiners
-    (i.e. >= 0.20.203), otherwise False.
-    """
-    return version_gte(version, '0.20')
 
 
-def supports_new_distributed_cache_options(version):
-    """Use ``-files`` and ``-archives`` instead of ``-cacheFile`` and
-    ``-cacheArchive``
-    """
-    # Although Hadoop 0.20 supports these options, that support is buggy:
-    # https://issues.apache.org/jira/browse/MAPREDUCE-2361
-    # https://issues.apache.org/jira/browse/HADOOP-6334
-    # The bug was fixed in Hadoop 0.20.203.0:
-    # http://hadoop.apache.org/common/docs/r0.20.203.0/releasenotes.html
-    return version_gte(version, '0.20.203')
-
-
-def uses_020_counters(version):
-    return version_gte(version, '0.20')
-
-
-def uses_generic_jobconf(version):
-    """Use ``-D`` instead of ``-jobconf``"""
-    return version_gte(version, '0.20')
-
-
-def version_gte(version, cmp_version_str):
-    """Return ``True`` if version >= *cmp_version_str*."""
-
-    if not isinstance(version, string_types):
-        raise TypeError('%r is not a string' % version)
-
-    if not isinstance(cmp_version_str, string_types):
-        raise TypeError('%r is not a string' % cmp_version_str)
-
-    return LooseVersion(version) >= LooseVersion(cmp_version_str)
-
-
-def add_translated_jobconf_for_hadoop_version(jobconf, hadoop_version):
+def translate_jobconf_dict(jobconf, hadoop_version=None):
     """Translates the configuration property name to match those that
     are accepted in hadoop_version. Prints a warning message if any
     configuration property name does not match the name in the hadoop
@@ -753,3 +715,44 @@ def add_translated_jobconf_for_all_versions(jobconf):
             translated_jobconf[translated_var] = value
 
     return translated_jobconf
+
+
+
+def supports_combiners_in_hadoop_streaming(version):
+    """Return ``True`` if this version of Hadoop Streaming supports combiners
+    (i.e. >= 0.20.203), otherwise False.
+    """
+    return version_gte(version, '0.20')
+
+
+def supports_new_distributed_cache_options(version):
+    """Use ``-files`` and ``-archives`` instead of ``-cacheFile`` and
+    ``-cacheArchive``
+    """
+    # Although Hadoop 0.20 supports these options, that support is buggy:
+    # https://issues.apache.org/jira/browse/MAPREDUCE-2361
+    # https://issues.apache.org/jira/browse/HADOOP-6334
+    # The bug was fixed in Hadoop 0.20.203.0:
+    # http://hadoop.apache.org/common/docs/r0.20.203.0/releasenotes.html
+    return version_gte(version, '0.20.203')
+
+
+def uses_020_counters(version):
+    return version_gte(version, '0.20')
+
+
+def uses_generic_jobconf(version):
+    """Use ``-D`` instead of ``-jobconf``"""
+    return version_gte(version, '0.20')
+
+
+def version_gte(version, cmp_version_str):
+    """Return ``True`` if version >= *cmp_version_str*."""
+
+    if not isinstance(version, string_types):
+        raise TypeError('%r is not a string' % version)
+
+    if not isinstance(cmp_version_str, string_types):
+        raise TypeError('%r is not a string' % cmp_version_str)
+
+    return LooseVersion(version) >= LooseVersion(cmp_version_str)

--- a/mrjob/compat.py
+++ b/mrjob/compat.py
@@ -635,6 +635,9 @@ def map_version(version, version_map):
     If *version* is less than any version in *version_map*, use the value for
     the earliest version in *version_map*.
     """
+    if version is None:
+        raise TypeError
+
     if not version_map:
         raise ValueError
 
@@ -655,6 +658,9 @@ def translate_jobconf(variable, version):
     """Translate *variable* to Hadoop version *version*. If it's not
     a variable we recognize, leave as-is.
     """
+    if version is None:
+        raise TypeError
+
     if variable in _JOBCONF_MAP:
         return map_version(version, _JOBCONF_MAP[variable])
     else:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -363,7 +363,6 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'emr_job_flow_pool_name': 'default',
             'hadoop_streaming_jar_on_emr': (
                 '/home/hadoop/contrib/streaming/hadoop-streaming.jar'),
-            'hadoop_version': None,  # override runner default
             'mins_to_end_of_hour': 5.0,
             'num_ec2_core_instances': 0,
             'num_ec2_instances': 1,

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -60,7 +60,7 @@ from mrjob.aws import MAX_STEPS_PER_JOB_FLOW
 from mrjob.aws import emr_endpoint_for_region
 from mrjob.aws import emr_ssl_host_for_region
 from mrjob.aws import s3_location_constraint_for_region
-from mrjob.compat import _map_version
+from mrjob.compat import map_version
 from mrjob.compat import version_gte
 from mrjob.conf import combine_cmds
 from mrjob.conf import combine_dicts
@@ -893,8 +893,8 @@ class EMRJobRunner(MRJobRunner):
         path: path to start page of job tracker/resource manager
         port: port job tracker/resource manager is running on.
         """
-        return _map_version(_AMI_VERSION_TO_SSH_TUNNEL_CONFIG,
-                            self.get_ami_version())
+        return map_version(self.get_ami_version(),
+                           _AMI_VERSION_TO_SSH_TUNNEL_CONFIG)
 
     def _set_up_ssh_tunnel(self, host):
         """set up the ssh tunnel to the job tracker, if it's not currently

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -1075,6 +1075,7 @@ class MRJob(MRJobLauncher):
                 else:
                     filtered_val = 'false'
 
+            # TODO: why would a jobconf variable be named 'hadoop_version'?
             # hadoop_version should be a string
             elif (key == 'hadoop_version' and
                     isinstance(unfiltered_val, float)):

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -29,7 +29,6 @@ from mrjob.options import add_basic_opts
 from mrjob.options import add_emr_opts
 from mrjob.options import add_hadoop_emr_opts
 from mrjob.options import add_hadoop_opts
-from mrjob.options import add_hadoop_shared_opts
 from mrjob.options import add_local_opts
 from mrjob.options import add_protocol_opts
 from mrjob.options import add_runner_opts
@@ -285,14 +284,6 @@ class MRJobLauncher(object):
         add_runner_opts(self.runner_opt_group, self._DEFAULT_RUNNER)
         add_basic_opts(self.runner_opt_group)
 
-        self.hadoop_opts_opt_group = OptionGroup(
-            self.option_parser,
-            'Configuring or emulating Hadoop (these apply when you set -r'
-            ' hadoop, -r emr, or -r local)')
-        self.option_parser.add_option_group(self.hadoop_opts_opt_group)
-
-        add_hadoop_shared_opts(self.hadoop_opts_opt_group)
-
         # options for inline/local runners
         self.local_opt_group = OptionGroup(
             self.option_parser,
@@ -321,8 +312,7 @@ class MRJobLauncher(object):
         # options for running the job on EMR
         self.emr_opt_group = OptionGroup(
             self.option_parser,
-            'Running on Amazon Elastic MapReduce (these apply when you set -r'
-            ' emr)')
+            'Running on EMR (these apply when you set -r emr)')
         self.option_parser.add_option_group(self.emr_opt_group)
 
         add_emr_opts(self.emr_opt_group)
@@ -330,7 +320,7 @@ class MRJobLauncher(object):
     def all_option_groups(self):
         return (self.option_parser, self.proto_opt_group,
                 self.runner_opt_group, self.hadoop_emr_opt_group,
-                self.emr_opt_group, self.hadoop_opts_opt_group)
+                self.emr_opt_group, self.local_opt_group)
 
     def is_task(self):
         """True if this is a mapper, combiner, or reducer.
@@ -448,8 +438,7 @@ class MRJobLauncher(object):
             sys.exit(0)
 
         if self.options.help_hadoop:
-            print_help_for_groups(self.hadoop_emr_opt_group,
-                                  self.hadoop_opts_opt_group)
+            print_help_for_groups(self.hadoop_emr_opt_group)
             sys.exit(0)
 
         if self.options.help_local:

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -199,14 +199,18 @@ def add_runner_opts(opt_group, default_runner='local'):
     ]
 
 
-def add_hadoop_shared_opts(opt_group):
-    """Options for ``hadoop``, ``local``, and ``emr`` runners"""
+def add_local_opts(opt_group):
+    """Options for ``inline`` and ``local`` runners."""
     return [
         opt_group.add_option(
             '--hadoop-version', dest='hadoop_version', default=None,
-            help=('Version of Hadoop to specify to EMR or to emulate for -r'
-                  ' local. Default is 0.20.')),
+            help=('Specific version of Hadoop to simulate')),
+    ]
 
+
+def add_hadoop_shared_opts(opt_group):
+    """Options for ``hadoop``, ``local``, and ``emr`` runners"""
+    return [
         # for more info about jobconf:
         # http://hadoop.apache.org/mapreduce/docs/current/mapred-default.html
         opt_group.add_option(

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -124,6 +124,14 @@ def add_runner_opts(opt_group, default_runner='local'):
             '--interpreter', dest='interpreter', default=None,
             help=('Non-python command to run your script, e.g. "ruby".')),
 
+        # for more info about jobconf:
+        # http://hadoop.apache.org/mapreduce/docs/current/mapred-default.html
+        opt_group.add_option(
+            '--jobconf', dest='jobconf', default=[], action='append',
+            help=('-jobconf arg to pass through to hadoop streaming; should'
+                  ' take the form KEY=VALUE. You can use --jobconf multiple'
+                  ' times.')),
+
         opt_group.add_option(
             '--no-bootstrap-mrjob', dest='bootstrap_mrjob',
             action='store_false', default=None,
@@ -205,19 +213,6 @@ def add_local_opts(opt_group):
         opt_group.add_option(
             '--hadoop-version', dest='hadoop_version', default=None,
             help=('Specific version of Hadoop to simulate')),
-    ]
-
-
-def add_hadoop_shared_opts(opt_group):
-    """Options for ``hadoop``, ``local``, and ``emr`` runners"""
-    return [
-        # for more info about jobconf:
-        # http://hadoop.apache.org/mapreduce/docs/current/mapred-default.html
-        opt_group.add_option(
-            '--jobconf', dest='jobconf', default=[], action='append',
-            help=('-jobconf arg to pass through to hadoop streaming; should'
-                  ' take the form KEY=VALUE. You can use --jobconf multiple'
-                  ' times.')),
     ]
 
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -31,7 +31,7 @@ from subprocess import Popen
 from subprocess import PIPE
 from subprocess import check_call
 
-from mrjob.compat import add_translated_jobconf_for_hadoop_version
+from mrjob.compat import translate_jobconf_dict
 from mrjob.compat import supports_combiners_in_hadoop_streaming
 from mrjob.compat import uses_generic_jobconf
 from mrjob.conf import combine_cmds
@@ -1159,7 +1159,7 @@ class MRJobRunner(object):
         step = self._get_step(step_num)
         jobconf = combine_dicts(self._opts['jobconf'], step.get('jobconf'))
 
-        return add_translated_jobconf_for_hadoop_version(
+        return translate_jobconf_dict(
             jobconf, self.get_hadoop_version())
 
     def _hadoop_args_for_step(self, step_num):

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -36,6 +36,10 @@ log = logging.getLogger(__name__)
 
 class SimRunnerOptionStore(RunnerOptionStore):
 
+    ALLOWED_KEYS = RunnerOptionStore.ALLOWED_KEYS.union(set([
+        'hadoop_version',
+    ]))
+
     COMBINERS = combine_dicts(RunnerOptionStore.COMBINERS, {
         'cmdenv': combine_local_envs,
     })

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -20,7 +20,7 @@ import os
 import shutil
 import stat
 
-from mrjob.compat import add_translated_jobconf_for_hadoop_version
+from mrjob.compat import translate_jobconf_dict
 from mrjob.compat import jobconf_from_dict
 from mrjob.compat import translate_jobconf
 from mrjob.conf import combine_dicts
@@ -430,7 +430,7 @@ class SimMRJobRunner(MRJobRunner):
 
         # auto-translate jobconf variables from the wrong version, like
         # other runners do
-        user_jobconf = add_translated_jobconf_for_hadoop_version(
+        user_jobconf = translate_jobconf_dict(
             self._jobconf_for_step(step_num), version)
 
         simulated_jobconf = self._simulate_jobconf_for_step(

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -22,6 +22,7 @@ from mrjob.compat import jobconf_from_dict
 from mrjob.compat import supports_combiners_in_hadoop_streaming
 from mrjob.compat import supports_new_distributed_cache_options
 from mrjob.compat import translate_jobconf
+from mrjob.compat import translate_jobconf_for_all_versions
 from mrjob.compat import uses_generic_jobconf
 from mrjob.compat import _map_version
 
@@ -108,6 +109,14 @@ class CompatTestCase(TestCase):
                          'user.name')
         self.assertEqual(translate_jobconf('user.name', '2.0'),
                          'mapreduce.job.user.name')
+
+        self.assertEqual(translate_jobconf('foo.bar', '2.0'), 'foo.bar')
+
+    def test_translate_jobconf_for_all_versions(self):
+        self.assertEqual(translate_jobconf_for_all_versions('user.name'),
+                         ['mapreduce.job.user.name', 'user.name'])
+        self.assertEqual(translate_jobconf_for_all_versions('foo.bar'),
+                         ['foo.bar'])
 
     def test_supports_combiners(self):
         self.assertEqual(supports_combiners_in_hadoop_streaming('0.19'),

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -23,7 +23,6 @@ from mrjob.compat import map_version
 from mrjob.compat import supports_combiners_in_hadoop_streaming
 from mrjob.compat import supports_new_distributed_cache_options
 from mrjob.compat import translate_jobconf
-from mrjob.compat import translate_jobconf_dict
 from mrjob.compat import translate_jobconf_for_all_versions
 from mrjob.compat import uses_generic_jobconf
 from mrjob.py2 import StringIO
@@ -126,42 +125,6 @@ class TranslateJobConfTestCase(TestCase):
                          ['mapreduce.job.user.name', 'user.name'])
         self.assertEqual(translate_jobconf_for_all_versions('foo.bar'),
                          ['foo.bar'])
-
-    def test_translate_jobconf_dict(self):
-        jobconf = {
-            'user.name': 'dave',
-            'foo.bar': 'baz',
-        }
-
-        with no_handlers_for_logger('mrjob.compat'):
-            stderr = StringIO()
-            log_to_stream('mrjob.compat', stderr)
-
-            translated_jobconf_1_0 = (
-                translate_jobconf_dict(jobconf, '1.0'))
-            self.assertEqual(translated_jobconf_1_0, jobconf)
-            self.assertEqual(stderr.getvalue(), '')
-
-            translated_jobconf_agnostic = (
-                translate_jobconf_dict(jobconf))
-            self.assertEqual(translated_jobconf_agnostic, {
-                'foo.bar': 'baz',
-                'mapreduce.job.user.name': 'dave',
-                'user.name': 'dave',
-            })
-            self.assertEqual(stderr.getvalue(), '')
-
-            translated_jobconf_2_0 = (
-                translate_jobconf_dict(jobconf, '2.0'))
-            self.assertEqual(translated_jobconf_2_0, {
-                'foo.bar': 'baz',
-                'mapreduce.job.user.name': 'dave',
-                'user.name': 'dave',
-            })
-            self.assertIn('do not match hadoop version',
-                          stderr.getvalue())
-            self.assertIn('user.name: mapreduce.job.user.name',
-                          stderr.getvalue())
 
 
 class MiscCompatTestCase(TestCase):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -17,7 +17,7 @@
 import os
 from distutils.version import LooseVersion
 
-from mrjob.compat import add_translated_jobconf_for_hadoop_version
+from mrjob.compat import translate_jobconf_dict
 from mrjob.compat import jobconf_from_dict
 from mrjob.compat import jobconf_from_env
 from mrjob.compat import map_version
@@ -127,7 +127,7 @@ class TranslateJobConfTestCase(TestCase):
         self.assertEqual(translate_jobconf_for_all_versions('foo.bar'),
                          ['foo.bar'])
 
-    def test_add_translated_jobconf_for_hadoop_version(self):
+    def test_translate_jobconf_dict(self):
         jobconf = {
             'user.name': 'dave',
             'foo.bar': 'baz',
@@ -138,12 +138,12 @@ class TranslateJobConfTestCase(TestCase):
             log_to_stream('mrjob.compat', stderr)
 
             translated_jobconf_1_0 = (
-                add_translated_jobconf_for_hadoop_version(jobconf, '1.0'))
+                translate_jobconf_dict(jobconf, '1.0'))
             self.assertEqual(translated_jobconf_1_0, jobconf)
             self.assertEqual(stderr.getvalue(), '')
 
             translated_jobconf_2_0 = (
-                add_translated_jobconf_for_hadoop_version(jobconf, '2.0'))
+                translate_jobconf_dict(jobconf, '2.0'))
             self.assertEqual(translated_jobconf_2_0, {
                 'foo.bar': 'baz',
                 'mapreduce.job.user.name': 'dave',

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -90,7 +90,7 @@ class JobConfFromDictTestCase(TestCase):
             jobconf_from_dict({}, 'user.defined', 'beauty'), 'beauty')
 
 
-class CompatTestCase(TestCase):
+class TranslateJobConfTestCase(TestCase):
 
     def test_translate_jobconf(self):
         self.assertEqual(translate_jobconf('user.name', '0.18'),
@@ -112,11 +112,19 @@ class CompatTestCase(TestCase):
 
         self.assertEqual(translate_jobconf('foo.bar', '2.0'), 'foo.bar')
 
+    def test_version_may_not_be_None(self):
+        self.assertRaises(TypeError, translate_jobconf, 'user.name', None)
+        # test unknown variables too, since they don't go through map_version()
+        self.assertRaises(TypeError, translate_jobconf, 'foo.bar', None)
+
     def test_translate_jobconf_for_all_versions(self):
         self.assertEqual(translate_jobconf_for_all_versions('user.name'),
                          ['mapreduce.job.user.name', 'user.name'])
         self.assertEqual(translate_jobconf_for_all_versions('foo.bar'),
                          ['foo.bar'])
+
+
+class MiscCompatTestCase(TestCase):
 
     def test_supports_combiners(self):
         self.assertEqual(supports_combiners_in_hadoop_streaming('0.19'),
@@ -146,6 +154,10 @@ class MapVersionTestCase(TestCase):
         self.assertRaises(ValueError, map_version, '0.5.0', None)
         self.assertRaises(ValueError, map_version, '0.5.0', {})
         self.assertRaises(ValueError, map_version, '0.5.0', [])
+
+    def test_version_may_not_be_None(self):
+        self.assertEqual(map_version('1', {'1': 'foo'}), 'foo')
+        self.assertRaises(TypeError, map_version, None, {'1': 'foo'})
 
     def test_dict(self):
         version_map = {

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -17,13 +17,13 @@
 import os
 from distutils.version import LooseVersion
 
-from mrjob.compat import translate_jobconf_dict
 from mrjob.compat import jobconf_from_dict
 from mrjob.compat import jobconf_from_env
 from mrjob.compat import map_version
 from mrjob.compat import supports_combiners_in_hadoop_streaming
 from mrjob.compat import supports_new_distributed_cache_options
 from mrjob.compat import translate_jobconf
+from mrjob.compat import translate_jobconf_dict
 from mrjob.compat import translate_jobconf_for_all_versions
 from mrjob.compat import uses_generic_jobconf
 from mrjob.py2 import StringIO
@@ -142,6 +142,15 @@ class TranslateJobConfTestCase(TestCase):
             self.assertEqual(translated_jobconf_1_0, jobconf)
             self.assertEqual(stderr.getvalue(), '')
 
+            translated_jobconf_agnostic = (
+                translate_jobconf_dict(jobconf))
+            self.assertEqual(translated_jobconf_agnostic, {
+                'foo.bar': 'baz',
+                'mapreduce.job.user.name': 'dave',
+                'user.name': 'dave',
+            })
+            self.assertEqual(stderr.getvalue(), '')
+
             translated_jobconf_2_0 = (
                 translate_jobconf_dict(jobconf, '2.0'))
             self.assertEqual(translated_jobconf_2_0, {
@@ -149,8 +158,10 @@ class TranslateJobConfTestCase(TestCase):
                 'mapreduce.job.user.name': 'dave',
                 'user.name': 'dave',
             })
-            self.assertIn('do not match hadoop version', stderr.getvalue())
-            self.assertIn('mapreduce.job.user.name', stderr.getvalue())
+            self.assertIn('do not match hadoop version',
+                          stderr.getvalue())
+            self.assertIn('user.name: mapreduce.job.user.name',
+                          stderr.getvalue())
 
 
 class MiscCompatTestCase(TestCase):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -17,14 +17,14 @@
 import os
 from distutils.version import LooseVersion
 
-from mrjob.compat import jobconf_from_env
 from mrjob.compat import jobconf_from_dict
+from mrjob.compat import jobconf_from_env
+from mrjob.compat import map_version
 from mrjob.compat import supports_combiners_in_hadoop_streaming
 from mrjob.compat import supports_new_distributed_cache_options
 from mrjob.compat import translate_jobconf
 from mrjob.compat import translate_jobconf_for_all_versions
 from mrjob.compat import uses_generic_jobconf
-from mrjob.compat import _map_version
 
 from tests.py2 import TestCase
 from tests.py2 import patch
@@ -143,9 +143,9 @@ class CompatTestCase(TestCase):
 class MapVersionTestCase(TestCase):
 
     def test_empty(self):
-        self.assertRaises(ValueError, _map_version, None, '0.5.0')
-        self.assertRaises(ValueError, _map_version, {}, '0.5.0'),
-        self.assertRaises(ValueError, _map_version, [], '0.5.0')
+        self.assertRaises(ValueError, map_version, '0.5.0', None)
+        self.assertRaises(ValueError, map_version, '0.5.0', {})
+        self.assertRaises(ValueError, map_version, '0.5.0', [])
 
     def test_dict(self):
         version_map = {
@@ -154,15 +154,15 @@ class MapVersionTestCase(TestCase):
             '3': 'baz',
         }
 
-        self.assertEqual(_map_version(version_map, '1.1'), 'foo')
+        self.assertEqual(map_version('1.1', version_map), 'foo')
         # test exact match
-        self.assertEqual(_map_version(version_map, '2'), 'bar')
+        self.assertEqual(map_version('2', version_map), 'bar')
         # versions are just minimums
-        self.assertEqual(_map_version(version_map, '4.5'), 'baz')
+        self.assertEqual(map_version('4.5', version_map), 'baz')
         # compare versions, not strings
-        self.assertEqual(_map_version(version_map, '11.11'), 'baz')
+        self.assertEqual(map_version('11.11', version_map), 'baz')
         # fall back to lowest version
-        self.assertEqual(_map_version(version_map, '0.1'), 'foo')
+        self.assertEqual(map_version('0.1', version_map), 'foo')
 
     def test_list_of_tuples(self):
         version_map = [
@@ -171,8 +171,8 @@ class MapVersionTestCase(TestCase):
             (LooseVersion('3'), 'baz'),
         ]
 
-        self.assertEqual(_map_version(version_map, '1.1'), 'foo')
-        self.assertEqual(_map_version(version_map, '2'), 'bar')
-        self.assertEqual(_map_version(version_map, '4.5'), 'baz')
-        self.assertEqual(_map_version(version_map, '11.11'), 'baz')
-        self.assertEqual(_map_version(version_map, '0.1'), 'foo')
+        self.assertEqual(map_version('1.1', version_map), 'foo')
+        self.assertEqual(map_version('2', version_map), 'bar')
+        self.assertEqual(map_version('4.5', version_map), 'baz')
+        self.assertEqual(map_version('11.11', version_map), 'baz')
+        self.assertEqual(map_version('0.1', version_map), 'foo')

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -175,17 +175,27 @@ class MiscCompatTestCase(TestCase):
                          True)
         self.assertEqual(supports_combiners_in_hadoop_streaming('0.20.203'),
                          True)
+        # default to True
+        self.assertEqual(supports_combiners_in_hadoop_streaming(None), True)
+
 
     def test_uses_generic_jobconf(self):
         self.assertEqual(uses_generic_jobconf('0.18'), False)
         self.assertEqual(uses_generic_jobconf('0.20'), True)
         self.assertEqual(uses_generic_jobconf('0.21'), True)
 
+        # default to True
+        self.assertEqual(uses_generic_jobconf(None), True)
+
     def test_cache_opts(self):
         self.assertEqual(supports_new_distributed_cache_options('0.18'), False)
         self.assertEqual(supports_new_distributed_cache_options('0.20'), False)
         self.assertEqual(
             supports_new_distributed_cache_options('0.20.203'), True)
+
+        # default to True
+        self.assertEqual(
+            supports_new_distributed_cache_options(None), True)
 
 
 class MapVersionTestCase(TestCase):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -517,6 +517,16 @@ class LocalMRJobRunnerJobConfTestCase(SimRunnerJobConfTestCase):
 
 class CompatTestCase(EmptyMrjobConfTestCase):
 
+    def test_environment_variables_version_agnostic(self):
+        job = MRWordCount(['-r', 'local'])
+        with job.make_runner() as runner:
+            simulated_jobconf = runner._simulate_jobconf_for_step(
+                0, 'mapper', 0, '/tmp/foo')
+            self.assertIn(
+                'mapred.cache.localArchives', simulated_jobconf)
+            self.assertIn(
+                'mapreduce.job.cache.local.archives', simulated_jobconf)
+
     def test_environment_variables_018(self):
         job = MRWordCount(['-r', 'local', '--hadoop-version', '0.18'])
         with job.make_runner() as runner:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -25,6 +25,7 @@ import tempfile
 from io import BytesIO
 from subprocess import CalledProcessError
 
+from mrjob.conf import combine_dicts
 from mrjob.inline import InlineMRJobRunner
 from mrjob.local import LocalMRJobRunner
 from mrjob.parse import JOB_KEY_RE
@@ -507,15 +508,17 @@ class HadoopArgsTestCase(EmptyMrjobConfTestCase):
 
     def test_configuration_translation(self):
         job = MRWordCount(
-            ['--jobconf', 'mapred.jobtracker.maxtasks.per.job=1',
-             '--hadoop-version', '0.21'])
+            ['--jobconf', 'mapred.jobtracker.maxtasks.per.job=1'])
 
         with job.make_runner() as runner:
-            with no_handlers_for_logger('mrjob.compat'):
-                self.assertEqual(runner._hadoop_args_for_step(0),
-                         ['-D', 'mapred.jobtracker.maxtasks.per.job=1',
-                          '-D', 'mapreduce.jobtracker.maxtasks.perjob=1'
-                          ])
+            with no_handlers_for_logger('mrjob.runner'):
+                with patch.object(runner,
+                                  'get_hadoop_version', return_value='0.21'):
+                    self.assertEqual(
+                        runner._hadoop_args_for_step(0),
+                        ['-D', 'mapred.jobtracker.maxtasks.per.job=1',
+                         '-D', 'mapreduce.jobtracker.maxtasks.perjob=1'
+                         ])
 
     def test_jobconf_from_step(self):
         jobconf = {'FOO': 'bar', 'BAZ': 'qux'}
@@ -560,6 +563,64 @@ class HadoopArgsTestCase(EmptyMrjobConfTestCase):
         job = MRWordCount(['--no-check-input-paths'])
         with job.make_runner() as runner:
             self.assertFalse(runner._opts['check_input_paths'])
+
+
+class UpdateJobConfForHadoopVersionTestCase(TestCase):
+
+    # jobconf with strange mix of Hadoop 1 and Hadoop 2 variables
+    JOBCONF = {
+        'foo.bar': 'baz',                   # unknown jobconf
+        'mapred.jar': 'a.jar',              # Hadoop 1 jobconf
+        'mapreduce.job.user.name': 'dave',  # Hadoop 2 jobconf
+    }
+
+    def setUp(self):
+        self.runner = InlineMRJobRunner(conf_paths=[])
+
+    def updated_and_warnings(self, jobconf, hadoop_version):
+        jobconf = jobconf.copy()
+        with no_handlers_for_logger('mrjob.runner'):
+            stderr = StringIO()
+            log_to_stream('mrjob.runner', stderr)
+            self.runner._update_jobconf_for_hadoop_version(
+                jobconf, hadoop_version)
+
+        return jobconf, stderr.getvalue()
+
+    def test_no_version(self):
+        updated, warnings = self.updated_and_warnings(
+            self.JOBCONF, None)
+
+        self.assertEqual(updated, self.JOBCONF)
+        self.assertEqual(warnings, '')
+
+    def test_hadoop_1(self):
+        updated, warnings = self.updated_and_warnings(
+            self.JOBCONF, '1.0')
+
+        self.assertEqual(updated,
+                         combine_dicts(self.JOBCONF, {'user.name': 'dave'}))
+        self.assertIn('do not match hadoop version', warnings)
+        self.assertIn('mapreduce.job.user.name: user.name', warnings)
+
+    def test_hadoop_2(self):
+        updated, warnings = self.updated_and_warnings(
+            self.JOBCONF, '2.0')
+
+        self.assertEqual(updated,
+                         combine_dicts(self.JOBCONF,
+                                       {'mapreduce.job.jar': 'a.jar'}))
+        self.assertIn('do not match hadoop version', warnings)
+        self.assertIn('mapred.jar: mapreduce.job.jar', warnings)
+
+    def test_dont_overwrite(self):
+        # this jobconf contains two versions of the same variable
+        jobconf = {'mapred.jar': 'a.jar', 'mapreduce.job.jar': 'b.jar'}
+
+        updated, warnings = self.updated_and_warnings(jobconf, '1.0')
+
+        self.assertEqual(updated, jobconf)
+        self.assertEqual(warnings, '')
 
 
 class SetupTestCase(SandboxedTestCase):


### PR DESCRIPTION
This change fully relegates `--hadoop-version` to something used only by inline/local mode for version simulation.

`hadoop_version` no longer has a default value. If it's not set, the local/inline runner runs in version-agnostic mode, where when it simulates jobconf variables, it sets them for all possible versions of hadoop. If *you* set jobconf variables, version-agnostic mode leaves them unmolested, rather than patching in their counterparts in the current Hadoop version (see #735 for more details).

This also fixes documentation and `--help` to clarify that inline mode supports jobconf too!