### PR TITLE
Pre-YARN task log parsing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -50,6 +50,7 @@ v0.5.0, 2015-??-?? -- ???
  * removed mrjob.conf.combine_cmd_lists()
  * removed fetch-logs tool (#1127)
  * Python-version-specific mrjob commands (#1104)
+ * use followlinks=True with os.walk()
  * mrjob.util:
    * file_ext() takes filename, not path
    * random_identifier() moved here from mrjob.aws

--- a/mrjob/fs/local.py
+++ b/mrjob/fs/local.py
@@ -35,7 +35,7 @@ class LocalFilesystem(Filesystem):
     def ls(self, path_glob):
         for path in glob.glob(path_glob):
             if os.path.isdir(path):
-                for dirname, _, filenames in os.walk(path):
+                for dirname, _, filenames in os.walk(path, followlinks=True):
                     for filename in filenames:
                         yield os.path.join(dirname, filename)
             else:

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -581,8 +581,15 @@ class HadoopJobRunner(MRJobRunner):
         # package up logs for _find_error_intask_logs(),
         # and log where we're looking.
         hadoop_version = self.get_hadoop_version()
-
         yarn = uses_yarn(hadoop_version)
+
+        if yarn and application_id is None:
+            log.warning("No application ID!")
+            return None
+
+        if not yarn and job_id is None:
+            log.warning("No job ID!")
+            return None
 
         # Note: this is unlikely to be super-helpful on "real" (multi-node)
         # pre-YARN Hadoop because task logs aren't generally shipped to a local

--- a/mrjob/logs/interpret.py
+++ b/mrjob/logs/interpret.py
@@ -50,7 +50,7 @@ def _find_error_in_task_logs(fs, log_dirs_stream, hadoop_version,
     is required, as task logs have very different paths in YARN.
 
     In YARN, you must set *application_id*, and pre-YARN, you must set
-    *job_id*, or we'll bail out with a warning.
+    *job_id*, or we'll bail out and return None.
 
     Returns a dictionary with the following keys ("optional" means
     that something may be None):
@@ -75,14 +75,8 @@ def _find_error_in_task_logs(fs, log_dirs_stream, hadoop_version,
 
     yarn = uses_yarn(hadoop_version)
 
-    if yarn:
-        if application_id is None:
-            log.warning("Need application ID to find error in task logs")
-            return None
-    else:
-        if job_id is None:
-            log.warning("Need job ID to find error in task logs")
-            return None
+    if ((yarn and application_id is None) or (not yarn and job_id is None)):
+        return None
 
     # we assume that each set of log paths contains the same copies
     # of syslogs, so stop once we find any non-empty set of log dirs

--- a/mrjob/logs/interpret.py
+++ b/mrjob/logs/interpret.py
@@ -36,6 +36,11 @@ def _cat_log(fs, path):
         log.warning("couldn't cat() %s: %r" % (path, e))
 
 
+def _find_error_in_pre_yarn_task_logs(fs, log_dirs_stream, job_id=None):
+    # TODO: merge this with _find_error_in_yarn_task_logs()
+    raise NotImplementedError
+
+
 def _find_error_in_yarn_task_logs(fs, log_dirs_stream, application_id=None):
     """Given a filesystem and a stream of lists of log dirs to search in,
     find the last error and return details about it.

--- a/mrjob/logs/interpret.py
+++ b/mrjob/logs/interpret.py
@@ -15,11 +15,13 @@
 """Scan logs for cause of failure and counters."""
 from logging import getLogger
 
-from mrjob.py2 import to_string
+from mrjob.compat import uses_yarn
+from mrjob.logs.ls import _ls_pre_yarn_task_syslogs
 from mrjob.logs.ls import _ls_yarn_task_syslogs
 from mrjob.logs.ls import _stderr_for_syslog
 from mrjob.logs.parse import _parse_task_syslog
 from mrjob.logs.parse import _parse_python_task_stderr
+from mrjob.py2 import to_string
 
 
 log = getLogger(__name__)

--- a/mrjob/logs/interpret.py
+++ b/mrjob/logs/interpret.py
@@ -18,7 +18,7 @@ from logging import getLogger
 from mrjob.py2 import to_string
 from mrjob.logs.ls import _ls_yarn_task_syslogs
 from mrjob.logs.ls import _stderr_for_syslog
-from mrjob.logs.parse import _parse_yarn_task_syslog
+from mrjob.logs.parse import _parse_task_syslog
 from mrjob.logs.parse import _parse_python_task_stderr
 
 
@@ -41,9 +41,14 @@ def _find_error_in_pre_yarn_task_logs(fs, log_dirs_stream, job_id=None):
     raise NotImplementedError
 
 
-def _find_error_in_yarn_task_logs(fs, log_dirs_stream, application_id=None):
+def _find_error_in_task_logs(fs, log_dirs_stream, hadoop_version,
+                             application_id=None, job_id=None):
     """Given a filesystem and a stream of lists of log dirs to search in,
-    find the last error and return details about it.
+    find the last error and return details about it. *hadoop_version*
+    is required, as task logs have very different paths in YARN.
+
+    In YARN, you must set *application_id*, and pre-YARN, you must set
+    *job_id*, or we'll bail out with a warning.
 
     Returns a dictionary with the following keys ("optional" means
     that something may be None):
@@ -66,17 +71,33 @@ def _find_error_in_yarn_task_logs(fs, log_dirs_stream, application_id=None):
     """
     syslog_paths = []
 
+    yarn = uses_yarn(hadoop_version)
+
+    if yarn:
+        if application_id is None:
+            log.warning("Need application ID to find error in task logs")
+            return None
+    else:
+        if job_id is None:
+            log.warning("Need job ID to find error in task logs")
+            return None
+
     # we assume that each set of log paths contains the same copies
     # of syslogs, so stop once we find any non-empty set of log dirs
     for log_dirs in log_dirs_stream:
-        syslog_paths = _ls_yarn_task_syslogs(fs, log_dirs,
-                                             application_id=application_id)
+        if yarn:
+            syslog_paths = _ls_yarn_task_syslogs(fs, log_dirs,
+                                                 application_id=application_id)
+        else:
+            syslog_paths = _ls_pre_yarn_task_syslogs(fs, log_dirs,
+                                                     job_id=job_id)
+
         if syslog_paths:
             break
 
     for syslog_path in syslog_paths:
         log.debug('Looking for error in %s' % syslog_path)
-        syslog_info = _parse_yarn_task_syslog(_cat_log(fs, syslog_path))
+        syslog_info = _parse_task_syslog(_cat_log(fs, syslog_path))
 
         if not syslog_info['error']:
             continue
@@ -131,13 +152,18 @@ def _format_error_from_task_logs(cause):
         lines.append(cause['stderr']['error']['exception'])
 
     if cause['syslog']['split']:
-        first_line = cause['syslog']['split']['start_line'] + 1
-        last_line = first_line + cause['syslog']['split']['num_lines']
+        split = cause['syslog']['split']
 
         lines.append('')
-        lines.append('while reading input from lines %d-%d of %s' %
-                     (first_line, last_line,
-                      cause['syslog']['split']['path']))
+
+        line_nums_desc = ''
+        if not (split['start_line'] is None or split['num_lines'] is None):
+            first_line = split['start_line'] + 1
+            last_line = first_line + split['num_lines']
+            line_nums_desc = 'lines %d-%d of ' % (first_line, last_line)
+
+        lines.append('while reading input from %s%s' %
+                     (line_nums_desc, split['path']))
 
     # if we didn't mention stderr above, mention it now
     if cause['stderr'] and not cause['stderr']['error']:

--- a/mrjob/logs/parse.py
+++ b/mrjob/logs/parse.py
@@ -210,7 +210,9 @@ def _parse_indented_counters(lines):
     return counters
 
 
-# TODO: handle "Output path already exists"
+# TODO: make this just _parse_task_syslog(), and handle other sorts
+# of exceptions and ways to read input URI (note this will make start_lines
+# and num_lines optional).
 def _parse_yarn_task_syslog(lines):
     """Parse out last Java stacktrace (if any) and last split (if any)
     from syslog file.

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -451,7 +451,7 @@ def read_input(path, stdin=None):
 
     # recurse through directories
     if os.path.isdir(path):
-        for dirname, _, filenames in os.walk(path):
+        for dirname, _, filenames in os.walk(path, followlinks=True):
             for filename in filenames:
                 for line in read_input(os.path.join(dirname, filename),
                                        stdin=stdin):
@@ -613,7 +613,7 @@ def tar_and_gzip(dir, out_path, filter=None, prefix=''):
 
     tar_gz = tarfile.open(out_path, mode='w:gz')
 
-    for dirpath, dirnames, filenames in os.walk(dir):
+    for dirpath, dirnames, filenames in os.walk(dir, followlinks=True):
         for filename in filenames:
             path = os.path.join(dirpath, filename)
             # janky version of os.path.relpath() (Python 2.6):

--- a/tests/logs/test_interpret.py
+++ b/tests/logs/test_interpret.py
@@ -89,6 +89,44 @@ class FormatCauseOfFailureTestCase(TestCase):
              '',
              'while reading input from lines 1-336 of ' + self.INPUT_URI])
 
+    def test_task_log_error_no_line_nums(self):
+        cause = dict(
+            type='task',
+            syslog=dict(
+                path=self.SYSLOG_PATH,
+                split=dict(
+                    start_line=None,
+                    num_lines=None,
+                    path=self.INPUT_URI,
+                ),
+                error=dict(
+                    stack_trace=self.JAVA_STACK_TRACE,
+                    exception=self.JAVA_EXCEPTION,
+                ),
+            ),
+            stderr=dict(
+                path=self.STDERR_PATH,
+                error=dict(
+                    exception=self.PYTHON_EXCEPTION,
+                    traceback=self.PYTHON_TRACEBACK,
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            _format_cause_of_failure(cause),
+            ['Probable cause of failure (from ' + self.SYSLOG_PATH + '):',
+             '',
+             self.JAVA_EXCEPTION] +
+            self.JAVA_STACK_TRACE +
+            ['',
+             'caused by Python exception (from ' + self.STDERR_PATH + '):',
+             ''] +
+            self.PYTHON_TRACEBACK +
+            [self.PYTHON_EXCEPTION,
+             '',
+             'while reading input from ' + self.INPUT_URI])
+
     def test_task_log_error_no_traceback(self):
         cause = dict(
             type='task',

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -360,7 +360,8 @@ class HadoopLogDirsTestCase(SandboxedTestCase):
         self.runner = HadoopJobRunner()
 
     def test_empty(self):
-        self.assertEqual(list(self.runner._hadoop_log_dirs()), [])
+        self.assertEqual(list(self.runner._hadoop_log_dirs()),
+                         ['/mnt/var/log/hadoop'])
 
     def test_precedence(self):
         os.environ['HADOOP_LOG_DIR'] = '/path/to/hadoop-log-dir'
@@ -374,7 +375,8 @@ class HadoopLogDirsTestCase(SandboxedTestCase):
              '/path/to/yarn-log-dir',
              'hdfs:///output/_logs',
              '/path/to/hadoop-prefix/logs',
-             '/path/to/hadoop-home/logs'])
+             '/path/to/hadoop-home/logs',
+             '/mnt/var/log/hadoop'])
 
     def test_hadoop_log_dirs_opt(self):
         self.runner = HadoopJobRunner(hadoop_log_dirs=['/logs1', '/logs2'])
@@ -392,10 +394,12 @@ class HadoopLogDirsTestCase(SandboxedTestCase):
 
         self.mock_hadoop_version = '2.0.0'
         self.assertEqual(list(self.runner._hadoop_log_dirs()),
-                         ['/path/to/yarn-log-dir'])
+                         ['/path/to/yarn-log-dir',
+                          '/mnt/var/log/hadoop'])
 
         self.mock_hadoop_version = '1.0.3'
-        self.assertEqual(list(self.runner._hadoop_log_dirs()), [])
+        self.assertEqual(list(self.runner._hadoop_log_dirs()),
+                         ['/mnt/var/log/hadoop'])
 
 
 


### PR DESCRIPTION
This change allows us to find probable cause of job failure in pre-YARN logs, by looking at job syslogs and stderr (though that's not so useful without some sort of log aggregation).

This also uses `followlinks=True` with `os.walk()`, so we can read logs from dirs that are symlinked to.



