### PR TITLE
Key pair warning

### DIFF
--- a/docs/guides/emr-quickstart.rst
+++ b/docs/guides/emr-quickstart.rst
@@ -10,9 +10,10 @@ Configuring your AWS credentials allows mrjob to run your jobs on Elastic
 MapReduce and use S3.
 
 * Create an `Amazon Web Services account <http://aws.amazon.com/>`_
-* Sign up for `Elastic MapReduce <http://aws.amazon.com/elasticmapreduce/>`_
-* Get your access and secret keys (click "Security Credentials" on `your
-  account page <http://aws.amazon.com/account/>`_)
+* Go to the `Your Security Credentials
+  <https://console.aws.amazon.com/iam/home?#security_credential>`__, click
+  on **Access Keys**, and then **Create New Access Key**. Make sure to copy the
+  secret access key, as there is no way to recover it after creation.
 
 Now you can either set the environment variables :envvar:`AWS_ACCESS_KEY_ID`
 and :envvar:`AWS_SECRET_ACCESS_KEY`, or set **aws_access_key_id** and
@@ -33,10 +34,10 @@ master nodes to view live progress, see the job tracker in your browser, and
 fetch error logs quickly.
 
 * Go to https://console.aws.amazon.com/ec2/home
-* Make sure the **Region** dropdown (upper left) matches the region you want
-  to run jobs in (usually "US East").
-* Click on **Key Pairs** (lower left)
-* Click on **Create Key Pair** (center).
+* Make sure the **Region** dropdown (upper right, second from the right)
+  matches the region you want to run jobs in (usually "Oregon").
+* Click on **Key Pairs** (left sidebar, under **Network & Security**)
+* Click on **Create Key Pair** (top left).
 * Name your key pair ``EMR`` (any name will work but that's what we're using
   in this example)
 * Save :file:`EMR.pem` wherever you like (``~/.ssh`` is a good place)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1601,17 +1601,14 @@ class EMRJobRunner(MRJobRunner):
                 log.info('  COMPLETED')
                 # will fetch counters, below, and then return
             else:
-                # step has failed somehow
-
-                # these fields definitely exist, but currently, message doesn't
-                # seem to be filled (at least, the AWS CLI can't see it
-                # either)
+                # step has failed somehow. *reason* seems to only be set
+                # when job is cancelled (e.g. 'Job terminated')
                 reason_desc = ''
                 reason = getattr(
                     getattr(step.status, 'statechangereason' ,''),
                     'message', '')
                 if reason:
-                    reason_desc = ' (%s)' % reason_desc
+                    reason_desc = ' (%s)' % reason
 
                 log.info('  %s%s' % (
                    step.status.state, reason_desc))

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -518,6 +518,7 @@ class HadoopJobRunner(MRJobRunner):
             args.append('-reducer')
             args.append(reducer)
         else:
+            # TODO: translate this to YARN/pre-YARN
             args.extend(['-D', 'mapred.reduce.tasks=0'])
 
         return args

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -59,7 +59,7 @@ class StepFailedException(Exception):
     This will automatically be caught
     and converted to an error message by :py:meth:`mrjob.job.MRJob.run`, but
     you may wish to catch it if you
-    :ref:`run your job programatically <runners-programmatically`.
+    :ref:`run your job programatically <runners-programmatically>`.
     """
 
     def __init__(self, reason=None, step_num=None, num_steps=None):


### PR DESCRIPTION
Issue a friendly warning when users have a problem with their SSH keys because we've changed the default region out from under them.

More testing would be useful here, but should probably wait until after the log interpretation refactor (see #1221).