### PR TITLE
Fix Hadoop du()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,6 +34,8 @@ v0.5.0, 2015-??-?? -- ???
    * Hadoop
      * hdfs_scratch_dir option is now hadoop_tmp_dir (#318)
      * use fs -ls -R and fs -rm -R in YARN (#1152)
+     * fs.du() now works on YARN (#1155)
+     * fs.du() now returns 0 for nonexistent files instead of erroring
      * fs.rm() now uses -skipTrash
  * removed mrjob.compat.get_jobconf_value() (use jobconf_from_env())
  * removed mrjob.conf.combine_cmd_lists()

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -185,13 +185,14 @@ class HadoopFilesystem(Filesystem):
             return proc.returncode
 
     def du(self, path_glob):
-        """Get the size of a file, or None if it's not a file or doesn't
-        exist."""
+        """Get the size of a file or directory (recursively), or 0
+        if it doesn't exist."""
         try:
             stdout = self.invoke_hadoop(['fs', '-du', path_glob],
-                                        return_stdout=True)
+                                        return_stdout=True,
+                                        ok_returncodes=[0, 1, 255])
         except CalledProcessError:
-            raise IOError(path_glob)
+            return 0
 
         try:
             return sum(int(line.split()[0])

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -188,13 +188,13 @@ class HadoopFilesystem(Filesystem):
         """Get the size of a file, or None if it's not a file or doesn't
         exist."""
         try:
-            stdout = self.invoke_hadoop(['fs', '-dus', path_glob],
+            stdout = self.invoke_hadoop(['fs', '-du', path_glob],
                                         return_stdout=True)
         except CalledProcessError:
             raise IOError(path_glob)
 
         try:
-            return sum(int(line.split()[1])
+            return sum(int(line.split()[0])
                        for line in stdout.split(b'\n')
                        if line.strip())
         except (ValueError, TypeError, IndexError):

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -132,6 +132,9 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         self.assertEqual(self.fs.du('hdfs:///more/data2'), 4)
         self.assertEqual(self.fs.du('hdfs:///more/data3'), 4)
 
+    def test_du_non_existent(self):
+        self.assertEqual(self.fs.du('hdfs:///does-not-exist'), 0)
+
     def test_mkdir(self):
         self.fs.mkdir('hdfs:///d/ave')
         local_path = os.path.join(self.tmp_dir, 'mock_hdfs_root', 'd', 'ave')


### PR DESCRIPTION
This makes `HadoopFileSystem.du()` work in YARN as well as pre-YARN, and returns 0 when we try to `du()` a path that doesn't exist (consistent with other filesystems). Fixes #1155.

Turned out to be easier to just use `hadoop fs -du` rather than bothering with `hadoop fs -dus` or `hadoop fs -du -s`. If we ever need to use these, `tests.mockhadoop` is now prepared for that.