### PR TITLE
Fix two bugs when running mrjob master:

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1054,9 +1054,12 @@ class EMRJobRunner(MRJobRunner):
 
     def _cleanup_job(self):
         # kill the job if we won't be taking down the whole job flow
-        if not (self._cluster_id or
-                self._opts['emr_job_flow_id'] or
-                self._opts['pool_emr_job_flows']):
+        if not self._cluster_id:
+            # Nothing we can do.
+            return
+
+        if (not self._opts['emr_job_flow_id'] and
+            not self._opts['pool_emr_job_flows']):
             # we're taking down the job flow, don't bother
             return
 

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -233,7 +233,15 @@ class S3Filesystem(Filesystem):
         s3_conn = self.make_s3_conn()
 
         bucket = s3_conn.get_bucket(bucket_name)
-        location = bucket.get_location()
+        try:
+            location = bucket.get_location()
+        except boto.exception.S3ResponseError as e:
+            if e.status == 403:
+                log.warning("Could not infer aws region for bucket %s; "
+                            "assuming it's %s", bucket_name, s3_conn.host)
+                return bucket
+
+            raise
 
         # connect to bucket on proper endpoint
         if (not self._s3_endpoint and

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2773,7 +2773,8 @@ class CleanUpJobTestCase(MockBotoTestCase):
             yield mock_dict
 
     def _quick_runner(self):
-        r = EMRJobRunner(conf_paths=[], ec2_key_pair_file='fake.pem')
+        r = EMRJobRunner(conf_paths=[], ec2_key_pair_file='fake.pem',
+                         pool_emr_job_flows=True)
         r._cluster_id = 'j-ESSEOWENS'
         r._address = 'Albuquerque, NM'
         r._ran_job = False
@@ -2823,6 +2824,13 @@ class CleanUpJobTestCase(MockBotoTestCase):
                               side_effect=die_ssh):
                 r._cleanup_job()
                 self.assertIn('Unable to kill job', stderr.getvalue())
+
+    def test_job_cleanup_mechanics_not_started(self):
+        r = self._quick_runner()
+        r._cluster_id = None
+        with patch.object(mrjob.emr, 'ssh_terminate_single_job') as p:
+            r._cleanup_job()
+            p.assert_not_called()
 
     def test_job_cleanup_mechanics_io_fail(self):
         def die_io(*args, **kwargs):


### PR DESCRIPTION
Don't attempt to clean up jobs that never started, even when pooling job flows.
Don't fail when get_location throws - e.g.
    `python -c 'import boto; boto.connect_s3().get_bucket("elasticmapreduce").get_location()'`