### PR TITLE
Fetch counters in pre-YARN Hadoop

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -185,7 +185,8 @@ Options available to hadoop runner only
 
    * ``$HADOOP_LOG_DIR``
    * ``$YARN_LOG_DIR`` (on YARN only)
-   * ``<job output dir>/_logs``
+   * ``hdfs:///tmp/hadoop-yarn/staging`` (on YARN only)
+   * ``<job output dir>/_logs`` (usually this is on HDFS)
    * ``$HADOOP_PREFIX/logs``
    * ``$HADOOP_HOME/logs``
    * ``$HADOOP_INSTALL/logs``

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -600,10 +600,11 @@ class HadoopJobRunner(MRJobRunner):
             # wrap _ls_history_logs() to add logging
             def ls_history_logs():
                 # there should be at most one history log
-                for path in _ls_history_logs(
+                for match in _ls_history_logs(
                         self.fs, stream_history_log_dirs(), job_id=job_id):
-                    log.info('reading counters/errors from %s' % path)
-                    yield path
+                    log.info(
+                        'reading counters/errors from %s' % match['path'])
+                    yield match
 
             step_info['history'] = _interpret_history_log(ls_history_logs())
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -437,7 +437,7 @@ class HadoopJobRunner(MRJobRunner):
             if not step_info['counters']:
                 log.info('Attempting to read counters from history log')
                 history = self._interpret_history_log(step_info)
-                if history is None:
+                if history:
                     step_info['counters'] = history['counters']
 
             self._steps_info.append(step_info)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -90,6 +90,10 @@ _HADOOP_STDOUT_RE = re.compile(br'^packageJobJar: ')
 # the one thing Hadoop streaming prints to stderr not in log format
 _HADOOP_NON_LOG_LINE_RE = re.compile(r'^Streaming Command Failed!')
 
+# where YARN stores history logs, etc. on HDFS by default
+_DEFAULT_YARN_HDFS_LOG_DIR = 'hdfs:///tmp/hadoop-yarn/staging'
+
+
 
 def fully_qualify_hdfs_path(path):
     """If path isn't an ``hdfs://`` URL, turn it into one."""
@@ -310,6 +314,8 @@ class HadoopJobRunner(MRJobRunner):
             yarn_log_dir = os.environ.get('YARN_LOG_DIR')
             if yarn_log_dir:
                 yield yarn_log_dir
+
+            yield _DEFAULT_YARN_HDFS_LOG_DIR
 
         if output_dir:
             # Cloudera style of logging

--- a/mrjob/logs/__init__.py
+++ b/mrjob/logs/__init__.py
@@ -35,11 +35,11 @@ _find_*_logs(fs, log_dir_stream, ...): Find paths of all logs of the given
 
      This yields dictionaries with the following format:
 
-     path: path/URI of log
      application_id: (YARN application ID)
+     attempt_id: (ID of task attempt)
      container_id: (YARN container ID)
      job_id: (ID of job)
-     task_attempt_id: (ID of task attempt)
+     path: path/URI of log
      task_id: (ID of task)
 
 

--- a/mrjob/logs/__init__.py
+++ b/mrjob/logs/__init__.py
@@ -48,7 +48,7 @@ _ls_*_logs(ls, log_dir, ...): Implementation of _find_*_logs().
     Use mrjob.logs.wrap _find_logs() to use this.
 
 
-_interpret_*_logs(fs, log_paths, ...):
+_interpret_*_logs(fs, matches, ...):
 
     Once we know where our logs are, search them for counters and/or errors.
 
@@ -68,9 +68,9 @@ _interpret_*_logs(fs, log_paths, ...):
             start_line: (see above)
             num_lines: (see above)
         application_id: (YARN application ID)
+        attempt_id: (ID of task attempt)
         container_id: (YARN container ID)
         job_id: (ID of job)
-        task_attempt_id: (ID of task attempt)
         task_id: (ID of task)
     ]
 

--- a/mrjob/logs/__init__.py
+++ b/mrjob/logs/__init__.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for parsing and interpreting logs.
+
+There is one module for each kind of logs:
+
+history: high-level job history info (found in <log dir>/history/)
+step: stderr of `hadoop jar` command (so named because on EMR it appears in
+    <log dir>/steps/)
+task: stderr and syslog of individual tasks (found in <log dir>/userlogs/)
+
+
+Each of these should have methods like this:
+
+
+_ls_*_logs(fs, log_dir_stream, ...): Find paths of all logs of the given
+     type.
+
+     log_dir_stream is a list of lists of log dirs. We assume that you might
+     have multiple ways to fetch the same logs (e.g. from S3, or by SSHing to
+     nodes), so once we find a list of log dirs that works, we stop searching.
+
+     This yields dictionaries with the following format:
+
+     path: path/URI of log
+     application_id: (YARN application ID)
+     container_id: (YARN container ID)
+     job_id: (ID of job)
+     task_attempt_id: (ID of task attempt)
+     task_id: (ID of task)
+
+
+_interpret_*_logs(fs, log_paths, ...):
+
+    Once we know where our logs are, search them for counters and/or errors.
+
+    In most cases, we want to stop when we find the first error.
+
+    counters: group -> counter -> amount
+    errors: [
+        hadoop_error:  (for errors internal to Hadoop)
+            error: string representation of Java stack trace
+            path: URI of log file containing error
+            start_line: first line of <path> with error (0-indexed)
+            num_lines: # of lines containing error
+        task_error:   (for errors caused by one task)
+            error: stderr explaining error (e.g. Python traceback)
+            command: command that was run to cause this error
+            path: (see above)
+            start_line: (see above)
+            num_lines: (see above)
+        application_id: (YARN application ID)
+        container_id: (YARN container ID)
+        job_id: (ID of job)
+        task_attempt_id: (ID of task attempt)
+        task_id: (ID of task)
+    ]
+
+    This assumes there might be several sets of logs dirs to look in (e.g.
+    the log dir on S3, directories on master and slave nodes, etc.).
+
+_parse_*_log(lines):
+
+    Pull important information from a log file. This generally follows the same
+    format as _interpret_<type>_logs(), above.
+
+
+_parse_*_records(lines):
+
+    Helper method which parses low-level records out of a given log type.
+
+
+There is one module for each kind of entity we want to deal with:
+
+    counters: manipulating and printing counters
+    errors: picking the best error, error reporting
+    ids: handles parsing IDs and sorting IDs by recency
+
+Finally:
+
+    log4j: handles log4j record parsing (used by step and task syslog)
+    wrap: module for listing and catting logs in an error-free
+        way (since log parsing shouldn't kill a job).

--- a/mrjob/logs/__init__.py
+++ b/mrjob/logs/__init__.py
@@ -25,7 +25,8 @@ task: stderr and syslog of individual tasks (found in <log dir>/userlogs/)
 Each of these should have methods like this:
 
 
-_ls_*_logs(fs, log_dir_stream, ...): Find paths of all logs of the given
+
+_find_*_logs(fs, log_dir_stream, ...): Find paths of all logs of the given
      type.
 
      log_dir_stream is a list of lists of log dirs. We assume that you might
@@ -40,6 +41,11 @@ _ls_*_logs(fs, log_dir_stream, ...): Find paths of all logs of the given
      job_id: (ID of job)
      task_attempt_id: (ID of task attempt)
      task_id: (ID of task)
+
+
+_ls_*_logs(ls, log_dir, ...): Implementation of _find_*_logs().
+
+    Use mrjob.logs.wrap _find_logs() to use this.
 
 
 _interpret_*_logs(fs, log_paths, ...):
@@ -76,6 +82,8 @@ _parse_*_log(lines):
     Pull important information from a log file. This generally follows the same
     format as _interpret_<type>_logs(), above.
 
+    Log lines are always strings (see mrjob.logs.wrap._cat_log()).
+
 
 _parse_*_records(lines):
 
@@ -93,3 +101,4 @@ Finally:
     log4j: handles log4j record parsing (used by step and task syslog)
     wrap: module for listing and catting logs in an error-free
         way (since log parsing shouldn't kill a job).
+"""

--- a/mrjob/logs/counters.py
+++ b/mrjob/logs/counters.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility methods for dealing with counters (not including parsers)."""
+
+
+def _sum_counters(*counters_list):
+    """Combine many maps from group to counter to amount."""
+    result = {}
+
+    for counters in counters_list:
+        for group, counter_to_amount in counters.items():
+            for counter, amount in counter_to_amount.items():
+                result.setdefault(group, {})
+                result[group].setdefault(counter, 0)
+                result[group][counter] += amount
+
+    return result

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Code for parsing the history file, which contains counters and error
+messages for each task."""
+import re
+
+from .wrap import _ls_logs
+
+
+# what job history (e.g. counters) look like on either YARN or pre-YARN.
+# YARN uses - instead of _ to separate fields. This should work for
+# non-streaming jars as well.
+_JOB_HISTORY_RE = re.compile(
+    r'^(?P<prefix>.*?/)'
+    r'(?P<job_id>job_\d+_\d{4})'
+    r'[_-]\d+[_-]hadoop[_-]\S*$')
+
+
+def _ls_history_logs(fs, log_dir_stream, job_id=None):
+    """Yield paths/URIs of job history files, optionally filtering by *job_id*.
+
+    *log_dir_stream* is a sequence of lists of log dirs. For each list, we'll
+    look in all directories, and if we find any logs, we'll stop. (The
+    assumption is that subsequent lists of log dirs would have copies
+    of the same logs, just in a different location.
+    """
+    return _ls_logs(fs, log_dir_stream, _match_job_history_log,
+                    job_id=job_id)
+
+
+def _match_history_log(path, job_id=None):
+    """Yield paths/uris of all job history files in the given directories,
+    optionally filtering by *job_id*.
+    """
+    m = _JOB_HISTORY_RE.match(path)
+    if not m:
+        return None
+
+    if not (job_id is None or m.group('job_id') == job_id):
+        return None
+
+    return dict(job_id=m.group('job_id'))

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -118,17 +118,19 @@ def _interpret_history_log(fs, matches):
     Returns a dictionary with the keys *counters* and *errors*.
     """
     for match in matches:
-        if match['yarn']:
-            return  # not yet implemented
-
         path = match['path']
-        result = _parse_pre_yarn_history_log(_cat_log(fs, path))
 
+        if match['yarn']:
+            # not yet implemented
+            continue
+        else:
+            result = _parse_pre_yarn_history_log(_cat_log(fs, path))
+
+        # patch path, task_id, etc. into errors
         for error in result['errors']:
-            # patch in path
             if 'hadoop_error' in error:
                 error['hadoop_error']['path'] = path
-            # patch in task_id, job_id
+
             _add_implied_ids(error)
 
         return result

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -80,7 +80,7 @@ def _ls_history_logs(fs, log_dir_stream, job_id=None):
     """Yield matching files, optionally filtering by *job_id*. Yields dicts
     with the keys:
 
-    job_id: job_id in path (must match *job_id* if set
+    job_id: job_id in path (must match *job_id* if set)
     path: path/URI of log file
     yarn: true if this is a YARN log file
 

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -117,12 +117,13 @@ def _interpret_history_log(fs, matches):
 
     Returns a dictionary with the keys *counters* and *errors*.
     """
+    # we expect to go through this for loop 0 or 1 times
     for match in matches:
         path = match['path']
 
         if match['yarn']:
             # not yet implemented
-            continue
+            result = _parse_yarn_history_log(_cat_log(fs, path))
         else:
             result = _parse_pre_yarn_history_log(_cat_log(fs, path))
 
@@ -138,10 +139,13 @@ def _interpret_history_log(fs, matches):
     return dict(counters={}, errors=[])
 
 
+def _parse_yarn_history_log(lines):
+    """Collect useful info from a YARN history file."""
+    raise NotImplementedError
+
+
 def _parse_pre_yarn_history_log(lines):
-    """Collect useful info from a pre-YARN history file. Expects a
-    sequence of ``(record_type, {record})`` (see
-    :py:func:`_parse_pre_yarn_history_records`).
+    """Collect useful info from a pre-YARN history file.
 
     This returns a dictionary with the following keys:
 

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -15,28 +15,79 @@
 """Code for parsing the history file, which contains counters and error
 messages for each task."""
 import re
+from logging import getLogger
 
+from .counters import _sum_counters
+from .ids import _add_implied_ids
 from .wrap import _ls_logs
+from .wrap import _cat_log
+
+
+log = getLogger(__name__)
 
 
 # what job history (e.g. counters) look like on either YARN or pre-YARN.
 # YARN uses - instead of _ to separate fields. This should work for
 # non-streaming jars as well.
-_JOB_HISTORY_RE = re.compile(
+_HISTORY_LOG_PATH_RE = re.compile(
     r'^(?P<prefix>.*?/)'
     r'(?P<job_id>job_\d+_\d{4})'
-    r'[_-]\d+[_-]hadoop[_-]\S*$')
+    r'[_-]\d+[_-]hadoop[_-]\S*?'
+    r'(?P<yarn_ext>\.jhist)?\S*$')
+
+# escape sequence in pre-YARN history file. Characters inside COUNTERS
+# fields are double escaped
+_PRE_YARN_HISTORY_ESCAPE_RE = re.compile(r'\\(.)')
+
+# capture key-value pairs like JOBNAME="streamjob8025762403845318969\.jar"
+_PRE_YARN_HISTORY_KEY_PAIR = re.compile(
+    r'(?P<key>\w+)="(?P<escaped_value>(\\.|[^"\\])*)"', re.MULTILINE)
+
+# an entire line in a pre-YARN history file
+_PRE_YARN_HISTORY_RECORD = re.compile(
+    r'^(?P<type>\w+)'
+    r'(?P<key_pairs>( ' + _PRE_YARN_HISTORY_KEY_PAIR.pattern + ')*)'
+    r' \.$', re.MULTILINE)
+
+# capture one group of counters
+# this looks like: {(group_id)(group_name)[counter][counter]...}
+_PRE_YARN_COUNTER_GROUP_RE = re.compile(
+    r'{\('
+    r'(?P<group_id>(\\.|[^)}\\])*)'
+    r'\)\('
+    r'(?P<group_name>(\\.|[^)}\\])*)'
+    r'\)'
+    r'(?P<counter_list_str>\[(\\.|[^}\\])*\])'
+    r'}')
+
+# parse a single counter from a counter group (counter_list_str above)
+# this looks like: [(counter_id)(counter_name)(amount)]
+_PRE_YARN_COUNTER_RE = re.compile(
+    r'\[\('
+    r'(?P<counter_id>(\\.|[^)\\])*)'
+    r'\)\('
+    r'(?P<counter_name>(\\.|[^)\\])*)'
+    r'\)\('
+    r'(?P<amount>\d+)'
+    r'\)\]')
+
+
 
 
 def _ls_history_logs(fs, log_dir_stream, job_id=None):
-    """Yield paths/URIs of job history files, optionally filtering by *job_id*.
+    """Yield matching files, optionally filtering by *job_id*. Yields dicts
+    with the keys:
+
+    job_id: job_id in path (must match *job_id* if set
+    path: path/URI of log file
+    yarn: true if this is a YARN log file
 
     *log_dir_stream* is a sequence of lists of log dirs. For each list, we'll
     look in all directories, and if we find any logs, we'll stop. (The
     assumption is that subsequent lists of log dirs would have copies
     of the same logs, just in a different location.
     """
-    return _ls_logs(fs, log_dir_stream, _match_job_history_log,
+    return _ls_logs(fs, log_dir_stream, _match_history_log,
                     job_id=job_id)
 
 
@@ -44,11 +95,191 @@ def _match_history_log(path, job_id=None):
     """Yield paths/uris of all job history files in the given directories,
     optionally filtering by *job_id*.
     """
-    m = _JOB_HISTORY_RE.match(path)
+    m = _HISTORY_LOG_PATH_RE.match(path)
     if not m:
         return None
 
     if not (job_id is None or m.group('job_id') == job_id):
         return None
 
-    return dict(job_id=m.group('job_id'))
+    return dict(job_id=m.group('job_id'), yarn=bool(m.group('yarn_ext')))
+
+
+def _interpret_history_log(fs, matches):
+    """Extract counters and errors from history log.
+
+    Matches is a list of dicts with the keys *job_id* and *yarn*
+    (see :py:func:`_ls_history_logs()`)
+
+    We expect *matches* to contain at most one match; further matches
+    will be ignored.
+
+    Returns a dictionary with the keys *counters* and *errors*.
+    """
+    for match in matches:
+        if match['yarn']:
+            return  # not yet implemented
+
+        path = match['path']
+        result = _parse_pre_yarn_history_log(_cat_log(fs, path))
+
+        for error in result['errors']:
+            # patch in path
+            if 'hadoop_error' in error:
+                error['hadoop_error']['path'] = path
+            # patch in task_id, job_id
+            _add_implied_ids(error)
+
+        return result
+
+    return dict(counters={}, errors=[])
+
+
+def _parse_pre_yarn_history_log(lines):
+    """Collect useful info from a pre-YARN history file. Expects a
+    sequence of ``(record_type, {record})`` (see
+    :py:func:`_parse_pre_yarn_history_records`).
+
+    This returns a dictionary with the following keys:
+
+    counters: map from group to counter to amount. If job failed, we sum
+        counters for succesful tasks
+    errors: a list of dictionaries with the keys:
+        hadoop_error:
+            error: lines of error, as as string
+            start_line: first line of log containing the error (0-indexed)
+            num_lines: # of lines of log containing the error
+        task_attempt_id: ID of task attempt with this error
+    """
+    # tantalizingly, STATE_STRING contains the split (URI and line numbers)
+    # read, but only for successful tasks, which doesn't help with debugging
+
+    task_id_to_counters = {}  # used for successful tasks in failed jobs
+    job_counters = None
+    errors = []
+
+    for record in _parse_pre_yarn_history_records(lines):
+        fields = record['fields']
+
+        # if job is successful, we get counters for the entire job at the end
+        if record['type'] == 'Job' and 'COUNTERS' in fields:
+            job_counters = _parse_pre_yarn_counters(fields['COUNTERS'])
+
+        # otherwise, compile counters for each successful task
+        #
+        # Note: this apparently records a higher total than the task tracker
+        # (possibly some tasks are duplicates?). Couldn't figure out the logic
+        # behind this while looking at the history file
+        elif (record['type'] == 'Task' and
+              'COUNTERS' in fields and 'TASKID' in fields):
+            task_id = fields['TASKID']
+            counters = _parse_pre_yarn_counters(fields['COUNTERS'])
+
+            task_id_to_counters[task_id] = counters
+
+        elif (record['type'] in ('MapAttempt', 'ReduceAttempt') and
+              'TASK_ATTEMPT_ID' in fields and 'ERROR' in fields):
+            errors.append(dict(
+                java_error=dict(
+                    error=fields['ERROR'],
+                    start_line=record['start_line'],
+                    num_lines=record['num_lines']),
+                task_attempt_id=fields['TASK_ATTEMPT_ID']))
+
+    # if job failed, patch together counters from successful tasks
+    if job_counters is None:
+        job_counters = _sum_counters(*task_id_to_counters.values())
+
+    return dict(counters=job_counters,
+                errors=errors)
+
+
+def _parse_pre_yarn_history_records(lines):
+    """Yield records from the given sequence of lines. For example,
+    a line like this:
+
+    Task TASKID="task_201512311928_0001_m_000003" \
+    TASK_TYPE="MAP" START_TIME="1451590341378" \
+    SPLITS="/default-rack/172\.31\.22\.226" .
+
+    into a record like:
+
+    {
+        'fields': {'TASKID': 'task_201512311928_0001_m_00000',
+                   'TASK_TYPE': 'MAP',
+                   'START_TIME': '1451590341378',
+                   'SPLITS': '/default-rack/172.31.22.226'},
+        'type': 'Task',
+        'line_num': 0,
+        'num_lines': 1,
+    }
+
+    This handles unescaping values, but doesn't do the further
+    unescaping needed to process counters. It can also handle multi-line
+    records (e.g. for Java stack traces).
+    """
+    def yield_record_strings(lines):
+        record_lines = []
+        start_line = 0
+
+        for line_num, line in enumerate(lines):
+            record_lines.append(line)
+            if line.endswith(' .\n'):
+                yield start_line, len(record_lines), ''.join(record_lines)
+                record_lines = []
+                start_line = line_num + 1
+
+    for start_line, num_lines, record_str in yield_record_strings(lines):
+        record_match = _PRE_YARN_HISTORY_RECORD.match(record_str)
+
+        if not record_match:
+            continue
+
+        record_type = record_match.group('type')
+        key_pairs = record_match.group('key_pairs')
+
+        fields = {}
+        for m in _PRE_YARN_HISTORY_KEY_PAIR.finditer(key_pairs):
+            key = m.group('key')
+            value = _pre_yarn_history_unescape(m.group('escaped_value'))
+
+            fields[key] = value
+
+        yield dict(
+            fields=fields,
+            num_lines=num_lines,
+            start_line=start_line,
+            type=record_type,
+        )
+
+
+def _parse_pre_yarn_counters(counters_str):
+    """Parse a COUNTERS field from a pre-YARN history file.
+
+    Returns a map from group to counter to amount.
+    """
+    counters = {}
+
+    for group_match in _PRE_YARN_COUNTER_GROUP_RE.finditer(counters_str):
+        group_name = _pre_yarn_history_unescape(
+            group_match.group('group_name'))
+
+        group_counters = {}
+
+        for counter_match in _PRE_YARN_COUNTER_RE.finditer(
+                group_match.group('counter_list_str')):
+
+            counter_name = _pre_yarn_history_unescape(
+                counter_match.group('counter_name'))
+            amount = int(counter_match.group('amount'))
+
+            group_counters[counter_name] = amount
+
+        counters[group_name] = group_counters
+
+    return counters
+
+
+def _pre_yarn_history_unescape(s):
+    """Un-escape string from a pre-YARN history file."""
+    return _PRE_YARN_HISTORY_ESCAPE_RE.sub(r'\1', s)

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -32,8 +32,7 @@ log = getLogger(__name__)
 _HISTORY_LOG_PATH_RE = re.compile(
     r'^(?P<prefix>.*?/)'
     r'(?P<job_id>job_\d+_\d{4})'
-    r'[_-]\d+[_-]hadoop[_-]\S*?'
-    r'(?P<yarn_ext>\.jhist)?\S*$')
+    r'[_-]\d+[_-]hadoop[_-](?P<suffix>\S*)$')
 
 # escape sequence in pre-YARN history file. Characters inside COUNTERS
 # fields are double escaped
@@ -102,7 +101,9 @@ def _match_history_log(path, job_id=None):
     if not (job_id is None or m.group('job_id') == job_id):
         return None
 
-    return dict(job_id=m.group('job_id'), yarn=bool(m.group('yarn_ext')))
+    # TODO: couldn't manage to include .jhist in regex; an optional
+    # group has less priority than a non-greedy match, apparently
+    return dict(job_id=m.group('job_id'), yarn='.jhist' in m.group('suffix'))
 
 
 def _interpret_history_log(fs, matches):

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -153,7 +153,7 @@ def _parse_yarn_history_log(lines):
             start_line: first line of log containing the error (0-indexed)
             num_lines: # of lines of log containing the error
         task_id: ID of task with this error
-        task_attempt_id: ID of task attempt with this error
+        attempt_id: ID of task attempt with this error
     """
     task_to_counters = {}  # used for successful tasks in failed jobs
     job_counters = None
@@ -283,8 +283,7 @@ def _parse_pre_yarn_history_log(lines):
                     error=fields['ERROR'],
                     start_line=record['start_line'],
                     num_lines=record['num_lines']),
-                # TODO: this should be just attempt_id
-                task_attempt_id=fields['TASK_ATTEMPT_ID']))
+                attempt_id=fields['TASK_ATTEMPT_ID']))
 
     # if job failed, patch together counters from successful tasks
     if job_counters is None:

--- a/mrjob/logs/ids.py
+++ b/mrjob/logs/ids.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility for handling IDs, especially sorting by recency."""
+
+
+def _sort_by_recency(ds):
+    """Sort the given list/sequence of dicts containing IDs so that the
+    most recent ones come first (e.g. to find the best error, or the best
+    log file to look for an error in).
+    """
+    return _sort_by_recency(ds, key=_time_sort_key, reverse=True)
+
+
+def _time_sort_key(d):
+    """Sort key to sort the given dictionaries containing IDs roughly by time
+    (earliest first).
+
+    We consider higher attempt_nums "later" than higher task_nums (of the
+    same step type) because fatal errors usually occur on the final
+    attempt of a task.
+    """
+    # break ID like
+    # {attempt,task,job}_201601081945_0005[_m[_000005[_0]]] into
+    # its component parts
+    attempt_parts = (d.get('attempt_id') or d.get('task_id')
+                     or d.get('job_id') or '').split('_')
+
+    timestamp_and_step = '_'.join(attempt_parts[1:3])
+    task_type = '_'.join(attempt_parts[3:4])
+    task_num = '_'.join(attempt_parts[4:5])
+    attempt_num = '_'.join(attempt_parts[5:6])
+
+    # numbers are 0-padded, so no need to convert anything to int
+    # also, 'm' (task_type in attempt_id) sorts before 'r', which is
+    # what we want
+    return (
+        d.get('application_id') or '',
+        d.get('container_id') or '',
+        timestamp_and_step,
+        task_type,
+        attempt_num,
+        task_num)
+
+
+def _add_implied_ids(d):
+    """If *d* (a dictionary) has *attempt_id* but not *task_id* add it.
+
+    Similarly, if *d* has *task_id* but not *job_id*, add it.
+    """
+    if d.get('attempt_id') and not d.get('task_id'):
+        d['task_id'] = _attempt_id_to_task_id(
+            d['attempt_id'])
+
+    if d.get('task_id') and not d.get('job_id'):
+        d['job_id'] = _task_id_to_job_id(d['task_id'])
+
+    # TODO: can we do anything with application_id or container_id?
+
+
+def _attempt_id_to_task_id(attempt_id):
+    """Convert e.g. ``'attempt_201601081945_0005_m_000005_0'``
+    to ``'task_201601081945_0005_m_000005'``"""
+    return 'task_' + '_'.join(attempt_id.split('_')[1:5])
+
+
+def _task_id_to_job_id(task_id):
+    """Convert e.g. ``'task_201601081945_0005_m_000005'``
+    to ``'job_201601081945_0005'``."""
+    return 'job_' + '_'.join(task_id.split('_')[1:3])

--- a/mrjob/logs/ls.py
+++ b/mrjob/logs/ls.py
@@ -425,8 +425,6 @@ def _ls_job_history_logs(fs, log_dirs, job_id=None):
     """Yield paths/uris of all job history files in the given directories,
     optionally filtering by *job_id*.
     """
-    # usually, there should only be one, so sorting doesn't really matter
-
     if isinstance(log_dirs, str):
         raise TypeError
 

--- a/mrjob/logs/ls.py
+++ b/mrjob/logs/ls.py
@@ -387,8 +387,9 @@ def _ls_syslogs_helper(fs, log_dirs, key_func):
     if isinstance(log_dirs, str):
         raise TypeError
 
+    path_to_sort_key = {}
+
     for log_dir in log_dirs:
-        path_to_sort_key = {}
 
         for path in _ls_logs(fs, log_dir):
             sort_key = key_func(path)
@@ -396,11 +397,8 @@ def _ls_syslogs_helper(fs, log_dirs, key_func):
             if sort_key:
                 path_to_sort_key[path] = sort_key
 
-        if path_to_sort_key:
-            return sorted(path_to_sort_key, key=lambda k: path_to_sort_key[k],
-                          reverse=True)
-
-    return []
+    return sorted(path_to_sort_key, key=lambda k: path_to_sort_key[k],
+                  reverse=True)
 
 
 def _stderr_for_syslog(path):

--- a/mrjob/logs/ls.py
+++ b/mrjob/logs/ls.py
@@ -420,11 +420,11 @@ def _stderr_for_syslog(path):
     return posixpath.join(stem, 'stderr' + file_ext(filename))
 
 
-def _ls_job_history_files(fs, log_dirs, job_id=None):
+def _ls_job_history_logs(fs, log_dirs, job_id=None):
     """Yield paths/uris of all job history files in the given directories,
     optionally filtering by *job_id*.
     """
-    # usually, there should only be one
+    # usually, there should only be one, so sorting doesn't really matter
 
     if isinstance(log_dirs, str):
         raise TypeError

--- a/mrjob/logs/ls.py
+++ b/mrjob/logs/ls.py
@@ -306,11 +306,12 @@ _PRE_YARN_TASK_SYSLOG_RE = re.compile(
     r'syslog(?P<suffix>\.\w+)?')
 
 # what job history (e.g. counters) look like on either YARN or pre-YARN.
-# YARN uses - instead of _ to separate fields, and has a bunch of stuff
-# after .jar
+# YARN uses - instead of _ to separate fields. This should work for
+# non-streaming jars as well.
 _JOB_HISTORY_RE = re.compile(
-    r'^(?P<job_id>job_\d+_\d{4})'
-    r'[_-]\d+[_-]hadoop[_-]streamjob\d+\.jar\S*')
+    r'^(?P<prefix>.*?/)'
+    r'(?P<job_id>job_\d+_\d{4})'
+    r'[_-]\d+[_-]hadoop[_-]\S*$')
 
 def _ls_logs(fs, log_dir):
     """ls() the given directory, but log a warning on IOError."""

--- a/mrjob/logs/parse.py
+++ b/mrjob/logs/parse.py
@@ -14,6 +14,8 @@
 import re
 from logging import getLogger
 
+from mrjob.logs.util import _sum_counters
+
 
 # log line format output by YARN hadoop jar command
 _HADOOP_LOG_LINE_RE = re.compile(
@@ -506,17 +508,3 @@ def _parse_pre_yarn_counters(counters_str):
         counters[group_name] = group_counters
 
     return counters
-
-
-def _sum_counters(*counters_list):
-    """Combine many maps from group to counter to amount."""
-    result = {}
-
-    for counters in counters_list:
-        for group, counter_to_amount in counters.items():
-            for counter, amount in counter_to_amount.items():
-                result.setdefault(group, {})
-                result[group].setdefault(counter, 0)
-                result[group][counter] += amount
-
-    return result

--- a/mrjob/logs/parse.py
+++ b/mrjob/logs/parse.py
@@ -77,11 +77,6 @@ _PYTHON_EXCEPTION_HEADER_RE = re.compile(
 # is part of the traceback
 _PYTHON_TRACEBACK_LINE_RE = re.compile(r'^\s+')
 
-# TODO: move to mrjob.hadoop
-_NON_HADOOP_LOG_LINE_RE = re.compile(
-    r'^(packageJobJar: |Streaming Command Failed!)')
-
-
 log = getLogger(__name__)
 
 

--- a/mrjob/logs/parse.py
+++ b/mrjob/logs/parse.py
@@ -86,7 +86,7 @@ log = getLogger(__name__)
 
 
 def _parse_hadoop_log_lines(lines):
-    """Parse lines from a hadoop log into log4j (I think?) records.
+    """Parse lines from a hadoop log into log4j records.
 
     Yield dictionaries with the following keys:
     timestamp -- unparsed timestamp, e.g. '15/12/07 20:49:28',

--- a/mrjob/logs/util.py
+++ b/mrjob/logs/util.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility methods for parsing and interpreting logs."""
+
+
+def _sum_counters(*counters_list):
+    """Combine many maps from group to counter to amount."""
+    result = {}
+
+    for counters in counters_list:
+        for group, counter_to_amount in counters.items():
+            for counter, amount in counter_to_amount.items():
+                result.setdefault(group, {})
+                result[group].setdefault(counter, 0)
+                result[group][counter] += amount
+
+    return result

--- a/mrjob/logs/wrap.py
+++ b/mrjob/logs/wrap.py
@@ -15,7 +15,20 @@
 """Utilities for ls()ing and cat()ing logs without raising exceptions."""
 from logging import getLogger
 
+from mrjob.py2 import to_string
+
+
 log = getLogger(__name__)
+
+
+def _cat_log(fs, path):
+    """fs.cat() the given log, converting lines to strings, and logging
+    errors."""
+    try:
+        for line in fs.cat(path):
+            yield to_string(line)
+    except IOError as e:
+        log.warning("couldn't cat() %s: %r" % (path, e))
 
 
 def _ls_logs(fs, log_dir_stream, matcher, **kwargs):

--- a/mrjob/logs/wrap.py
+++ b/mrjob/logs/wrap.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for ls()ing and cat()ing logs without raising exceptions."""
+from logging import getLogger
+
+log = getLogger(__name__)
+
+
+def _ls_logs(fs, log_dir_stream, matcher, **kwargs):
+    """Yield logs matching *matcher*. Used to implement _ls_*_logs() functions.
+
+    This yields dictionaries with ``path`` set to matching log path, and
+    other information (e.g. corresponding job_id) returned by *matcher*
+
+    *fs* is a :py:class:`mrjob.fs.Filesystem`
+
+    *log_dir_stream* is a sequence of lists of log dirs. The idea is that
+    there may be copies of the same logs in multiple places (e.g.
+    on S3 and by SSHing into nodes) and we want to list them all without
+    finding duplicate copies. This function will go through the lists of
+    log dirs in turn, stopping if it finds any matches from a list.
+
+    *matcher* is a function that takes (log_path, **kwargs)
+    and returns either None (no match) or a dictionary with information
+    about the path (e.g. the corresponding job_id). It's okay to return
+    an empty dict.
+    """
+    # wrapper for _fs_ls() that turns IOErrors into warnings
+    def _fs_ls(path):
+        try:
+            for path in fs.ls(log_dir):
+                yield path
+        except IOError as e:
+            log.warning("couldn't ls() %s: %r" % (log_dir, e))
+
+    for log_dirs in log_dir_stream:
+        if isinstance(log_dirs, str):
+            raise TypeError
+
+        matched = False
+
+        for log_dir in log_dirs:
+            for path in _fs_ls(log_dir):
+                m = matcher(path, **kwargs)
+                if m is not None:
+                    matched = True
+                    m['path'] = path
+                    yield m
+
+        if matched:
+            return

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -65,11 +65,9 @@ Use the ``StringIO`` from this module to deal with strings (it's
 Please use ``%`` for format strings and not ``format()``, which is much more
 picky about mixing unicode and bytes.
 
-This module provides a ``string_types`` tuple (name from the ``six`` library)
-so you can check if something is a string.
+We don't provide a ``unicode`` type:
 
-We don't provide a ``unicode`` constant:
-
+- Use ``isinstance(..., string_types)`` to check if something is a string
 - Use ``not isinstance(..., bytes)`` to check if a string is Unicode
 - To convert ``bytes`` to ``unicode``, use ``.decode('utf_8')`.
 - Python 3.3+ has ``u''`` literals; please use sparingly

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -14,10 +14,14 @@
 # limitations under the License.
 
 from mrjob.logs.history import _match_history_log
+from mrjob.logs.history import _parse_pre_yarn_history_log
+from mrjob.logs.history import _parse_pre_yarn_history_records
+from mrjob.logs.history import _parse_pre_yarn_counters
 
 from tests.py2 import TestCase
 
 
+# path matching
 class MatchHistoryLogTestCase(TestCase):
 
     def test_empty(self):
@@ -86,3 +90,269 @@ class MatchHistoryLogTestCase(TestCase):
         self.assertEqual(
             _match_history_log(history_path, job_id='job_1451592123989_0002'),
             None)
+
+
+# TODO: test _interpret_history_log()
+
+
+
+
+# log parsing
+class ParsePreYARNHistoryLogTestCase(TestCase):
+
+    def test_empty(self):
+        self.assertEqual(
+            _parse_pre_yarn_history_log([]),
+            dict(counters={}, errors=[]))
+
+    def test_job_counters(self):
+        lines = [
+            'Job JOBID="job_201106092314_0003" FINISH_TIME="1307662284564"'
+            ' JOB_STATUS="SUCCESS" FINISHED_MAPS="2" FINISHED_REDUCES="1"'
+            ' FAILED_MAPS="0" FAILED_REDUCES="0" COUNTERS="'
+            '{(org\.apache\.hadoop\.mapred\.JobInProgress$Counter)'
+            '(Job Counters )'
+            '[(TOTAL_LAUNCHED_REDUCES)(Launched reduce tasks)(1)]}" .\n'
+        ]
+
+        self.assertEqual(
+            _parse_pre_yarn_history_log(lines),
+            dict(counters={'Job Counters ': {'Launched reduce tasks': 1}},
+                 errors=[]))
+
+    def test_task_counters(self):
+        lines = [
+            'Task TASKID="task_201601081945_0005_m_000005" TASK_TYPE="SETUP"'
+            ' TASK_STATUS="SUCCESS" FINISH_TIME="1452283612363"'
+            ' COUNTERS="{(FileSystemCounters)(FileSystemCounters)'
+            '[(FILE_BYTES_WRITTEN)(FILE_BYTES_WRITTEN)(27785)]}" .\n',
+            'Task TASKID="task_201601081945_0005_m_000000" TASK_TYPE="MAP"'
+            ' TASK_STATUS="SUCCESS" FINISH_TIME="1452283651437"'
+            ' COUNTERS="{'
+            '(org\.apache\.hadoop\.mapred\.FileOutputFormat$Counter)'
+            '(File Output Format Counters )'
+            '[(BYTES_WRITTEN)(Bytes Written)(0)]}'
+            '{(FileSystemCounters)(FileSystemCounters)'
+            '[(FILE_BYTES_WRITTEN)(FILE_BYTES_WRITTEN)(27785)]'
+            '[(HDFS_BYTES_READ)(HDFS_BYTES_READ)(248)]}" .\n',
+        ]
+
+        self.assertEqual(
+            _parse_pre_yarn_history_log(lines),
+            dict(
+                counters={
+                    'FileSystemCounters': {
+                        'FILE_BYTES_WRITTEN': 55570,
+                        'HDFS_BYTES_READ': 248,
+                    },
+                    'File Output Format Counters ': {
+                        'Bytes Written': 0,
+                        },
+                },
+                errors=[]))
+
+    def test_errors(self):
+        lines = [
+            'MapAttempt TASK_TYPE="MAP"'
+            ' TASKID="task_201601081945_0005_m_000001"'
+            ' TASK_ATTEMPT_ID='
+            '"task_201601081945_0005_m_00000_2"'
+            ' TASK_STATUS="FAILED"'
+            ' ERROR="java\.lang\.RuntimeException:'
+            ' PipeMapRed\.waitOutputThreads():'
+            ' subprocess failed with code 1\n',
+            '        at org\\.apache\\.hadoop\\.streaming\\.PipeMapRed'
+            '\\.waitOutputThreads(PipeMapRed\\.java:372)\n',
+            '        at org\\.apache\\.hadoop\\.streaming\\.PipeMapRed'
+            '\\.mapRedFinished(PipeMapRed\\.java:586)\n',
+            '" .\n',
+        ]
+
+        path = '/history/history.jar'
+
+        self.assertEqual(
+            _parse_pre_yarn_history_log(lines),
+            dict(
+                counters={},
+                errors=[
+                    dict(
+                        java_error=dict(
+                            error=(
+                                'java.lang.RuntimeException: PipeMapRed'
+                                '.waitOutputThreads():'
+                                ' subprocess failed with code 1\n'
+                                '        at org.apache.hadoop.streaming'
+                                '.PipeMapRed.waitOutputThreads'
+                                '(PipeMapRed.java:372)\n'
+                                '        at org.apache.hadoop.streaming'
+                                '.PipeMapRed.mapRedFinished'
+                                '(PipeMapRed.java:586)\n'),
+                            num_lines=4,
+                            start_line=0,
+                        ),
+                        task_attempt_id='task_201601081945_0005_m_00000_2',
+                    ),
+                ]))
+
+
+# edge cases in pre-YARN history record parsing
+class ParsePreYARNHistoryRecordsTestCase(TestCase):
+
+    def test_empty(self):
+        self.assertEqual(list(_parse_pre_yarn_history_records([])), [])
+
+    def test_basic(self):
+        lines = [
+            'Meta VERSION="1" .\n',
+            'Job JOBID="job_201601081945_0005" JOB_PRIORITY="NORMAL" .\n',
+        ]
+        self.assertEqual(
+            list(_parse_pre_yarn_history_records(lines)),
+            [
+                dict(
+                    fields=dict(
+                        VERSION='1'
+                    ),
+                    start_line=0,
+                    num_lines=1,
+                    type='Meta',
+                ),
+                dict(
+                    fields=dict(
+                        JOBID='job_201601081945_0005',
+                        JOB_PRIORITY='NORMAL'
+                    ),
+                    num_lines=1,
+                    start_line=1,
+                    type='Job',
+                )
+            ])
+
+    def test_unescape(self):
+        lines = [
+            'Task TASKID="task_201512311928_0001_m_000003" TASK_TYPE="MAP"'
+            ' START_TIME="1451590341378"'
+            ' SPLITS="/default-rack/172\\.31\\.22\\.226" .\n',
+        ]
+
+        self.assertEqual(
+            list(_parse_pre_yarn_history_records(lines)),
+            [
+                dict(
+                    fields=dict(
+                        TASKID='task_201512311928_0001_m_000003',
+                        TASK_TYPE='MAP',
+                        START_TIME='1451590341378',
+                        SPLITS='/default-rack/172.31.22.226',
+                    ),
+                    num_lines=1,
+                    start_line=0,
+                    type='Task',
+                ),
+            ])
+
+    def test_multiline(self):
+        lines = [
+            'MapAttempt TASK_TYPE="MAP"'
+            ' TASKID="task_201601081945_0005_m_000001"'
+            ' TASK_STATUS="FAILED"'
+            ' ERROR="java\.lang\.RuntimeException:'
+            ' PipeMapRed\.waitOutputThreads():'
+            ' subprocess failed with code 1\n',
+            '        at org\\.apache\\.hadoop\\.streaming\\.PipeMapRed'
+            '\\.waitOutputThreads(PipeMapRed\\.java:372)\n',
+            '        at org\\.apache\\.hadoop\\.streaming\\.PipeMapRed'
+            '\\.mapRedFinished(PipeMapRed\\.java:586)\n',
+            '" .\n',
+        ]
+
+        self.assertEqual(
+            list(_parse_pre_yarn_history_records(lines)),
+            [
+                dict(
+                    fields=dict(
+                        ERROR=(
+                            'java.lang.RuntimeException: PipeMapRed'
+                            '.waitOutputThreads():'
+                            ' subprocess failed with code 1\n'
+                            '        at org.apache.hadoop.streaming.PipeMapRed'
+                            '.waitOutputThreads(PipeMapRed.java:372)\n'
+                            '        at org.apache.hadoop.streaming.PipeMapRed'
+                            '.mapRedFinished(PipeMapRed.java:586)\n'),
+                        TASK_TYPE='MAP',
+                        TASKID='task_201601081945_0005_m_000001',
+                        TASK_STATUS='FAILED',
+                    ),
+                    num_lines=4,
+                    start_line=0,
+                    type='MapAttempt',
+                ),
+            ])
+
+    def test_bad_records(self):
+        # should just silently ignore bad records and yield good ones
+        lines = [
+            '\n',
+            'Foo BAZ .\n',
+            'Job JOBID="job_201601081945_0005" JOB_PRIORITY="NORMAL" .\n',
+            'Job JOBID="\n',
+        ]
+
+        self.assertEqual(
+            list(_parse_pre_yarn_history_records(lines)),
+            [
+                dict(
+                    fields=dict(
+                        JOBID='job_201601081945_0005',
+                        JOB_PRIORITY='NORMAL'
+                    ),
+                    num_lines=1,
+                    start_line=2,
+                    type='Job',
+                )
+            ])
+
+
+# edge cases in pre-YARN counter parsing
+class ParsePreYARNCountersTestCase(TestCase):
+
+    def test_empty(self):
+        self.assertEqual(_parse_pre_yarn_counters(''), {})
+
+    def test_basic(self):
+        counter_str = (
+            '{(org.apache.hadoop.mapred.JobInProgress$Counter)'
+            '(Job Counters )'
+            '[(TOTAL_LAUNCHED_REDUCES)(Launched reduce tasks)(1)]'
+            '[(TOTAL_LAUNCHED_MAPS)(Launched map tasks)(2)]}'
+            '{(FileSystemCounters)(FileSystemCounters)'
+            '[(FILE_BYTES_READ)(FILE_BYTES_READ)(10547174)]}')
+
+        self.assertEqual(
+            _parse_pre_yarn_counters(counter_str), {
+                'Job Counters ': {
+                    'Launched reduce tasks': 1,
+                    'Launched map tasks': 2,
+                },
+                'FileSystemCounters': {
+                    'FILE_BYTES_READ': 10547174,
+                },
+            })
+
+    def test_escape_sequences(self):
+        counter_str = (
+            r'{(\)\(\)\(\)\})(\)\(\)\(\)\})'
+            r'[(\\)(\\)(1)]'
+            r'[(\[\])(\[\])(2)]'
+            r'[(\{\})(\{\})(3)]'
+            r'[(\(\))(\(\))(4)]}')
+
+        self.assertEqual(
+            _parse_pre_yarn_counters(counter_str), {
+                ')()()}': {
+                    '\\': 1,
+                    '[]': 2,
+                    '{}': 3,
+                    '()': 4,
+                },
+            })

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -165,6 +165,8 @@ class InterpretHistoryLogTestCase(PatcherTestCase):
         self.assertEqual(self.mock_parse_yarn_history_log.call_count, 1)
 
     def test_patch_errors(self):
+        # TODO: test inferring IDs
+
         self.mock_parse_yarn_history_log.return_value = dict(
             counters={},
             errors=[
@@ -181,8 +183,6 @@ class InterpretHistoryLogTestCase(PatcherTestCase):
                          dict(hadoop_error=dict(
                              path='/path/to/yarn-history.jhist')),
                     ]))
-
-
 
 
 # log parsing

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -97,7 +97,6 @@ class MatchHistoryLogTestCase(TestCase):
             None)
 
 
-# TODO: test _interpret_history_log()
 class InterpretHistoryLogTestCase(PatcherTestCase):
 
     def setUp(self):
@@ -166,12 +165,11 @@ class InterpretHistoryLogTestCase(PatcherTestCase):
         self.assertEqual(self.mock_parse_yarn_history_log.call_count, 1)
 
     def test_patch_errors(self):
-        # TODO: test inferring IDs
 
         self.mock_parse_yarn_history_log.return_value = dict(
             counters={},
             errors=[
-                dict(),
+                dict(attempt_id='attempt_1449525218032_0005_m_000000_0'),
                 dict(hadoop_error=dict()),
             ])
 
@@ -180,9 +178,14 @@ class InterpretHistoryLogTestCase(PatcherTestCase):
                 [dict(path='/path/to/yarn-history.jhist', yarn=True)]),
                 dict(counters={},
                      errors=[
-                         dict(),
-                         dict(hadoop_error=dict(
-                             path='/path/to/yarn-history.jhist')),
+                         dict(
+                             attempt_id=(
+                                 'attempt_1449525218032_0005_m_000000_0'),
+                             job_id='job_1449525218032_0005',
+                             task_id='task_1449525218032_0005_m_000000'),
+                         dict(
+                             hadoop_error=dict(
+                                 path='/path/to/yarn-history.jhist')),
                     ]))
 
 

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -31,7 +31,7 @@ class MatchHistoryLogTestCase(TestCase):
 
         self.assertEqual(
             _match_history_log(history_path),
-            dict(job_id='job_201512311928_0001'))
+            dict(job_id='job_201512311928_0001', yarn=False))
 
         conf_path = (
             '/logs/history/done/version-1/host_1451590133273_/2015/12/31'
@@ -49,7 +49,7 @@ class MatchHistoryLogTestCase(TestCase):
 
         self.assertEqual(
             _match_history_log(history_path, job_id='job_201512311928_0001'),
-            dict(job_id='job_201512311928_0001'))
+            dict(job_id='job_201512311928_0001', yarn=False))
 
         self.assertEqual(
             _match_history_log(history_path, job_id='job_201512311928_0002'),
@@ -63,7 +63,7 @@ class MatchHistoryLogTestCase(TestCase):
 
         self.assertEqual(
             _match_history_log(history_path),
-            dict(job_id='job_1451592123989_0001'))
+            dict(job_id='job_1451592123989_0001', yarn=True))
 
         conf_path = (
             'hdfs:///tmp/hadoop-yarn/staging/history/done/2015/12/31/000000/'
@@ -81,7 +81,7 @@ class MatchHistoryLogTestCase(TestCase):
 
         self.assertEqual(
             _match_history_log(history_path, job_id='job_1451592123989_0001'),
-            dict(job_id='job_1451592123989_0001'))
+            dict(job_id='job_1451592123989_0001', yarn=True))
 
         self.assertEqual(
             _match_history_log(history_path, job_id='job_1451592123989_0002'),

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -1,0 +1,88 @@
+# -*- encoding: utf-8 -*-
+# Copyright 2015 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mrjob.logs.history import _match_history_log
+
+from tests.py2 import TestCase
+
+
+class MatchHistoryLogTestCase(TestCase):
+
+    def test_empty(self):
+        self.assertEqual(_match_history_log(''), None)
+
+    def test_pre_yarn(self):
+        history_path = (
+            '/logs/history/done/version-1/host_1451590133273_/2015/12/31'
+            '/000000/job_201512311928_0001_1451590317008_hadoop'
+            '_streamjob8025762403845318969.jar')
+
+        self.assertEqual(
+            _match_history_log(history_path),
+            dict(job_id='job_201512311928_0001'))
+
+        conf_path = (
+            '/logs/history/done/version-1/host_1451590133273_/2015/12/31'
+            '/000000/job_201512311928_0001_conf.xml')
+
+        self.assertEqual(
+            _match_history_log(conf_path),
+            None)
+
+    def test_pre_yarn_filter_by_job_id(self):
+        history_path = (
+            '/logs/history/done/version-1/host_1451590133273_/2015/12/31'
+            '/000000/job_201512311928_0001_1451590317008_hadoop'
+            '_streamjob8025762403845318969.jar')
+
+        self.assertEqual(
+            _match_history_log(history_path, job_id='job_201512311928_0001'),
+            dict(job_id='job_201512311928_0001'))
+
+        self.assertEqual(
+            _match_history_log(history_path, job_id='job_201512311928_0002'),
+            None)
+
+    def test_yarn(self):
+        history_path = (
+            'hdfs:///tmp/hadoop-yarn/staging/history/done/2015/12/31/000000/'
+            'job_1451592123989_0001-1451592605470-hadoop-QuasiMonteCarlo'
+            '-1451592786882-10-1-SUCCEEDED-default-1451592631082.jhist')
+
+        self.assertEqual(
+            _match_history_log(history_path),
+            dict(job_id='job_1451592123989_0001'))
+
+        conf_path = (
+            'hdfs:///tmp/hadoop-yarn/staging/history/done/2015/12/31/000000/'
+            'job_1451592123989_0001_conf.xml')
+
+        self.assertEqual(
+            _match_history_log(conf_path),
+            None)
+
+    def test_yarn_filter_by_job_id(self):
+        history_path = (
+            'hdfs:///tmp/hadoop-yarn/staging/history/done/2015/12/31/000000/'
+            'job_1451592123989_0001-1451592605470-hadoop-QuasiMonteCarlo'
+            '-1451592786882-10-1-SUCCEEDED-default-1451592631082.jhist')
+
+        self.assertEqual(
+            _match_history_log(history_path, job_id='job_1451592123989_0001'),
+            dict(job_id='job_1451592123989_0001'))
+
+        self.assertEqual(
+            _match_history_log(history_path, job_id='job_1451592123989_0002'),
+            None)

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -244,7 +244,7 @@ class ParsePreYARNHistoryLogTestCase(TestCase):
             'MapAttempt TASK_TYPE="MAP"'
             ' TASKID="task_201601081945_0005_m_000001"'
             ' TASK_ATTEMPT_ID='
-            '"task_201601081945_0005_m_00000_2"'
+            '"attempt_201601081945_0005_m_00000_2"'
             ' TASK_STATUS="FAILED"'
             ' ERROR="java\.lang\.RuntimeException:'
             ' PipeMapRed\.waitOutputThreads():'
@@ -278,7 +278,7 @@ class ParsePreYARNHistoryLogTestCase(TestCase):
                             num_lines=4,
                             start_line=0,
                         ),
-                        task_attempt_id='task_201601081945_0005_m_00000_2',
+                        attempt_id='attempt_201601081945_0005_m_00000_2',
                     ),
                 ]))
 

--- a/tests/logs/test_ls.py
+++ b/tests/logs/test_ls.py
@@ -273,27 +273,8 @@ class LsYarnTaskSyslogsTestCase(LsTaskSyslogsTestCase):
              '/log/dir/userlogs/application_1450486922681_0005'
              '/container_1450486922681_0005_01_000003/syslog'])
 
-    def test_read_logs_from_at_most_one_dir(self):
-        self.mock_paths = [
-            '/log/dir/userlogs/application_1450486922681_0004'
-            '/container_1450486922681_0005_01_000003/syslog',
-        ]
-
-        self.assertEqual(
-            _ls_yarn_task_syslogs(
-                self.mock_fs, ['hdfs:///output/_logs', '/log/dir']),
-            ['/log/dir/userlogs/application_1450486922681_0004'
-             '/container_1450486922681_0005_01_000003/syslog'])
-
-        self.mock_paths.append(
-            'hdfs:///output/_logs/userlogs/application_1450486922681_0004'
-            '/container_1450486922681_0005_01_000003/syslog')
-
-        self.assertEqual(
-            _ls_yarn_task_syslogs(
-                self.mock_fs, ['hdfs:///output/_logs', '/log/dir']),
-            ['hdfs:///output/_logs/userlogs/application_1450486922681_0004'
-             '/container_1450486922681_0005_01_000003/syslog'])
+    # reading from multiple dirs is handled by code shared with
+    # _ls_pre_yarn_task_syslogs(), and thus is tested below
 
 
 class LsPreYarnTaskSyslogsTestCase(LsTaskSyslogsTestCase):
@@ -330,5 +311,20 @@ class LsPreYarnTaskSyslogsTestCase(LsTaskSyslogsTestCase):
                 job_id='job_201512232143_0006'),
             ['/userlogs/attempt_201512232143_0006_m_000000_0/syslog'])
 
-    # subdirs and reading from at most one subdir are handled by code
-    # shared with _ls_yarn_task_syslogs(), and thus are tested above
+    def test_read_logs_from_multiple_dirs(self):
+        self.mock_paths = [
+            'ssh://node1/logs/attempt_201512232143_0008_m_000000_0/syslog',
+            'ssh://node2/logs/attempt_201512232143_0008_r_000000_0/syslog',
+            'ssh://node1/etc/sys-stuff',
+        ]
+
+        self.assertEqual(
+            _ls_pre_yarn_task_syslogs(
+                self.mock_fs,
+                ['ssh://node1/logs', 'ssh://node2/logs']),
+            ['ssh://node2/logs/attempt_201512232143_0008_r_000000_0/syslog',
+             'ssh://node1/logs/attempt_201512232143_0008_m_000000_0/syslog',])
+
+
+    # subdirs are handled by code shared with _ls_yarn_task_syslogs(), and
+    # thus are tested above

--- a/tests/logs/test_ls.py
+++ b/tests/logs/test_ls.py
@@ -19,6 +19,7 @@ from mrjob.logs.ls import _PRE_YARN_TASK_SYSLOG_RE
 from mrjob.logs.ls import _TASK_LOG_PATH_RE
 from mrjob.logs.ls import _YARN_TASK_SYSLOG_RE
 from mrjob.logs.ls import _stderr_for_syslog
+from mrjob.logs.ls import _ls_job_history_logs
 from mrjob.logs.ls import _ls_logs
 from mrjob.logs.ls import _ls_pre_yarn_task_syslogs
 from mrjob.logs.ls import _ls_yarn_task_syslogs
@@ -209,10 +210,10 @@ class LsLogsTestCase(TestCase):
             self.assertIn("couldn't ls() /path/to/logs", stderr.getvalue())
 
 
-class LsTaskSyslogsTestCase(PatcherTestCase):
+class MockLsLogsTestCase(PatcherTestCase):
 
     def setUp(self):
-        super(LsTaskSyslogsTestCase, self).setUp()
+        super(MockLsLogsTestCase, self).setUp()
 
         self.mock_fs = 'MOCK_FS'
         self.mock_paths = []
@@ -226,7 +227,7 @@ class LsTaskSyslogsTestCase(PatcherTestCase):
         self.start(patch('mrjob.logs.ls._ls_logs', mock_ls_logs))
 
 
-class LsYarnTaskSyslogsTestCase(LsTaskSyslogsTestCase):
+class LsYarnTaskSyslogsTestCase(MockLsLogsTestCase):
 
     def test_no_log_dirs(self):
         self.assertEqual(_ls_yarn_task_syslogs(self.mock_fs, []), [])
@@ -277,7 +278,7 @@ class LsYarnTaskSyslogsTestCase(LsTaskSyslogsTestCase):
     # _ls_pre_yarn_task_syslogs(), and thus is tested below
 
 
-class LsPreYarnTaskSyslogsTestCase(LsTaskSyslogsTestCase):
+class LsPreYarnTaskSyslogsTestCase(MockLsLogsTestCase):
 
     def test_no_log_dirs(self):
         self.assertEqual(_ls_pre_yarn_task_syslogs(self.mock_fs, []), [])
@@ -328,3 +329,11 @@ class LsPreYarnTaskSyslogsTestCase(LsTaskSyslogsTestCase):
 
     # subdirs are handled by code shared with _ls_yarn_task_syslogs(), and
     # thus are tested above
+
+
+class LsJobHistoryLogs(MockLsLogsTestCase):
+
+    def test_no_log_dirs(self):
+        self.assertEqual(list(_ls_job_history_logs(self.mock_fs, [])), [])
+
+    # TODO: non-empty tests

--- a/tests/logs/test_wrap.py
+++ b/tests/logs/test_wrap.py
@@ -1,0 +1,156 @@
+# -*- encoding: utf-8 -*-
+# Copyright 2015 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mrjob.logs.wrap import _ls_logs
+from mrjob.py2 import StringIO
+from mrjob.util import log_to_stream
+
+from tests.py2 import Mock
+from tests.py2 import TestCase
+from tests.quiet import no_handlers_for_logger
+
+
+class LsLogsTestCase(TestCase):
+
+    def setUp(self):
+        super(LsLogsTestCase, self).setUp()
+
+        self.mock_fs = Mock()
+        self.mock_paths = []
+
+        def mock_fs_ls(log_dir):
+            prefix = log_dir.rstrip('/') + '/'
+
+            for p in self.mock_paths:
+                if isinstance(p, Exception):
+                    raise p
+                elif p.startswith(prefix):
+                    yield p
+
+        self.mock_fs.ls = Mock(side_effect=mock_fs_ls)
+
+        # a matcher that cheerfully passes through kwargs
+        def mock_matcher(path, **kwargs):
+            return dict(**kwargs)
+
+        self.mock_matcher = Mock(side_effect=mock_matcher)
+
+    def _ls_logs(self, log_dir_stream, **kwargs):
+        """Call _ls_logs() with self.mock_fs and self.mock_matcher,
+        and return a list."""
+        return list(_ls_logs(
+            self.mock_fs, log_dir_stream, self.mock_matcher, **kwargs))
+
+    def test_no_log_dirs(self):
+        self.assertEqual(self._ls_logs([]), [])
+
+    def test_no_paths(self):
+        self.assertEqual(self._ls_logs([['/path/to/logs']]), [])
+
+    def test_log_dirs_cant_be_str(self):
+        self.assertRaises(TypeError, self._ls_logs, ['/path/to/logs'])
+
+    def test_paths(self):
+        self.mock_paths = [
+            '/path/to/logs/oak',
+            '/path/to/logs/pine',
+            '/path/to/logs/redwood',
+        ]
+
+        self.assertEqual(self._ls_logs([['/path/to/logs']]),
+                         [dict(path='/path/to/logs/oak'),
+                          dict(path='/path/to/logs/pine'),
+                          dict(path='/path/to/logs/redwood')])
+
+    def test_multiple_log_dirs(self):
+        self.mock_paths = [
+            'ssh://node1/logs/syslog',
+            'ssh://node2/logs/syslog',
+        ]
+
+        self.assertEqual(
+            self._ls_logs([['ssh://node1/logs/', 'ssh://node2/logs/']]),
+            [dict(path='ssh://node1/logs/syslog'),
+             dict(path='ssh://node2/logs/syslog')])
+
+    def test_stop_after_match(self):
+        self.mock_paths = [
+            's3://bucket/logs/node1/syslog',
+            's3://bucket/logs/node2/syslog',
+            'ssh://node1/logs/syslog',
+            'ssh://node2/logs/syslog',
+        ]
+
+        self.assertEqual(
+            self._ls_logs([
+                ['s3://bucket/logs'],
+                ['ssh://node1/logs/', 'ssh://node2/logs/']]),
+            [dict(path='s3://bucket/logs/node1/syslog'),
+             dict(path='s3://bucket/logs/node2/syslog')])
+
+    def test_matcher_can_filter(self):
+        def matcher(path):
+            if path.endswith('/syslog'):
+                return {}
+            else:
+                return None
+
+        self.mock_matcher.side_effect = matcher
+
+        self.mock_paths = [
+            's3://bucket/logs/master/stderr',
+            'ssh://master/logs/stderr',
+            'ssh://master/logs/syslog',
+        ]
+
+        self.assertEqual(
+            self._ls_logs([['s3://bucket/logs'], ['ssh://master/logs/']]),
+            [dict(path='ssh://master/logs/syslog')])
+
+    def test_kwargs_passed_to_matcher(self):
+        self.mock_paths = [
+            '/path/to/logs/oak',
+            '/path/to/logs/pine',
+            '/path/to/logs/redwood',
+        ]
+
+        self.assertEqual(self._ls_logs([['/path/to/logs']], foo='bar'),
+                         [dict(path='/path/to/logs/oak', foo='bar'),
+                          dict(path='/path/to/logs/pine', foo='bar'),
+                          dict(path='/path/to/logs/redwood', foo='bar')])
+
+    def test_warn_on_io_error(self):
+        self.mock_paths = [
+            '/path/to/logs/oak',
+            IOError(),
+        ]
+
+        with no_handlers_for_logger('mrjob.logs.ls'):
+            stderr = StringIO()
+            log_to_stream('mrjob.logs.wrap', stderr)
+
+            self.assertEqual(self._ls_logs([['/path/to/logs']]),
+                             [dict(path='/path/to/logs/oak')])
+
+            self.mock_fs.ls.assert_called_once_with('/path/to/logs')
+
+            self.assertIn("couldn't ls() /path/to/logs", stderr.getvalue())
+
+    def test_raise_other_exceptions(self):
+        self.mock_paths = [
+            '/path/to/logs/oak',
+            ValueError(),
+        ]
+
+        self.assertRaises(ValueError, self._ls_logs, [['/path/to/logs']])

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -361,7 +361,8 @@ class HadoopLogDirsTestCase(SandboxedTestCase):
 
     def test_empty(self):
         self.assertEqual(list(self.runner._hadoop_log_dirs()),
-                         ['/mnt/var/log/hadoop'])
+                         ['hdfs:///tmp/hadoop-yarn/staging',
+                          '/mnt/var/log/hadoop'])
 
     def test_precedence(self):
         os.environ['HADOOP_LOG_DIR'] = '/path/to/hadoop-log-dir'
@@ -373,6 +374,7 @@ class HadoopLogDirsTestCase(SandboxedTestCase):
             list(self.runner._hadoop_log_dirs(output_dir='hdfs:///output/')),
             ['/path/to/hadoop-log-dir',
              '/path/to/yarn-log-dir',
+             'hdfs:///tmp/hadoop-yarn/staging',
              'hdfs:///output/_logs',
              '/path/to/hadoop-prefix/logs',
              '/path/to/hadoop-home/logs',
@@ -389,12 +391,13 @@ class HadoopLogDirsTestCase(SandboxedTestCase):
             ['/logs1', '/logs2'])
 
 
-    def test_need_yarn_for_yarn_log_dir(self):
+    def test_need_yarn_for_yarn_log_dir_and_hdfs_log_dir(self):
         os.environ['YARN_LOG_DIR'] = '/path/to/yarn-log-dir'
 
         self.mock_hadoop_version = '2.0.0'
         self.assertEqual(list(self.runner._hadoop_log_dirs()),
                          ['/path/to/yarn-log-dir',
+                          'hdfs:///tmp/hadoop-yarn/staging',
                           '/mnt/var/log/hadoop'])
 
         self.mock_hadoop_version = '1.0.3'


### PR DESCRIPTION
This change allows `HadoopJobRunner` to fetch counters on pre-YARN Hadoop (and YARN, if it somehow can't parse them from the Hadoop command's stderr). This fixes #1207.

This is all thanks to a partial refactor, which `mrjob/logs/__init__.py` explains and of which only `mrjob.logs.history` is completed (see  #1123). But it works, and it doesn't break anything, so going to push now, and finish the refactor next.

This change also gives us the ability to parse errors from history logs (both YARN and pre-YARN).