### PR TITLE
Wait for s3 logs

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1855,9 +1855,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
             try:
                 log.info(
-                    'Waiting %d minutes for logs to transfer to S3...\n'
-                    '(ctrl-c to skip this)\n\n'
-                    'You can fetch logs faster over SSH; see '
+                    'Waiting %d minutes for logs to transfer to S3...'
+                    ' (ctrl-c to skip)\n\n'
+                    'To fetch logs immediately next time, set up SSH. See:\n'
                     'https://pythonhosted.org/mrjob/guides'
                     '/emr-quickstart.html#configuring-ssh-credentials\n' %
                     _S3_LOG_WAIT_MINUTES)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -154,6 +154,10 @@ _PRE_4_X_STREAMING_JAR = '/home/hadoop/contrib/streaming/hadoop-streaming.jar'
 # intermediary jar used on 4.x AMIs
 _4_X_INTERMEDIARY_JAR = 'command-runner.jar'
 
+# we have to wait this many minutes for logs to transfer to S3 (or wait
+# for the cluster to terminate)
+_S3_LOG_WAIT_MINUTES = 5
+
 
 def s3_key_to_uri(s3_key):
     """Convert a boto Key object into an ``s3://`` URI"""
@@ -651,6 +655,10 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         #
         # This will be filled by _wait_for_steps_to_complete()
         self._log_interpretations = []
+
+        # set of step numbers (0-indexed) where we waited 5 minutes for logs to
+        # transfer to S3 (so we don't do it twice)
+        self._waited_for_logs_on_s3 = set()
 
     def _fix_s3_tmp_and_log_uri_opts(self):
         """Fill in s3_tmp_dir and s3_log_uri (in self._opts) if they
@@ -1817,7 +1825,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                     path) for host in hosts]
 
         # wait for logs to be on S3
-        self._wait_for_terminating_cluster_to_terminate()
+        self._wait_for_logs_on_s3()
 
         if self._s3_log_dir():
             s3_log_uri = posixpath.join(
@@ -1825,7 +1833,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             log.info('Looking for %s in %s...' % (log_desc, s3_log_uri))
             yield [s3_log_uri]
 
-    def _wait_for_terminating_cluster_to_terminate(self):
+    def _wait_for_logs_on_s3(self):
         """If the cluster is already terminating, wait for it to terminate,
         so that logs will be transferred to S3.
 
@@ -1838,7 +1846,30 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             return  # already terminated
 
         if cluster.status.state != 'TERMINATING':
-            return  # not going to terminate anytime soon
+            # going to need to wait for logs to get archived to S3
+            step_num = len(self._log_interpretations)
+
+            # already did this for this step
+            if step_num in self._waited_for_logs_on_s3:
+                return
+
+            try:
+                log.info(
+                    'Waiting %d minutes for logs to transfer to S3...\n'
+                    '(ctrl-c to skip this)\n\n'
+                    'You can fetch logs faster over SSH; see '
+                    'https://pythonhosted.org/mrjob/guides'
+                    '/emr-quickstart.html#configuring-ssh-credentials\n' %
+                    _S3_LOG_WAIT_MINUTES)
+
+                time.sleep(60 * _S3_LOG_WAIT_MINUTES)
+            except KeyboardInterrupt:
+                pass
+
+            # do this even if they ctrl-c'ed; don't make them do it
+            # for every log for this step
+            self._waited_for_logs_on_s3.add(step_num)
+            return
 
         log.info('Waiting for cluster (%s) to terminate...' %
                  cluster.id)

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1013,7 +1013,7 @@ class MockEmrConnection(object):
 
         if cluster.status.state == 'TERMINATING':
             # simulate progress, to support
-            # _wait_for_terminating_cluster_to_terminate()
+            # _wait_for_logs_on_s3()
             self.simulate_progress(cluster_id)
 
         return cluster

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3232,10 +3232,10 @@ class SetupLineEncodingTestCase(MockBotoTestCase):
                         m_open.mock_calls)
 
 
-class WaitForTerminatingClusterToTerminateTestCase(MockBotoTestCase):
+class WaitForLogsOnS3TestCase(MockBotoTestCase):
 
     def setUp(self):
-        super(WaitForTerminatingClusterToTerminateTestCase, self).setUp()
+        super(WaitForLogsOnS3TestCase, self).setUp()
 
         job = MRTwoStepJob(['-r', 'emr'])
         job.sandbox(stdin=BytesIO(b'foo\nbar\n'))
@@ -3247,41 +3247,87 @@ class WaitForTerminatingClusterToTerminateTestCase(MockBotoTestCase):
 
         self.mock_log = self.start(patch('mrjob.emr.log'))
 
-    def _test_silently_exits_on_state(self, state):
-        self.cluster.status.state = state
+        self.mock_sleep = self.start(patch('time.sleep'))
 
-        self.runner._wait_for_terminating_cluster_to_terminate()
+    def assert_waits_five_minutes(self):
+        waited = set(self.runner._waited_for_logs_on_s3)
+        step_num = len(self.runner._log_interpretations)
 
-        self.assertEqual(self.runner._describe_cluster().status.state, state)
+        self.runner._wait_for_logs_on_s3()
+
+        self.assertTrue(self.mock_log.info.called)
+        self.mock_sleep.assert_called_once_with(300)
+
+        self.assertEqual(
+            self.runner._waited_for_logs_on_s3,
+            waited | set([step_num]))
+
+    def assert_silently_exits(self):
+        state = self.cluster.status.state
+        waited = set(self.runner._waited_for_logs_on_s3)
+
+        self.runner._wait_for_logs_on_s3()
+
         self.assertFalse(self.mock_log.info.called)
+        self.assertEqual(waited, self.runner._waited_for_logs_on_s3)
+        self.assertEqual(self.runner._describe_cluster().status.state, state)
 
     def test_starting(self):
-        self._test_silently_exits_on_state('STARTING')
+        self.cluster.status.state = 'STARTING'
+        self.assert_waits_five_minutes()
 
     def test_bootstrapping(self):
-        self._test_silently_exits_on_state('BOOTSTRAPPING')
+        self.cluster.status.state = 'BOOTSTRAPPING'
+        self.assert_waits_five_minutes()
 
     def test_running(self):
-        self._test_silently_exits_on_state('RUNNING')
+        self.cluster.status.state = 'RUNNING'
+        self.assert_waits_five_minutes()
 
     def test_waiting(self):
-        self._test_silently_exits_on_state('WAITING')
+        self.cluster.status.state = 'WAITING'
+        self.assert_waits_five_minutes()
 
     def test_terminating(self):
         self.cluster.status.state = 'TERMINATING'
         self.cluster.delay_progress_simulation = 1
 
-        self.runner._wait_for_terminating_cluster_to_terminate()
+        self.runner._wait_for_logs_on_s3()
 
         self.assertEqual(self.runner._describe_cluster().status.state,
                          'TERMINATED')
         self.assertTrue(self.mock_log.info.called)
 
     def test_terminated(self):
-        self._test_silently_exits_on_state('TERMINATED')
+        self.cluster.status.state = 'TERMINATED'
+        self.assert_silently_exits()
 
     def test_terminated_with_errors(self):
-        self._test_silently_exits_on_state('TERMINATED_WITH_ERRORS')
+        self.cluster.status.state = 'TERMINATED_WITH_ERRORS'
+        self.assert_silently_exits()
+
+    def test_ctrl_c(self):
+        self.mock_sleep.side_effect = KeyboardInterrupt
+
+        self.assertEqual(self.runner._waited_for_logs_on_s3, set())
+
+        self.runner._wait_for_logs_on_s3()
+
+        self.assertTrue(self.mock_log.info.called)
+        self.mock_sleep.assert_called_once_with(300)
+
+        # still shouldn't make user ctrl-c again
+        self.assertEqual(self.runner._waited_for_logs_on_s3, set([0]))
+
+    def test_already_waited_five_minutes(self):
+        self.runner._waited_for_logs_on_s3.add(0)
+        self.assert_silently_exits()
+
+    def test_waited_for_previous_step(self):
+        self.runner._waited_for_logs_on_s3.add(0)
+        self.runner._log_interpretations.append({})
+
+        self.assert_waits_five_minutes()
 
 
 class StreamLogDirsTestCase(MockBotoTestCase):
@@ -3307,9 +3353,9 @@ class StreamLogDirsTestCase(MockBotoTestCase):
             'mrjob.emr.EMRJobRunner._s3_log_dir',
             return_value='s3://bucket/logs/j-CLUSTERID'))
 
-        self._wait_for_terminating_cluster_to_terminate = self.start(patch(
+        self._wait_for_logs_on_s3 = self.start(patch(
             'mrjob.emr.EMRJobRunner'
-            '._wait_for_terminating_cluster_to_terminate'))
+            '._wait_for_logs_on_s3'))
 
     def test_cant_stream_history_log_dirs_in_yarn(self):
         runner = EMRJobRunner()
@@ -3330,7 +3376,7 @@ class StreamLogDirsTestCase(MockBotoTestCase):
                 'ssh://master/mnt/var/log/hadoop/history',
             ])
             self.assertFalse(
-                self._wait_for_terminating_cluster_to_terminate.called)
+                self._wait_for_logs_on_s3.called)
             self.log.info.assert_called_once_with(
                 'Looking for history log in /mnt/var/log/hadoop/history'
                 ' on master...')
@@ -3341,7 +3387,7 @@ class StreamLogDirsTestCase(MockBotoTestCase):
             's3://bucket/logs/j-CLUSTERID/jobs',
         ])
         self.assertTrue(
-            self._wait_for_terminating_cluster_to_terminate.called)
+            self._wait_for_logs_on_s3.called)
         self.log.info.assert_called_once_with(
             'Looking for history log in'
             ' s3://bucket/logs/j-CLUSTERID/jobs...')
@@ -3368,7 +3414,7 @@ class StreamLogDirsTestCase(MockBotoTestCase):
                 'ssh://master/mnt/var/log/hadoop/steps/s-STEPID',
             ])
             self.assertFalse(
-                self._wait_for_terminating_cluster_to_terminate.called)
+                self._wait_for_logs_on_s3.called)
             self.log.info.assert_called_once_with(
                 'Looking for step log in /mnt/var/log/hadoop/steps/s-STEPID'
                 ' on master...')
@@ -3379,7 +3425,7 @@ class StreamLogDirsTestCase(MockBotoTestCase):
             's3://bucket/logs/j-CLUSTERID/steps/s-STEPID',
         ])
         self.assertTrue(
-            self._wait_for_terminating_cluster_to_terminate.called)
+            self._wait_for_logs_on_s3.called)
         self.log.info.assert_called_once_with(
             'Looking for step log in'
             ' s3://bucket/logs/j-CLUSTERID/steps/s-STEPID...')
@@ -3425,7 +3471,7 @@ class StreamLogDirsTestCase(MockBotoTestCase):
                     ' on master and task/core nodes...')
 
             self.assertFalse(
-                self._wait_for_terminating_cluster_to_terminate.called)
+                self._wait_for_logs_on_s3.called)
 
         self.log.reset_mock()
 
@@ -3433,7 +3479,7 @@ class StreamLogDirsTestCase(MockBotoTestCase):
             's3://bucket/logs/j-CLUSTERID/task-attempts',
         ])
         self.assertTrue(
-            self._wait_for_terminating_cluster_to_terminate.called)
+            self._wait_for_logs_on_s3.called)
         self.log.info.assert_called_once_with(
             'Looking for task logs in'
             ' s3://bucket/logs/j-CLUSTERID/task-attempts...')


### PR DESCRIPTION
EMR only updates logs on S3 every 5 minutes, so... we now wait five minutes (or wait for the cluster to terminate, if it's doing that) before parsing logs on S3 (fixes #1236).

We also tell people they can ctrl-c if frustrated, or skip the wait entirely next time by setting up SSH.