### PR TITLE
Don't join an EMR cluster with a different ec2_key_pair.

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2227,6 +2227,14 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         key_cluster_steps_list = []
 
         def add_if_match(cluster):
+            # skip if user specified a key pair and it doesn't match
+            if (self._opts['ec2_key_pair'] and
+                self._opts['ec2_key_pair'] !=
+                getattr(getattr(cluster,
+                    'ec2instanceattributes',
+                    object()), 'ec2keyname', None)):
+                return
+
             # this may be a retry due to locked clusters
             if cluster.id in exclude:
                 return


### PR DESCRIPTION
This PR should fix issue #1230. 

Sorry there are no tests for this particular feature, I couldn't quickly figure out how to trigger this behavior in the test suite, but it's been hand tested. 

If this is not useful please ignore.