### PR TITLE
Fix HadoopRunner.get_hadoop_version() in Python 3

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -217,9 +217,9 @@ class HadoopJobRunner(MRJobRunner):
                 if m:
                     self._hadoop_version = to_string(m.group('version'))
                     log.info("Using Hadoop version %s" % self._hadoop_version)
-                    return self._hadoop_version
-            self._hadoop_version = '0.20.203'
-            log.info("Unable to determine Hadoop version. Assuming 0.20.203.")
+                else:
+                    raise Exception('Unable to determine Hadoop version.')
+
         return self._hadoop_version
 
     def _run(self):

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -212,10 +212,10 @@ class HadoopJobRunner(MRJobRunner):
         if not self._hadoop_version:
             stdout = self.invoke_hadoop(['version'], return_stdout=True)
             if stdout:
-                first_line = stdout.split('\n')[0]
+                first_line = stdout.split(b'\n')[0]
                 m = HADOOP_VERSION_RE.match(first_line)
                 if m:
-                    self._hadoop_version = m.group('version')
+                    self._hadoop_version = to_string(m.group('version'))
                     log.info("Using Hadoop version %s" % self._hadoop_version)
                     return self._hadoop_version
             self._hadoop_version = '0.20.203'

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -462,7 +462,7 @@ def hadoop_version(stdout, stderr, environ, *args):
 #  -r 911707
 # Compiled by chrisdo on Fri Feb 19 08:07:34 UTC 2010
 # """)
-    stderr.write("Hadoop " + environ['MOCK_HADOOP_VERSION'])
+    stdout.write("Hadoop " + environ['MOCK_HADOOP_VERSION'])
     return 0
 
 

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -152,6 +152,12 @@ class GetHadoopVersionTestCase(MockHadoopTestCase):
         runner = HadoopJobRunner()
         self.assertEqual(runner.get_hadoop_version(), '1.2.0')
 
+    def test_missing_hadoop_version(self):
+        with patch.dict('os.environ', MOCK_HADOOP_VERSION=''):
+            runner = HadoopJobRunner()
+            self.assertRaises(Exception, runner.get_hadoop_version)
+
+
 
 class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -146,6 +146,13 @@ class MockHadoopTestCase(SandboxedTestCase):
         self.add_mrjob_to_pythonpath()
 
 
+class GetHadoopVersionTestCase(MockHadoopTestCase):
+
+    def test_get_hadoop_version(self):
+        runner = HadoopJobRunner()
+        self.assertEqual(runner.get_hadoop_version(), '1.2.0')
+
+
 class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
     def _test_end_to_end(self, args=()):


### PR DESCRIPTION
Fix `HadoopJobRunner.get_hadoop_version()` on Python 3 (fixes #1142). Basically, we were still treating the output of the `hadoop` command as a `str` rather than `bytes`.

This was masked by a bug in `tests.mockhadoop` combined with `HadoopJobRunner` falling back to an arbitrary version if `hadoop version` produced empty output. Fixed `mockhadoop`, removed the fall-back, and added explicit tests for `get_hadoop_version()`.