### PR TITLE
!clear tag in mrjob confs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ pygments_style = 'sphinx'
 # project info
 
 project = u'mrjob'
-copyright = u'2009-2013 Yelp and Contributors'
+copyright = u'2009-2015 Yelp and Contributors'
 # The short X.Y version. Can refer to in docs with |version|.
 version = mrjob.__version__.split('-')[0]
 # The full version, including alpha/beta/rc tags.

--- a/docs/guides/configs-basics.rst
+++ b/docs/guides/configs-basics.rst
@@ -339,7 +339,12 @@ is equivalent to:
         setup:
         - /run/this/other/command
 
-If you find it more readable, you can also put the ``!clear`` tag *before* the
+The ``!clear`` tag overrides any previously read config files, not just
+included ones. For example, you could get the same result by removing the
+``include:`` from ``~/mrjob.conf`` above and running your job with
+``-c ~/mrjob.base.conf -c ~/mrjob.conf``.
+
+If you find it more readable, you may put the ``!clear`` tag *before* the
 key you want to clear. For example,
 
 .. code-block:: yaml

--- a/docs/guides/configs-basics.rst
+++ b/docs/guides/configs-basics.rst
@@ -339,10 +339,10 @@ is equivalent to:
         setup:
         - /run/this/other/command
 
-The ``!clear`` tag overrides any previously read config files, not just
-included ones. For example, you could get the same result by removing the
-``include:`` from ``~/mrjob.conf`` above and running your job with
-``-c ~/mrjob.base.conf -c ~/mrjob.conf``.
+If you specify multiple config files (e.g.
+``-c ~/mrjob.base.conf -c ~/mrjob.conf``), a ``!clear`` in a later file will
+override earlier files. ``include:`` is really just another way to prepend
+to the list of config files to load.
 
 If you find it more readable, you may put the ``!clear`` tag *before* the
 key you want to clear. For example,

--- a/docs/guides/configs-basics.rst
+++ b/docs/guides/configs-basics.rst
@@ -139,7 +139,6 @@ When these are specified more than once, the last non-``None`` value is used.
     :py:func:`shlex.split`, or list of command + arguments. Combined with
     :py:func:`~mrjob.conf.combine_cmds`.
 
-
 .. _data-type-path:
 
 **Path**
@@ -173,13 +172,14 @@ than once, each has custom behavior described below.
 .. _data-type-plain-dict:
 
 **Plain dict**
-    Values specified later override values specified earlier.
+    Values specified later override values specified earlier. Combined with
+    :py:func:`~mrjob.conf.combine_dicts`.
 
 .. _data-type-env-dict:
 
 **Environment variable dict**
     Values specified later override values specified earlier, **except for
-    those with keys ending in ``PATH``**, in which values are concatenated and
+    those with keys ending in PATH**, in which values are concatenated and
     separated by a colon (``:``) rather than overwritten. The later value comes
     first.
 
@@ -187,7 +187,10 @@ than once, each has custom behavior described below.
 
     .. code-block:: yaml
 
-        runners: {emr: {cmdenv: {PATH: "/usr/bin"}}}
+        runners:
+          emr:
+            cmdenv:
+              PATH: /usr/bin
 
     when run with this command::
 
@@ -197,9 +200,12 @@ than once, each has custom behavior described below.
 
         ``/usr/local/bin:/usr/bin``
 
+    The function that handles this is :py:func:`~mrjob.conf.combine_envs`.
+
     **The one exception** to this behavior is in the ``local`` runner, which
     uses the local system separator (on Windows ``;``, on everything else still
-    ``:``) instead of always using ``:``.
+    ``:``) instead of always using ``:``. In local mode, the function that
+    combines config values is :py:func:`~mrjob.conf.combine_local_envs`.
 
 .. _multiple-config-files:
 
@@ -217,9 +223,9 @@ accomplish this, use the ``include`` option:
 
     include: ~/.mrjob.base.conf
     runners:
-        emr:
-            num_ec2_core_instances: 20
-            ec2_core_instance_type: m1.xlarge
+      emr:
+        num_ec2_core_instances: 20
+        ec2_core_instance_type: m1.xlarge
 
 :file:`~/mrjob.very-small.conf`:
 
@@ -227,19 +233,19 @@ accomplish this, use the ``include`` option:
 
     include: $HOME/.mrjob.base.conf
     runners:
-        emr:
-            num_ec2_core_instances: 2
-            ec2_core_instance_type: m1.small
+      emr:
+        num_ec2_core_instances: 2
+        ec2_core_instance_type: m1.small
 
 :file:`~/.mrjob.base.conf`:
 
 .. code-block:: yaml
 
     runners:
-        emr:
-            aws_access_key_id: HADOOPHADOOPBOBADOOP
-            aws_region: us-west-1
-            aws_secret_access_key: MEMIMOMADOOPBANANAFANAFOFADOOPHADOOP
+      emr:
+        aws_access_key_id: HADOOPHADOOPBOBADOOP
+        aws_region: us-west-1
+        aws_secret_access_key: MEMIMOMADOOPBANANAFANAFOFADOOPHADOOP
 
 Options that are lists, commands, dictionaries, etc. combine the same way they
 do between the config files and the command line (with combiner functions).
@@ -247,9 +253,9 @@ do between the config files and the command line (with combiner functions).
 You can use ``$ENVIRONMENT_VARIABLES`` and ``~/file_in_your_home_dir`` inside
 ``include``.
 
-You can inherit from multiple config files by passing ``include`` a list instead
-of a string. Files on the right will have precedence over files on the left.
-To continue the above examples, this config:
+You can inherit from multiple config files by passing ``include`` a list
+instead of a string. Files on the right will have precedence over files on the
+left. To continue the above examples, this config:
 
 :file:`~/.mrjob.everything.conf`
 
@@ -266,12 +272,91 @@ will be equivalent to this one:
 .. code-block:: yaml
 
     runners:
-        emr:
-            aws_access_key_id: HADOOPHADOOPBOBADOOP
-            aws_region: us-west-1
-            aws_secret_access_key: MEMIMOMADOOPBANANAFANAFOFADOOPHADOOP
-            num_ec2_core_instances: 20
-            ec2_core_instace_type: m1.xlarge
+      emr:
+        aws_access_key_id: HADOOPHADOOPBOBADOOP
+        aws_region: us-west-1
+        aws_secret_access_key: MEMIMOMADOOPBANANAFANAFOFADOOPHADOOP
+        ec2_core_instace_type: m1.xlarge
+        num_ec2_core_instances: 20
 
 In this case, :file:`~/.mrjob.very-large.conf` has taken precedence over
 :file:`~/.mrjob.very-small.conf`.
+
+
+.. _clearing-configs:
+
+Clearing configs
+----------------
+
+Sometimes, you just want to override a list-type config (e.g. ``setup``) or
+a ``*PATH`` environment variable, rather than having mrjob cleverly concatenate
+it with previous configs.
+
+You can do this in YAML config files by tagging the values you want to take
+precedence with the ``!clear`` tag.
+
+For example:
+
+:file:`~/.mrjob.base.conf`
+
+.. code-block:: yaml
+
+    runners:
+      emr:
+        aws_access_key_id: HADOOPHADOOPBOBADOOP
+        aws_secret_access_key: MEMIMOMADOOPBANANAFANAFOFADOOPHADOOP
+        cmdenv:
+          PATH: /this/nice/path
+          PYTHONPATH: /here/be/serpents
+          USER: dave
+        setup:
+        - /run/this/command
+
+:file:`~/.mrjob.conf`
+
+.. code-block:: yaml
+
+    include: ~/mrjob.base.conf
+    runners:
+      emr:
+        cmdenv:
+          PATH: !clear /this/even/better/path/yay
+          PYTHONPATH: !clear
+        setup: !clear
+        - /run/this/other/command
+
+is equivalent to:
+
+.. code-block:: yaml
+
+    runners:
+      emr:
+        aws_access_key_id: HADOOPHADOOPBOBADOOP
+        aws_secret_access_key: MEMIMOMADOOPBANANAFANAFOFADOOPHADOOP
+        cmdenv:
+          PATH: /this/even/better/path/yay
+          USER: dave
+        setup:
+        - /run/this/other/command
+
+If you find it more readable, you can also put the ``!clear`` tag *before* the
+key you want to clear. For example,
+
+.. code-block:: yaml
+
+    runners:
+      emr:
+        !clear setup:
+        - /run/this/other/command
+
+is equivalent to:
+
+.. code-block:: yaml
+
+    runners:
+      emr:
+        setup: !clear
+        - /run/this/other/command
+
+``!clear`` tags in lists are ignored. You cannot currently clear an entire set
+of configs (e.g. ``runners: emr: !clear ...`` does not work).

--- a/docs/guides/emr-bootstrap-cookbook.rst
+++ b/docs/guides/emr-bootstrap-cookbook.rst
@@ -5,15 +5,15 @@ Bootstrapping allows you to configure EMR machines to your needs.
 
 AMI 2.x and AMI 3.x version differences
 -----------------------------------------------
-AMI versions 2.x are based on `Debian 6.0.2 (Squeeze) 
+AMI versions 2.x are based on `Debian 6.0.2 (Squeeze)
 <http://www.debian.org/News/2011/20110625>`_.  The package management system is ``apt-get``. Any package distributed with Debian Squeeze should be available.
 
-AMI versions 3.x are based on `Amazon Linux Release 2012.09 
+AMI versions 3.x are based on `Amazon Linux Release 2012.09
 <https://aws.amazon.com/amazon-linux-ami/2012.09-release-notes/>`_. This major bump changed the package management system to ``yum``. You can view the list of RPM packages Amazon distributed with the 2012.09.1 release `here
-<https://aws.amazon.com/amazon-linux-ami/2012.09-packages/>`_.
+<https://aws.amazon.com/amazon-linux-ami/2012.09-packages/>`__.
 
-You can follow the AMI changelog `here 
-<http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-ami.html>`_.
+You can follow the AMI changelog `here
+<http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-ami.html>`__.
 
 Installing Python packages with pip
 -----------------------------------
@@ -84,7 +84,7 @@ for custom-built packages):
     --bootstrap 'sudo pip install $MY_PYTHON_PKGS/*.tar.gz#'
 
 Installing Debian packages on AMI 2.x:
---------------------------
+--------------------------------------
 
 As we did with :command:`pip`, you can use ``apt-get`` to install any
 package from the Debian archive. For example, to install Python 3:
@@ -100,7 +100,7 @@ If you have particular ``.deb`` files you want to install, do:
     --bootstrap 'sudo dpkg -i path/to/packages/*.deb#'
 
 Installing RPM Packages on AMI 3.x:
---------------------------
+-----------------------------------
 
 Conversely, while running on an AMI 3.x you can install the Python 3 RPM archive by using ``yum``:
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -194,15 +194,13 @@ def _cleared_value_representer(dumper, data):
     return node
 
 
-class ClearedValueSafeDumper(yaml.SafeDumper):
-    pass
-
-
-ClearedValueSafeDumper.add_representer(
-    ClearedValue, _cleared_value_representer)
-
-
 def _dump_yaml_with_clear_tags(data, stream=None, **kwds):
+    class ClearedValueSafeDumper(yaml.SafeDumper):
+        pass
+
+    ClearedValueSafeDumper.add_representer(
+        ClearedValue, _cleared_value_representer)
+
     return yaml.dump_all([data], stream, Dumper=ClearedValueSafeDumper, **kwds)
 
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -112,6 +112,9 @@ class ClearedValue(object):
         else:
             return False
 
+    def __hash__(self):
+        return hash(self.value)
+
     def __repr__(self):
         return '%s(%s)' % (self.__class__.__name__, repr(self.value))
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -457,14 +457,15 @@ def combine_dicts(*dicts):
     result = {}
 
     for d in dicts:
-        for k, v in d.items():
-            # delete cleared key
-            if isinstance(v, ClearedValue) and v.value is None:
-                result.pop(k, None)
+        if d:
+            for k, v in d.items():
+                # delete cleared key
+                if isinstance(v, ClearedValue) and v.value is None:
+                    result.pop(k, None)
 
-            # just set the value
-            else:
-                result[k] = _strip_clear_tag(v)
+                # just set the value
+                else:
+                    result[k] = _strip_clear_tag(v)
 
     return result
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -1,5 +1,6 @@
 # Copyright 2009-2012 Yelp
 # Copyright 2013 David Marin
+# Copyright 2015 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -145,7 +146,7 @@ def _load_yaml_with_clear_tag(stream):
         loader.dispose()
 
 
-def _fix_clear_tag(x):
+def _fix_clear_tags(x):
     """Recursively resolve ClearedValues so that they only wrap values in
     dictionaries.
 
@@ -164,9 +165,10 @@ def _fix_clear_tag(x):
                 if isinstance(k, ClearedValue):
                     del x[k]
                     x[_strip_clear_tag(k)] = ClearedValue(_strip_clear_tag(v))
+        elif isinstance(x, ClearedValue):
+            x = ClearedValue(_fix(x.value))
 
         return x
-
 
     return _strip_clear_tag(_fix(x))
 
@@ -224,7 +226,7 @@ def conf_object_at_path(conf_path):
 
     with open(conf_path) as f:
         if yaml:
-            return _fix_clear_tag(_load_yaml_with_clear_tag(f))
+            return _fix_clear_tags(_load_yaml_with_clear_tag(f))
         else:
             try:
                 return json.load(f)

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -115,7 +115,8 @@ def _cleared_value_constructor(loader, node):
     if isinstance(node, yaml.MappingNode):
         value = loader.construct_mapping(node)
     elif isinstance(node, yaml.ScalarNode):
-        value = loader.construct_scalar(node)
+        # resolve null as None, not u'null'
+        value = yaml.safe_load(node.value)
     elif isinstance(node, yaml.SequenceNode):
         value = loader.construct_sequence(node)
     else:

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -106,6 +106,12 @@ class ClearedValue(object):
     def __init__(self, value):
         self.value = value
 
+    def __eq__(self, other):
+        if isinstance(other, ClearedValue):
+            return self.value == other.value
+        else:
+            return False
+
     def __repr__(self):
         return '%s(%s)' % (self.__class__.__name__, repr(self.value))
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ try:
         'install_requires': [
             'boto>=2.6.0',
             'filechunkio',
-            'PyYAML',
+            'PyYAML>=3.10',
             'simplejson>=2.0.9',
         ],
         'provides': ['mrjob'],

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -159,6 +159,7 @@ class MRJobBasicConfTestCase(MRJobConfTestCase):
     def test_round_trip(self):
         self._test_round_trip({'runners': {'foo': {'qux': 'quux'}}})
 
+    @unittest.skipIf(mrjob.conf.yaml is None, 'no yaml module')
     def test_round_trip_with_clear_tag(self):
         self._test_round_trip(
             {'runners': {'foo': {'qux': ClearedValue('quux')}}})
@@ -513,6 +514,7 @@ class CombineAndExpandPathsTestCase(SandboxedTestCase):
              's3://walrus/foo'])
 
 
+@unittest.skipIf(mrjob.conf.yaml is None, 'no yaml module')
 class LoadYAMLWithClearTag(unittest.TestCase):
 
     def test_empty(self):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -246,7 +246,7 @@ class CombineDictsTestCase(unittest.TestCase):
             {'TMPDIR': '/var/tmp', 'HOME': '/home/dave'})
 
     def test_skip_None(self):
-        self.assertEqual(combine_envs(None, {'USER': 'dave'}, None,
+        self.assertEqual(combine_dicts(None, {'USER': 'dave'}, None,
                                   {'TERM': 'xterm'}, None),
                      {'USER': 'dave', 'TERM': 'xterm'})
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -550,19 +550,20 @@ class LoadYAMLWithClearTag(unittest.TestCase):
 
 class FixClearTag(unittest.TestCase):
 
-    # clear tags are always stripped at top level
-
     def test_none(self):
         self.assertEqual(_fix_clear_tags(None), None)
-        self.assertEqual(_fix_clear_tags(ClearedValue(None)), None)
+        self.assertEqual(_fix_clear_tags(ClearedValue(None)),
+                         ClearedValue(None))
 
     def test_string(self):
         self.assertEqual(_fix_clear_tags('foo'), 'foo')
-        self.assertEqual(_fix_clear_tags(ClearedValue('foo')), 'foo')
+        self.assertEqual(_fix_clear_tags(ClearedValue('foo')),
+                         ClearedValue('foo'))
 
     def test_int(self):
         self.assertEqual(_fix_clear_tags(18), 18)
-        self.assertEqual(_fix_clear_tags(ClearedValue(18)), 18)
+        self.assertEqual(_fix_clear_tags(ClearedValue(18)),
+                         ClearedValue(18))
 
     def test_list(self):
         self.assertEqual(_fix_clear_tags(['foo', 'bar']),
@@ -571,21 +572,21 @@ class FixClearTag(unittest.TestCase):
         # here, !clear is only stripped because it's at the top level
         # see test_nesting() for a ClearedValue([...]) as a dict key
         self.assertEqual(_fix_clear_tags(ClearedValue(['foo', 'bar'])),
-                         ['foo', 'bar'])
+                         ClearedValue(['foo', 'bar']))
 
         self.assertEqual(_fix_clear_tags(['foo', ClearedValue('bar')]),
-                         ['foo', 'bar'])
+                         ['bar'])
 
         self.assertEqual(
             _fix_clear_tags(
                 ClearedValue([ClearedValue('foo'), ClearedValue('bar')])),
-            ['foo', 'bar'])
+            ClearedValue(['bar']))
 
     def test_dict(self):
         self.assertEqual(_fix_clear_tags({'foo': 'bar'}), {'foo': 'bar'})
 
         self.assertEqual(_fix_clear_tags(ClearedValue({'foo': 'bar'})),
-                         {'foo': 'bar'})
+                         ClearedValue({'foo': 'bar'}))
 
         self.assertEqual(_fix_clear_tags({ClearedValue('foo'): 'bar'}),
                          {'foo': ClearedValue('bar')})
@@ -596,7 +597,7 @@ class FixClearTag(unittest.TestCase):
         self.assertEqual(
             _fix_clear_tags(
                 ClearedValue({ClearedValue('foo'): ClearedValue('bar')})),
-            {'foo': ClearedValue('bar')})
+            ClearedValue({'foo': ClearedValue('bar')}))
 
         # ClearedValue('foo') key overrides 'foo' key
         self.assertEqual(
@@ -610,21 +611,18 @@ class FixClearTag(unittest.TestCase):
         self.assertEqual(
             _fix_clear_tags(
                 ClearedValue({'foo': ['bar', {'baz': 'qux'}]})),
-            {'foo': ['bar', {'baz': 'qux'}]})
+            ClearedValue({'foo': ['bar', {'baz': 'qux'}]}))
 
         self.assertEqual(
             _fix_clear_tags(
                 {ClearedValue('foo'): ['bar', {'baz': 'qux'}]}),
             {'foo': ClearedValue(['bar', {'baz': 'qux'}])})
 
-        # here we keep the ClearedValue(...) wrapping the list, because
-        # it's a value in a dict
         self.assertEqual(
             _fix_clear_tags(
                 {'foo': ClearedValue(['bar', {'baz': 'qux'}])}),
             {'foo': ClearedValue(['bar', {'baz': 'qux'}])})
 
-        # ClearedValue inside a list is still meaningless, even when nested
         self.assertEqual(
             _fix_clear_tags(
                 {'foo': [ClearedValue('bar'), {'baz': 'qux'}]}),
@@ -633,7 +631,7 @@ class FixClearTag(unittest.TestCase):
         self.assertEqual(
             _fix_clear_tags(
                 {'foo': ['bar', ClearedValue({'baz': 'qux'})]}),
-            {'foo': ['bar', {'baz': 'qux'}]})
+            {'foo': [{'baz': 'qux'}]})
 
         self.assertEqual(
             _fix_clear_tags(

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -25,6 +25,7 @@ except ImportError:
 from mock import patch
 
 import mrjob.conf
+from mrjob.conf import ClearedValue
 from mrjob.conf import combine_cmd_lists
 from mrjob.conf import combine_cmds
 from mrjob.conf import combine_dicts
@@ -39,6 +40,7 @@ from mrjob.conf import conf_object_at_path
 from mrjob.conf import dump_mrjob_conf
 from mrjob.conf import expand_path
 from mrjob.conf import find_mrjob_conf
+from mrjob.conf import _load_yaml_with_clear_tag
 from mrjob.conf import load_opts_from_mrjob_conf
 from mrjob.conf import real_mrjob_conf_path
 from tests.quiet import logger_disabled
@@ -453,3 +455,14 @@ class CombineAndExpandPathsTestCase(SandboxedTestCase):
             [bar_path, foo_path, foo_path,
              os.path.join(self.tmp_dir, 'q*'),
              's3://walrus/foo'])
+
+
+class LoadYAMLWithClearTag(unittest.TestCase):
+
+    def test_empty(self):
+        self.assertEqual(_load_yaml_with_clear_tag('!clear'),
+                         ClearedValue(None))
+
+    def test_null(self):
+        self.assertEqual(_load_yaml_with_clear_tag('!clear null'),
+                         ClearedValue(None))

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -625,18 +625,16 @@ class FixClearTag(unittest.TestCase):
         self.assertEqual(_fix_clear_tags(['foo', 'bar']),
                          ['foo', 'bar'])
 
-        # here, !clear is only stripped because it's at the top level
-        # see test_nesting() for a ClearedValue([...]) as a dict key
         self.assertEqual(_fix_clear_tags(ClearedValue(['foo', 'bar'])),
                          ClearedValue(['foo', 'bar']))
 
         self.assertEqual(_fix_clear_tags(['foo', ClearedValue('bar')]),
-                         ['bar'])
+                         ['foo', 'bar'])
 
         self.assertEqual(
             _fix_clear_tags(
                 ClearedValue([ClearedValue('foo'), ClearedValue('bar')])),
-            ClearedValue(['bar']))
+            ClearedValue(['foo', 'bar']))
 
     def test_dict(self):
         self.assertEqual(_fix_clear_tags({'foo': 'bar'}), {'foo': 'bar'})
@@ -687,7 +685,7 @@ class FixClearTag(unittest.TestCase):
         self.assertEqual(
             _fix_clear_tags(
                 {'foo': ['bar', ClearedValue({'baz': 'qux'})]}),
-            {'foo': [{'baz': 'qux'}]})
+            {'foo': ['bar', {'baz': 'qux'}]})
 
         self.assertEqual(
             _fix_clear_tags(

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -460,9 +460,52 @@ class CombineAndExpandPathsTestCase(SandboxedTestCase):
 class LoadYAMLWithClearTag(unittest.TestCase):
 
     def test_empty(self):
+        self.assertEqual(_load_yaml_with_clear_tag(''),
+                         None)
         self.assertEqual(_load_yaml_with_clear_tag('!clear'),
                          ClearedValue(None))
 
     def test_null(self):
+        self.assertEqual(_load_yaml_with_clear_tag('null'),
+                         None)
         self.assertEqual(_load_yaml_with_clear_tag('!clear null'),
                          ClearedValue(None))
+
+    def test_string(self):
+        self.assertEqual(_load_yaml_with_clear_tag('foo'),
+                         'foo')
+        self.assertEqual(_load_yaml_with_clear_tag('!clear foo'),
+                         ClearedValue('foo'))
+
+    def test_int(self):
+        self.assertEqual(_load_yaml_with_clear_tag('18'),
+                         18)
+        self.assertEqual(_load_yaml_with_clear_tag('!clear 18'),
+                         ClearedValue(18))
+
+    def test_list(self):
+        self.assertEqual(_load_yaml_with_clear_tag('- foo\n- bar'),
+                         ['foo', 'bar'])
+        self.assertEqual(_load_yaml_with_clear_tag('!clear\n- foo\n- bar'),
+                         ClearedValue(['foo', 'bar']))
+        self.assertEqual(_load_yaml_with_clear_tag('- foo\n- !clear bar'),
+                         ['foo', ClearedValue('bar')])
+        self.assertEqual(
+            _load_yaml_with_clear_tag('!clear\n- !clear foo\n- !clear bar'),
+            ClearedValue([ClearedValue('foo'), ClearedValue('bar')]))
+
+    def test_dict(self):
+        self.assertEqual(_load_yaml_with_clear_tag('foo: bar'),
+                         {'foo': 'bar'})
+        self.assertEqual(_load_yaml_with_clear_tag('!clear\nfoo: bar'),
+                         ClearedValue({'foo': 'bar'}))
+        self.assertEqual(_load_yaml_with_clear_tag('!clear foo: bar'),
+                         {ClearedValue('foo'): 'bar'})
+        self.assertEqual(_load_yaml_with_clear_tag('foo: !clear bar'),
+                         {'foo': ClearedValue('bar')})
+        self.assertEqual(
+            _load_yaml_with_clear_tag('!clear\n!clear foo: !clear bar'),
+            ClearedValue({ClearedValue('foo'): ClearedValue('bar')}))
+        self.assertEqual(
+            _load_yaml_with_clear_tag('!clear foo: bar\nfoo: baz'),
+            {ClearedValue('foo'): 'bar', 'foo': 'baz'})

--- a/tests/test_option_store.py
+++ b/tests/test_option_store.py
@@ -325,7 +325,7 @@ class ClearTagTestCase(ConfigFilesTestCase):
         'runners': {
             'inline': {
                 'cmdenv': {
-                    'PATH': '/some/dir',
+                    'PATH': '/some/nice/dir',
                 },
                 'jobconf': {
                     'some.property': 'something',
@@ -341,6 +341,52 @@ class ClearTagTestCase(ConfigFilesTestCase):
         self.base_conf_path = self.save_conf('base.conf', self.BASE_CONF)
         self.base_opts = RunnerOptionStore('inline', {}, [self.base_conf_path])
 
+    def test_clear_cmdenv_path(self):
+        opts = self.opts_for_conf('extend.conf', {
+            'include': self.base_conf_path,
+            'runners': {
+                'inline': {
+                    'cmdenv': {
+                        'PATH': ClearedValue('/some/even/better/dir')
+                    }
+                }
+            }
+        })
+
+        self.assertEqual(opts['cmdenv'], {'PATH': '/some/even/better/dir'})
+        self.assertEqual(opts['jobconf'], self.base_opts['jobconf'])
+        self.assertEqual(opts['setup'], self.base_opts['setup'])
+
+    def test_clear_cmdenv(self):
+        opts = self.opts_for_conf('extend.conf', {
+            'include': self.base_conf_path,
+            'runners': {
+                'inline': {
+                    'cmdenv': ClearedValue({
+                        'USER': 'dave'
+                    })
+                }
+            }
+        })
+
+        self.assertEqual(opts['cmdenv'], {'USER': 'dave'})
+        self.assertEqual(opts['jobconf'], self.base_opts['jobconf'])
+        self.assertEqual(opts['setup'], self.base_opts['setup'])
+
+    def test_clear_jobconf(self):
+        opts = self.opts_for_conf('extend.conf', {
+            'include': self.base_conf_path,
+            'runners': {
+                'inline': {
+                    'jobconf': ClearedValue(None)
+                }
+            }
+        })
+
+        self.assertEqual(opts['cmdenv'], self.base_opts['cmdenv'])
+        self.assertEqual(opts['jobconf'], {})
+        self.assertEqual(opts['setup'], self.base_opts['setup'])
+
     def test_clear_setup(self):
         opts = self.opts_for_conf('extend.conf', {
             'include': self.base_conf_path,
@@ -354,11 +400,6 @@ class ClearTagTestCase(ConfigFilesTestCase):
         self.assertEqual(opts['cmdenv'], self.base_opts['cmdenv'])
         self.assertEqual(opts['jobconf'], self.base_opts['jobconf'])
         self.assertEqual(opts['setup'], ['instead do this'])
-
-    # TODO: test clearing cmdenv and jobconf
-
-
-
 
 
 class TestExtraKwargs(ConfigFilesTestCase):


### PR DESCRIPTION
This adds a `!clear` tag to mrjob's YAML config format. When the value of an option is tagged with `!clear`, values of that option included from other config files are ignored. For example:

/etc/mrjob.base.conf:
```yaml
runners:
  emr:
    setup: do-something
```

/etc/mrjob.conf:
```yaml
include: /etc/mrjob.base.conf
runners:
  emr:
    setup: !clear do-something else
```

Using `!clear` alone is equivalent to `!clear null` (this is a natural consequence of YAML syntax).

If you specify multiple config files (e.g. with `-c` on the command line), a `!clear` in a later file will override earlier files (`include` is really just a way to add to your list of config files).

You currently cannot do this:

```yaml
include: /etc/mrjob.base.conf
runners:
  emr: !clear
    ...
```
