### PR TITLE
Hadoop counters

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -35,7 +35,7 @@ v0.5.0, 2015-??-?? -- ???
        * added --release-label switch (--ami-version 4.0.0 also works)
      * don't try to clean up job when there's no cluster ID (#1170)
    * Hadoop
-     * counters are parsed from Hadoop binary stderr (#1153)
+     * counters are parsed from Hadoop binary stderr in YARN (#1153)
      * hdfs_scratch_dir option is now hadoop_tmp_dir (#318)
      * use fs -ls -R and fs -rm -R in YARN (#1152)
      * fs.du() now works on YARN (#1155)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -35,6 +35,7 @@ v0.5.0, 2015-??-?? -- ???
        * added --release-label switch (--ami-version 4.0.0 also works)
      * don't try to clean up job when there's no cluster ID (#1170)
    * Hadoop
+     * counters are parsed from Hadoop binary stderr (#1153)
      * hdfs_scratch_dir option is now hadoop_tmp_dir (#318)
      * use fs -ls -R and fs -rm -R in YARN (#1152)
      * fs.du() now works on YARN (#1155)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1619,7 +1619,7 @@ class EMRJobRunner(MRJobRunner):
             log.info('Running time was %.1fs (not counting time spent waiting'
                      ' for the EC2 instances)' % total_step_time)
             self._fetch_counters(step_nums, lg_step_num_mapping)
-            self.print_counters(range(1, len(step_nums) + 1))
+            self._print_counters()
         else:
             msg = 'Job on job flow %s failed with status %s: %s' % (
                 cluster.id, job_state, reason)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -52,10 +52,10 @@ from mrjob.util import which
 log = logging.getLogger(__name__)
 
 # to filter out the log4j stuff that hadoop streaming prints out
-HADOOP_STREAMING_OUTPUT_RE = re.compile(br'^(\S+ \S+ \S+ \S+: )?(.*)$')
+_HADOOP_STREAMING_OUTPUT_RE = re.compile(br'^(\S+ \S+ \S+ \S+: )?(.*)$')
 
 # used to extract the job timestamp from stderr
-HADOOP_JOB_TIMESTAMP_RE = re.compile(
+_HADOOP_JOB_TIMESTAMP_RE = re.compile(
     br'(INFO: )?Running job: job_(?P<timestamp>\d+)_(?P<step_num>\d+)')
 
 # don't look for the hadoop streaming jar here!
@@ -436,7 +436,7 @@ class HadoopJobRunner(MRJobRunner):
         counter_group_indent = None
 
         for line in lines:
-            line = HADOOP_STREAMING_OUTPUT_RE.match(line).group(2)
+            line = _HADOOP_STREAMING_OUTPUT_RE.match(line).group(2)
 
             # don't print HADOOP: <counter stuff>, since we print
             # counters later anyway
@@ -483,7 +483,7 @@ class HadoopJobRunner(MRJobRunner):
             # once because we know how many steps we have and just want to know
             # what Hadoop thinks the first step's number is.
             if self._job_timestamp is None:
-                m = HADOOP_JOB_TIMESTAMP_RE.match(line)
+                m = _HADOOP_JOB_TIMESTAMP_RE.match(line)
                 if m:
                     self._job_timestamp = m.group('timestamp')
                     self._start_step_num = int(m.group('step_num'))

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -450,22 +450,14 @@ class HadoopJobRunner(MRJobRunner):
                     continue
 
             if parsing_counters:
-                log.debug('  counter_group == %r' % counter_group)
-                log.debug(
-                    '  counter_group_indent == %r' % counter_group_indent)
-
-                if counter_group is not None:
+                if not (counter_group is None or counter_group_indent is None):
                     m = _HADOOP_COUNTER_RE.match(line)
-
-                    if m:
-                        log.debug('  possible counter line: %s' % line)
-                        log.debug("  len(m.group('indent')) == %r" %
-                                  len(m.group('indent')))
-
                     if m and len(m.group('indent')) > counter_group_indent:
-                        log.debug('  counter line: %s' % line)
+
                         counter = m.group('counter')
                         amount = int(m.group('amount'))
+
+                        log.debug('  counter: %s=%d' % (counter, amount))
 
                         step_counters.setdefault(counter_group, {})
                         step_counters[counter_group][counter] = amount
@@ -474,9 +466,11 @@ class HadoopJobRunner(MRJobRunner):
 
                 m = _HADOOP_COUNTER_GROUP_RE.match(line)
                 if m:
-                    log.debug('  counter group line: %s' % line)
-                    counter_group_indent = len(m.group('indent'))
                     counter_group = m.group('group')
+                    counter_group_indent = len(m.group('indent'))
+
+                    log.debug('  counter group: %s' % counter_group)
+
                     continue
                 else:
                     parsing_counters = False

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -369,8 +369,8 @@ class HadoopJobRunner(MRJobRunner):
             else:
                 self._fetch_counters([step_num + self._start_step_num])
 
-            # printing needs step number relevant to this run of mrjob
-                self.print_counters([step_num + 1])
+            # just print counters for this one step
+            self.print_counters([step_num + 1])
 
             if returncode:
                 msg = ('Job failed with return code %d: %s' %

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -466,7 +466,10 @@ class HadoopJobRunner(MRJobRunner):
                         log.debug('  counter line: %s' % line)
                         counter = m.group('counter')
                         amount = int(m.group('amount'))
+
+                        step_counters.setdefault(counter_group, {})
                         step_counters[counter_group][counter] = amount
+
                         continue
 
                 m = _HADOOP_COUNTER_GROUP_RE.match(line)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -420,7 +420,7 @@ class HadoopJobRunner(MRJobRunner):
                         raise
 
         return self._process_streaming_stderr_lines(
-            line.rstrip('\r\n') for line in treat_eio_as_eof(stderr))
+            line.rstrip(b'\r\n') for line in treat_eio_as_eof(stderr))
 
 
     def _process_streaming_stderr_lines(self, lines):

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -362,6 +362,8 @@ class HadoopJobRunner(MRJobRunner):
                             master)
                         _, returncode = os.waitpid(pid, 0)
 
+            # TODO: looks like we are parsing counters
+            # but they don't get printed out.
             if step_counters:
                 self._counters.append(step_counters)
             else:

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -370,7 +370,7 @@ class HadoopJobRunner(MRJobRunner):
                 self._fetch_counters([step_num + self._start_step_num])
 
             # just print counters for this one step
-            self.print_counters([step_num + 1])
+            self._print_counters(step_nums=[step_num])
 
             if returncode:
                 msg = ('Job failed with return code %d: %s' %

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -77,7 +77,7 @@ _HADOOP_COUNTER_GROUP_RE = re.compile('^(?P<indent>\s+)(?P<group>.*)$')
 
 # line for a counter
 _HADOOP_COUNTER_RE = re.compile(
-    '^(?P<indent>\s+)(?P<group>.*)=(?P<amount>\d+)$')
+    '^(?P<indent>\s+)(?P<counter>.*)=(?P<amount>\d+)\s*$')
 
 
 def fully_qualify_hdfs_path(path):

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -433,7 +433,7 @@ class HadoopJobRunner(MRJobRunner):
             if parsing_counters:
                 if counter_group is not None:
                     m = _HADOOP_COUNTER_RE.match(line)
-                    if len(m.group('indent')) > counter_group_indent:
+                    if m and len(m.group('indent')) > counter_group_indent:
                         counter = m.group('counter')
                         amount = int(m.group('amount'))
                         step_counters[counter_group][counter] = amount

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -454,7 +454,7 @@ class HadoopJobRunner(MRJobRunner):
                     m = _HADOOP_COUNTER_RE.match(line)
                     if m and len(m.group('indent')) > counter_group_indent:
 
-                        counter = m.group('counter')
+                        counter = to_string(m.group('counter'))
                         amount = int(m.group('amount'))
 
                         log.debug('  counter: %s=%d' % (counter, amount))
@@ -466,7 +466,7 @@ class HadoopJobRunner(MRJobRunner):
 
                 m = _HADOOP_COUNTER_GROUP_RE.match(line)
                 if m:
-                    counter_group = m.group('group')
+                    counter_group = to_string(m.group('group'))
                     counter_group_indent = len(m.group('indent'))
 
                     log.debug('  counter group: %s' % counter_group)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -70,14 +70,14 @@ _EMR_HADOOP_STREAMING_JAR_DIRS = [
 ]
 
 # start of Counters printed by Hadoop
-_HADOOP_COUNTERS_START_RE = re.compile('^Counters: (?P<amount>\d+)\s*$')
+_HADOOP_COUNTERS_START_RE = re.compile(b'^Counters: (?P<amount>\d+)\s*$')
 
 # header for a group of counters
-_HADOOP_COUNTER_GROUP_RE = re.compile('^(?P<indent>\s+)(?P<group>.*)$')
+_HADOOP_COUNTER_GROUP_RE = re.compile(b'^(?P<indent>\s+)(?P<group>.*)$')
 
 # line for a counter
 _HADOOP_COUNTER_RE = re.compile(
-    '^(?P<indent>\s+)(?P<counter>.*)=(?P<amount>\d+)\s*$')
+    b'^(?P<indent>\s+)(?P<counter>.*)=(?P<amount>\d+)\s*$')
 
 
 def fully_qualify_hdfs_path(path):

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -433,8 +433,19 @@ class HadoopJobRunner(MRJobRunner):
                     continue
 
             if parsing_counters:
+                log.debug('  counter_group == %r' % counter_group)
+                log.debug(
+                    '  counter_group_indent == %r' % counter_group_indent)
+
                 if counter_group is not None:
                     m = _HADOOP_COUNTER_RE.match(line)
+
+                    if m:
+                        log.debug(
+                            '  possible counter line: %s' % line.rstrip())
+                        log.debug("  len(m.group('indent')) == %r" %
+                                  len(m.group('indent')))
+
                     if m and len(m.group('indent')) > counter_group_indent:
                         log.debug('  counter line: %s' % line.rstrip())
                         counter = m.group('counter')

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -436,6 +436,7 @@ class HadoopJobRunner(MRJobRunner):
                 if counter_group is not None:
                     m = _HADOOP_COUNTER_RE.match(line)
                     if m and len(m.group('indent')) > counter_group_indent:
+                        log.debug('  counter line: %s' % line.rstrip())
                         counter = m.group('counter')
                         amount = int(m.group('amount'))
                         step_counters[counter_group][counter] = amount
@@ -443,11 +444,11 @@ class HadoopJobRunner(MRJobRunner):
 
                 m = _HADOOP_COUNTER_GROUP_RE.match(line)
                 if m:
+                    log.debug('  counter group line: %s' % line.rstrip())
                     counter_group_indent = len(m.group('indent'))
                     counter_group = m.group('group')
                     continue
                 else:
-                    # done with counters
                     parsing_counters = False
 
             log.info('HADOOP: ' + to_string(line))

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -69,6 +69,16 @@ _EMR_HADOOP_STREAMING_JAR_DIRS = [
     '/usr/lib/hadoop-mapreduce',
 ]
 
+# start of Counters printed by Hadoop
+_HADOOP_COUNTERS_START_RE = re.compile('^Counters: (?P<amount>\d+)\s*$')
+
+# header for a group of counters
+_HADOOP_COUNTER_GROUP_RE = re.compile('^(?P<indent>\s+)(?P<group>.*)$')
+
+# line for a counter
+_HADOOP_COUNTER_RE = re.compile(
+    '^(?P<indent>\s+)(?P<group>.*)=(?P<amount>\d+)$')
+
 
 def fully_qualify_hdfs_path(path):
     """If path isn't an ``hdfs://`` URL, turn it into one."""
@@ -329,7 +339,8 @@ class HadoopJobRunner(MRJobRunner):
                 # no PTYs, just use Popen
                 step_proc = Popen(step_args, stdout=PIPE, stderr=PIPE)
 
-                self._process_stderr_from_streaming(step_proc.stderr)
+                step_counters = self._process_stderr_from_streaming(
+                    step_proc.stderr)
 
                 # there shouldn't be much output to STDOUT
                 for line in step_proc.stdout:
@@ -347,15 +358,19 @@ class HadoopJobRunner(MRJobRunner):
                     with os.fdopen(master_fd, 'rb') as master:
                         # reading from master gives us the subprocess's
                         # stderr and stdout (it's a fake terminal)
-                        self._process_stderr_from_streaming(master)
+                        step_counters = self._process_stderr_from_streaming(
+                            master)
                         _, returncode = os.waitpid(pid, 0)
 
-            if returncode == 0:
-                # parsing needs step number for whole job
-                self._fetch_counters([step_num + self._start_step_num])
-                # printing needs step number relevant to this run of mrjob
-                self.print_counters([step_num + 1])
+            if step_counters:
+                self._counters.append(step_counters)
             else:
+                self._fetch_counters([step_num + self._start_step_num])
+
+            # printing needs step number relevant to this run of mrjob
+                self.print_counters([step_num + 1])
+
+            if returncode:
                 msg = ('Job failed with return code %d: %s' %
                        (returncode, step_args))
                 log.error(msg)
@@ -383,6 +398,12 @@ class HadoopJobRunner(MRJobRunner):
 
     def _process_stderr_from_streaming(self, stderr):
 
+        # counter-parsing state
+        step_counters = {}
+        parsing_counters = False
+        counter_group = None
+        counter_group_indent = None
+
         def treat_eio_as_eof(iter):
             # on Linux, the PTY gives us a specific IOError when the
             # when the child process exits, rather than EOF.
@@ -397,18 +418,50 @@ class HadoopJobRunner(MRJobRunner):
 
         for line in treat_eio_as_eof(stderr):
             line = HADOOP_STREAMING_OUTPUT_RE.match(line).group(2)
-            log.info('HADOOP: ' + to_string(line))
 
+            # don't print HADOOP: <counter stuff>, since we print
+            # counters later anyway
+
+            # start of counters
+            if not (parsing_counters or step_counters):
+                m = _HADOOP_COUNTERS_START_RE.match(line)
+                if m:
+                    parsing_counters = True
+                    log.info('Parsing counters from hadoop output')
+                    continue
+
+            if parsing_counters:
+                if counter_group is not None:
+                    m = _HADOOP_COUNTER_RE.match(line)
+                    if len(m.group('indent')) > counter_group_indent:
+                        counter = m.group('counter')
+                        amount = int(m.group('amount'))
+                        step_counters[counter_group][counter] = amount
+                        continue
+
+                m = _HADOOP_COUNTER_GROUP_RE.match(line)
+                if m:
+                    counter_group_indent = len(m.group('indent'))
+                    counter_group = m.group('group')
+                    continue
+                else:
+                    # done with counters
+                    parsing_counters = False
+
+            log.info('HADOOP: ' + to_string(line))
             if b'Streaming Job Failed!' in line:
                 raise Exception(line)
 
             # The job identifier is printed to stderr. We only want to parse it
             # once because we know how many steps we have and just want to know
             # what Hadoop thinks the first step's number is.
-            m = HADOOP_JOB_TIMESTAMP_RE.match(line)
-            if m and self._job_timestamp is None:
-                self._job_timestamp = m.group('timestamp')
-                self._start_step_num = int(m.group('step_num'))
+            if self._job_timestamp is None:
+                m = HADOOP_JOB_TIMESTAMP_RE.match(line)
+                if m:
+                    self._job_timestamp = m.group('timestamp')
+                    self._start_step_num = int(m.group('step_num'))
+
+        return step_counters
 
     def _args_for_step(self, step_num):
         step = self._get_step(step_num)

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -249,7 +249,7 @@ class LocalMRJobRunner(SimMRJobRunner):
         returncode = proc.wait()
 
         if returncode != 0:
-            self.print_counters([step_num + 1])
+            self._print_counters(step_nums=[step_num])
             # try to throw a useful exception
             if tb_lines:
                 raise Exception(

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -596,29 +596,23 @@ class MRJobRunner(object):
         """
         raise NotImplementedError
 
-    def print_counters(self, limit_to_steps=None):
-        """Display this run's counters in a user-friendly way.
+    def _print_counters(self, step_nums=None):
+        """Log this run's counters in a user-friendly way.
 
-        :type first_step_num: int
-        :param first_step_num: Display step number of the counters from the
-                               first step
-        :type limit_to_steps: list of int
-        :param limit_to_steps: List of step numbers *relative to this job* to
-                               print, indexed from 1
+        :type step_nums: list of int
+        :param step_nums: Optional list of indexes of steps in
+                          ``self.counters()`` to filter on.
         """
         for step_num, step_counters in enumerate(self.counters()):
-            step_num = step_num + 1
-            if limit_to_steps is None or step_num in limit_to_steps:
-                log.info('Counters from step %d:' % step_num)
-                if step_counters.keys():
-                    for group_name in sorted(step_counters.keys()):
-                        log.info('  %s:' % group_name)
-                        group_counters = step_counters[group_name]
-                        for counter_name in sorted(group_counters.keys()):
-                            log.info('    %s: %d' % (
-                                counter_name, group_counters[counter_name]))
+            if step_nums is None or step_num in step_nums:
+                log.info('Counters from step %d:' % (step_num + 1))
+                if step_counters:
+                    for group, group_counters in sorted(step_counters.items()):
+                        log.info('\t%s' % group)
+                        for counter, amount in sorted(group_counters.items()):
+                            log.info('\t\t%s=%d' % (counter, amount))
                 else:
-                    log.info('  (no counters found)')
+                    log.info('  (none found)')
 
     ### hooks for the with statement ###
 

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -266,7 +266,7 @@ class SimMRJobRunner(MRJobRunner):
             self._prev_outfiles.append(output_path)
 
         self.per_step_runner_finish(step_num)
-        self.print_counters([step_num + 1])
+        self._print_counters(step_nums=[step_num])
 
     def _run_step(self, step_num, step_type, input_path, output_path,
                   working_dir, env):

--- a/mrjob/tools/emr/fetch_logs.py
+++ b/mrjob/tools/emr/fetch_logs.py
@@ -112,7 +112,7 @@ def perform_actions(options, runner):
         steps = runner._list_steps_for_cluster()
         runner._fetch_counters(
             range(1, len(steps) + 1), skip_s3_wait=True)
-        runner.print_counters()
+        runner._print_counters()
 
     if options.find_failure:
         find_failure(runner, options.step_num)

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -53,7 +53,7 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         self.env['MOCK_HDFS_ROOT'] = self.makedirs('mock_hdfs_root')
         self.env['MOCK_HADOOP_OUTPUT'] = self.makedirs('mock_hadoop_output')
         self.env['USER'] = 'mrjob_tests'
-        # don't set MOCK_HADOOP_LOG, we get command history other ways]
+        # don't set MOCK_HADOOP_CMD_LOG, we get command history other ways]
 
         self.env['MOCK_HADOOP_VERSION'] = '2.7.1'
 

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -21,6 +21,7 @@ from mrjob.util import which
 
 from tests.compress import gzip_compress
 from tests.fs import MockSubprocessTestCase
+from tests.mockhadoop import get_mock_hdfs_root
 from tests.mockhadoop import main as mock_hadoop_main
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
@@ -50,15 +51,14 @@ class HadoopFSTestCase(MockSubprocessTestCase):
             'i are java bytecode',
         )
 
-        self.env['MOCK_HDFS_ROOT'] = self.makedirs('mock_hdfs_root')
-        self.env['MOCK_HADOOP_OUTPUT'] = self.makedirs('mock_hadoop_output')
-        self.env['USER'] = 'mrjob_tests'
-        # don't set MOCK_HADOOP_CMD_LOG, we get command history other ways]
-
+        self.env['MOCK_HADOOP_TMP'] = self.makedirs('mock_hadoop')
         self.env['MOCK_HADOOP_VERSION'] = '2.7.1'
 
+        self.env['USER'] = 'mrjob_tests'
+
     def make_mock_file(self, name, contents='contents'):
-        return self.makefile(os.path.join('mock_hdfs_root', name), contents)
+        return self.makefile(
+            os.path.join(get_mock_hdfs_root(self.env), name), contents)
 
     def test_ls_empty(self):
         self.assertEqual(list(self.fs.ls('hdfs:///')), [])
@@ -137,7 +137,7 @@ class HadoopFSTestCase(MockSubprocessTestCase):
 
     def test_mkdir(self):
         self.fs.mkdir('hdfs:///d/ave')
-        local_path = os.path.join(self.tmp_dir, 'mock_hdfs_root', 'd', 'ave')
+        local_path = os.path.join(get_mock_hdfs_root(self.env), 'd', 'ave')
         self.assertEqual(os.path.isdir(local_path), True)
 
     def test_exists_no(self):

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -1,5 +1,7 @@
 # Copyright 2009-2012 Yelp
 # Copyright 2013 Tom Arnfeld and David Marin
+# Copyright 2014 Contributors
+# Copyright 2015 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,14 +17,16 @@
 """A mock version of the hadoop binary that actually manipulates the
 filesystem. This imitates only things that mrjob actually uses.
 
-Relies on these environment variables:
-MOCK_HDFS_ROOT -- root dir for our fake filesystem(s). Used regardless of
-URI scheme or host (so this is also the root of every S3 bucket).
-MOCK_HADOOP_OUTPUT -- a directory containing directories containing
-fake job output (to add output, use add_mock_output())
-MOCK_HADOOP_VERSION -- version of Hadoop to emulate (e.g. '2.7.1').
-MOCK_HADOOP_CMD_LOG -- optional: if this is set, append arguments passed
-to the fake hadoop binary to this file, one line per invocation
+Uses these environment variables:
+  MOCK_HADOOP_CMD_LOG (optional): if this is set, append arguments passed
+    to the fake hadoop binary to this file, one line per invocation
+  MOCK_HADOOP_OUTPUT: a directory containing directories containing
+    fake job output (to add output, use add_mock_output()). Each fake job
+    output directory will be deleted once it is output.
+  MOCK_HADOOP_VERSION: version of Hadoop to emulate (e.g. '2.7.1').
+  MOCK_HDFS_ROOT: root dir for our fake filesystem(s). Used
+    regardless of URI scheme or host (so this is also the root of every S3
+    bucket).
 
 This is designed to run as: python -m tests.mockhadoop <hadoop args>
 

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -82,10 +82,14 @@ def iso_now():
     return '%s.%06d' % (now.strftime('%Y%m%d.%H%M%S'), now.microsecond)
 
 
-def get_mock_dir(*subdirs):
+def get_mock_dir(*subdirs, **kwargs):
     """Get a directory within $MOCK_HADOOP_TMP, creating it if it doesn't
-    already exist."""
-    path = os.path.join(os.environ['MOCK_HADOOP_TMP'], *subdirs)
+    already exist.
+
+    Takes optional *environ* keyword arg (defaults to ``os.environ``)."""
+    environ = kwargs.get('environ') or os.environ
+
+    path = os.path.join(environ['MOCK_HADOOP_TMP'], *subdirs)
 
     if not os.path.exists(path):
         os.makedirs(os.path.abspath(path))
@@ -152,10 +156,7 @@ def next_mock_hadoop_counters():
 def get_mock_hdfs_root(environ=None):
     """Get the path of mock root of HDFS. Creates the directory if it
     doesn't already exist."""
-    if environ is None:
-        environ = os.environ
-
-    return get_mock_dir('hdfs')
+    return get_mock_dir('hdfs', environ=environ)
 
 
 def mock_hadoop_uses_yarn(environ):
@@ -223,7 +224,7 @@ def main(stdin, stdout, stderr, argv, environ):
     """Implements hadoop <args>"""
 
     # log what commands we ran
-    cmd_log_path = os.path.join(get_mock_dir(), 'cmd.log')
+    cmd_log_path = os.path.join(get_mock_dir(environ=environ), 'cmd.log')
     with open(cmd_log_path, 'a') as cmd_log:
         cmd_log.write(' '.join(pipes.quote(arg) for arg in argv[1:]))
         cmd_log.write('\n')

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -185,12 +185,12 @@ def hdfs_uri_to_real_path(hdfs_uri, environ):
     if not scheme and not path.startswith('/'):
         path = '/user/%s/%s' % (environ['USER'], path)
 
-    return os.path.join(get_mock_hdfs_root(), path.lstrip('/'))
+    return os.path.join(get_mock_hdfs_root(environ=environ), path.lstrip('/'))
 
 
 def real_path_to_hdfs_uri(real_path, environ):
     """Map a real path to an hdfs:/// URI."""
-    hdfs_root = get_mock_hdfs_root()
+    hdfs_root = get_mock_hdfs_root(environ=environ)
 
     if not real_path.startswith(hdfs_root):
         raise ValueError('path %s is not in %s' % (real_path, hdfs_root))
@@ -222,7 +222,6 @@ def invoke_cmd(stdout, stderr, environ, prefix, cmd, cmd_args, error_msg,
 
 def main(stdin, stdout, stderr, argv, environ):
     """Implements hadoop <args>"""
-
     # log what commands we ran
     cmd_log_path = os.path.join(get_mock_dir(environ=environ), 'cmd.log')
     with open(cmd_log_path, 'a') as cmd_log:

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -142,8 +142,8 @@ def main(stdin, stdout, stderr, argv, environ):
     """Implements hadoop <args>"""
 
     # log what commands we ran
-    if environ.get('MOCK_HADOOP_LOG'):
-        with open(environ['MOCK_HADOOP_LOG'], 'a') as cmd_log:
+    if environ.get('MOCK_HADOOP_CMD_LOG'):
+        with open(environ['MOCK_HADOOP_CMD_LOG'], 'a') as cmd_log:
             cmd_log.write(' '.join(pipes.quote(arg) for arg in argv[1:]))
             cmd_log.write('\n')
             cmd_log.flush()

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -359,8 +359,8 @@ class MockHadoopTestCase(SandboxedTestCase):
         os.environ['MOCK_HADOOP_OUTPUT'] = mock_output_dir
 
         # set up cmd log
-        mock_log_path = self.makefile('mock_hadoop_logs', '')
-        os.environ['MOCK_HADOOP_LOG'] = mock_log_path
+        mock_cmd_log_path = self.makefile('mock_hadoop_cmd_log', '')
+        os.environ['MOCK_HADOOP_CMD_LOG'] = mock_cmd_log_path
 
         # make sure the fake hadoop binaries can find mrjob
         self.add_mrjob_to_pythonpath()
@@ -455,8 +455,8 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
                          [(1, 'qux'), (2, 'bar'), (2, 'foo'), (5, None)])
 
         # make sure we called hadoop the way we expected
-        with open(os.environ['MOCK_HADOOP_LOG']) as mock_log:
-            hadoop_cmd_args = [shlex_split(cmd) for cmd in mock_log]
+        with open(os.environ['MOCK_HADOOP_CMD_LOG']) as hadoop_cmd_log:
+            hadoop_cmd_args = [shlex_split(cmd) for cmd in hadoop_cmd_log]
 
         jar_cmd_args = [cmd_args for cmd_args in hadoop_cmd_args
                         if cmd_args[:1] == ['jar']]
@@ -684,8 +684,8 @@ class JarStepTestCase(MockHadoopTestCase):
         with job.make_runner() as runner:
             runner.run()
 
-        with open(os.environ['MOCK_HADOOP_LOG']) as hadoop_log:
-            hadoop_jar_lines = [line for line in hadoop_log
+        with open(os.environ['MOCK_HADOOP_CMD_LOG']) as hadoop_cmd_log:
+            hadoop_jar_lines = [line for line in hadoop_cmd_log
                                 if line.startswith('jar ')]
             self.assertEqual(len(hadoop_jar_lines), 1)
             self.assertEqual(hadoop_jar_lines[0].rstrip(), 'jar ' + fake_jar)
@@ -705,9 +705,9 @@ class JarStepTestCase(MockHadoopTestCase):
                 # `hadoop jar` doesn't actually accept URIs
                 self.assertRaises(CalledProcessError, runner.run)
 
-        with open(os.environ['MOCK_HADOOP_LOG']) as hadoop_log:
+        with open(os.environ['MOCK_HADOOP_CMD_LOG']) as hadoop_cmd_log:
             hadoop_jar_lines = [
-                line for line in hadoop_log if line.startswith('jar ')]
+                line for line in hadoop_cmd_log if line.startswith('jar ')]
             self.assertEqual(len(hadoop_jar_lines), 1)
             self.assertEqual(hadoop_jar_lines[0].rstrip(), 'jar ' + jar_uri)
 
@@ -728,9 +728,9 @@ class JarStepTestCase(MockHadoopTestCase):
         with job.make_runner() as runner:
             runner.run()
 
-            with open(os.environ['MOCK_HADOOP_LOG']) as hadoop_log:
+            with open(os.environ['MOCK_HADOOP_CMD_LOG']) as hadoop_cmd_log:
                 hadoop_jar_lines = [
-                    line for line in hadoop_log if line.startswith('jar ')]
+                    line for line in hadoop_cmd_log if line.startswith('jar ')]
 
                 self.assertEqual(len(hadoop_jar_lines), 2)
                 jar_args = hadoop_jar_lines[0].rstrip().split()

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -28,6 +28,7 @@ from mrjob.hadoop import fully_qualify_hdfs_path
 from mrjob.py2 import PY2
 from mrjob.util import bash_wrap
 
+from tests.mockhadoop import add_mock_hadoop_counters
 from tests.mockhadoop import add_mock_hadoop_output
 from tests.mockhadoop import create_mock_hadoop_script
 from tests.mockhadoop import get_mock_hadoop_cmd_args
@@ -385,6 +386,10 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
         check_call([self.hadoop_bin,
                     'fs', '-put', input_to_upload, remote_input_path])
 
+        # add counters
+        add_mock_hadoop_counters({'foo': {'bar': 23}})
+        add_mock_hadoop_counters({'baz': {'qux': 42}})
+
         # doesn't matter what the intermediate output is; just has to exist.
         add_mock_hadoop_output([b''])
         add_mock_hadoop_output([b'1\t"qux"\n2\t"bar"\n',
@@ -440,6 +445,10 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
                 self.assertTrue(any(
                     ('export PYTHONPATH' in line and mrjob_tar_gz_name in line)
                     for line in wrapper))
+
+        self.assertEqual(runner.counters(),
+                         [{'foo': {'bar': 23}},
+                          {'baz': {'qux': 42}}])
 
         self.assertEqual(sorted(results),
                          [(1, 'qux'), (2, 'bar'), (2, 'foo'), (5, None)])

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -319,7 +319,7 @@ class LargeAmountsOfStderrTestCase(TestCase):
             raise TimeoutException('Stalled on large amounts of stderr;'
                                    ' probably pipe buffer is full.')
         self._old_alarm_handler = signal.signal(signal.SIGALRM, alarm_handler)
-        signal.alarm(10)
+        signal.alarm(30)
 
     def restore_old_alarm_handler(self):
         signal.alarm(0)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -340,7 +340,7 @@ class LargeAmountsOfStderrTestCase(TestCase):
             # look for expected output from MRVerboseJob
             stderr = mr_job.stderr.getvalue()
             self.assertIn(
-                b"Counters from step 1:\n  Foo:\n    Bar: 10000", stderr)
+                b"Counters from step 1:\n\tFoo\n\t\tBar=10000", stderr)
             self.assertIn(b'status: 0\n', stderr)
             self.assertIn(b'status: 99\n', stderr)
             self.assertNotIn(b'status: 100\n', stderr)


### PR DESCRIPTION
In YARN, the `hadoop jar` command prints the counters to stderr. This change allows us to parse and save them, fixing #1153.

Also:
 * hid `MRJobRunner.print_counters()` and made it use 0-indexed step numbers (it was 1-indexed for some reason). 
 * reworked `mockhadoop` (tired of adding an environment variable for every new feature)

