### PR TITLE
Step log rotation

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -81,7 +81,7 @@ from mrjob.logs.counters import _format_counters
 from mrjob.logs.counters import _pick_counters
 from mrjob.logs.errors import _format_error
 from mrjob.logs.mixin import LogInterpretationMixin
-from mrjob.logs.step import _interpret_emr_step_log
+from mrjob.logs.step import _interpret_emr_step_logs
 from mrjob.logs.step import _ls_emr_step_logs
 from mrjob.parse import is_s3_uri
 from mrjob.parse import is_uri
@@ -1769,7 +1769,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             log.warning("Can't fetch step log; missing step ID")
             return
 
-        return _interpret_emr_step_log(
+        return _interpret_emr_step_logs(
             self.fs, self._ls_step_logs(step_id=step_id))
 
     def _ls_step_logs(self, step_id):

--- a/mrjob/logs/mixin.py
+++ b/mrjob/logs/mixin.py
@@ -99,7 +99,7 @@ class LogInterpretationMixin(object):
 
         if not counters:
             log.info('Attempting to fetch counters from logs...')
-            self._interpret_step_log(log_interpretation)
+            self._interpret_step_logs(log_interpretation)
             counters = _pick_counters(log_interpretation)
 
         if not counters:
@@ -113,7 +113,7 @@ class LogInterpretationMixin(object):
         if not all(log_type in log_interpretation for
                    log_type in ('job', 'step', 'task')):
             log.info('Scanning logs for probable cause of failure...')
-            self._interpret_step_log(log_interpretation)
+            self._interpret_step_logs(log_interpretation)
             self._interpret_history_log(log_interpretation)
             self._interpret_task_logs(log_interpretation)
 
@@ -148,7 +148,7 @@ class LogInterpretationMixin(object):
             log.info('  Parsing history log: %s' % match['path'])
             yield match
 
-    def _interpret_step_log(self, log_interpretation):
+    def _interpret_step_logs(self, log_interpretation):
         """Add *step* to the log interpretation, if it's not already there."""
         if 'step' in log_interpretation:
             return

--- a/tests/logs/test_mixin.py
+++ b/tests/logs/test_mixin.py
@@ -115,7 +115,7 @@ class InterpretStepLogTestCase(LogInterpretationMixinTestCase):
     def test_step_interpretation_already_filled(self):
         log_interpretation = dict(step={})
 
-        self.runner._interpret_step_log(log_interpretation)
+        self.runner._interpret_step_logs(log_interpretation)
 
         self.assertEqual(
             log_interpretation, dict(step={}))
@@ -128,7 +128,7 @@ class InterpretStepLogTestCase(LogInterpretationMixinTestCase):
 
         log_interpretation = {}
 
-        self.runner._interpret_step_log(log_interpretation)
+        self.runner._interpret_step_logs(log_interpretation)
 
         self.assertEqual(
             log_interpretation,
@@ -142,7 +142,7 @@ class InterpretStepLogTestCase(LogInterpretationMixinTestCase):
 
         log_interpretation = {}
 
-        self.runner._interpret_step_log(log_interpretation)
+        self.runner._interpret_step_logs(log_interpretation)
 
         self.assertEqual(log_interpretation, {})
 
@@ -316,7 +316,7 @@ class PickCountersTestCase(LogInterpretationMixinTestCase):
         super(PickCountersTestCase, self).setUp()
 
         self.runner._interpret_history_log = Mock()
-        self.runner._interpret_step_log = Mock()
+        self.runner._interpret_step_logs = Mock()
 
         # no need to mock mrjob.logs.counters._pick_counters();
         # what it does is really straightforward
@@ -332,16 +332,16 @@ class PickCountersTestCase(LogInterpretationMixinTestCase):
         # don't log anything if runner._pick_counters() doesn't have
         # to fetch any new information
         self.assertFalse(self.log.info.called)
-        self.assertFalse(self.runner._interpret_step_log.called)
+        self.assertFalse(self.runner._interpret_step_logs.called)
         self.assertFalse(self.runner._interpret_history_log.called)
 
     def test_counter_from_step_logs(self):
-        def mock_interpret_step_log(log_interpretation):
+        def mock_interpret_step_logs(log_interpretation):
             log_interpretation['step'] = dict(
                 counters={'foo': {'bar': 1}})
 
-        self.runner._interpret_step_log = Mock(
-            side_effect=mock_interpret_step_log)
+        self.runner._interpret_step_logs = Mock(
+            side_effect=mock_interpret_step_logs)
 
         log_interpretation = {}
 
@@ -350,7 +350,7 @@ class PickCountersTestCase(LogInterpretationMixinTestCase):
             {'foo': {'bar': 1}})
 
         self.assertTrue(self.log.info.called)  # 'Attempting to fetch...'
-        self.assertTrue(self.runner._interpret_step_log.called)
+        self.assertTrue(self.runner._interpret_step_logs.called)
         self.assertFalse(self.runner._interpret_history_log.called)
 
     def test_counter_from_history_logs(self):
@@ -368,7 +368,7 @@ class PickCountersTestCase(LogInterpretationMixinTestCase):
             {'foo': {'bar': 1}})
 
         self.assertTrue(self.log.info.called)  # 'Attempting to fetch...'
-        self.assertTrue(self.runner._interpret_step_log.called)
+        self.assertTrue(self.runner._interpret_step_logs.called)
         self.assertTrue(self.runner._interpret_history_log.called)
 
 
@@ -466,7 +466,7 @@ class PickErrorsTestCase(LogInterpretationMixinTestCase):
         super(PickErrorsTestCase, self).setUp()
 
         self.runner._interpret_history_log = Mock()
-        self.runner._interpret_step_log = Mock()
+        self.runner._interpret_step_logs = Mock()
         self.runner._interpret_task_logs = Mock()
 
         self._pick_error = self.start(
@@ -483,7 +483,7 @@ class PickErrorsTestCase(LogInterpretationMixinTestCase):
         # don't log a message or interpret logs
         self.assertFalse(self.log.info.called)
         self.assertFalse(self.runner._interpret_history_log.called)
-        self.assertFalse(self.runner._interpret_step_log.called)
+        self.assertFalse(self.runner._interpret_step_logs.called)
         self.assertFalse(self.runner._interpret_task_logs.called)
 
     def _test_interpret_all_logs(self, log_interpretation):
@@ -494,7 +494,7 @@ class PickErrorsTestCase(LogInterpretationMixinTestCase):
         # log a message ('Scanning logs...') and call _interpret() methods
         self.assertTrue(self.log.info.called)
         self.assertTrue(self.runner._interpret_history_log.called)
-        self.assertTrue(self.runner._interpret_step_log.called)
+        self.assertTrue(self.runner._interpret_step_logs.called)
         self.assertTrue(self.runner._interpret_task_logs.called)
 
     def test_empty_log_interpretation(self):

--- a/tests/logs/test_step.py
+++ b/tests/logs/test_step.py
@@ -370,8 +370,9 @@ class MatchEMRStepLogPathTestCase(TestCase):
     def test_empty(self):
         self.assertEqual(_match_emr_step_log_path(''), None)
 
-    def test_local(self):
-        log_path = '/mnt/var/log/hadoop/steps/s-2BQ5U0ZHTR16N/syslog'
+    def test_ssh(self):
+        log_path = (
+            'ssh://masterssh://master/mnt/var/log/hadoop/steps/s-2BQ5U0ZHTR16N/syslog')
 
         self.assertEqual(
             _match_emr_step_log_path(log_path),
@@ -396,7 +397,7 @@ class MatchEMRStepLogPathTestCase(TestCase):
             dict(step_id='s-2BQ5U0ZHTR16N', timestamp='2016-02-26-23'))
 
     def test_match_syslog_only(self):
-        log_path = '/mnt/var/log/hadoop/steps/s-2BQ5U0ZHTR16N/controller'
+        log_path = 'ssh://master/mnt/var/log/hadoop/steps/s-2BQ5U0ZHTR16N/controller'
 
         self.assertEqual(_match_emr_step_log_path(log_path), None)
 
@@ -451,7 +452,7 @@ class InterpretEMRStepLogsTestCase(PatcherTestCase):
         self.assertEqual(self.interpret_emr_step_logs(), {})
 
     def test_single_log(self):
-        log_path = '/mnt/var/log/hadoop/steps/s-STEPID/syslog'
+        log_path = 'ssh://master/mnt/var/log/hadoop/steps/s-STEPID/syslog'
 
         self.mock_paths = [log_path]
 
@@ -463,7 +464,7 @@ class InterpretEMRStepLogsTestCase(PatcherTestCase):
                          dict(output_dir='hdfs:///output'))
 
     def test_implied_job_id(self):
-        log_path = '/mnt/var/log/hadoop/steps/s-STEPID/syslog'
+        log_path = 'ssh://master/mnt/var/log/hadoop/steps/s-STEPID/syslog'
 
         self.mock_paths = [log_path]
 
@@ -477,7 +478,7 @@ class InterpretEMRStepLogsTestCase(PatcherTestCase):
 
     def test_error(self):
         # test patching in path and implied ID
-        log_path = '/mnt/var/log/hadoop/steps/s-STEPID/syslog'
+        log_path = 'ssh://master/mnt/var/log/hadoop/steps/s-STEPID/syslog'
 
         self.mock_paths = [log_path]
 

--- a/tests/logs/test_step.py
+++ b/tests/logs/test_step.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 import errno
 
+from mrjob.logs.step import _interpret_emr_step_logs
 from mrjob.logs.step import _interpret_hadoop_jar_command_stderr
+from mrjob.logs.step import _ls_emr_step_logs
 from mrjob.logs.step import _match_emr_step_log_path
 from mrjob.logs.step import _parse_hadoop_log4j_records
 from mrjob.logs.step import _parse_indented_counters
@@ -21,9 +23,11 @@ from mrjob.logs.step import _parse_step_log
 from mrjob.py2 import StringIO
 from mrjob.util import log_to_stream
 
+from tests.py2 import Mock
 from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
+from tests.sandbox import PatcherTestCase
 
 
 # abbreviated version of real output from Hadoop 2.7.0.
@@ -395,3 +399,159 @@ class MatchEMRStepLogPathTestCase(TestCase):
         log_path = '/mnt/var/log/hadoop/steps/s-2BQ5U0ZHTR16N/controller'
 
         self.assertEqual(_match_emr_step_log_path(log_path), None)
+
+
+class InterpretEMRStepLogsTestCase(PatcherTestCase):
+
+    def setUp(self):
+        super(InterpretEMRStepLogsTestCase, self).setUp()
+
+        # instead of mocking out contents of files, just mock out
+        # what _parse_task_{syslog,stderr}() should return, and have
+        # _cat_log() just pass through the path
+        self.mock_paths = []
+        self.path_to_mock_result = {}
+
+        self.mock_paths_catted = []
+
+        def mock_cat_log(fs, path):
+            if path in self.mock_paths:
+                self.mock_paths_catted.append(path)
+            return path
+
+        # (the real _parse_step_log() expects lines, not paths)
+        def mock_parse_step_log(path_from_mock_cat_log):
+            return self.path_to_mock_result.get(path_from_mock_cat_log, {})
+
+        # need to mock ls so that _ls_task_syslogs() can work
+        def mock_exists(path):
+            return path in self.mock_paths
+
+        def mock_ls(log_dir):
+            return self.mock_paths
+
+        self.mock_fs = Mock()
+        self.mock_fs.ls = Mock(side_effect=mock_ls)
+
+        self.mock_cat_log = self.start(
+            patch('mrjob.logs.step._cat_log', side_effect=mock_cat_log))
+
+        self.start(patch('mrjob.logs.step._parse_step_log',
+                         side_effect=mock_parse_step_log))
+
+    def mock_path_matches(self):
+        mock_log_dir_stream = [['']]  # needed to make _ls_logs() work
+        return _ls_emr_step_logs(self.mock_fs, mock_log_dir_stream)
+
+    def interpret_emr_step_logs(self, **kwargs):
+        return _interpret_emr_step_logs(
+            self.mock_fs, self.mock_path_matches(), **kwargs)
+
+    def test_empty(self):
+        self.assertEqual(self.interpret_emr_step_logs(), {})
+
+    def test_single_log(self):
+        log_path = '/mnt/var/log/hadoop/steps/s-STEPID/syslog'
+
+        self.mock_paths = [log_path]
+
+        self.path_to_mock_result = {
+            log_path: dict(output_dir='hdfs:///output')
+        }
+
+        self.assertEqual(self.interpret_emr_step_logs(),
+                         dict(output_dir='hdfs:///output'))
+
+    def test_implied_job_id(self):
+        log_path = '/mnt/var/log/hadoop/steps/s-STEPID/syslog'
+
+        self.mock_paths = [log_path]
+
+        self.path_to_mock_result = {
+            log_path: dict(application_id='application_1')
+        }
+
+        self.assertEqual(self.interpret_emr_step_logs(),
+                         dict(application_id='application_1',
+                              job_id='job_1'))
+
+    def test_error(self):
+        # test patching in path and implied ID
+        log_path = '/mnt/var/log/hadoop/steps/s-STEPID/syslog'
+
+        self.mock_paths = [log_path]
+
+        self.path_to_mock_result = {
+            log_path: dict(errors=[dict(
+                attempt_id='attempt_201512232143_0008_m_000001_3',
+                hadoop_error=dict(message='BOOM'),
+            )]),
+        }
+
+        self.assertEqual(
+            self.interpret_emr_step_logs(),
+            dict(errors=[dict(
+                attempt_id='attempt_201512232143_0008_m_000001_3',
+                hadoop_error=dict(
+                    message='BOOM',
+                    path=log_path,
+                ),
+                task_id='task_201512232143_0008_m_000001')]))
+
+    def test_multiple_logs(self):
+        prev_path = 's3://bucket/logs/steps/s-STEPID/syslog.2015-05-06-09.gz'
+        current_path = 's3://bucket/logs/steps/s-STEPID/syslog.gz'
+
+        # current log would come first in alphabetical sort
+        self.mock_paths = [prev_path, current_path]
+
+        self.path_to_mock_result = {
+            prev_path: dict(
+                errors=[
+                    dict(
+                        hadoop_error=dict(
+                            message='first error',
+                        ),
+                    ),
+                ],
+                job_id='job_1',
+            ),
+            current_path: dict(
+                counters=dict(foo=dict(bar=1)),
+                errors=[
+                    dict(
+                        hadoop_error=dict(
+                            message='second error',
+                        ),
+                    ),
+                ],
+            ),
+        }
+
+        # both errors should appear, in the correct order
+        self.assertEqual(
+            self.interpret_emr_step_logs(),
+            dict(
+                counters=dict(foo=dict(bar=1)),
+                errors=[
+                    dict(
+                        hadoop_error=dict(
+                            message='first error',
+                            path=prev_path,
+                        ),
+                    ),
+                    dict(
+                        hadoop_error=dict(
+                            message='second error',
+                            path=current_path,
+                        ),
+                    ),
+                ],
+                job_id='job_1',
+            ),
+        )
+
+        self.assertEqual(self.mock_paths_catted, [prev_path, current_path])
+
+
+    maxDiff = None

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3502,8 +3502,8 @@ class GetStepLogInterpretationTestCase(MockBotoTestCase):
 
         self.log = self.start(patch('mrjob.emr.log'))
 
-        self._interpret_emr_step_log = self.start(patch(
-            'mrjob.emr._interpret_emr_step_log'))
+        self._interpret_emr_step_logs = self.start(patch(
+            'mrjob.emr._interpret_emr_step_logs'))
         self._ls_step_logs = self.start(patch(
             'mrjob.emr.EMRJobRunner._ls_step_logs'))
 
@@ -3516,11 +3516,11 @@ class GetStepLogInterpretationTestCase(MockBotoTestCase):
 
         self.assertEqual(
             runner._get_step_log_interpretation(log_interpretation),
-            self._interpret_emr_step_log.return_value)
+            self._interpret_emr_step_logs.return_value)
 
         self.assertFalse(self.log.warning.called)
         self._ls_step_logs.assert_called_once_with(step_id='s-STEPID')
-        self._interpret_emr_step_log.assert_called_once_with(
+        self._interpret_emr_step_logs.assert_called_once_with(
             runner.fs, self._ls_step_logs.return_value)
 
     def test_no_step_id(self):
@@ -3535,4 +3535,4 @@ class GetStepLogInterpretationTestCase(MockBotoTestCase):
 
         self.assertTrue(self.log.warning.called)
         self.assertFalse(self._ls_step_logs.called)
-        self.assertFalse(self._interpret_emr_step_log.called)
+        self.assertFalse(self._interpret_emr_step_logs.called)


### PR DESCRIPTION
Account for EMR breaking the step log into pieces, and add missing unit tests for EMR functions in `mrjob.logs.step`.
