### PR TITLE
Replace _print_counters()

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -35,6 +35,7 @@ from mrjob.conf import combine_paths
 from mrjob.fs.composite import CompositeFilesystem
 from mrjob.fs.hadoop import HadoopFilesystem
 from mrjob.fs.local import LocalFilesystem
+from mrjob.logs.counters import _format_counters
 from mrjob.logs.counters import _pick_counters
 from mrjob.logs.errors import _format_error
 from mrjob.logs.errors import _pick_error
@@ -445,12 +446,15 @@ class HadoopJobRunner(MRJobRunner):
 
             log_interpretation['step'] = step_interpretation
 
-            if 'counters' not in step_interpretation:
-                log.info('Attempting to read counters from history log')
+            counters = _pick_counters(log_interpretation)
+            if not counters:
                 self._interpret_history_log(log_interpretation)
+                counters = _pick_counters(log_interpretation)
 
-            # just print counters for this one step
-            self._print_counters(step_nums=[step_num])
+            if counters:
+                log.info(_format_counters(counters))
+            else:
+                log.warning('No counters found')
 
             if returncode:
                 error = self._pick_error(log_interpretation)

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -18,11 +18,12 @@ import logging
 from subprocess import Popen
 from subprocess import PIPE
 
-from mrjob.sim import SimMRJobRunner
-from mrjob.sim import SimRunnerOptionStore
+from mrjob.logs.counters import _format_counters
 from mrjob.parse import find_python_traceback
 from mrjob.parse import parse_mr_job_stderr
 from mrjob.py2 import string_types
+from mrjob.sim import SimMRJobRunner
+from mrjob.sim import SimRunnerOptionStore
 from mrjob.util import cmd_line
 from mrjob.util import shlex_split
 
@@ -249,7 +250,11 @@ class LocalMRJobRunner(SimMRJobRunner):
         returncode = proc.wait()
 
         if returncode != 0:
-            self._print_counters(step_nums=[step_num])
+            # show counters before raising exception
+            counters = self._counters[step_num]
+            if counters:
+                log.info(_format_counters(counters))
+
             # try to throw a useful exception
             if tb_lines:
                 raise Exception(

--- a/mrjob/logs/counters.py
+++ b/mrjob/logs/counters.py
@@ -14,6 +14,24 @@
 # limitations under the License.
 """Utility methods for dealing with counters (not including parsers)."""
 
+
+def _format_counters(counters, indent='\t'):
+    """Convert a map from group -> counter name -> amount to a message
+    similar to that printed by the Hadoop binary, with no trailing newline.
+    """
+    num_counters = sum(len(counter_to_amount)
+                       for group, counter_to_amount in counters.items())
+    message = 'Counters: %d' % num_counters
+
+    for group, group_counters in sorted(counters.items()):
+        if group_counters:
+            message += '\n%s%s' % (indent, group)
+            for counter, amount in sorted(group_counters.items()):
+                message += '\n%s%s%s=%d' % (indent, indent, counter, amount)
+
+    return message
+
+
 def _pick_counters(log_interpretation):
     """Pick counters from a dictionary possibly containing
     step and history interpretations."""

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -231,6 +231,7 @@ class RunnerOptionStore(OptionStore):
 
             if opt in _CLEANUP_DEPRECATED_ALIASES:
                 aliased_opt = _CLEANUP_DEPRECATED_ALIASES[opt]
+                # TODO: don't do this when option value is None
                 log.warning(
                     'Deprecated %s option %s%s has been renamed to %s' % (
                         opt_key, opt, from_where, aliased_opt))
@@ -593,28 +594,6 @@ class MRJobRunner(object):
         The list contains an entry for every step of the current job.
         """
         raise NotImplementedError
-
-    # TODO: move this to mrjob.logs.counters
-    def _print_counters(self, step_nums=None):
-        """Log this run's counters in a user-friendly way.
-
-        :type step_nums: list of int
-        :param step_nums: Optional list of indexes of steps in
-                          ``self.counters()`` to filter on.
-
-        Prints step nums 1-indexed (e.g. "step 1"), but *step_nums* is
-        0-indexed (e.g. [0]).
-        """
-        for step_num, step_counters in enumerate(self.counters()):
-            if step_nums is None or step_num in step_nums:
-                log.info('Counters from step %d:' % (step_num + 1))
-                if step_counters:
-                    for group, group_counters in sorted(step_counters.items()):
-                        log.info('\t%s' % group)
-                        for counter, amount in sorted(group_counters.items()):
-                            log.info('\t\t%s=%d' % (counter, amount))
-                else:
-                    log.info('  (none found)')
 
     ### hooks for the with statement ###
 

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -25,6 +25,7 @@ from mrjob.compat import translate_jobconf
 from mrjob.compat import translate_jobconf_for_all_versions
 from mrjob.conf import combine_dicts
 from mrjob.conf import combine_local_envs
+from mrjob.logs.counters import _format_counters
 from mrjob.runner import MRJobRunner
 from mrjob.runner import RunnerOptionStore
 from mrjob.util import read_input
@@ -266,7 +267,9 @@ class SimMRJobRunner(MRJobRunner):
             self._prev_outfiles.append(output_path)
 
         self.per_step_runner_finish(step_num)
-        self._print_counters(step_nums=[step_num])
+        counters = self._counters[step_num]
+        if counters:
+            log.info(_format_counters(counters))
 
     def _run_step(self, step_num, step_type, input_path, output_path,
                   working_dir, env):

--- a/tests/logs/test_counters.py
+++ b/tests/logs/test_counters.py
@@ -1,0 +1,74 @@
+# -*- encoding: utf-8 -*-
+# Copyright 2015 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mrjob.logs.counters import _format_counters
+from mrjob.logs.step import _parse_indented_counters
+
+from tests.py2 import TestCase
+
+
+class FormatCountersTestCase(TestCase):
+
+    COUNTERS = {
+        'File System Counters': {
+            'FILE: Number of bytes read': 8,
+            'FILE: Number of bytes written': 359982,
+        },
+        'Job Counters': {
+            'Launched map tasks': 2,
+        },
+    }
+
+    def test_empty(self):
+        self.assertEqual(_format_counters({}), 'Counters: 0')
+
+    def test_basic(self):
+        self.assertEqual(
+            _format_counters(self.COUNTERS),
+            ('Counters: 3\n'
+             '\tFile System Counters\n'
+             '\t\tFILE: Number of bytes read=8\n'
+             '\t\tFILE: Number of bytes written=359982\n'
+             '\tJob Counters\n'
+             '\t\tLaunched map tasks=2'))
+
+    def test_indent(self):
+        self.assertEqual(
+            _format_counters(self.COUNTERS, indent='  '),
+            ('Counters: 3\n'
+             '  File System Counters\n'
+             '    FILE: Number of bytes read=8\n'
+             '    FILE: Number of bytes written=359982\n'
+             '  Job Counters\n'
+             '    Launched map tasks=2'))
+
+    def test_empty_group(self):
+        # counter groups should always have at least one counter
+        self.assertEqual(
+            _format_counters({
+                'File System Counters': {},
+                'Job Counters': {
+                    'Launched map tasks': 2,
+                },
+            }),
+            ('Counters: 1\n'
+             '\tJob Counters\n'
+             '\t\tLaunched map tasks=2'))
+
+    def test_round_trip(self):
+        # are we outputting counters in the same format as the Hadoop binary?
+        self.assertEqual(
+            _parse_indented_counters(
+                _format_counters(self.COUNTERS).splitlines()),
+            self.COUNTERS)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -340,7 +340,7 @@ class LargeAmountsOfStderrTestCase(TestCase):
             # look for expected output from MRVerboseJob
             stderr = mr_job.stderr.getvalue()
             self.assertIn(
-                b"Counters from step 1:\n\tFoo\n\t\tBar=10000", stderr)
+                b"Counters: 1\n\tFoo\n\t\tBar=10000", stderr)
             self.assertIn(b'status: 0\n', stderr)
             self.assertIn(b'status: 99\n', stderr)
             self.assertNotIn(b'status: 100\n', stderr)


### PR DESCRIPTION
This replaces `runner._print_counters()` with appropriate calls to `mrjob.logs.counters._format_counters()` (fixes #1220).