### PR TITLE
local/inline runner.fs refuses URIs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,6 +37,8 @@ v0.5.0, 2015-??-?? -- ???
      * fs.du() now works on YARN (#1155)
      * fs.du() now returns 0 for nonexistent files instead of erroring
      * fs.rm() now uses -skipTrash
+   * Inline/Local
+     * runner.fs raises IOError if passed URIs (#1185)
  * removed mrjob.compat.get_jobconf_value() (use jobconf_from_env())
  * removed mrjob.conf.combine_cmd_lists()
  * Python-version-specific mrjob commands (#1104)

--- a/mrjob/fs/composite.py
+++ b/mrjob/fs/composite.py
@@ -57,7 +57,7 @@ class CompositeFilesystem(Filesystem):
                         first_exception = e
 
         if first_exception is None:
-            raise IOError('Could not %s: %s %s' % (action, path, args))
+            raise IOError("Can't handle path: %s" % path)
         else:
             raise first_exception
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -45,6 +45,7 @@ from mrjob.conf import combine_paths
 from mrjob.conf import combine_path_lists
 from mrjob.conf import load_opts_from_mrjob_confs
 from mrjob.conf import OptionStore
+from mrjob.fs.composite import CompositeFilesystem
 from mrjob.fs.local import LocalFilesystem
 from mrjob.py2 import PY2
 from mrjob.py2 import string_types
@@ -425,7 +426,9 @@ class MRJobRunner(object):
         0.6.0, but **this behavior is deprecated.**
         """
         if self._fs is None:
-            self._fs = LocalFilesystem()
+            # wrap LocalFilesystem in CompositeFilesystem to get IOError
+            # on URIs (see #1185)
+            self._fs = CompositeFilesystem(LocalFilesystem())
         return self._fs
 
     def __getattr__(self, name):

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -19,6 +19,7 @@
 """Tests for InlineMRJobRunner"""
 import gzip
 import os
+import os.path
 from io import BytesIO
 
 from mrjob import conf
@@ -374,6 +375,22 @@ class InlineMRJobRunnerNoMapperTestCase(SandboxedTestCase):
             self.assertEqual(sorted(results),
                              [(1, ['blue', 'one', 'red', 'two']),
                               (4, ['fish'])])
+
+
+class InlineMRJobRunnerFSTestCase(SandboxedTestCase):
+
+    RUNNER_CLASS = InlineMRJobRunner
+
+    def setUp(self):
+        super(InlineMRJobRunnerFSTestCase, self).setUp()
+        self.runner = self.RUNNER_CLASS()
+
+    def test_can_handle_paths(self):
+        self.assertEqual(
+            self.runner.fs.exists(os.path.join(self.tmp_dir, 'foo')), False)
+
+    def test_cant_handle_uris(self):
+        self.assertRaises(IOError, self.runner.fs.ls, 's3://walrus/foo')
 
 
 class ErrorOnBadPathsTestCase(TestCase):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -46,6 +46,7 @@ from tests.quiet import no_handlers_for_logger
 from tests.sandbox import EmptyMrjobConfTestCase
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_conf_patcher
+from tests.test_inline import InlineMRJobRunnerFSTestCase
 from tests.test_inline import InlineMRJobRunnerJobConfTestCase
 from tests.test_inline import InlineMRJobRunnerNoMapperTestCase
 
@@ -519,6 +520,11 @@ class LocalMRJobRunnerJobConfTestCase(InlineMRJobRunnerJobConfTestCase):
 class LocalMRJobRunnerNoMapperTestCase(InlineMRJobRunnerNoMapperTestCase):
 
     RUNNER = 'local'
+
+
+class LocalMRJobRunnerFSTestCase(InlineMRJobRunnerFSTestCase):
+
+    RUNNER_CLASS = LocalMRJobRunner
 
 
 class CompatTestCase(EmptyMrjobConfTestCase):


### PR DESCRIPTION
This should eliminate confusion where people try to pass s3:// URIs to their job in local mode, only to have it tell them the URI doesn't exist. Fixes #1185.