### PR TITLE
4.x log fetching

### DIFF
--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -155,12 +155,12 @@ def find_mrjob_conf():
         yield '/etc/mrjob.conf'
 
     for path in candidates():
-        log.debug('looking for configs in %s' % path)
+        log.debug('Looking for configs in %s' % path)
         if os.path.exists(path):
-            log.info('using configs in %s' % path)
+            log.info('Using configs in %s' % path)
             return path
     else:
-        log.info("no configs found; falling back on auto-configuration")
+        log.info('No configs found; falling back on auto-configuration')
         return None
 
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -864,7 +864,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         log.info('Copying local files to %s...' % self._upload_mgr.prefix)
 
         for path, s3_uri in self._upload_mgr.path_to_uri().items():
-            log.info('  %s -> %s' % (path, s3_uri))
+            log.debug('  %s -> %s' % (path, s3_uri))
             self._upload_contents(s3_uri, path)
 
     def _upload_contents(self, s3_uri, path):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -156,8 +156,10 @@ _PRE_4_X_STREAMING_JAR = '/home/hadoop/contrib/streaming/hadoop-streaming.jar'
 _4_X_INTERMEDIARY_JAR = 'command-runner.jar'
 
 # we have to wait this many minutes for logs to transfer to S3 (or wait
-# for the cluster to terminate)
-_S3_LOG_WAIT_MINUTES = 5
+# for the cluster to terminate). Docs say logs are transferred every 5
+# minutes, but I've seen it take longer on the 4.3.0 AMI. Probably it's
+# 5 minutes plus time to copy the logs, or something like that.
+_S3_LOG_WAIT_MINUTES = 10
 
 
 def s3_key_to_uri(s3_key):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1873,7 +1873,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 return
 
             try:
-                if not fs.can_handle_path('ssh:///'):
+                if not self.fs.can_handle_path('ssh:///'):
                     log.info(
                         'Waiting %d minutes for logs to transfer to S3...'
                         ' (ctrl-c to skip)\n\n'

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1750,7 +1750,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     def _stream_history_log_dirs(self, output_dir=None):
         """Yield lists of directories to look for the history log in."""
         if version_gte(self.get_ami_version(), '4'):
-            # currently denied access by the yarn user, see #1244
+            # denied access on some 4.x AMIs by the yarn user, see #1244
             dir_name = 'hadoop-mapreduce/history'
             s3_dir_name = 'hadoop-mapreduce/history'
         elif version_gte(self.get_ami_version(), '3'):
@@ -1770,7 +1770,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     def _stream_task_log_dirs(self, application_id=None, output_dir=None):
         """Get lists of directories to look for the task logs in."""
         if version_gte(self.get_ami_version(), '4'):
-            # currently denied access by the yarn user, see #1244
+            # denied access on some 4.x AMIs by the yarn user, see #1244
             dir_name = 'hadoop-yarn/containers'
             s3_dir_name = 'containers'
         else:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1750,6 +1750,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     def _stream_history_log_dirs(self, output_dir=None):
         """Yield lists of directories to look for the history log in."""
         if version_gte(self.get_ami_version(), '4'):
+            # currently denied access by the yarn user, see #1244
             dir_name = 'hadoop-mapreduce/history'
             s3_dir_name = 'hadoop-mapreduce/history'
         elif version_gte(self.get_ami_version(), '3'):
@@ -1769,6 +1770,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     def _stream_task_log_dirs(self, application_id=None, output_dir=None):
         """Get lists of directories to look for the task logs in."""
         if version_gte(self.get_ami_version(), '4'):
+            # currently denied access by the yarn user, see #1244
             dir_name = 'hadoop-yarn/containers'
             s3_dir_name = 'containers'
         else:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1873,15 +1873,16 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 return
 
             try:
+                log.info('Waiting %d minutes for logs to transfer to S3...'
+                         ' (ctrl-c to skip)' % _S3_LOG_WAIT_MINUTES)
+
                 if not self.fs.can_handle_path('ssh:///'):
                     log.info(
-                        'Waiting %d minutes for logs to transfer to S3...'
-                        ' (ctrl-c to skip)\n\n'
+                        '\n'
                         'To fetch logs immediately next time, set up SSH.'
                         ' See:\n'
                         'https://pythonhosted.org/mrjob/guides'
-                        '/emr-quickstart.html#configuring-ssh-credentials\n' %
-                        _S3_LOG_WAIT_MINUTES)
+                        '/emr-quickstart.html#configuring-ssh-credentials\n')
 
                 time.sleep(60 * _S3_LOG_WAIT_MINUTES)
             except KeyboardInterrupt:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -672,7 +672,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         # set s3_tmp_dir by checking for existing buckets
         if not self._opts['s3_tmp_dir']:
             self._set_s3_tmp_dir()
-            log.info('using %s as our temp dir on S3' %
+            log.info('Using %s as our temp dir on S3' %
                      self._opts['s3_tmp_dir'])
 
         self._opts['s3_tmp_dir'] = self._check_and_fix_s3_dir(
@@ -1153,7 +1153,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             # Something happened with boto and the user should know.
             log.exception(e)
             return
-        log.info('cluster %s successfully terminated' % self._cluster_id)
+        log.info('Cluster %s successfully terminated' % self._cluster_id)
 
     def _wait_for_s3_eventual_consistency(self):
         """Sleep for a little while, to give S3 a chance to sync up.

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1871,13 +1871,15 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 return
 
             try:
-                log.info(
-                    'Waiting %d minutes for logs to transfer to S3...'
-                    ' (ctrl-c to skip)\n\n'
-                    'To fetch logs immediately next time, set up SSH. See:\n'
-                    'https://pythonhosted.org/mrjob/guides'
-                    '/emr-quickstart.html#configuring-ssh-credentials\n' %
-                    _S3_LOG_WAIT_MINUTES)
+                if not fs.can_handle_path('ssh:///'):
+                    log.info(
+                        'Waiting %d minutes for logs to transfer to S3...'
+                        ' (ctrl-c to skip)\n\n'
+                        'To fetch logs immediately next time, set up SSH.'
+                        ' See:\n'
+                        'https://pythonhosted.org/mrjob/guides'
+                        '/emr-quickstart.html#configuring-ssh-credentials\n' %
+                        _S3_LOG_WAIT_MINUTES)
 
                 time.sleep(60 * _S3_LOG_WAIT_MINUTES)
             except KeyboardInterrupt:

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -663,7 +663,7 @@ class MRJobRunner(object):
         cleaned up by self.cleanup()"""
         if not self._local_tmp_dir:
             path = os.path.join(self._opts['local_tmp_dir'], self._job_key)
-            log.info('creating temp directory %s' % path)
+            log.info('Creating temp directory %s' % path)
             if os.path.isdir(path):
                 shutil.rmtree(path)
             os.makedirs(path)

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -663,7 +663,7 @@ class MRJobRunner(object):
         cleaned up by self.cleanup()"""
         if not self._local_tmp_dir:
             path = os.path.join(self._opts['local_tmp_dir'], self._job_key)
-            log.info('creating tmp directory %s' % path)
+            log.info('creating temp directory %s' % path)
             if os.path.isdir(path):
                 shutil.rmtree(path)
             os.makedirs(path)

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -37,7 +37,7 @@ except ImportError:
 from mrjob.compat import map_version
 from mrjob.compat import version_gte
 from mrjob.conf import combine_values
-from mrjob.emr import _EMR_HADOOP_LOG_DIR
+from mrjob.emr import _EMR_LOG_DIR
 from mrjob.emr import EMRJobRunner
 from mrjob.parse import _RFC1123
 from mrjob.parse import is_s3_uri
@@ -194,7 +194,7 @@ class MockBotoTestCase(SandboxedTestCase):
         # Create temporary directories and add them to MOCK_SSH_ROOTS
         master_ssh_root = tempfile.mkdtemp(prefix='master_ssh_root.')
         os.environ['MOCK_SSH_ROOTS'] = 'testmaster=%s' % master_ssh_root
-        mock_ssh_dir('testmaster', _EMR_HADOOP_LOG_DIR + '/history')
+        mock_ssh_dir('testmaster', _EMR_LOG_DIR + '/hadoop/history')
 
         if not hasattr(self, 'slave_ssh_roots'):
             self.slave_ssh_roots = []

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3249,14 +3249,14 @@ class WaitForLogsOnS3TestCase(MockBotoTestCase):
 
         self.mock_sleep = self.start(patch('time.sleep'))
 
-    def assert_waits_five_minutes(self):
+    def assert_waits_ten_minutes(self):
         waited = set(self.runner._waited_for_logs_on_s3)
         step_num = len(self.runner._log_interpretations)
 
         self.runner._wait_for_logs_on_s3()
 
         self.assertTrue(self.mock_log.info.called)
-        self.mock_sleep.assert_called_once_with(300)
+        self.mock_sleep.assert_called_once_with(600)
 
         self.assertEqual(
             self.runner._waited_for_logs_on_s3,
@@ -3274,19 +3274,19 @@ class WaitForLogsOnS3TestCase(MockBotoTestCase):
 
     def test_starting(self):
         self.cluster.status.state = 'STARTING'
-        self.assert_waits_five_minutes()
+        self.assert_waits_ten_minutes()
 
     def test_bootstrapping(self):
         self.cluster.status.state = 'BOOTSTRAPPING'
-        self.assert_waits_five_minutes()
+        self.assert_waits_ten_minutes()
 
     def test_running(self):
         self.cluster.status.state = 'RUNNING'
-        self.assert_waits_five_minutes()
+        self.assert_waits_ten_minutes()
 
     def test_waiting(self):
         self.cluster.status.state = 'WAITING'
-        self.assert_waits_five_minutes()
+        self.assert_waits_ten_minutes()
 
     def test_terminating(self):
         self.cluster.status.state = 'TERMINATING'
@@ -3314,12 +3314,12 @@ class WaitForLogsOnS3TestCase(MockBotoTestCase):
         self.runner._wait_for_logs_on_s3()
 
         self.assertTrue(self.mock_log.info.called)
-        self.mock_sleep.assert_called_once_with(300)
+        self.mock_sleep.assert_called_once_with(600)
 
         # still shouldn't make user ctrl-c again
         self.assertEqual(self.runner._waited_for_logs_on_s3, set([0]))
 
-    def test_already_waited_five_minutes(self):
+    def test_already_waited_ten_minutes(self):
         self.runner._waited_for_logs_on_s3.add(0)
         self.assert_silently_exits()
 
@@ -3327,7 +3327,7 @@ class WaitForLogsOnS3TestCase(MockBotoTestCase):
         self.runner._waited_for_logs_on_s3.add(0)
         self.runner._log_interpretations.append({})
 
-        self.assert_waits_five_minutes()
+        self.assert_waits_ten_minutes()
 
 
 class StreamLogDirsTestCase(MockBotoTestCase):


### PR DESCRIPTION
This fixes log fetching on the 4.x AMIs, which put the history and task logs in radically different places (but at least make them available).

Also cleaned up status logging for the EMR runner to my satisfaction (see #1044).