### PR TITLE
List combiners

### DIFF
--- a/docs/guides/configs-basics.rst
+++ b/docs/guides/configs-basics.rst
@@ -163,6 +163,27 @@ once, the lists are concatenated together.
     List of :ref:`paths <data-type-path>`. Combined with
     :py:func:`~mrjob.conf.combine_path_lists`.
 
+.. versionchanged:: 0.4.6
+   strings and non-sequence data types (e.g. numbers) are treated as
+   single-item lists.
+
+For example,
+
+.. code-block:: yaml
+
+    runners:
+      emr:
+        setup: /run/some/command with args
+
+is equivalent to:
+
+.. code-block:: yaml
+
+    runners:
+      emr:
+        setup:
+        - /run/some/command with args
+
 Dict data types
 ^^^^^^^^^^^^^^^
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -442,6 +442,8 @@ def combine_cmd_lists(*seqs_of_cmds):
 
     Returns a list of lists (each sublist contains the command plus arguments).
     """
+    log.warning(
+        'combine_cmd_lists() is deprecated and will be removed in v0.5.0')
     seq_of_cmds = combine_lists(*seqs_of_cmds)
     return [combine_cmds(cmd) for cmd in seq_of_cmds]
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -407,12 +407,24 @@ def combine_lists(*seqs):
 
     Generally this is used for a list of commands we want to run; the
     "default" commands get run before any commands specific to your job.
+
+    .. versionchanged:: 0.4.6
+       Strings and non-sequence objects (e.g. numbers) are treated as
+       single-item lists.
     """
     result = []
 
     for seq in seqs:
-        if seq:
-            result.extend(seq)
+        if seq is None:
+            continue
+
+        if isinstance(seq, basestring):
+            result.append(seq)
+        else:
+            try:
+                result.extend(seq)
+            except:
+                result.append(seq)
 
     return result
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -544,7 +544,11 @@ def combine_paths(*paths):
 def combine_path_lists(*path_seqs):
     """Concatenate the given sequences into a list. Ignore None values.
     Resolve ``~`` (home dir) and environment variables, and expand globs
-    that refer to the local filesystem."""
+    that refer to the local filesystem.
+
+    .. versionchanged:: 0.4.6
+       Can take single strings as well as lists.
+    """
     results = []
 
     for path in combine_lists(*path_seqs):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -320,19 +320,24 @@ class CombineCmdsTestCase(unittest.TestCase):
 class CombineCmdsListsCase(unittest.TestCase):
 
     def test_empty(self):
-        self.assertEqual(combine_cmd_lists(), [])
+        with logger_disabled('mrjob.conf'):
+            self.assertEqual(combine_cmd_lists(), [])
 
     def test_concatenation(self):
-        self.assertEqual(
-            combine_cmd_lists(
-                [['echo', 'foo']], None, (['mkdir', 'bar'], ['rmdir', 'bar'])),
-            [['echo', 'foo'], ['mkdir', 'bar'], ['rmdir', 'bar']])
+        with logger_disabled('mrjob.conf'):
+            self.assertEqual(
+                combine_cmd_lists(
+                    [['echo', 'foo']],
+                    None,
+                    (['mkdir', 'bar'], ['rmdir', 'bar'])),
+                [['echo', 'foo'], ['mkdir', 'bar'], ['rmdir', 'bar']])
 
     def test_conversion(self):
-        self.assertEqual(
-            combine_cmd_lists(
-                ['echo "Hello World!"'], None, [('mkdir', '/tmp/baz')]),
-            [['echo', 'Hello World!'], ['mkdir', '/tmp/baz']])
+        with logger_disabled('mrjob.conf'):
+            self.assertEqual(
+                combine_cmd_lists(
+                    ['echo "Hello World!"'], None, [('mkdir', '/tmp/baz')]),
+                [['echo', 'Hello World!'], ['mkdir', '/tmp/baz']])
 
 
 class CombineEnvsTestCase(unittest.TestCase):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -512,6 +512,11 @@ class CombineAndExpandPathsTestCase(SandboxedTestCase):
             combine_path_lists(['~/tmp'], [], ['/dev/null', '/tmp/$USER']),
             ['/home/foo/tmp', '/dev/null', '/tmp/foo'])
 
+    def test_combine_path_lists_on_strings(self):
+        self.assertEqual(
+            combine_path_lists('~/tmp', [], ['/dev/null', '/tmp/$USER']),
+            ['/home/foo/tmp', '/dev/null', '/tmp/foo'])
+
     def test_globbing(self):
         foo_path = os.path.join(self.tmp_dir, 'foo')
         bar_path = os.path.join(self.tmp_dir, 'bar')

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -424,6 +424,18 @@ class CombineListsTestCase(unittest.TestCase):
     def test_concatenation(self):
         self.assertEqual(combine_lists([1, 2], None, (3, 4)), [1, 2, 3, 4])
 
+    def test_strings(self):
+        self.assertEqual(combine_lists('one', None, 'two', u'three'),
+                         ['one', 'two', u'three'])
+
+    def test_scalars(self):
+        self.assertEqual(combine_lists(None, False, b'\x00', 42, 3.14),
+                         [False, b'\x00', 42, 3.14])
+
+    def test_mix_lists_and_scalars(self):
+        self.assertEqual(combine_lists([1, 2], 3, (4, 5), 6),
+                        [1, 2, 3, 4, 5, 6])
+
 
 class CombineOptsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Deprecated `combine_cmd_lists()` (fixes #1168)

`combine_lists()` can now take strings and scalar values, treating them as single-item lists (fixes #1172)