### PR TITLE
relative conf includes

### DIFF
--- a/docs/guides/configs-basics.rst
+++ b/docs/guides/configs-basics.rst
@@ -303,6 +303,28 @@ will be equivalent to this one:
 In this case, :file:`~/.mrjob.very-large.conf` has taken precedence over
 :file:`~/.mrjob.very-small.conf`.
 
+.. versionchanged:: 0.4.6
+    Relative ``include:`` paths are relative to the real (after resolving
+    symlinks) path of the including conf file.
+
+For example, you could do this:
+
+:file:`~/.mrjob/base.conf`
+
+.. code-block:: yaml
+
+    runners:
+      ...
+
+:file:`~/.mrjob/default.conf`
+
+.. code-block:: yaml
+
+    include: base.conf
+
+You could then load your configs via a symlink :file:`~/.mrjob.conf` to
+:file:`~/.mrjob/default.conf` and file:`~/.mrjob/base.conf` would still be
+included (even though it's not in the same directory as the symlink).
 
 .. _clearing-configs:
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -345,8 +345,8 @@ def load_opts_from_mrjob_conf(runner_alias, conf_path=None,
         # handle includes in reverse order so that include order takes
         # precedence over inheritance
         for include in reversed(includes):
-            # make include relative to conf_path (see #1166)
-            include = os.path.join(os.path.dirname(conf_path), include)
+            # make include relative to (real) conf_path (see #1166)
+            include = os.path.join(os.path.dirname(real_conf_path), include)
 
             inherited.extend(
                 load_opts_from_mrjob_conf(

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -342,14 +342,17 @@ def load_opts_from_mrjob_conf(runner_alias, conf_path=None,
         if isinstance(includes, basestring):
             includes = [includes]
 
-        for include in includes:
+        # handle includes in reverse order so that include order takes
+        # precedence over inheritance
+        for include in reversed(includes):
             # make include relative to conf_path (see #1166)
             include = os.path.join(os.path.dirname(conf_path), include)
 
             inherited.extend(
                 load_opts_from_mrjob_conf(
                     runner_alias, include, already_loaded))
-    return inherited + [(conf_path, values)]
+
+    return list(reversed(inherited)) + [(conf_path, values)]
 
 
 def load_opts_from_mrjob_confs(runner_alias, conf_paths=None):
@@ -371,10 +374,12 @@ def load_opts_from_mrjob_confs(runner_alias, conf_paths=None):
         # don't include conf files that were loaded earlier in conf_paths
         already_loaded = []
 
-        return list(chain(*[
+        # load opts in reversed order so that order of conf paths takes
+        # precedence over inheritance
+        return list(reversed(list(chain(*[
             load_opts_from_mrjob_conf(
                 runner_alias, path, already_loaded=already_loaded)
-            for path in conf_paths]))
+            for path in reversed(conf_paths)]))))
 
 
 ### writing mrjob.conf ###

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -357,11 +357,10 @@ def load_opts_from_mrjob_conf(runner_alias, conf_path=None,
             # make include relative to (real) conf_path (see #1166)
             include = os.path.join(os.path.dirname(real_conf_path), include)
 
-            inherited.extend(
-                load_opts_from_mrjob_conf(
-                    runner_alias, include, already_loaded))
+            inherited = load_opts_from_mrjob_conf(
+                runner_alias, include, already_loaded) + inherited
 
-    return list(reversed(inherited)) + [(conf_path, values)]
+    return inherited + [(conf_path, values)]
 
 
 def load_opts_from_mrjob_confs(runner_alias, conf_paths=None):
@@ -389,12 +388,15 @@ def load_opts_from_mrjob_confs(runner_alias, conf_paths=None):
         # don't include conf files that were loaded earlier in conf_paths
         already_loaded = []
 
-        # load opts in reversed order so that order of conf paths takes
+        # load configs in reversed order so that order of conf paths takes
         # precedence over inheritance
-        return list(reversed(list(chain(*[
-            load_opts_from_mrjob_conf(
-                runner_alias, path, already_loaded=already_loaded)
-            for path in reversed(conf_paths)]))))
+        results = []
+
+        for path in reversed(conf_paths):
+            results = load_opts_from_mrjob_conf(
+                runner_alias, path, already_loaded=already_loaded) + results
+
+        return results
 
 
 ### writing mrjob.conf ###

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -322,8 +322,15 @@ def load_opts_from_mrjob_conf(runner_alias, conf_path=None,
     if already_loaded is None:
         already_loaded = []
 
-    already_loaded.append(os.path.realpath(conf_path))
+    # don't load same conf file twice
+    real_conf_path = os.path.realpath(conf_path)
 
+    if real_conf_path in already_loaded:
+        return []
+    else:
+        already_loaded.append(real_conf_path)
+
+    # get configs for our runner out of conf file
     try:
         values = conf['runners'][runner_alias] or {}
     except (KeyError, TypeError, ValueError):
@@ -339,15 +346,9 @@ def load_opts_from_mrjob_conf(runner_alias, conf_path=None,
             # make include relative to conf_path (see #1166)
             include = os.path.join(os.path.dirname(conf_path), include)
 
-            if os.path.realpath(include) in already_loaded:
-                log.warn('%s tries to recursively include %s! (Already'
-                         ' included:  %s)' % (
-                             conf_path, conf['include'],
-                             ', '.join(already_loaded)))
-            else:
-                inherited.extend(
-                    load_opts_from_mrjob_conf(
-                        runner_alias, include, already_loaded))
+            inherited.extend(
+                load_opts_from_mrjob_conf(
+                    runner_alias, include, already_loaded))
     return inherited + [(conf_path, values)]
 
 
@@ -370,10 +371,10 @@ def load_opts_from_mrjob_confs(runner_alias, conf_paths=None):
         # don't include conf files that were loaded earlier in conf_paths
         already_loaded = []
 
-        return chain(*[
+        return list(chain(*[
             load_opts_from_mrjob_conf(
                 runner_alias, path, already_loaded=already_loaded)
-            for path in conf_paths])
+            for path in conf_paths]))
 
 
 ### writing mrjob.conf ###

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -21,6 +21,7 @@ import glob
 from itertools import chain
 import logging
 import os
+import os.path
 
 from mrjob.util import expand_path
 
@@ -134,9 +135,9 @@ def real_mrjob_conf_path(conf_path=None):
     if conf_path is False:
         return None
     elif conf_path is None:
-        return find_mrjob_conf()
+        return os.path.realpath(find_mrjob_conf())
     else:
-        return expand_path(conf_path)
+        return os.path.realpath(expand_path(conf_path))
 
 
 ### !clear tag ###
@@ -323,6 +324,8 @@ def load_opts_from_mrjob_conf(runner_alias, conf_path=None,
             includes = [includes]
 
         for include in includes:
+            include = os.path.realpath(include)
+
             if include in already_loaded:
                 log.warn('%s tries to recursively include %s! (Already'
                          ' included:  %s)' % (
@@ -351,8 +354,12 @@ def load_opts_from_mrjob_confs(runner_alias, conf_paths=None):
     if conf_paths is None:
         return load_opts_from_mrjob_conf(runner_alias, find_mrjob_conf())
     else:
+        # don't include conf files that were loaded earlier in conf_paths
+        already_loaded = []
+
         return chain(*[
-            load_opts_from_mrjob_conf(runner_alias, path)
+            load_opts_from_mrjob_conf(
+                runner_alias, path, already_loaded=already_loaded)
             for path in conf_paths])
 
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -300,8 +300,8 @@ def conf_object_at_path(conf_path):
 def load_opts_from_mrjob_conf(runner_alias, conf_path=None,
                               already_loaded=None):
     """Load a list of dictionaries representing the options in a given
-    mrjob.conf for a specific runner. Returns ``[(path, values)]``. If
-    conf_path is not found, return [(None, {})].
+    mrjob.conf for a specific runner, resolving includes. Returns
+    ``[(path, values)]``. If *conf_path* is not found, return ``[(None, {})]``.
 
     :type runner_alias: str
     :param runner_alias: String identifier of the runner type, e.g. ``emr``,
@@ -310,8 +310,17 @@ def load_opts_from_mrjob_conf(runner_alias, conf_path=None,
     :param conf_path: location of the file to load
     :type already_loaded: list
     :param already_loaded: list of real (according to ``os.path.realpath()``)
-                           :file:`mrjob.conf` paths that have already
-                           been loaded
+                           conf paths that have already
+                           been loaded (used by
+                           :py:func:`load_opts_from_mrjob_confs`).
+
+    .. versionchanged:: 0.4.6
+        Relative ``include:`` paths are relative to the real (after resolving
+        symlinks) path of the including conf file
+
+    .. versionchanged:: 0.4.6
+        This will only load each config file once, even if it's referenced
+        from multiple paths due to symlinks.
     """
     conf_path = real_mrjob_conf_path(conf_path)
     conf = conf_object_at_path(conf_path)
@@ -358,15 +367,21 @@ def load_opts_from_mrjob_conf(runner_alias, conf_path=None,
 def load_opts_from_mrjob_confs(runner_alias, conf_paths=None):
     """Load a list of dictionaries representing the options in a given
     list of mrjob config files for a specific runner. Returns
-    ``[(path, values)]``. If a path is not found, use (None, {}) as its value.
+    ``[(path, values), ...]``. If a path is not found, use ``(None, {})`` as
+    its value.
+
     If *conf_paths* is ``None``, look for a config file in the default
-    locations.
+    locations (see :py:func:`find_mrjob_conf`).
 
     :type runner_alias: str
     :param runner_alias: String identifier of the runner type, e.g. ``emr``,
                          ``local``, etc.
     :type conf_paths: list or ``None``
     :param conf_path: locations of the files to load
+
+    .. versionchanged:: 0.4.6
+        This will only load each config file once, even if it's referenced
+        from multiple paths due to symlinks.
     """
     if conf_paths is None:
         return load_opts_from_mrjob_conf(runner_alias, find_mrjob_conf())

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -16,6 +16,7 @@
 
 """Test configuration parsing and option combining"""
 import os
+import os.path
 
 try:
     import unittest2 as unittest
@@ -44,6 +45,7 @@ from mrjob.conf import dump_mrjob_conf
 from mrjob.conf import expand_path
 from mrjob.conf import find_mrjob_conf
 from mrjob.conf import load_opts_from_mrjob_conf
+from mrjob.conf import load_opts_from_mrjob_confs
 from mrjob.conf import real_mrjob_conf_path
 from tests.quiet import logger_disabled
 from tests.quiet import no_handlers_for_logger
@@ -149,6 +151,17 @@ class MRJobBasicConfTestCase(MRJobConfTestCase):
                 load_opts_from_mrjob_conf('bar', conf_path=conf_path)[0][1],
                 {})
 
+    def test_duplicate_conf_path(self):
+        conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
+
+        with open(conf_path, 'w') as f:
+            f.write('{"runners": {"foo": {"qux": "quux"}}}')
+
+        self.assertEqual(
+            load_opts_from_mrjob_confs(
+                'foo', conf_paths=[conf_path, conf_path]),
+            [(conf_path, {'qux': 'quux'})])
+
     def _test_round_trip(self, conf):
         conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
 
@@ -163,6 +176,8 @@ class MRJobBasicConfTestCase(MRJobConfTestCase):
     def test_round_trip_with_clear_tag(self):
         self._test_round_trip(
             {'runners': {'foo': {'qux': ClearedValue('quux')}}})
+
+
 
 
 class MRJobConfNoYAMLTestCase(MRJobConfTestCase):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -155,12 +155,87 @@ class MRJobBasicConfTestCase(MRJobConfTestCase):
         conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
 
         with open(conf_path, 'w') as f:
-            f.write('{"runners": {"foo": {"qux": "quux"}}}')
+            dump_mrjob_conf({}, f)
 
         self.assertEqual(
             load_opts_from_mrjob_confs(
-                'foo', conf_paths=[conf_path, conf_path]),
-            [(conf_path, {'qux': 'quux'})])
+                'foo', [conf_path, conf_path]),
+            [(conf_path, {})])
+
+    def test_symlink_to_duplicate_conf_path(self):
+        conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
+        with open(conf_path, 'w') as f:
+            dump_mrjob_conf({}, f)
+
+        conf_symlink_path = os.path.join(self.tmp_dir, 'mrjob.conf.symlink')
+        os.symlink('mrjob.conf', conf_symlink_path)
+
+        self.assertEqual(
+            load_opts_from_mrjob_confs(
+                'foo', [conf_path, conf_symlink_path]),
+            [(conf_symlink_path, {})])
+
+        self.assertEqual(
+            load_opts_from_mrjob_confs(
+                'foo', [conf_symlink_path, conf_path]),
+            [(conf_path, {})])
+
+    def test_recursive_include(self):
+        conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
+        with open(conf_path, 'w') as f:
+            dump_mrjob_conf({'include': conf_path}, f)
+
+        self.assertEqual(
+            load_opts_from_mrjob_conf('foo', conf_path),
+            [(conf_path, {})])
+
+    def test_doubly_recursive_include(self):
+        conf_path_1 = os.path.join(self.tmp_dir, 'mrjob.1.conf')
+        conf_path_2 = os.path.join(self.tmp_dir, 'mrjob.2.conf')
+
+        with open(conf_path_1, 'w') as f:
+            dump_mrjob_conf({'include': conf_path_2}, f)
+
+        with open(conf_path_2, 'w') as f:
+            dump_mrjob_conf({'include': conf_path_1}, f)
+
+        self.assertEqual(
+            load_opts_from_mrjob_conf('foo', conf_path_1),
+            [(conf_path_2, {}), (conf_path_1, {})])
+
+    def test_conf_path_order_beats_include(self):
+        conf_path_1 = os.path.join(self.tmp_dir, 'mrjob.1.conf')
+        conf_path_2 = os.path.join(self.tmp_dir, 'mrjob.2.conf')
+
+        with open(conf_path_1, 'w') as f:
+            dump_mrjob_conf({'include': conf_path_2}, f)
+
+        with open(conf_path_2, 'w') as f:
+            dump_mrjob_conf({}, f)
+
+        # shouldn't matter that conf_path_1 includes conf_path_2
+        self.assertEqual(
+            load_opts_from_mrjob_confs('foo', [conf_path_1, conf_path_2]),
+            [(conf_path_1, {}), (conf_path_2, {})])
+
+    def test_include_order_beats_include(self):
+        conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
+        conf_path_1 = os.path.join(self.tmp_dir, 'mrjob.1.conf')
+        conf_path_2 = os.path.join(self.tmp_dir, 'mrjob.2.conf')
+
+        with open(conf_path, 'w') as f:
+            dump_mrjob_conf({'include': [conf_path_1, conf_path_2]}, f)
+
+        with open(conf_path_1, 'w') as f:
+            dump_mrjob_conf({'include': [conf_path_2]}, f)
+
+        with open(conf_path_2, 'w') as f:
+            dump_mrjob_conf({}, f)
+
+        # shouldn't matter that conf_path_1 includes conf_path_2
+        self.assertEqual(
+            load_opts_from_mrjob_conf('foo', conf_path),
+            [(conf_path_1, {}), (conf_path_2, {}), (conf_path, {})])
 
     def _test_round_trip(self, conf):
         conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -237,6 +237,34 @@ class MRJobBasicConfTestCase(MRJobConfTestCase):
             load_opts_from_mrjob_conf('foo', conf_path),
             [(conf_path_1, {}), (conf_path_2, {}), (conf_path, {})])
 
+    def test_nested_include(self):
+        conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
+        conf_path_1 = os.path.join(self.tmp_dir, 'mrjob.1.conf')
+        conf_path_2 = os.path.join(self.tmp_dir, 'mrjob.2.conf')
+        conf_path_3 = os.path.join(self.tmp_dir, 'mrjob.3.conf')
+
+        # accidentally reversed the order of nested includes when
+        # trying to make precedence work; this test would catch that
+
+        with open(conf_path, 'w') as f:
+            dump_mrjob_conf({'include': conf_path_1}, f)
+
+        with open(conf_path_1, 'w') as f:
+            dump_mrjob_conf({'include': [conf_path_2, conf_path_3]}, f)
+
+        with open(conf_path_2, 'w') as f:
+            dump_mrjob_conf({}, f)
+
+        with open(conf_path_3, 'w') as f:
+            dump_mrjob_conf({}, f)
+
+        self.assertEqual(
+            load_opts_from_mrjob_conf('foo', conf_path),
+            [(conf_path_2, {}),
+             (conf_path_3, {}),
+             (conf_path_1, {}),
+             (conf_path, {})])
+
     def test_relative_include(self):
         base_conf_path = os.path.join(self.tmp_dir, 'mrjob.base.conf')
         real_base_conf_path = os.path.realpath(base_conf_path)

--- a/tests/test_option_store.py
+++ b/tests/test_option_store.py
@@ -209,19 +209,6 @@ class MultipleConfigFilesValuesTestCase(ConfigFilesTestCase):
 
 class MultipleConfigFilesMachineryTestCase(ConfigFilesTestCase):
 
-    def test_recurse(self):
-        path = os.path.join(self.tmp_dir, 'LOL.conf')
-        recurse_conf = dict(include=path)
-        with open(path, 'w') as f:
-            dump_mrjob_conf(recurse_conf, f)
-
-        stderr = StringIO()
-        with no_handlers_for_logger():
-            log_to_stream('mrjob.conf', stderr)
-            RunnerOptionStore('inline', {}, [path])
-            self.assertIn('%s tries to recursively include %s!' % (path, path),
-                          stderr.getvalue())
-
     def test_empty_runner_error(self):
         conf = dict(runner=dict(local=dict(base_tmp_dir='/tmp')))
         path = self.save_conf('basic', conf)


### PR DESCRIPTION
If you use a relative path in `include:` in a config file, it's now relative to the real path (after resolving symlinks) of the config file.