### PR TITLE
Recursive S3 ls

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,11 +23,13 @@ v0.5.0, 2015-??-?? -- ???
        * connect to each S3 bucket on appropriate endpoint (#1028)
        * create/select temp bucket in same region as EMR jobs (#687)
      * added iam_endpoint option (#1067)
-     * SSH tunnel now works on 3.x AMIs (#1013)
+     * SSH tunnel now works on 3.x and 4.x AMIs (#1013)
        * renamed ssh_tunnel_to_job_tracker option to ssh_tunnel
      * removed s3_conn args from methods in EMRJobRunner and S3Filesystem
+     * S3 Filesystem:
+       * removed support for _$folder$ keys
+       * recurse "subdirectories" even if uri lacks trailing / (#1183)
      * removed iam_job_flow_role option (use iam_instance_profile)
-     * removed support for _$folder$ keys, which EMR no longer creates
      * custom hadoop_streaming_jar gets properly uploaded
      * 4.x AMIs are supported (#1105)
        * added --release-label switch (--ami-version 4.0.0 also works)

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -101,12 +101,15 @@ class S3Filesystem(Filesystem):
     def ls(self, path_glob):
         """Recursively list files on S3.
 
-        This doesn't list "directories" unless there's actually a
-        corresponding key ending with a '/' (which is weird and confusing;
-        don't make S3 keys ending in '/')
+        *path_glob* can include ``?`` to match single characters or
+        ``*`` to match 0 or more characters. Both ``?`` and ``*`` can match
+        ``/``.
 
-        To list a directory, path_glob must end with a trailing
-        slash (foo and foo/ are different on S3)
+        .. versionchanged:: 0.5.0
+
+            You no longer need a trailing slash to list "directories" on S3;
+            both ``ls('s3://b/dir')`` and `ls('s3://b/dir/')` will list
+            all keys starting with ``dir/``.
         """
 
         # clean up the  base uri to ensure we have an equal uri to boto (s3://)

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -130,11 +130,22 @@ class S3FSTestCase(MockBotoTestCase):
 
     def test_rm(self):
         self.add_mock_s3_data({
-            'walrus': {'data/foo': b'abcd'}})
+            'walrus': {'foo': b''}})
+
+        self.assertEqual(self.fs.exists('s3://walrus/foo'), True)
+        self.fs.rm('s3://walrus/foo')
+        self.assertEqual(self.fs.exists('s3://walrus/foo'), False)
+
+    def test_rm_dir(self):
+        self.add_mock_s3_data({
+            'walrus': {'data/foo': b'',
+                       'data/bar/baz': b''}})
 
         self.assertEqual(self.fs.exists('s3://walrus/data/foo'), True)
-        self.fs.rm('s3://walrus/data/foo')
+        self.assertEqual(self.fs.exists('s3://walrus/data/bar/baz'), True)
+        self.fs.rm('s3://walrus/data')
         self.assertEqual(self.fs.exists('s3://walrus/data/foo'), False)
+        self.assertEqual(self.fs.exists('s3://walrus/data/bar/baz'), False)
 
 
 class S3FSRegionTestCase(MockBotoTestCase):

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -74,8 +74,9 @@ class S3FSTestCase(MockBotoTestCase):
             's3://walrus/data/foo',
         ]
 
-        self.assertEqual(list(self.fs.ls('s3://walrus/')), paths)
-        self.assertEqual(list(self.fs.ls('s3://walrus/*')), paths)
+        self.assertEqual(list(self.fs.ls('s3://walrus/data/')), paths)
+        self.assertEqual(list(self.fs.ls('s3://walrus/data/*')), paths)
+        self.assertEqual(list(self.fs.ls('s3://walrus/data')), paths)
 
     def test_ls_glob(self):
         self.add_mock_s3_data(

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -53,32 +53,35 @@ class S3FSTestCase(MockBotoTestCase):
         self.assertEqual(list(self.fs._cat_file('s3://walrus/data/foo.gz')),
                          [b'foo\n'] * 10000)
 
-    def test_ls_basic(self):
+    def test_ls_key(self):
         self.add_mock_s3_data(
-            {'walrus': {'data/foo': b'foo\nfoo\n'}})
+            {'walrus': {'data/foo': b''}})
 
         self.assertEqual(list(self.fs.ls('s3://walrus/data/foo')),
                          ['s3://walrus/data/foo'])
-        self.assertEqual(list(self.fs.ls('s3://walrus/')),
-                         ['s3://walrus/data/foo'])
 
-    def test_ls_recurse(self):
+    def test_ls_recursively(self):
         self.add_mock_s3_data(
-            {'walrus': {'data/bar': b'bar\nbar\n',
-                        'data/bar/baz': b'baz\nbaz\n',
-                        'data/foo': b'foo\nfoo\n'}})
+            {'walrus': {'data/bar': b'',
+                        'data/bar/baz': b'',
+                        'data/foo': b'',
+                        'qux': b''}})
 
-        paths = [
+        uris = [
             's3://walrus/data/bar',
             's3://walrus/data/bar/baz',
             's3://walrus/data/foo',
+            's3://walrus/qux',
         ]
 
-        self.assertEqual(list(self.fs.ls('s3://walrus/data/')), paths)
-        self.assertEqual(list(self.fs.ls('s3://walrus/data/*')), paths)
-        self.assertEqual(list(self.fs.ls('s3://walrus/data')), paths)
+        self.assertEqual(list(self.fs.ls('s3://walrus/')), uris)
+        self.assertEqual(list(self.fs.ls('s3://walrus/*')), uris)
 
-    def test_ls_glob(self):
+        self.assertEqual(list(self.fs.ls('s3://walrus/data')), uris[:-1])
+        self.assertEqual(list(self.fs.ls('s3://walrus/data/')), uris[:-1])
+        self.assertEqual(list(self.fs.ls('s3://walrus/data/*')), uris[:-1])
+
+    def test_ls_globs(self):
         self.add_mock_s3_data(
             {'walrus': {'data/bar': b'bar\nbar\n',
                         'data/bar/baz': b'baz\nbaz\n',

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -83,12 +83,26 @@ class S3FSTestCase(MockBotoTestCase):
 
     def test_ls_globs(self):
         self.add_mock_s3_data(
-            {'walrus': {'data/bar': b'bar\nbar\n',
-                        'data/bar/baz': b'baz\nbaz\n',
-                        'data/foo': b'foo\nfoo\n'}})
+            {'w': {'a': b'',
+                   'a/b': b'',
+                   'ab': b'',
+                   'b': b''}})
 
-        self.assertEqual(list(self.fs.ls('s3://walrus/*/baz')),
-                         ['s3://walrus/data/bar/baz'])
+        self.assertEqual(list(self.fs.ls('s3://w/')),
+                         ['s3://w/a', 's3://w/a/b', 's3://w/ab', 's3://w/b'])
+        self.assertEqual(list(self.fs.ls('s3://w/*')),
+                         ['s3://w/a', 's3://w/a/b', 's3://w/ab', 's3://w/b'])
+        self.assertEqual(list(self.fs.ls('s3://w/*/')),
+                         ['s3://w/a/b'])
+        self.assertEqual(list(self.fs.ls('s3://w/*/*')),
+                         ['s3://w/a/b'])
+        self.assertEqual(list(self.fs.ls('s3://w/a?')),
+                         ['s3://w/ab'])
+        # * can match /
+        self.assertEqual(list(self.fs.ls('s3://w/a*')),
+                         ['s3://w/a', 's3://w/a/b', 's3://w/ab'])
+        self.assertEqual(list(self.fs.ls('s3://w/*b')),
+                         ['s3://w/a/b', 's3://w/ab', 's3://w/b'])
 
     def test_ls_s3n(self):
         self.add_mock_s3_data(

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -193,32 +193,3 @@ class S3FSRegionTestCase(MockBotoTestCase):
         # can't access this bucket from wrong endpoint!
         self.assertRaises(boto.exception.S3ResponseError,
                           fs.get_bucket, 'walrus-west')
-
-
-class TestS3Ls(MockBotoTestCase):
-
-    def test_s3_ls(self):
-        self.add_mock_s3_data(
-            {'walrus': {'one': b'', 'two': b'', 'three': b''}})
-
-        fs = S3Filesystem()
-
-        self.assertEqual(set(fs._s3_ls('s3://walrus/')),
-                         set(['s3://walrus/one',
-                              's3://walrus/two',
-                              's3://walrus/three',
-                              ]))
-
-        self.assertEqual(set(fs._s3_ls('s3://walrus/t')),
-                         set(['s3://walrus/two',
-                              's3://walrus/three',
-                              ]))
-
-        self.assertEqual(set(fs._s3_ls('s3://walrus/t/')),
-                         set([]))
-
-        # if we ask for a nonexistent bucket, we should get some sort
-        # of exception (in practice, buckets with random names will
-        # probably be owned by other people, and we'll get some sort
-        # of permissions error)
-        self.assertRaises(Exception, set, fs._s3_ls('s3://lolcat/'))


### PR DESCRIPTION
`S3Filesystem.ls()` and the methods that use it now always try to recurse through "subdirectories" even if the URI lacks a trailing slash (fixes #1183).