### PR TITLE
Skip test if no jar command

### DIFF
--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -24,6 +24,7 @@ import os
 import pipes
 import random
 import shlex
+import shutil
 import sys
 import tarfile
 import zipfile
@@ -31,6 +32,7 @@ import zlib
 from collections import defaultdict
 from copy import deepcopy
 from datetime import timedelta
+from distutils.spawn import find_executable
 from logging import getLogger
 
 try:
@@ -663,6 +665,18 @@ def to_lines(chunks):
         yield b''.join(leftovers)
 
 
+def unique(items):
+    """Yield items from *item* in order, skipping duplicates."""
+    seen = set()
+
+    for item in items:
+        if item in seen:
+            continue
+        else:
+            yield item
+            seen.add(item)
+
+
 def unarchive(archive_path, dest):
     """Extract the contents of a tar or zip file at *archive_path* into the
     directory *dest*.
@@ -697,3 +711,17 @@ def unarchive(archive_path, dest):
                         dest_file.write(archive.read(name))
     else:
         raise IOError('Unknown archive type: %s' % (archive_path,))
+
+
+def which(cmd, path=None):
+    """Like the UNIX which command: search in *path* for the executable named
+    *cmd*. *path* defaults to :envvar:`PATH`.
+
+    This is basically ``shutil.which()`` (which was introduced in Python 3.3)
+    without the *mode* argument. Best practice is to always specify *path*
+    as a keyword argument.
+    """
+    if hasattr(shutil, 'which'):
+        return shutil.which(cmd, path=path)
+    else:
+        return find_executable(cmd, path=path)

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -16,6 +16,7 @@
 import os
 import os.path
 import random
+import stat
 from contextlib import contextmanager
 from tempfile import mkdtemp
 from shutil import rmtree
@@ -123,13 +124,17 @@ class SandboxedTestCase(EmptyMrjobConfTestCase):
             os.makedirs(abs_path)
         return abs_path
 
-    def makefile(self, path, contents):
+    def makefile(self, path, contents=b'', executable=False):
         self.makedirs(os.path.split(path)[0])
         abs_path = os.path.join(self.tmp_dir, path)
 
         mode = 'wb' if isinstance(contents, bytes) else 'w'
         with open(abs_path, mode) as f:
             f.write(contents)
+        if executable:
+            os.chmod(abs_path,
+                     os.stat(abs_path).st_mode | stat.S_IXUSR)
+
         return abs_path
 
     def abs_paths(self, *paths):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,6 +17,7 @@ import gzip
 import optparse
 import os
 import shutil
+import stat
 import sys
 import tarfile
 import tempfile
@@ -37,12 +38,16 @@ from mrjob.util import read_input
 from mrjob.util import safeeval
 from mrjob.util import scrape_options_into_new_groups
 from mrjob.util import tar_and_gzip
-from mrjob.util import unarchive
 from mrjob.util import to_lines
+from mrjob.util import unarchive
+from mrjob.util import unique
+from mrjob.util import which
 
 from tests.py2 import TestCase
+from tests.py2 import patch
 from tests.quiet import logger_disabled
 from tests.quiet import no_handlers_for_logger
+from tests.sandbox import SandboxedTestCase
 from tests.sandbox import random_seed
 
 
@@ -601,3 +606,44 @@ class RandomIdentifierTestCase(TestCase):
         # heh
         with random_seed(0):
             self.assertNotEqual(random_identifier(), random_identifier())
+
+
+class UniqueTestCase(TestCase):
+
+    def test_empty(self):
+        self.assertEqual(list(unique([])), [])
+
+    def test_de_duplication(self):
+        self.assertEqual(list(unique([1, 2, 1, 5, 1])),
+                         [1, 2, 5])
+
+    def test_preserves_order(self):
+        self.assertEqual(list(unique([6, 7, 2, 0, 7, 1])),
+                         [6, 7, 2, 0, 1])
+
+    def test_mixed_types_ok(self):
+        self.assertEqual(list(unique(['a', None, 33, 'a'])),
+                         ['a', None, 33])
+
+
+class WhichTestCase(SandboxedTestCase):
+
+    # which() is just a passthrough to shutil.which() and
+    # distutils.spawn.find_executable, so we're really just
+    # testing for consistent behavior across versions
+
+    def setUp(self):
+        super(WhichTestCase, self).setUp()
+
+        self.shekondar_path = self.makefile('shekondar', executable=True)
+
+    def test_explicit_path(self):
+        self.assertEqual(which('shekondar', path=self.tmp_dir),
+                         self.shekondar_path)
+
+    def test_path_from_environment(self):
+        with patch.dict(os.environ, PATH=self.tmp_dir):
+            self.assertEqual(which('shekondar'), self.shekondar_path)
+
+    def test_not_found(self):
+        self.assertEqual(which('shekondar-the-fearsome', self.tmp_dir), None)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -453,7 +453,7 @@ class ArchiveTestCase(TestCase):
             'tar.bz2',
             ['tar', 'cjhf', '%(archive_name)s', '%(files_to_archive)s'])
 
-    @skipIf(not which('jar'), 'no jar command')
+    @skipIf(which('jar') is None, 'no jar command')
     def test_unarchive_jar(self):
         # this test requires that jar is present
         self.archive_and_unarchive(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -45,6 +45,7 @@ from mrjob.util import which
 
 from tests.py2 import TestCase
 from tests.py2 import patch
+from tests.py2 import skipIf
 from tests.quiet import logger_disabled
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import SandboxedTestCase
@@ -452,6 +453,7 @@ class ArchiveTestCase(TestCase):
             'tar.bz2',
             ['tar', 'cjhf', '%(archive_name)s', '%(files_to_archive)s'])
 
+    @skipIf(not which('jar'), 'no jar command')
     def test_unarchive_jar(self):
         # this test requires that jar is present
         self.archive_and_unarchive(


### PR DESCRIPTION
This skips `tests.test_util.ArchiveTestCase.test_unarchive_jar()` if there is no `jar` command.

Brought in `which()` from the `hadoop-prefix` branch.