### PR TITLE
Call runner.fs.<method>() explicitly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,8 @@ v0.5.0, 2015-??-?? -- ???
      * removed IS_SUCCESSFUL cleanup option (use ALL)
      * *SCRATCH cleanup options renamed to *TMP (#318)
      * base_tmp_dir option has been renamed to local_tmp_dir (#318)
+     * deprecation warning: use runner.fs explicitly (#1146)
+     * fs methods path_exists() and path_join() are now exists() and join()
    * EMR:
      * default AWS region is us-west-2 (#1025)
      * s3_scratch_uri option is now s3_tmp_dir (#318)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -669,7 +669,7 @@ class EMRJobRunner(MRJobRunner):
 
     def _set_s3_job_log_uri(self, cluster):
         """Given a job flow description, set self._s3_job_log_uri. This allows
-        us to call self.ls(), etc. without running the job.
+        us to call self.fs.ls(), etc. without running the job.
         """
         log_uri = getattr(cluster, 'loguri', '')
         if log_uri:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2308,7 +2308,7 @@ class EMRJobRunner(MRJobRunner):
             # guarantee the ordering of dicts -- they can vary
             # depending on insertion/deletion order.
             sorted(
-                (name, self.md5sum(path)) for name, path
+                (name, self.fs.md5sum(path)) for name, path
                 in self._bootstrap_dir_mgr.name_to_path('file').items()
                 if not path == self._mrjob_tar_gz_path),
             self._opts['additional_emr_info'],

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1033,7 +1033,7 @@ class EMRJobRunner(MRJobRunner):
         if self._s3_tmp_dir:
             try:
                 log.info('Removing all files in %s' % self._s3_tmp_dir)
-                self.rm(self._s3_tmp_dir)
+                self.fs.rm(self._s3_tmp_dir)
                 self._s3_tmp_dir = None
             except Exception as e:
                 log.exception(e)
@@ -1047,7 +1047,7 @@ class EMRJobRunner(MRJobRunner):
                 and not self._opts['pool_emr_job_flows']:
             try:
                 log.info('Removing all files in %s' % self._s3_job_log_uri)
-                self.rm(self._s3_job_log_uri)
+                self.fs.rm(self._s3_job_log_uri)
                 self._s3_job_log_uri = None
             except Exception as e:
                 log.exception(e)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -748,7 +748,7 @@ class EMRJobRunner(MRJobRunner):
                 if is_uri(path) and not is_s3_uri(path):
                     continue  # can't check non-S3 URIs, hope for the best
 
-                if not self.fs.path_exists(path):
+                if not self.fs.exists(path):
                     raise AssertionError(
                         'Input path %s does not exist!' % (path,))
 
@@ -757,7 +757,7 @@ class EMRJobRunner(MRJobRunner):
         provisioning a cluster only to have Hadoop refuse to launch.
         """
         try:
-            if self.fs.path_exists(self._output_dir):
+            if self.fs.exists(self._output_dir):
                 raise IOError(
                     'Output path %s already exists!' % (self._output_dir,))
         except boto.exception.S3ResponseError:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -748,7 +748,7 @@ class EMRJobRunner(MRJobRunner):
                 if is_uri(path) and not is_s3_uri(path):
                     continue  # can't check non-S3 URIs, hope for the best
 
-                if not self.path_exists(path):
+                if not self.fs.path_exists(path):
                     raise AssertionError(
                         'Input path %s does not exist!' % (path,))
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -633,7 +633,7 @@ class EMRJobRunner(MRJobRunner):
 
     def _set_s3_tmp_dir(self):
         """Helper for _fix_s3_tmp_and_log_uri_opts"""
-        buckets = self.fs.make_s3_conn().get_all_buckets()
+        buckets = self.fs.get_all_buckets()
         mrjob_buckets = [b for b in buckets if b.name.startswith('mrjob-')]
 
         # Loop over buckets until we find one that is not region-
@@ -679,12 +679,11 @@ class EMRJobRunner(MRJobRunner):
     def _create_s3_tmp_bucket_if_needed(self):
         """Make sure temp bucket exists"""
         if self._s3_tmp_bucket_to_create:
-            s3_conn = self.make_s3_conn()
             log.info('creating S3 bucket %r to use as temp space' %
                      self._s3_tmp_bucket_to_create)
             location = s3_location_constraint_for_region(
                 self._opts['aws_region'])
-            s3_conn.create_bucket(
+            self.fs.create_bucket(
                 self._s3_tmp_bucket_to_create, location=location)
             self._s3_tmp_bucket_to_create = None
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2468,8 +2468,8 @@ class EMRJobRunner(MRJobRunner):
         log.debug('creating IAM connection to %s' % host)
 
         raw_iam_conn = boto.connect_iam(
-            aws_access_key_id=self._aws_access_key_id,
-            aws_secret_access_key=self._aws_secret_access_key,
+            aws_access_key_id=self._opts['aws_access_key_id'],
+            aws_secret_access_key=self._opts['aws_secret_access_key'],
             host=host,
             security_token=self._opts['aws_security_token'])
 

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -16,7 +16,6 @@ import os.path
 import posixpath
 
 from mrjob.parse import is_uri
-from mrjob.py2 import urljoin
 
 log = logging.getLogger(__name__)
 

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -1,4 +1,4 @@
-# Copyright 2009-2012 Yelp and Contributors
+# Copyright 2009-2015 Yelp and Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os.path
 
+from mrjob.parse import is_uri
+from mrjob.py2 import urljoin
 
 log = logging.getLogger(__name__)
 
@@ -73,7 +76,10 @@ class Filesystem(object):
 
     def join(self, dirname, filename):
         """Join *filename* onto *dirname* (which may be a URI)"""
-        raise NotImplementedError
+        if is_uri(dirname) or is_uri(filename):
+            return urljoin(dirname, filename)
+        else:
+            return os.path.join(dirname, filename)
 
     def mkdir(self, path):
         """Create the given dir and its subdirs (if they don't already

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import os.path
+import posixpath
 
 from mrjob.parse import is_uri
 from mrjob.py2 import urljoin
@@ -76,8 +77,10 @@ class Filesystem(object):
 
     def join(self, dirname, filename):
         """Join *filename* onto *dirname* (which may be a URI)"""
-        if is_uri(dirname) or is_uri(filename):
-            return urljoin(dirname, filename)
+        if is_uri(filename):
+            return filename
+        elif is_uri(dirname):
+            return posixpath.join(dirname, filename)
         else:
             return os.path.join(dirname, filename)
 

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -64,6 +64,17 @@ class Filesystem(object):
     def _cat_file(self, path):
         raise NotImplementedError
 
+    def exists(self, path_glob):
+        """Does the given path/URI exist?
+
+        Corresponds roughly to: ``hadoop fs -test -e path_glob``
+        """
+        raise NotImplementedError
+
+    def join(self, dirname, filename):
+        """Join *filename* onto *dirname* (which may be a URI)"""
+        raise NotImplementedError
+
     def mkdir(self, path):
         """Create the given dir and its subdirs (if they don't already
         exist).
@@ -73,14 +84,22 @@ class Filesystem(object):
         raise NotImplementedError
 
     def path_exists(self, path_glob):
-        """Does the given path exist?
+        """Alias for :py:meth:`exists`. Going away in v0.6.0
 
-        Corresponds roughly to: ``hadoop fs -test -e path_glob``
+        .. deprecated: 0.5.0
         """
-        raise NotImplementedError
+        log.warning('path_exists() has been renamed to exists(). This'
+                    ' alias will be removed in v0.6.0')
+        return self.exists(path_glob)
 
     def path_join(self, dirname, filename):
-        raise NotImplementedError
+        """Alias for :py:meth:`join`. Going away in v0.6.0
+
+        .. deprecated: 0.5.0
+        """
+        log.warning('path_join() has been renamed to join(). This'
+                    ' alias will be removed in v0.6.0')
+        return self.join(dirname, filename)
 
     def rm(self, path_glob):
         """Recursively delete the given file/directory, if it exists

--- a/mrjob/fs/composite.py
+++ b/mrjob/fs/composite.py
@@ -74,10 +74,10 @@ class CompositeFilesystem(Filesystem):
     def mkdir(self, path):
         return self._do_action('mkdir', path)
 
-    def path_exists(self, path_glob):
+    def exists(self, path_glob):
         return self._do_action('path_exists', path_glob)
 
-    def path_join(self, dirname, filename):
+    def join(self, dirname, filename):
         return self._do_action('path_join', dirname, filename)
 
     def rm(self, path_glob):

--- a/mrjob/fs/composite.py
+++ b/mrjob/fs/composite.py
@@ -75,10 +75,10 @@ class CompositeFilesystem(Filesystem):
         return self._do_action('mkdir', path)
 
     def exists(self, path_glob):
-        return self._do_action('path_exists', path_glob)
+        return self._do_action('exists', path_glob)
 
     def join(self, dirname, filename):
-        return self._do_action('path_join', dirname, filename)
+        return self._do_action('join', dirname, filename)
 
     def rm(self, path_glob):
         return self._do_action('rm', path_glob)

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -255,9 +255,6 @@ class HadoopFilesystem(Filesystem):
         except CalledProcessError:
             raise IOError("Could not check path %s" % path_glob)
 
-    def join(self, dirname, filename):
-        return posixpath.join(dirname, filename)
-
     def _put(self, local_path, target):
         # used by HadoopMRJobRunner._upload_to_hdfs()
 

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 # used by mkdir()
 _HADOOP_FILE_EXISTS_RE = re.compile(br'.*File exists.*')
 
-# used by ls() and path_exists()
+# used by ls() and exists()
 _HADOOP_LS_NO_SUCH_FILE = re.compile(
     br'^lsr?: Cannot access .*: No such file.*$')
 
@@ -239,7 +239,7 @@ class HadoopFilesystem(Filesystem):
         except CalledProcessError:
             raise IOError("Could not mkdir %s" % path)
 
-    def path_exists(self, path_glob):
+    def exists(self, path_glob):
         """Does the given path exist?
 
         If dest is a directory (ends with a "/"), we check if there are
@@ -255,7 +255,7 @@ class HadoopFilesystem(Filesystem):
         except CalledProcessError:
             raise IOError("Could not check path %s" % path_glob)
 
-    def path_join(self, dirname, filename):
+    def join(self, dirname, filename):
         return posixpath.join(dirname, filename)
 
     def _put(self, local_path, target):

--- a/mrjob/fs/local.py
+++ b/mrjob/fs/local.py
@@ -51,10 +51,6 @@ class LocalFilesystem(Filesystem):
     def exists(self, path_glob):
         return bool(glob.glob(path_glob))
 
-    def join(self, dirname, filename):
-        """Join a directory name and filename."""
-        return os.path.join(dirname, filename)
-
     def rm(self, path_glob):
         for path in glob.glob(path_glob):
             if os.path.isdir(path):

--- a/mrjob/fs/local.py
+++ b/mrjob/fs/local.py
@@ -48,10 +48,10 @@ class LocalFilesystem(Filesystem):
         if not os.path.isdir(path):
             os.makedirs(path)
 
-    def path_exists(self, path_glob):
+    def exists(self, path_glob):
         return bool(glob.glob(path_glob))
 
-    def path_join(self, dirname, filename):
+    def join(self, dirname, filename):
         """Join a directory name and filename."""
         return os.path.join(dirname, filename)
 

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -164,7 +164,7 @@ class S3Filesystem(Filesystem):
         """
         pass
 
-    def path_exists(self, path_glob):
+    def exists(self, path_glob):
         """Does the given path exist?
 
         If dest is a directory (ends with a "/"), we check if there are
@@ -177,7 +177,7 @@ class S3Filesystem(Filesystem):
             paths = []
         return any(paths)
 
-    def path_join(self, dirname, filename):
+    def join(self, dirname, filename):
         return posixpath.join(dirname, filename)
 
     def rm(self, path_glob):

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -293,4 +293,5 @@ class S3Filesystem(Filesystem):
 
     def create_bucket(self, bucket_name, location=''):
         """Create a bucket on S3, optionally setting location constraint."""
-        return self.make_s3_conn().create_bucket(bucket_name, location='')
+        return self.make_s3_conn().create_bucket(
+            bucket_name, location=location)

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -286,3 +286,11 @@ class S3Filesystem(Filesystem):
         bucket = self.get_bucket(bucket_name)
         for key in bucket.list(key_prefix):
             yield key
+
+    def get_all_buckets(self):
+        """Get a stream of all buckets owned by this user on S3."""
+        return self.make_s3_conn().get_all_buckets()
+
+    def create_bucket(self, bucket_name, location=''):
+        """Create a bucket on S3, optionally setting location constraint."""
+        return self.make_s3_conn().create_bucket(bucket_name, location='')

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -177,9 +177,6 @@ class S3Filesystem(Filesystem):
             paths = []
         return any(paths)
 
-    def join(self, dirname, filename):
-        return posixpath.join(dirname, filename)
-
     def rm(self, path_glob):
         """Remove all files matching the given glob."""
         for uri in self.ls(path_glob):

--- a/mrjob/fs/ssh.py
+++ b/mrjob/fs/ssh.py
@@ -137,9 +137,6 @@ class SSHFilesystem(Filesystem):
         except IOError:
             return False
 
-    def join(self, dirname, filename):
-        return posixpath.join(dirname, filename)
-
     def rm(self, path_glob):
         raise IOError()  # not implemented
 

--- a/mrjob/fs/ssh.py
+++ b/mrjob/fs/ssh.py
@@ -130,7 +130,7 @@ class SSHFilesystem(Filesystem):
     def mkdir(self, dest):
         raise IOError()  # not implemented
 
-    def path_exists(self, path_glob):
+    def exists(self, path_glob):
         # just fall back on ls(); it's smart
         paths = self.ls(path_glob)
         try:
@@ -139,7 +139,7 @@ class SSHFilesystem(Filesystem):
             path_exists = False
         return path_exists
 
-    def path_join(self, dirname, filename):
+    def join(self, dirname, filename):
         return posixpath.join(dirname, filename)
 
     def rm(self, path_glob):

--- a/mrjob/fs/ssh.py
+++ b/mrjob/fs/ssh.py
@@ -132,12 +132,10 @@ class SSHFilesystem(Filesystem):
 
     def exists(self, path_glob):
         # just fall back on ls(); it's smart
-        paths = self.ls(path_glob)
         try:
-            path_exists = any(paths)
+            return any(self.ls(path_glob))
         except IOError:
-            path_exists = False
-        return path_exists
+            return False
 
     def join(self, dirname, filename):
         return posixpath.join(dirname, filename)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -220,7 +220,7 @@ class HadoopJobRunner(MRJobRunner):
                 continue  # STDIN always exists
 
             if self._opts['check_input_paths']:
-                if not self.path_exists(path):
+                if not self.fs.path_exists(path):
                     raise AssertionError(
                         'Input path %s does not exist!' % (path,))
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -220,7 +220,7 @@ class HadoopJobRunner(MRJobRunner):
                 continue  # STDIN always exists
 
             if self._opts['check_input_paths']:
-                if not self.fs.path_exists(path):
+                if not self.fs.exists(path):
                     raise AssertionError(
                         'Input path %s does not exist!' % (path,))
 

--- a/mrjob/logparsers.py
+++ b/mrjob/logparsers.py
@@ -103,7 +103,7 @@ def _scan_for_input_uri(log_file_uri, runner):
     if log_file_uri.endswith('.gz'):
         syslog_uri += '.gz'
 
-    syslog_lines = runner.cat(syslog_uri)
+    syslog_lines = runner.fs.cat(syslog_uri)
     if syslog_lines:
         log.debug('scanning %s for input URI' % syslog_uri)
         return find_input_uri_for_mapper(syslog_lines)

--- a/mrjob/logparsers.py
+++ b/mrjob/logparsers.py
@@ -91,7 +91,7 @@ def _parse_task_attempts(fs, log_paths):
             }
 
 
-def _scan_for_input_uri(log_file_uri, runner):
+def _scan_for_input_uri(log_file_uri, fs):
     """Scan the syslog file corresponding to log_file_uri for
     information about the input file.
 
@@ -103,7 +103,7 @@ def _scan_for_input_uri(log_file_uri, runner):
     if log_file_uri.endswith('.gz'):
         syslog_uri += '.gz'
 
-    syslog_lines = runner.fs.cat(syslog_uri)
+    syslog_lines = fs.cat(syslog_uri)
     if syslog_lines:
         log.debug('scanning %s for input URI' % syslog_uri)
         return find_input_uri_for_mapper(syslog_lines)

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -137,20 +137,17 @@ if PY2:
     from urlparse import ParseResult
     from urllib import quote
     from urllib import unquote
-    from urlparse import urljoin
     from urllib2 import urlopen
     from urlparse import urlparse
 else:
     from urllib.parse import ParseResult
     from urllib.parse import quote
     from urllib.parse import unquote
-    from urllib.parse import urljoin
     from urllib.request import urlopen
     from urllib.parse import urlparse
 ParseResult
 quote
 unquote
-urljoin
 urlopen
 urlparse
 

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -131,24 +131,28 @@ else:
     from io import StringIO
 StringIO  # quiet, pyflakes
 
-# urlparse() (in most cases you should use ``mrjob.parse.urlparse()``)
+# urllib stuff
+# in most cases you should use ``mrjob.parse.urlparse()``
 if PY2:
+    from urlparse import ParseResult
     from urllib import quote
     from urllib import unquote
+    from urlparse import urljoin
     from urllib2 import urlopen
     from urlparse import urlparse
-    from urlparse import ParseResult
 else:
+    from urllib.parse import ParseResult
     from urllib.parse import quote
     from urllib.parse import unquote
+    from urllib.parse import urljoin
     from urllib.request import urlopen
     from urllib.parse import urlparse
-    from urllib.parse import ParseResult
+ParseResult
 quote
 unquote
+urljoin
 urlopen
 urlparse
-ParseResult
 
 
 def to_string(s):

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -426,12 +426,12 @@ class MRJobRunner(object):
             self._fs = LocalFilesystem()
         return self._fs
 
-    def __getattr__(self, name):
-        # For backward compatibility, forward filesystem methods
-        try:
-            return getattr(self.fs, name)
-        except AttributeError:
-            raise AttributeError(name)
+    #def __getattr__(self, name):
+    #    # For backward compatibility, forward filesystem methods
+    #    try:
+    #        return getattr(self.fs, name)
+    #    except AttributeError:
+    #        raise AttributeError(name)
 
     ### Running the job and parsing output ###
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -426,12 +426,12 @@ class MRJobRunner(object):
             self._fs = LocalFilesystem()
         return self._fs
 
-    #def __getattr__(self, name):
-    #    # For backward compatibility, forward filesystem methods
-    #    try:
-    #        return getattr(self.fs, name)
-    #    except AttributeError:
-    #        raise AttributeError(name)
+    def __getattr__(self, name):
+        # For backward compatibility, forward filesystem methods
+        try:
+            return getattr(self.fs, name)
+        except AttributeError:
+            raise AttributeError(name)
 
     ### Running the job and parsing output ###
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -476,10 +476,10 @@ class MRJobRunner(object):
 
                 path = base
 
-        for filename in self.ls(output_dir):
+        for filename in self.fs.ls(output_dir):
             subpath = filename[len(output_dir):]
             if not any(name.startswith('_') for name in split_path(subpath)):
-                for line in self._cat_file(filename):
+                for line in self.fs._cat_file(filename):
                     yield line
 
     def _cleanup_mode(self, mode=None):

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -26,6 +26,8 @@ import re
 import shutil
 import sys
 import tempfile
+from inspect import isfunction
+from inspect import ismethod
 from subprocess import CalledProcessError
 from subprocess import Popen
 from subprocess import PIPE
@@ -429,9 +431,23 @@ class MRJobRunner(object):
     def __getattr__(self, name):
         # For backward compatibility, forward filesystem methods
         try:
-            return getattr(self.fs, name)
+            value = getattr(self.fs, name)
         except AttributeError:
             raise AttributeError(name)
+
+        # friendly deprecation warning
+        is_func = ismethod(value) or isfunction(value)
+        log.warning(
+            'deprecated: %s %s.fs.%s%s directly'
+            ' (%s.%s is going away in v0.6.0)' % (
+                'call' if is_func else 'access',
+                self.__class__.__name__,
+                name,
+                '()' if is_func else '',
+                self.__class__.__name__,
+                name))
+
+        return value
 
     ### Running the job and parsing output ###
 

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -549,7 +549,7 @@ def _error_on_bad_paths(fs, paths):
     for path in paths:
         if path == '-':
             return
-        if fs.path_exists(path):
+        if fs.exists(path):
             return
 
     raise ValueError("At least one valid path is required. "

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -133,7 +133,7 @@ class SimMRJobRunner(MRJobRunner):
         log.debug('setting up working dir in %s' % working_dir)
 
         # create the working directory
-        self.mkdir(working_dir)
+        self.fs.mkdir(working_dir)
 
         files = self._working_dir_mgr.name_to_path('file').items()
         # give all our files names, and symlink or unarchive them
@@ -154,7 +154,7 @@ class SimMRJobRunner(MRJobRunner):
 
         if not os.path.isdir(self._output_dir):
             log.debug('Creating output directory %s' % self._output_dir)
-            self.mkdir(self._output_dir)
+            self.fs.mkdir(self._output_dir)
 
     def _check_step_works_with_runner(self, step_dict):
         """ Raise an exception if the runner cannot run this step
@@ -336,7 +336,7 @@ class SimMRJobRunner(MRJobRunner):
         # determine the size of each file split
         total_size = 0
         for input_path in input_paths_to_split:
-            for path in self.ls(input_path):
+            for path in self.fs.ls(input_path):
                 total_size += os.stat(path)[stat.ST_SIZE]
         split_size = total_size / num_splits
 

--- a/mrjob/tools/emr/s3_tmpwatch.py
+++ b/mrjob/tools/emr/s3_tmpwatch.py
@@ -93,7 +93,7 @@ def s3_cleanup(glob_path, time_old, dry_run=False, **runner_kwargs):
     log.info('Deleting all files in %s that are older than %s' %
              (glob_path, time_old))
 
-    for path in runner.ls(glob_path):
+    for path in runner.fs.ls(glob_path):
         bucket_name, key_name = parse_s3_uri(path)
         bucket = runner.fs.get_bucket(bucket_name)
 

--- a/mrjob/tools/emr/terminate_idle_job_flows.py
+++ b/mrjob/tools/emr/terminate_idle_job_flows.py
@@ -357,7 +357,7 @@ def terminate_and_notify(runner, cluster_id, cluster_name, num_steps,
         did_terminate = True
     else:
         status = attempt_to_acquire_lock(
-            runner.make_s3_conn(),
+            runner.fs.make_s3_conn(),
             runner._lock_uri(cluster_id, num_steps),
             runner._opts['s3_sync_wait_time'],
             '%s (%s)' % (msg,

--- a/tests/fs/test_base.py
+++ b/tests/fs/test_base.py
@@ -16,7 +16,9 @@ import posixpath
 
 from mrjob.fs.base import Filesystem
 
+from tests.py2 import TestCase
 from tests.py2 import patch
+from tests.quiet import no_handlers_for_logger
 from tests.sandbox import SandboxedTestCase
 
 
@@ -52,3 +54,24 @@ class JoinTestCase(SandboxedTestCase):
 
         self.assertFalse(os.path.join.called)
         self.assertFalse(posixpath.join.called)
+
+
+class DeprecatedAliasesTestCase(TestCase):
+
+    def test_path_exists(self):
+        fs = Filesystem()
+
+        with patch.object(fs, 'exists'):
+            with no_handlers_for_logger('mrjob.fs.base'):
+                fs.path_exists('foo')
+
+            fs.exists.assert_called_once_with('foo')
+
+    def test_path_join(self):
+        fs = Filesystem()
+
+        with patch.object(fs, 'join'):
+            with no_handlers_for_logger('mrjob.fs.base'):
+                fs.path_join('foo', 'bar')
+
+            fs.join.assert_called_once_with('foo', 'bar')

--- a/tests/fs/test_base.py
+++ b/tests/fs/test_base.py
@@ -25,6 +25,8 @@ from tests.sandbox import SandboxedTestCase
 class JoinTestCase(SandboxedTestCase):
 
     def setUp(self):
+        super(JoinTestCase, self).setUp()
+
         # os.path.join() and posixpath.join() do the same thing in
         # UNIX and OS X, so track which one we called
         self.start(patch('os.path.join', wraps=os.path.join))

--- a/tests/fs/test_base.py
+++ b/tests/fs/test_base.py
@@ -1,0 +1,54 @@
+# Copyright 2009-2015 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os.path
+import posixpath
+
+from mrjob.fs.base import Filesystem
+
+from tests.py2 import patch
+from tests.sandbox import SandboxedTestCase
+
+
+class JoinTestCase(SandboxedTestCase):
+
+    def setUp(self):
+        # os.path.join() and posixpath.join() do the same thing in
+        # UNIX and OS X, so track which one we called
+        self.start(patch('os.path.join', wraps=os.path.join))
+        self.start(patch('posixpath.join', wraps=posixpath.join))
+
+        self.fs = Filesystem()
+
+    def test_local_paths(self):
+        self.assertEqual(self.fs.join('foo', 'bar'),
+                         'foo%sbar' % os.path.sep)
+        self.assertEqual(self.fs.join('foo', '%sbar' % os.path.sep),
+                         '%sbar' % os.path.sep)
+
+        self.assertTrue(os.path.join.called)
+
+    def test_path_onto_uri(self):
+        self.assertEqual(self.fs.join('hdfs://host', 'path'),
+                         'hdfs://host/path')
+
+        self.assertTrue(posixpath.join.called)
+
+    def test_uri_onto_anything(self):
+        self.assertEqual(self.fs.join('hdfs://host', 'hdfs://host2/path'),
+                         'hdfs://host2/path')
+        self.assertEqual(self.fs.join('/', 'hdfs://host2/path'),
+                         'hdfs://host2/path')
+
+        self.assertFalse(os.path.join.called)
+        self.assertFalse(posixpath.join.called)

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -141,6 +141,10 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         path = 'hdfs:///f'
         self.assertEqual(self.fs.exists(path), True)
 
+    def test_join(self):
+        self.assertEqual(self.fs.join('hdfs://host', 'path'),
+                         'hdfs://host/path')
+
     def test_rm(self):
         local_path = self.make_mock_file('f')
         self.assertEqual(os.path.exists(local_path), True)

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -141,12 +141,6 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         path = 'hdfs:///f'
         self.assertEqual(self.fs.exists(path), True)
 
-    def test_join(self):
-        self.assertEqual(self.fs.join('hdfs://host', 'path'),
-                         'hdfs://host/path')
-        self.assertEqual(self.fs.join('hdfs://host', 'hdfs://host2/path'),
-                         'hdfs://host2/path')
-
     def test_rm(self):
         local_path = self.make_mock_file('f')
         self.assertEqual(os.path.exists(local_path), True)

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -132,11 +132,11 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         local_path = os.path.join(self.tmp_dir, 'mock_hdfs_root', 'd', 'ave')
         self.assertEqual(os.path.isdir(local_path), True)
 
-    def test_path_exists_no(self):
+    def test_exists_no(self):
         path = 'hdfs:///f'
         self.assertEqual(self.fs.exists(path), False)
 
-    def test_path_exists_yes(self):
+    def test_exists_yes(self):
         self.make_mock_file('f')
         path = 'hdfs:///f'
         self.assertEqual(self.fs.exists(path), True)

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -94,7 +94,7 @@ class HadoopFSTestCase(MockSubprocessTestCase):
     def test_cat_uncompressed(self):
         self.make_mock_file('data/foo', 'foo\nfoo\n')
 
-        remote_path = self.fs.path_join('hdfs:///data', 'foo')
+        remote_path = self.fs.join('hdfs:///data', 'foo')
 
         self.assertEqual(list(self.fs._cat_file(remote_path)),
                          [b'foo\n', b'foo\n'])
@@ -102,7 +102,7 @@ class HadoopFSTestCase(MockSubprocessTestCase):
     def test_cat_bz2(self):
         self.make_mock_file('data/foo.bz2', bz2.compress(b'foo\n' * 1000))
 
-        remote_path = self.fs.path_join('hdfs:///data', 'foo.bz2')
+        remote_path = self.fs.join('hdfs:///data', 'foo.bz2')
 
         self.assertEqual(list(self.fs._cat_file(remote_path)),
                          [b'foo\n'] * 1000)
@@ -110,7 +110,7 @@ class HadoopFSTestCase(MockSubprocessTestCase):
     def test_cat_gz(self):
         self.make_mock_file('data/foo.gz', gzip_compress(b'foo\n' * 10000))
 
-        remote_path = self.fs.path_join('hdfs:///data', 'foo.gz')
+        remote_path = self.fs.join('hdfs:///data', 'foo.gz')
 
         self.assertEqual(list(self.fs._cat_file(remote_path)),
                          [b'foo\n'] * 10000)
@@ -134,12 +134,12 @@ class HadoopFSTestCase(MockSubprocessTestCase):
 
     def test_path_exists_no(self):
         path = 'hdfs:///f'
-        self.assertEqual(self.fs.path_exists(path), False)
+        self.assertEqual(self.fs.exists(path), False)
 
     def test_path_exists_yes(self):
         self.make_mock_file('f')
         path = 'hdfs:///f'
-        self.assertEqual(self.fs.path_exists(path), True)
+        self.assertEqual(self.fs.exists(path), True)
 
     def test_rm(self):
         local_path = self.make_mock_file('f')

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -144,6 +144,8 @@ class HadoopFSTestCase(MockSubprocessTestCase):
     def test_join(self):
         self.assertEqual(self.fs.join('hdfs://host', 'path'),
                          'hdfs://host/path')
+        self.assertEqual(self.fs.join('hdfs://host', 'hdfs://host2/path'),
+                         'hdfs://host2/path')
 
     def test_rm(self):
         local_path = self.make_mock_file('f')

--- a/tests/fs/test_local.py
+++ b/tests/fs/test_local.py
@@ -91,25 +91,25 @@ class LocalFSTestCase(SandboxedTestCase):
 
     def test_path_exists_no(self):
         path = os.path.join(self.tmp_dir, 'f')
-        self.assertEqual(self.fs.path_exists(path), False)
+        self.assertEqual(self.fs.exists(path), False)
 
     def test_path_exists_yes(self):
         path = self.makefile('f', 'contents')
-        self.assertEqual(self.fs.path_exists(path), True)
+        self.assertEqual(self.fs.exists(path), True)
 
     def test_rm_file(self):
         path = self.makefile('f', 'contents')
-        self.assertEqual(self.fs.path_exists(path), True)
+        self.assertEqual(self.fs.exists(path), True)
 
         self.fs.rm(path)
-        self.assertEqual(self.fs.path_exists(path), False)
+        self.assertEqual(self.fs.exists(path), False)
 
     def test_rm_dir(self):
         path = self.makedirs('foobar')
-        self.assertEqual(self.fs.path_exists(path), True)
+        self.assertEqual(self.fs.exists(path), True)
 
         self.fs.rm(path)
-        self.assertEqual(self.fs.path_exists(path), False)
+        self.assertEqual(self.fs.exists(path), False)
 
     def test_touchz(self):
         path = os.path.join(self.tmp_dir, 'f')

--- a/tests/fs/test_local.py
+++ b/tests/fs/test_local.py
@@ -97,6 +97,12 @@ class LocalFSTestCase(SandboxedTestCase):
         path = self.makefile('f', 'contents')
         self.assertEqual(self.fs.exists(path), True)
 
+    def test_join(self):
+        self.assertEqual(self.fs.join('foo', 'bar'),
+                         'foo%sbar' % os.path.sep)
+        self.assertEqual(self.fs.join('foo', '%sbar' % os.path.sep),
+                         '%sbar' % os.path.sep)
+
     def test_rm_file(self):
         path = self.makefile('f', 'contents')
         self.assertEqual(self.fs.exists(path), True)

--- a/tests/fs/test_local.py
+++ b/tests/fs/test_local.py
@@ -97,12 +97,6 @@ class LocalFSTestCase(SandboxedTestCase):
         path = self.makefile('f', 'contents')
         self.assertEqual(self.fs.exists(path), True)
 
-    def test_join(self):
-        self.assertEqual(self.fs.join('foo', 'bar'),
-                         'foo%sbar' % os.path.sep)
-        self.assertEqual(self.fs.join('foo', '%sbar' % os.path.sep),
-                         '%sbar' % os.path.sep)
-
     def test_rm_file(self):
         path = self.makefile('f', 'contents')
         self.assertEqual(self.fs.exists(path), True)

--- a/tests/fs/test_local.py
+++ b/tests/fs/test_local.py
@@ -89,11 +89,11 @@ class LocalFSTestCase(SandboxedTestCase):
         self.fs.mkdir(path)
         self.assertEqual(os.path.isdir(path), True)
 
-    def test_path_exists_no(self):
+    def test_exists_no(self):
         path = os.path.join(self.tmp_dir, 'f')
         self.assertEqual(self.fs.exists(path), False)
 
-    def test_path_exists_yes(self):
+    def test_exists_yes(self):
         path = self.makefile('f', 'contents')
         self.assertEqual(self.fs.exists(path), True)
 

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -110,10 +110,6 @@ class S3FSTestCase(MockBotoTestCase):
         self.assertEqual(self.fs.exists('s3://walrus/data/foo'), True)
         self.assertEqual(self.fs.exists('s3://walrus/data/bar'), False)
 
-    def test_join(self):
-        self.assertEqual(self.fs.join('s3://bucket', 'key'),
-                         's3://bucket/key')
-
     def test_rm(self):
         self.add_mock_s3_data({
             'walrus': {'data/foo': b'abcd'}})

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -104,19 +104,19 @@ class S3FSTestCase(MockBotoTestCase):
         self.assertEqual(self.fs.du('s3://walrus/data/foo'), 5)
         self.assertEqual(self.fs.du('s3://walrus/data/bar/baz'), 3)
 
-    def test_path_exists(self):
+    def test_exists(self):
         self.add_mock_s3_data({
             'walrus': {'data/foo': b'abcd'}})
-        self.assertEqual(self.fs.path_exists('s3://walrus/data/foo'), True)
-        self.assertEqual(self.fs.path_exists('s3://walrus/data/bar'), False)
+        self.assertEqual(self.fs.exists('s3://walrus/data/foo'), True)
+        self.assertEqual(self.fs.exists('s3://walrus/data/bar'), False)
 
     def test_rm(self):
         self.add_mock_s3_data({
             'walrus': {'data/foo': b'abcd'}})
 
-        self.assertEqual(self.fs.path_exists('s3://walrus/data/foo'), True)
+        self.assertEqual(self.fs.exists('s3://walrus/data/foo'), True)
         self.fs.rm('s3://walrus/data/foo')
-        self.assertEqual(self.fs.path_exists('s3://walrus/data/foo'), False)
+        self.assertEqual(self.fs.exists('s3://walrus/data/foo'), False)
 
 
 class S3FSRegionTestCase(MockBotoTestCase):

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -164,3 +164,32 @@ class S3FSRegionTestCase(MockBotoTestCase):
         # can't access this bucket from wrong endpoint!
         self.assertRaises(boto.exception.S3ResponseError,
                           fs.get_bucket, 'walrus-west')
+
+
+class TestS3Ls(MockBotoTestCase):
+
+    def test_s3_ls(self):
+        self.add_mock_s3_data(
+            {'walrus': {'one': b'', 'two': b'', 'three': b''}})
+
+        fs = S3Filesystem()
+
+        self.assertEqual(set(fs._s3_ls('s3://walrus/')),
+                         set(['s3://walrus/one',
+                              's3://walrus/two',
+                              's3://walrus/three',
+                              ]))
+
+        self.assertEqual(set(fs._s3_ls('s3://walrus/t')),
+                         set(['s3://walrus/two',
+                              's3://walrus/three',
+                              ]))
+
+        self.assertEqual(set(fs._s3_ls('s3://walrus/t/')),
+                         set([]))
+
+        # if we ask for a nonexistent bucket, we should get some sort
+        # of exception (in practice, buckets with random names will
+        # probably be owned by other people, and we'll get some sort
+        # of permissions error)
+        self.assertRaises(Exception, set, fs._s3_ls('s3://lolcat/'))

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -110,6 +110,10 @@ class S3FSTestCase(MockBotoTestCase):
         self.assertEqual(self.fs.exists('s3://walrus/data/foo'), True)
         self.assertEqual(self.fs.exists('s3://walrus/data/bar'), False)
 
+    def test_join(self):
+        self.assertEqual(self.fs.join('s3://bucket', 'key'),
+                         's3://bucket/key')
+
     def test_rm(self):
         self.add_mock_s3_data({
             'walrus': {'data/foo': b'abcd'}})

--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -139,10 +139,6 @@ class SSHFSTestCase(MockSubprocessTestCase):
         path = 'ssh://testmaster/f'
         self.assertEqual(self.fs.exists(path), True)
 
-    def test_join(self):
-        self.assertEqual(self.fs.join('ssh://testmaster', 'path'),
-                         'ssh://testmaster/path')
-
     def test_rm(self):
         self.make_master_file('f', 'contents')
         # not implemented

--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -84,7 +84,7 @@ class SSHFSTestCase(MockSubprocessTestCase):
 
     def test_cat_uncompressed(self):
         self.make_master_file(os.path.join('data', 'foo'), 'foo\nfoo\n')
-        remote_path = self.fs.path_join('ssh://testmaster/data', 'foo')
+        remote_path = self.fs.join('ssh://testmaster/data', 'foo')
 
         self.assertEqual(list(self.fs._cat_file(remote_path)),
                          [b'foo\n', b'foo\n'])
@@ -92,7 +92,7 @@ class SSHFSTestCase(MockSubprocessTestCase):
     def test_cat_bz2(self):
         self.make_master_file(os.path.join('data', 'foo.bz2'),
                               bz2.compress(b'foo\n' * 1000))
-        remote_path = self.fs.path_join('ssh://testmaster/data', 'foo.bz2')
+        remote_path = self.fs.join('ssh://testmaster/data', 'foo.bz2')
 
         self.assertEqual(list(self.fs._cat_file(remote_path)),
                          [b'foo\n'] * 1000)
@@ -100,7 +100,7 @@ class SSHFSTestCase(MockSubprocessTestCase):
     def test_cat_gz(self):
         self.make_master_file(os.path.join('data', 'foo.gz'),
                               gzip_compress(b'foo\n' * 10000))
-        remote_path = self.fs.path_join('ssh://testmaster/data', 'foo.gz')
+        remote_path = self.fs.join('ssh://testmaster/data', 'foo.gz')
 
         self.assertEqual(list(self.fs._cat_file(remote_path)),
                          [b'foo\n'] * 10000)
@@ -132,12 +132,12 @@ class SSHFSTestCase(MockSubprocessTestCase):
 
     def test_path_exists_no(self):
         path = 'ssh://testmaster/f'
-        self.assertEqual(self.fs.path_exists(path), False)
+        self.assertEqual(self.fs.exists(path), False)
 
     def test_path_exists_yes(self):
         self.make_master_file('f', 'contents')
         path = 'ssh://testmaster/f'
-        self.assertEqual(self.fs.path_exists(path), True)
+        self.assertEqual(self.fs.exists(path), True)
 
     def test_rm(self):
         self.make_master_file('f', 'contents')

--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -139,6 +139,10 @@ class SSHFSTestCase(MockSubprocessTestCase):
         path = 'ssh://testmaster/f'
         self.assertEqual(self.fs.exists(path), True)
 
+    def test_join(self):
+        self.assertEqual(self.fs.join('ssh://testmaster', 'path'),
+                         'ssh://testmaster/path')
+
     def test_rm(self):
         self.make_master_file('f', 'contents')
         # not implemented

--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -130,11 +130,11 @@ class SSHFSTestCase(MockSubprocessTestCase):
         # not implemented
         self.assertRaises(IOError, self.fs.mkdir, 'ssh://testmaster/d')
 
-    def test_path_exists_no(self):
+    def test_exists_no(self):
         path = 'ssh://testmaster/f'
         self.assertEqual(self.fs.exists(path), False)
 
-    def test_path_exists_yes(self):
+    def test_exists_yes(self):
         self.make_master_file('f', 'contents')
         path = 'ssh://testmaster/f'
         self.assertEqual(self.fs.exists(path), True)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1628,36 +1628,6 @@ class TestEMREndpoints(MockBotoTestCase):
                          'elasticmapreduce.us-west-1.amazonaws.com')
 
 
-class TestS3Ls(MockBotoTestCase):
-
-    def test_s3_ls(self):
-        self.add_mock_s3_data(
-            {'walrus': {'one': b'', 'two': b'', 'three': b''}})
-
-        runner = EMRJobRunner(s3_tmp_dir='s3://walrus/tmp',
-                              conf_paths=[])
-
-        self.assertEqual(set(runner._s3_ls('s3://walrus/')),
-                         set(['s3://walrus/one',
-                              's3://walrus/two',
-                              's3://walrus/three',
-                              ]))
-
-        self.assertEqual(set(runner._s3_ls('s3://walrus/t')),
-                         set(['s3://walrus/two',
-                              's3://walrus/three',
-                              ]))
-
-        self.assertEqual(set(runner._s3_ls('s3://walrus/t/')),
-                         set([]))
-
-        # if we ask for a nonexistent bucket, we should get some sort
-        # of exception (in practice, buckets with random names will
-        # probably be owned by other people, and we'll get some sort
-        # of permissions error)
-        self.assertRaises(Exception, set, runner._s3_ls('s3://lolcat/'))
-
-
 class TestSSHLs(MockBotoTestCase):
 
     def setUp(self):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -146,7 +146,7 @@ class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
             local_tmp_dir = runner._get_local_tmp_dir()
             # make sure cleanup hasn't happened yet
             self.assertTrue(os.path.exists(local_tmp_dir))
-            self.assertTrue(any(runner.ls(runner.get_output_dir())))
+            self.assertTrue(any(runner.fs.ls(runner.get_output_dir())))
 
             cluster = runner._describe_cluster()
             self.assertEqual(cluster.status.state, 'TERMINATED')
@@ -187,7 +187,7 @@ class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
 
         # make sure cleanup happens
         self.assertFalse(os.path.exists(local_tmp_dir))
-        self.assertFalse(any(runner.ls(runner.get_output_dir())))
+        self.assertFalse(any(runner.fs.ls(runner.get_output_dir())))
 
         # job should get terminated
         emr_conn = runner.make_emr_conn()
@@ -1682,16 +1682,16 @@ class TestSSHLs(MockBotoTestCase):
                       posixpath.join('test', 'three'), b'')
 
         self.assertEqual(
-            sorted(self.runner.ls('ssh://testmaster/test')),
+            sorted(self.runner.fs.ls('ssh://testmaster/test')),
             ['ssh://testmaster/test/one', 'ssh://testmaster/test/two'])
 
         self.assertEqual(
-            list(self.runner.ls('ssh://testmaster!testslave0/test')),
+            list(self.runner.fs.ls('ssh://testmaster!testslave0/test')),
             ['ssh://testmaster!testslave0/test/three'])
 
         # ls() is a generator, so the exception won't fire until we list() it
         self.assertRaises(IOError, list,
-                          self.runner.ls('ssh://testmaster/does_not_exist'))
+                          self.runner.fs.ls('ssh://testmaster/does_not_exist'))
 
 
 class TestNoBoto(TestCase):
@@ -3237,7 +3237,7 @@ class JarStepTestCase(MockBotoTestCase):
 
             self.assertIn(fake_jar, runner._upload_mgr.path_to_uri())
             jar_uri = runner._upload_mgr.uri(fake_jar)
-            self.assertTrue(runner.ls(jar_uri))
+            self.assertTrue(runner.fs.ls(jar_uri))
 
             emr_conn = runner.make_emr_conn()
             steps = list(_yield_all_steps(emr_conn, runner.get_cluster_id()))

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1850,7 +1850,7 @@ class TestMasterBootstrapScript(MockBotoTestCase):
         self.assertEqual(actions[2].name, 'master')
 
         # make sure master bootstrap script is on S3
-        self.assertTrue(runner.fs.path_exists(actions[2].scriptpath))
+        self.assertTrue(runner.fs.exists(actions[2].scriptpath))
 
     def test_bootstrap_mrjob_uses_python_bin(self):
         # use all the bootstrap options
@@ -1898,7 +1898,7 @@ class TestMasterBootstrapScript(MockBotoTestCase):
         self.assertEqual(actions[1].name, 'master')
 
         # make sure master bootstrap script is on S3
-        self.assertTrue(runner.fs.path_exists(actions[1].scriptpath))
+        self.assertTrue(runner.fs.exists(actions[1].scriptpath))
 
 
 class EMRNoMapperTestCase(MockBotoTestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -254,7 +254,7 @@ class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
 
             list(runner.stream_output())
 
-        conn = runner.make_s3_conn()
+        conn = runner.fs.make_s3_conn()
         bucket = conn.get_bucket(tmp_bucket)
         self.assertEqual(len(list(bucket.list())), tmp_len)
 
@@ -3462,7 +3462,7 @@ class SecurityTokenTestCase(MockBotoTestCase):
         self.assertIn('security_token', iam_kwargs)
         self.assertEqual(iam_kwargs['security_token'], security_token)
 
-        runner.make_s3_conn()
+        runner.fs.make_s3_conn()
 
         self.assertTrue(self.mock_s3.called)
         s3_kwargs = self.mock_s3.call_args[1]

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3376,7 +3376,7 @@ class MultiPartUploadTestCase(MockBotoTestCase):
         with patch.object(runner, '_upload_parts', wraps=runner._upload_parts):
             self.upload_data(runner, data)
 
-            s3_key = runner.get_s3_key(self.TEST_S3_URI)
+            s3_key = runner.fs.get_s3_key(self.TEST_S3_URI)
             self.assertEqual(s3_key.get_contents_as_string(), data)
             self.assertEqual(runner._upload_parts.called, expect_multipart)
 
@@ -3431,7 +3431,7 @@ class MultiPartUploadTestCase(MockBotoTestCase):
         with patch.object(runner, '_upload_parts', side_effect=IOError):
             self.assertRaises(IOError, self.upload_data, runner, data)
 
-            s3_key = runner.get_s3_key(self.TEST_S3_URI)
+            s3_key = runner.fs.get_s3_key(self.TEST_S3_URI)
             self.assertTrue(s3_key.mock_multipart_upload_was_cancelled())
 
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2762,19 +2762,19 @@ class TestCatFallback(MockBotoTestCase):
         runner = EMRJobRunner(s3_tmp_dir='s3://walrus/tmp',
                               conf_paths=[])
 
-        self.assertEqual(list(runner.cat('s3://walrus/one')), [b'one_text'])
+        self.assertEqual(list(runner.fs.cat('s3://walrus/one')), [b'one_text'])
 
     def test_ssh_cat(self):
         runner = EMRJobRunner(conf_paths=[])
         self.prepare_runner_for_ssh(runner)
         mock_ssh_file('testmaster', 'etc/init.d', b'meow')
 
-        ssh_cat_gen = runner.cat(
+        ssh_cat_gen = runner.fs.cat(
             SSH_PREFIX + runner._address + '/etc/init.d')
         self.assertEqual(list(ssh_cat_gen)[0].rstrip(), b'meow')
         self.assertRaises(
             IOError, list,
-            runner.cat(SSH_PREFIX + runner._address + '/does_not_exist'))
+            runner.fs.cat(SSH_PREFIX + runner._address + '/does_not_exist'))
 
     def test_ssh_cat_errlog(self):
         # A file *containing* an error message shouldn't cause an error.
@@ -2784,7 +2784,7 @@ class TestCatFallback(MockBotoTestCase):
         error_message = b'cat: logs/err.log: No such file or directory\n'
         mock_ssh_file('testmaster', 'logs/err.log', error_message)
         self.assertEqual(
-            list(runner.cat(SSH_PREFIX + runner._address + '/logs/err.log')),
+            list(runner.fs.cat(SSH_PREFIX + runner._address + '/logs/err.log')),
             [error_message])
 
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1880,7 +1880,7 @@ class TestMasterBootstrapScript(MockBotoTestCase):
         self.assertEqual(actions[2].name, 'master')
 
         # make sure master bootstrap script is on S3
-        self.assertTrue(runner.path_exists(actions[2].scriptpath))
+        self.assertTrue(runner.fs.path_exists(actions[2].scriptpath))
 
     def test_bootstrap_mrjob_uses_python_bin(self):
         # use all the bootstrap options
@@ -1928,7 +1928,7 @@ class TestMasterBootstrapScript(MockBotoTestCase):
         self.assertEqual(actions[1].name, 'master')
 
         # make sure master bootstrap script is on S3
-        self.assertTrue(runner.path_exists(actions[1].scriptpath))
+        self.assertTrue(runner.fs.path_exists(actions[1].scriptpath))
 
 
 class EMRNoMapperTestCase(MockBotoTestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2907,8 +2907,6 @@ class JobWaitTestCase(MockBotoTestCase):
                 self.mock_cluster_ids.append(cluster_id)
 
         self.start(patch.object(EMRJobRunner, 'make_emr_conn'))
-        self.start(patch.object(S3Filesystem, 'make_s3_conn',
-                                side_effect=self.connect_s3))
         self.start(patch.object(EMRJobRunner, '_usable_clusters',
                                 side_effect=side_effect_usable_clusters))
         self.start(patch.object(EMRJobRunner, '_lock_uri',

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -203,7 +203,7 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
             local_tmp_dir = runner._get_local_tmp_dir()
             # make sure cleanup hasn't happened yet
             assert os.path.exists(local_tmp_dir)
-            assert any(runner.ls(runner.get_output_dir()))
+            assert any(runner.fs.ls(runner.get_output_dir()))
 
             # make sure we're writing to the correct path in HDFS
             hdfs_root = os.environ['MOCK_HDFS_ROOT']
@@ -265,7 +265,7 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
         # make sure cleanup happens
         assert not os.path.exists(local_tmp_dir)
-        assert not any(runner.ls(runner.get_output_dir()))
+        assert not any(runner.fs.ls(runner.get_output_dir()))
 
     def test_end_to_end(self):
         self._test_end_to_end()

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -384,8 +384,8 @@ class ErrorOnBadPathsTestCase(TestCase):
 
     def test_with_paths(self):
         _error_on_bad_paths(self.fs, self.paths)
-        self.fs.path_exists.assert_called_once_with(self.paths[0])
+        self.fs.exists.assert_called_once_with(self.paths[0])
 
     def test_no_paths(self):
-        self.fs.path_exists.return_value = False
+        self.fs.exists.return_value = False
         self.assertRaises(ValueError, _error_on_bad_paths, self.fs, self.paths)

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -73,47 +73,6 @@ class MRCustomJobLauncher(MRJobLauncher):
 ### Test cases ###
 
 
-class MakeRunnerTestCase(SandboxedTestCase):
-
-    def setUp(self):
-        self.start(patch.dict(sys.modules))
-
-        for name in sorted(sys.modules):
-            if name.split('.')[0] == 'boto' or name == 'mrjob.emr':
-                del sys.modules[name]
-
-    def test_local_runner(self):
-        launcher = MRJobLauncher(args=['--no-conf', '-r', 'local', ''])
-        with no_handlers_for_logger('mrjob.runner'):
-            with launcher.make_runner() as runner:
-                self.assertIsInstance(runner, LocalMRJobRunner)
-
-        self.assertNotIn('boto', sorted(sys.modules))
-
-    def test_hadoop_runner(self):
-        # you can't instantiate a HadoopJobRunner without Hadoop installed
-        launcher = MRJobLauncher(args=['--no-conf', '-r', 'hadoop', '',
-                                       '--hadoop-streaming-jar', 'HUNNY'])
-        with no_handlers_for_logger('mrjob.runner'):
-            with patch.dict(os.environ, {'HADOOP_HOME': '100-Acre Wood'}):
-                with launcher.make_runner() as runner:
-                    self.assertIsInstance(runner, HadoopJobRunner)
-
-        self.assertNotIn('boto', sorted(sys.modules))
-
-    def test_emr_runner(self):
-        launcher = MRJobLauncher(args=['--no-conf', '-r', 'emr', ''])
-        with no_handlers_for_logger('mrjob'):
-            with patch_fs_s3():
-                with launcher.make_runner() as runner:
-                    # we dumped mrjob.emr in setUp(), so import here
-                    from mrjob.emr import EMRJobRunner
-                    self.assertIsInstance(runner, EMRJobRunner)
-
-        self.assertIn('boto', sorted(sys.modules))
-
-
-
 class NoOutputTestCase(TestCase):
 
     def test_no_output(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -945,7 +945,7 @@ class FSPassthroughTestCase(TestCase):
 
     def test_prefer_own_methods(self):
         # TODO: currently can't initialize HadoopRunner without setting these
-        runner = HadoopMRJobRunner(
+        runner = HadoopJobRunner(
             hadoop_bin='hadoop',
             hadoop_home='kansas',
             hadoop_streaming_jar='streaming.jar')

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -939,9 +939,19 @@ class FSPassthroughTestCase(TestCase):
         runner = InlineMRJobRunner()
 
         with no_handlers_for_logger('mrjob.runner'):
+            stderr = StringIO()
+            log_to_stream('mrjob.runner', stderr)
+
             self.assertEqual(runner.ls, runner.fs.ls)
             # no special rules for underscore methods
             self.assertEqual(runner._cat_file, runner.fs._cat_file)
+
+            self.assertIn(
+                'deprecated: call InlineMRJobRunner.fs.ls() directly',
+                stderr.getvalue())
+            self.assertIn(
+                'deprecated: call InlineMRJobRunner.fs._cat_file() directly',
+                stderr.getvalue())
 
     def test_prefer_own_methods(self):
         # TODO: currently can't initialize HadoopRunner without setting these
@@ -951,8 +961,35 @@ class FSPassthroughTestCase(TestCase):
             hadoop_streaming_jar='streaming.jar')
 
         with no_handlers_for_logger('mrjob.runner'):
+            stderr = StringIO()
+            log_to_stream('mrjob.runner', stderr)
+
             self.assertEqual(runner.ls, runner.fs.ls)
 
             # Hadoop Runner has its own version
             self.assertNotEqual(runner.get_hadoop_version,
                                 runner.fs.get_hadoop_version)
+
+            self.assertIn(
+                'deprecated: call HadoopJobRunner.fs.ls() directly',
+                stderr.getvalue())
+            self.assertNotIn('get_hadoop_version', stderr.getvalue())
+
+
+    def test_pass_through_fields(self):
+        # TODO: currently can't initialize HadoopRunner without setting these
+        runner = HadoopJobRunner(
+            hadoop_bin='hadoooooooooop',
+            hadoop_home='kansas',
+            hadoop_streaming_jar='streaming.jar')
+
+        with no_handlers_for_logger('mrjob.runner'):
+            stderr = StringIO()
+            log_to_stream('mrjob.runner', stderr)
+
+            self.assertEqual(runner._hadoop_bin, runner.fs._hadoop_bin)
+
+            # deprecation warning is different for non-functions
+            self.assertIn(
+                'deprecated: access HadoopJobRunner.fs._hadoop_bin directly',
+                stderr.getvalue())

--- a/tests/tools/emr/test_s3_tmpwatch.py
+++ b/tests/tools/emr/test_s3_tmpwatch.py
@@ -57,7 +57,7 @@ class S3TmpWatchTestCase(MockBotoTestCase):
                                           'data/bar': b'bar\n',
                                           'data/qux': b'qux\n'}})
 
-        s3_conn = runner.make_s3_conn()
+        s3_conn = runner.fs.make_s3_conn()
         bucket_name, key_name = parse_s3_uri(remote_input_path)
         bucket = s3_conn.get_bucket(bucket_name)
 


### PR DESCRIPTION
When we broke the runner filesystem out into separate objects in v0.4.0, it was supposedly deprecated to call them on `runner` rather than `runner.fs`, but we didn't add a deprecation warning.

This adds the warning, and fixes all internal calls to access `fs.<method>()` explicitly.

This also renames `path_exists()` and `path_join()` to `exists()` and `join()`.  (`runner.exists(path)` would be confusing, but `runner.fs.exists(path)` is pretty clear.) Also noticed that `join()` was barely used and completely un-tested; re-worked it, and added proper tests.
