### PR TITLE
StepFailedException

### DIFF
--- a/docs/guides/runners.rst
+++ b/docs/guides/runners.rst
@@ -148,6 +148,7 @@ work.
     class MyJob(MRJob):
         # (your job)
 
+    # no, stop, what are you doing?!?!
     mr_job = MyJob(args=[args])
     with mr_job.make_runner() as runner:
         runner.run()

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -111,6 +111,7 @@ from mrjob.setup import parse_legacy_hash_path
 from mrjob.setup import parse_setup_cmd
 from mrjob.ssh import ssh_slave_addresses
 from mrjob.ssh import ssh_terminate_single_job
+from mrjob.step import StepFailedException
 from mrjob.util import cmd_line
 from mrjob.util import shlex_split
 from mrjob.util import random_identifier
@@ -1483,7 +1484,7 @@ class EMRJobRunner(MRJobRunner):
         # try to find a cluster from the pool. basically auto-fill
         # 'cluster_id' if possible and then follow normal behavior.
         if self._opts['pool_clusters'] and not self._cluster_id:
-            cluster_id = self._find_cluster(num_steps=len(self._get_steps()))
+            cluster_id = self._find_cluster(num_steps=self._num_steps())
             if cluster_id:
                 self._cluster_id = cluster_id
 
@@ -1532,10 +1533,11 @@ class EMRJobRunner(MRJobRunner):
             # this will raise an exception if a step fails
             log.info('Waiting for step %d of %d (%s) to complete...' % (
                 step_num + 1, num_steps, step_id))
-            self._wait_for_step_to_complete(step_id)
+            self._wait_for_step_to_complete(step_id, step_num, num_steps)
 
 
-    def _wait_for_step_to_complete(self, step_id):
+    def _wait_for_step_to_complete(
+            self, step_id, step_num=None, num_steps=None):
         """Helper for _wait_for_step_to_complete(). Wait for
         step with the given ID to complete, and fetch counters.
         If it fails, attempt to diagnose the error, and raise an
@@ -1545,6 +1547,9 @@ class EMRJobRunner(MRJobRunner):
         :param step_num: which step this is out of the steps
                          belonging to our job (0-indexed)
         :param num_steps: number of steps in our job
+
+        *step_num* and *num_steps* are optional and only used when raising
+        a :py:class:`~mrjob.step.StepFailedException`.
 
         This also adds an item to self._log_interpretations
         """
@@ -1645,7 +1650,7 @@ class EMRJobRunner(MRJobRunner):
                     log.error('Probable cause of failure:\n\n%s\n\n' %
                               _format_error(error))
 
-            raise Exception
+            raise StepFailedException(step_num=step_num, num_steps=num_steps)
 
     def _log_step_progress(self):
         """Tunnel to the job tracker/resource manager and log the

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1760,9 +1760,12 @@ class EMRJobRunner(MRJobRunner):
             # wait for logs to be on S3
             self._wait_for_terminating_cluster_to_terminate()
 
-            s3_log_uri = posixpath.join(
-                self._s3_log_dir(), (s3_dir_name or dir_name))
-            log.info('Looking for %s in %s...' % (log_desc, s3_log_uri))
+            # TODO: test that this gets run!
+            if self._s3_log_dir():
+                s3_log_uri = posixpath.join(
+                    self._s3_log_dir(), (s3_dir_name or dir_name))
+                log.info('Looking for %s in %s...' % (log_desc, s3_log_uri))
+                yield [s3_log_uri]
 
     def _wait_for_terminating_cluster_to_terminate(self):
         """If the cluster is already terminating, wait for it to terminate,

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -51,6 +51,7 @@ from mrjob.py2 import to_string
 from mrjob.runner import MRJobRunner
 from mrjob.runner import RunnerOptionStore
 from mrjob.setup import UploadDirManager
+from mrjob.step import StepFailedException
 from mrjob.util import cmd_line
 from mrjob.util import unique
 from mrjob.util import which
@@ -462,7 +463,10 @@ class HadoopJobRunner(MRJobRunner):
                     log.error('Probable cause of failure:\n\n%s\n' %
                               _format_error(error))
 
-                raise CalledProcessError(returncode, step_args)
+                reason = str(CalledProcessError(returncode, step_args))
+                raise StepFailedException(
+                    reason=reason, step_num=step_num,
+                    num_steps=self._num_steps())
 
     def _args_for_step(self, step_num):
         step = self._get_step(step_num)

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -39,6 +39,7 @@ from mrjob.parse import parse_key_value_list
 from mrjob.parse import parse_port_range_list
 from mrjob.py2 import PY2
 from mrjob.runner import CLEANUP_CHOICES
+from mrjob.step import StepFailedException
 from mrjob.util import log_to_null
 from mrjob.util import log_to_stream
 from mrjob.util import parse_and_save_options
@@ -222,7 +223,13 @@ class MRJobLauncher(object):
                             stream=log_stream)
 
         with self.make_runner() as runner:
-            runner.run()
+            try:
+                runner.run()
+            except StepFailedException as e:
+                # no need for a runner stacktrace if step failed; runners will
+                # log more useful information anyway
+                log.error(str(e))
+                sys.exit(1)
 
             if not self.options.no_output:
                 for line in runner.stream_output():

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -53,6 +53,46 @@ def _IDENTITY_REDUCER(key, values):
         yield key, value
 
 
+class StepFailedException(Exception):
+    """Exception to throw when a step fails.
+
+    This will automatically be caught
+    and converted to an error message by :py:meth:`mrjob.job.MRJob.run`, but
+    you may wish to catch it if you
+    :ref:`run your job programatically <runners-programmatically`.
+    """
+
+    def __init__(self, reason=None, step_num=None, num_steps=None):
+        """Initialize a reason for step failure.
+
+        :param string reason: brief explanation of which step failed
+        :param int step_num: which step failed (0-indexed)
+        :param int num_steps: number of steps in the job
+
+        *reason* should not be several lines long; use ``log.error(...)``
+        for that.
+        """
+        self.reason = reason
+        self.step_num = step_num
+        self.num_steps = num_steps
+
+    def __str__(self):
+        """Human-readable version of the exception. Note that this 1-indexes
+        *step_num*."""
+        return 'Step%s%s failed%s' % (
+            '' if self.step_num is None else ' %d' % (self.step_num + 1),
+            '' if (self.step_num is None or self.num_steps is None) else
+                   ' of %d' % self.num_steps,
+            '' if self.reason is None else ': %s' % self.reason)
+
+    def __repr__(self):
+        return '%s(%s)' % (
+            self.__class__.__name__,
+            ', '.join(('%s=%r' % (k, getattr(self, k))
+                       for k in ('reason', 'step_num', 'num_steps')
+                       if getattr(self, k) is not None)))
+
+
 class MRStep(object):
     """Represents steps handled by the script containing your job.
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -50,6 +50,7 @@ from mrjob.py2 import PY2
 from mrjob.py2 import StringIO
 from mrjob.ssh import SSH_LOG_ROOT
 from mrjob.ssh import SSH_PREFIX
+from mrjog.step import StepFailedException
 from mrjob.util import bash_wrap
 from mrjob.util import log_to_stream
 from mrjob.util import tar_and_gzip
@@ -211,7 +212,7 @@ class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
             with mr_job.make_runner() as runner:
                 self.assertIsInstance(runner, EMRJobRunner)
 
-                self.assertRaises(Exception, runner.run)
+                self.assertRaises(StepFailedException, runner.run)
                 self.assertIn('\n  FAILED\n',
                               stderr.getvalue())
 
@@ -341,7 +342,7 @@ class ExistingClusterTestCase(MockBotoTestCase):
             self.assertIsInstance(runner, EMRJobRunner)
             self.prepare_runner_for_ssh(runner)
             with logger_disabled('mrjob.emr'):
-                self.assertRaises(Exception, runner.run)
+                self.assertRaises(StepFailedException, runner.run)
 
             emr_conn = runner.make_emr_conn()
             cluster_id = runner.get_cluster_id()
@@ -2073,7 +2074,7 @@ class PoolMatchingTestCase(MockBotoTestCase):
             self.assertIsInstance(runner, EMRJobRunner)
             self.prepare_runner_for_ssh(runner)
             with logger_disabled('mrjob.emr'):
-                self.assertRaises(Exception, runner.run)
+                self.assertRaises(StepFailedException, runner.run)
 
             emr_conn = runner.make_emr_conn()
             cluster_id = runner.get_cluster_id()
@@ -2108,7 +2109,7 @@ class PoolMatchingTestCase(MockBotoTestCase):
             self.assertIsInstance(runner, EMRJobRunner)
             self.prepare_runner_for_ssh(runner)
             with logger_disabled('mrjob.emr'):
-                self.assertRaises(Exception, runner.run)
+                self.assertRaises(StepFailedException, runner.run)
 
             self.assertEqual(runner.get_cluster_id(), cluster_id)
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -50,7 +50,7 @@ from mrjob.py2 import PY2
 from mrjob.py2 import StringIO
 from mrjob.ssh import SSH_LOG_ROOT
 from mrjob.ssh import SSH_PREFIX
-from mrjog.step import StepFailedException
+from mrjob.step import StepFailedException
 from mrjob.util import bash_wrap
 from mrjob.util import log_to_stream
 from mrjob.util import tar_and_gzip

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -27,6 +27,7 @@ from mrjob.fs.hadoop import HadoopFilesystem
 from mrjob.hadoop import HadoopJobRunner
 from mrjob.hadoop import fully_qualify_hdfs_path
 from mrjob.py2 import PY2
+from mrjob.step import StepFailedException
 from mrjob.util import bash_wrap
 
 from tests.mockhadoop import add_mock_hadoop_counters
@@ -719,7 +720,7 @@ class JarStepTestCase(MockHadoopTestCase):
         with job.make_runner() as runner:
             with logger_disabled('mrjob.hadoop'):
                 # `hadoop jar` doesn't actually accept URIs
-                self.assertRaises(Exception, runner.run)
+                self.assertRaises(StepFailedException, runner.run)
 
         hadoop_cmd_args = get_mock_hadoop_cmd_args()
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -34,7 +34,6 @@ from tests.py2 import Mock
 from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
-from tests.sandbox import PatcherTestCase
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_pythonpath
 from tests.sandbox import patch_fs_s3
@@ -76,16 +75,7 @@ class MRCustomJobLauncher(MRJobLauncher):
 ### Test cases ###
 
 
-class RunJobTestCase(PatcherTestCase):
-
-    class MockSystemExit(Exception):
-        pass
-
-    def setUp(self):
-        super(RunJobTestCase, self).setUp()
-
-        self.mock_exit = self.start(
-            patch('sys.exit', side_effect=self.MockSystemExit))
+class RunJobTestCase(TestCase):
 
     def _make_launcher(self, *args):
         """Make a launcher, add a mock runner (``launcher.mock_runner``), and
@@ -124,9 +114,7 @@ class RunJobTestCase(PatcherTestCase):
         launcher = self._make_launcher()
         launcher.mock_runner.run.side_effect = StepFailedException
 
-        self.assertRaises(self.MockSystemExit, launcher.run_job)
-
-        self.mock_exit.assert_called_once_with(1)
+        self.assertRaises(SystemExit, launcher.run_job)
 
         self.assertEqual(launcher.stdout.getvalue(), b'')
         self.assertIn(b'Step failed', launcher.stderr.getvalue())
@@ -136,8 +124,6 @@ class RunJobTestCase(PatcherTestCase):
         launcher.mock_runner.run.side_effect = OSError
 
         self.assertRaises(OSError, launcher.run_job)
-
-        self.assertFalse(self.mock_exit.called)
 
         self.assertEqual(launcher.stdout.getvalue(), b'')
         self.assertEqual(launcher.stderr.getvalue(), b'')

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -27,11 +27,14 @@ from mrjob.job import MRJob
 from mrjob.launch import MRJobLauncher
 from mrjob.local import LocalMRJobRunner
 from mrjob.py2 import StringIO
+from mrjob.step import StepFailedException
 
+from tests.py2 import MagicMock
 from tests.py2 import Mock
 from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
+from tests.sandbox import PatcherTestCase
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_pythonpath
 from tests.sandbox import patch_fs_s3
@@ -73,18 +76,71 @@ class MRCustomJobLauncher(MRJobLauncher):
 ### Test cases ###
 
 
-class NoOutputTestCase(TestCase):
+class RunJobTestCase(PatcherTestCase):
+
+    class MockSystemExit(Exception):
+        pass
+
+    def setUp(self):
+        super(RunJobTestCase, self).setUp()
+
+        self.mock_exit = self.start(
+            patch('sys.exit', side_effect=self.MockSystemExit))
+
+    def _make_launcher(self, *args):
+        """Make a launcher, add a mock runner (``launcher.mock_runner``), and
+        set it up so that ``launcher.make_runner().__enter__()`` returns
+        ``launcher.mock_runner()``.
+        """
+        launcher = MRJobLauncher(args=['--no-conf', ''] + list(args))
+        launcher.sandbox()
+
+        launcher.mock_runner = Mock()
+        launcher.mock_runner.stream_output.return_value = [b'a line\n']
+
+        launcher.make_runner = MagicMock()  # include __enter__
+        launcher.make_runner.return_value.__enter__.return_value = (
+            launcher.mock_runner)
+
+        return launcher
+
+    def test_output(self):
+        launcher = self._make_launcher()
+
+        launcher.run_job()
+
+        self.assertEqual(launcher.stdout.getvalue(), b'a line\n')
+        self.assertEqual(launcher.stderr.getvalue(), b'')
 
     def test_no_output(self):
-        launcher = MRJobLauncher(args=['--no-conf', '--no-output', ''])
-        launcher.sandbox()
-        with patch.object(launcher, 'make_runner') as m_make_runner:
-            runner = Mock()
-            _mock_context_mgr(m_make_runner, runner)
-            runner.stream_output.return_value = ['a line']
-            launcher.run_job()
-            self.assertEqual(launcher.stdout.getvalue(), b'')
-            self.assertEqual(launcher.stderr.getvalue(), b'')
+        launcher = self._make_launcher('--no-output')
+
+        launcher.run_job()
+
+        self.assertEqual(launcher.stdout.getvalue(), b'')
+        self.assertEqual(launcher.stderr.getvalue(), b'')
+
+    def test_exit_on_step_failure(self):
+        launcher = self._make_launcher()
+        launcher.mock_runner.run.side_effect = StepFailedException
+
+        self.assertRaises(self.MockSystemExit, launcher.run_job)
+
+        self.mock_exit.assert_called_once_with(1)
+
+        self.assertEqual(launcher.stdout.getvalue(), b'')
+        self.assertIn(b'Step failed', launcher.stderr.getvalue())
+
+    def test_pass_through_other_exceptions(self):
+        launcher = self._make_launcher()
+        launcher.mock_runner.run.side_effect = OSError
+
+        self.assertRaises(OSError, launcher.run_job)
+
+        self.assertFalse(self.mock_exit.called)
+
+        self.assertEqual(launcher.stdout.getvalue(), b'')
+        self.assertEqual(launcher.stderr.getvalue(), b'')
 
 
 class CommandLineArgsTestCase(TestCase):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -24,7 +24,7 @@ from io import BytesIO
 
 import mrjob
 from mrjob.local import LocalMRJobRunner
-
+from mrjob.step import StepFailedException
 from mrjob.util import bash_wrap
 from mrjob.util import cmd_line
 from mrjob.util import read_file
@@ -346,7 +346,7 @@ class LargeAmountsOfStderrTestCase(TestCase):
             self.assertNotIn(b'status: 100\n', stderr)
             self.assertIn(b'STDERR: Qux\n', stderr)
             # exception should appear in exception message
-            self.assertIn('BOOM', repr(e))
+            self.assertIn(b'BOOM', stderr)
         else:
             raise AssertionError()
 
@@ -359,7 +359,7 @@ class ExitWithoutExceptionTestCase(TestCase):
 
         try:
             mr_job.run_job()
-        except Exception as e:
+        except StepFailedException as e:
             self.assertIn('returned non-zero exit status 42', repr(e))
             return
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -334,8 +334,9 @@ class LargeAmountsOfStderrTestCase(TestCase):
                 mr_job.run_job()
         except TimeoutException:
             raise
-        except Exception as e:
-            # we expect the job to throw an exception
+        except SystemExit as e:
+            # we expect the job to throw a StepFailedException,
+            # which causes run_job to call sys.exit()
 
             # look for expected output from MRVerboseJob
             stderr = mr_job.stderr.getvalue()
@@ -357,13 +358,10 @@ class ExitWithoutExceptionTestCase(TestCase):
         mr_job = MRExit42Job(['--no-conf', '--runner=local'])
         mr_job.sandbox()
 
-        try:
-            mr_job.run_job()
-        except StepFailedException as e:
-            self.assertIn('returned non-zero exit status 42', repr(e))
-            return
+        self.assertRaises(SystemExit, mr_job.run_job)
 
-        self.fail()
+        self.assertIn(b'returned non-zero exit status 42',
+                      mr_job.stderr.getvalue())
 
 
 class PythonBinTestCase(EmptyMrjobConfTestCase):

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -16,6 +16,7 @@
 from mrjob.step import _IDENTITY_MAPPER
 from mrjob.step import JarStep
 from mrjob.step import MRStep
+from mrjob.step import StepFailedException
 
 from tests.py2 import TestCase
 from tests.quiet import logger_disabled
@@ -30,6 +31,37 @@ def identity_mapper(k=None, v=None):
 def identity_reducer(k, vals):
     for v in vals:
         yield k, v
+
+
+class StepFailedExceptionTestCase(TestCase):
+
+    def test_empty(self):
+        ex = StepFailedException()
+        self.assertEqual(str(ex), 'Step failed')
+        self.assertEqual(repr(ex), 'StepFailedException()')
+
+    def test_reason(self):
+        ex = StepFailedException('Hadoop is feeling sad today')
+        self.assertEqual(str(ex), 'Step failed: Hadoop is feeling sad today')
+        self.assertEqual(
+            repr(ex),
+            "StepFailedException(reason='Hadoop is feeling sad today')")
+
+    def test_step_num(self):
+        ex = StepFailedException(step_num=0)
+        self.assertEqual(str(ex), 'Step 1 failed')
+        self.assertEqual(repr(ex), 'StepFailedException(step_num=0)')
+
+    def test_step_num_with_num_steps(self):
+        ex = StepFailedException(step_num=0, num_steps=4)
+        self.assertEqual(str(ex), 'Step 1 of 4 failed')
+        self.assertEqual(repr(ex),
+                         'StepFailedException(step_num=0, num_steps=4)')
+
+    def test_num_steps_with_no_step_num(self):
+        ex = StepFailedException(num_steps=4)
+        self.assertEqual(str(ex), 'Step failed')
+        self.assertEqual(repr(ex), 'StepFailedException(num_steps=4)')
 
 
 class JarStepTestCase(TestCase):


### PR DESCRIPTION
When the local, Hadoop, and EMR runners have a step that fails, they raise `mrjob.step.StepFailedException` rather than a plain `Exception` or `CalledProcessError`. `MRLauncher.run_job()` catches `StepFailedException` and exits so that logging messages aren't obscured by a stacktrace somewhere inside the runner.

(The inline runner just passes job exceptions straight through, so it doesn't have the problem of stacktraces inside the runner distracting from stacktraces inside the job.)

Embarassingly, noticed that we weren't properly streaming S3 log dirs. Made a note of it in #1221.