### PR TITLE
mkdir -p in Hadoop 2

### DIFF
--- a/mrjob/compat.py
+++ b/mrjob/compat.py
@@ -757,6 +757,13 @@ def uses_generic_jobconf(version):
     return version_gte(version, '0.20')
 
 
+def uses_yarn(version):
+    """Basically, is this Hadoop 2? This also handles versions in the
+    zero series (0.23+) where YARN originated."""
+    return (version_gte(version, '2') or
+            version_gte(version, '0.23') and not version_gte(version, '1'))
+
+
 def version_gte(version, cmp_version_str):
     """Return ``True`` if version >= *cmp_version_str*."""
 

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -20,7 +20,7 @@ from subprocess import Popen
 from subprocess import PIPE
 from subprocess import CalledProcessError
 
-from mrjob.compat import version_gte
+from mrjob.compat import uses_yarn
 from mrjob.fs.base import Filesystem
 from mrjob.py2 import to_string
 from mrjob.parse import is_uri
@@ -217,9 +217,8 @@ class HadoopFilesystem(Filesystem):
     def mkdir(self, path):
         version = self.get_hadoop_version()
 
-        # use -p on Hadoop 2
-        if (version_gte(version, '2') or
-            version_gte(version, '0.23') and not version_gte(version, '1')):
+        # use -p on Hadoop 2 (see #991, #845)
+        if uses_yarn(version):
             args = ['fs', '-mkdir', '-p', path]
         else:
             args = ['fs', '-mkdir', path]

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -20,6 +20,7 @@ from subprocess import Popen
 from subprocess import PIPE
 from subprocess import CalledProcessError
 
+from mrjob.compat import version_gte
 from mrjob.fs.base import Filesystem
 from mrjob.py2 import to_string
 from mrjob.parse import is_uri
@@ -31,29 +32,53 @@ from mrjob.util import read_file
 log = logging.getLogger(__name__)
 
 # used by mkdir()
-HADOOP_FILE_EXISTS_RE = re.compile(br'.*File exists.*')
+_HADOOP_FILE_EXISTS_RE = re.compile(br'.*File exists.*')
 
 # used by ls() and path_exists()
 _HADOOP_LS_NO_SUCH_FILE = re.compile(
     br'^lsr?: Cannot access .*: No such file or directory.')
 
 # used by rm() (see below)
-HADOOP_RMR_NO_SUCH_FILE = re.compile(br'^rmr: hdfs://.*$')
+_HADOOP_RMR_NO_SUCH_FILE = re.compile(br'^rmr: hdfs://.*$')
+
+# find version string in "Hadoop 0.20.203" etc.
+_HADOOP_VERSION_RE = re.compile(br'^.*?(?P<version>(\d|\.)+).*?$')
+
 
 
 class HadoopFilesystem(Filesystem):
     """Filesystem for URIs accepted by ``hadoop fs``. Typically you will get
     one of these via ``HadoopJobRunner().fs``, composed with
     :py:class:`~mrjob.fs.local.LocalFilesystem`.
+
+    This also helps with other invocations of the ``hadoop`` binary, such
+    as ``hadoop version`` (see :py:meth:`invoke_hadoop`).
     """
 
     def __init__(self, hadoop_bin):
         """:param hadoop_bin: path to ``hadoop`` binary"""
         super(HadoopFilesystem, self).__init__()
         self._hadoop_bin = hadoop_bin
+        self._hadoop_version = None  # cache for get_hadoop_version()
 
     def can_handle_path(self, path):
         return is_uri(path)
+
+    def get_hadoop_version(self):
+        """Invoke the hadoop executable to determine its version"""
+        # mkdir() needs this
+        if not self._hadoop_version:
+            stdout = self.invoke_hadoop(['version'], return_stdout=True)
+            if stdout:
+                first_line = stdout.split(b'\n')[0]
+                m = _HADOOP_VERSION_RE.match(first_line)
+                if m:
+                    self._hadoop_version = to_string(m.group('version'))
+                    log.info("Using Hadoop version %s" % self._hadoop_version)
+                else:
+                    raise Exception('Unable to determine Hadoop version.')
+
+        return self._hadoop_version
 
     def invoke_hadoop(self, args, ok_returncodes=None, ok_stderr=None,
                       return_stdout=False):
@@ -190,9 +215,17 @@ class HadoopFilesystem(Filesystem):
         return read_file(filename, cat_proc.stdout, cleanup=cleanup)
 
     def mkdir(self, path):
+        version = self.get_hadoop_version()
+
+        # use -p on Hadoop 2
+        if (version_gte(version, '2') or
+            version_gte(version, '0.23') and not version_gte(version, '1')):
+            args = ['fs', '-mkdir', '-p', path]
+        else:
+            args = ['fs', '-mkdir', path]
+
         try:
-            self.invoke_hadoop(
-                ['fs', '-mkdir', path], ok_stderr=[HADOOP_FILE_EXISTS_RE])
+            self.invoke_hadoop(args, ok_stderr=[_HADOOP_FILE_EXISTS_RE])
         except CalledProcessError:
             raise IOError("Could not mkdir %s" % path)
 
@@ -231,7 +264,7 @@ class HadoopFilesystem(Filesystem):
             try:
                 self.invoke_hadoop(
                     ['fs', '-rmr', path_glob],
-                    return_stdout=True, ok_stderr=[HADOOP_RMR_NO_SUCH_FILE])
+                    return_stdout=True, ok_stderr=[_HADOOP_RMR_NO_SUCH_FILE])
             except CalledProcessError:
                 raise IOError("Could not rm %s" % path_glob)
 

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -600,7 +600,6 @@ def parse_hadoop_counters_from_line(line, hadoop_version=None):
 
     :return: (counter_dict, step_num) or (None, None)
     """
-    # start with 2.x parsing, which parses the entire line as JSON
     if (hadoop_version is None or
         version_gte(hadoop_version, '2') or
         (version_gte(hadoop_version, '0.21') and

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -600,6 +600,7 @@ def parse_hadoop_counters_from_line(line, hadoop_version=None):
 
     :return: (counter_dict, step_num) or (None, None)
     """
+    # start with 2.x parsing, which parses the entire line as JSON
     if (hadoop_version is None or
         version_gte(hadoop_version, '2') or
         (version_gte(hadoop_version, '0.21') and

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -125,12 +125,19 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         self.assertEqual(self.fs.du('hdfs:///more/data2'), 4)
         self.assertEqual(self.fs.du('hdfs:///more/data3'), 4)
 
-    def test_mkdir(self):
-        for hadoop_version in ['0.20.0', '0.23.0', '1.2.0', '2.0.0']:
-            self.env['MOCK_HADOOP_VERSION'] = hadoop_version
-            self.fs.mkdir('hdfs:///d')
-            local_path = os.path.join(self.tmp_dir, 'mock_hdfs_root', 'd')
-            self.assertEqual(os.path.isdir(local_path), True)
+    def _test_mkdir(self):
+        self.fs.mkdir('hdfs:///d/ave')
+        local_path = os.path.join(self.tmp_dir, 'mock_hdfs_root', 'd', 'ave')
+        self.assertEqual(os.path.isdir(local_path), True)
+
+    def test_mkdir_hadoop_1(self):
+        self.env['MOCK_HADOOP_VERSION'] = '1.2.0'
+        self._test_mkdir()
+
+    def test_mkdir_hadoop_2(self):
+        # this catches issue #991
+        self.env['MOCK_HADOOP_VERSION'] = '2.0.0'
+        self._test_mkdir()
 
     def test_path_exists_no(self):
         path = 'hdfs:///f'

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -225,6 +225,7 @@ def _hadoop_ls_line(real_path, scheme, netloc, size=0, max_size=0, environ={}):
         '%srwxrwxrwx - %s %s 2010-10-01 15:16 %s' %
         (file_type, user_and_group, size, hdfs_path))
 
+
 def hadoop_fs_lsr(stdout, stderr, environ, *args):
     """Implements hadoop fs -lsr."""
     hdfs_path_globs = args or ['']

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -42,6 +42,7 @@ import shutil
 import stat
 import sys
 
+from mrjob.compat import version_gte
 from mrjob.parse import HADOOP_STREAMING_JAR_RE
 from mrjob.parse import urlparse
 
@@ -308,14 +309,17 @@ def hadoop_fs_mkdir(stdout, stderr, environ, *args):
         return -1
 
     failed = False
-    if environ['MOCK_HADOOP_VERSION'] in ['0.23.0', '2.0.0']:
-        # for version 0.23 and 2.0 or above, expect a -p parameter for mkdir
+
+    version = environ['MOCK_HADOOP_VERSION']
+
+    if (version_gte(version, '2') or
+        version_gte(version, '0.23') and not version_gte(version, '1')):
+        # for Hadoop 2, expect a -p parameter for mkdir
         if args[0] == '-p':
             args = args[1:]
         else:
             failed = True
-    else: # version 0.20, 1.2
-        pass
+
     for path in args:
         real_path = hdfs_path_to_real_path(path, environ)
         if os.path.exists(real_path):

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -42,7 +42,7 @@ import shutil
 import stat
 import sys
 
-from mrjob.compat import version_gte
+from mrjob.compat import uses_yarn
 from mrjob.parse import HADOOP_STREAMING_JAR_RE
 from mrjob.parse import urlparse
 
@@ -313,9 +313,8 @@ def hadoop_fs_mkdir(stdout, stderr, environ, *args):
 
     version = environ['MOCK_HADOOP_VERSION']
 
-    if (version_gte(version, '2') or
-        version_gte(version, '0.23') and not version_gte(version, '1')):
-        # for Hadoop 2, expect a -p parameter for mkdir
+    if uses_yarn(version):
+        # expect a -p parameter for mkdir
         if args[0] == '-p':
             args = args[1:]
         else:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -25,6 +25,7 @@ from mrjob.compat import supports_new_distributed_cache_options
 from mrjob.compat import translate_jobconf
 from mrjob.compat import translate_jobconf_for_all_versions
 from mrjob.compat import uses_generic_jobconf
+from mrjob.compat import uses_yarn
 
 from tests.py2 import TestCase
 from tests.py2 import patch
@@ -157,6 +158,13 @@ class MiscCompatTestCase(TestCase):
         # default to True
         self.assertEqual(
             supports_new_distributed_cache_options(None), True)
+
+    def test_uses_yarn(self):
+        self.assertEqual(uses_yarn('0.22'), False)
+        self.assertEqual(uses_yarn('0.23'), True)
+        self.assertEqual(uses_yarn('0.24'), True)
+        self.assertEqual(uses_yarn('1.0.0'), False)
+        self.assertEqual(uses_yarn('2.0.0'), True)
 
 
 class MapVersionTestCase(TestCase):

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -158,7 +158,6 @@ class GetHadoopVersionTestCase(MockHadoopTestCase):
             self.assertRaises(Exception, runner.get_hadoop_version)
 
 
-
 class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
     def _test_end_to_end(self, args=()):
@@ -279,6 +278,10 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
     def test_end_to_end_with_disabled_input_path_check(self):
         self._test_end_to_end(['--no-check-input-paths'])
+
+    def test_end_to_end_with_hadoop_2_0(self):
+        with patch.dict('os.environ', MOCK_HADOOP_VERSION='2.0.0'):
+            self._test_end_to_end()
 
 
 class StreamingArgsTestCase(EmptyMrjobConfTestCase):

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -22,6 +22,7 @@ from io import BytesIO
 from subprocess import CalledProcessError
 from subprocess import check_call
 
+from mrjob.fs.hadoop import HadoopFilesystem
 from mrjob.hadoop import HadoopJobRunner
 from mrjob.hadoop import find_hadoop_streaming_jar
 from mrjob.hadoop import fully_qualify_hdfs_path
@@ -298,7 +299,6 @@ class StreamingArgsTestCase(EmptyMrjobConfTestCase):
             mr_job_script='my_job.py', stdin=BytesIO())
         self.runner._add_job_files_for_upload()
 
-        self.runner._hadoop_version='0.20.204'
         self.start(patch.object(self.runner, '_upload_args',
                                 return_value=['new_upload_args']))
         self.start(patch.object(self.runner, '_pre_0_20_upload_args',
@@ -309,6 +309,8 @@ class StreamingArgsTestCase(EmptyMrjobConfTestCase):
                                 return_value=['hdfs_step_input_files']))
         self.start(patch.object(self.runner, '_hdfs_step_output_dir',
                                 return_value='hdfs_step_output_dir'))
+        self.start(patch.object(HadoopFilesystem, 'get_hadoop_version',
+                                return_value='1.2.0'))
         self.runner._script_path = 'my_job.py'
 
         self._new_basic_args = [
@@ -331,7 +333,7 @@ class StreamingArgsTestCase(EmptyMrjobConfTestCase):
             self._new_basic_args + args)
 
     def _assert_streaming_step_old(self, step, args):
-        self.runner._hadoop_version = '0.18'
+        HadoopFilesystem.get_hadoop_version.return_value = '0.18'
         self.runner._steps = [step]
         self.assertEqual(
             self.runner._args_for_streaming_step(0),


### PR DESCRIPTION
This makes `HadoopFilesystem.mkdir()` use `-p` when we're on Hadoop 2 (fixes #991).

This required a bit of re-working; it used to be that `HadoopJobRunner` was responsible for figuring out the version of Hadoop we're using, but `HadoopFilesystem.mkdir()` needed version as well, so moved `get_hadoop_version()` from `HadoopJobRunner` to `HadoopFilesystem`.

Also, got rid of the redundant `_mkdir_on_hdfs()` method, and added `mrjob.compat.uses_yarn()`.


