### PR TITLE
Stop apt-getting

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -402,12 +402,14 @@ and install another Python binary.
    :set: emr
    :default: ``True``
 
-   Attempt to install a compatible version of Python at bootstrap time.
+   Attempt to install a compatible version of Python at bootstrap time,
+   and, if possible, `ujson`.
 
-   Python 2 is already installed on all AMIs, but if you're in Python 2,
-   this will also install :command:`pip` and the ``ujson`` library.
+   In Python 2, install :command:`pip` and the ``ujson`` library (Python 2
+   is already installed on all AMIs). This does nothing on the (deprecated)
+   2.x AMIs because :command:`apt-get` no longer works.
 
-   In Python 3 this option attempts to install Python 3.4 from a package
+   In Python 3, this option attempts to install Python 3.4 from a package
    (``sudo yum install -y python34``), which will work unless you've set
    :mrjob-opt:`ami_version` to something earlier than 3.7.0.
 
@@ -436,7 +438,8 @@ and install another Python binary.
     ``pip install path/to/tarballs/*.tar.gz#`` to :mrjob-opt:`bootstrap`
     instead.
 
-    In addition to being deprecated, this option only works in Python 2.
+    In addition to being deprecated, this option only works in Python 2,
+    and only on the 3.x AMIs and later.
     See :ref:`Installing packages with pip on Python 3 <using-pip-py3>`
     to see how to do this on Python 3.
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1951,7 +1951,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             return []
 
         # apt-get no longer works on 2.x AMIs
-        if not (version_get(self._opts['ami_version'], '3')):
+        if not (version_gte(self._opts['ami_version'], '3')):
             return []
 
         if PY2:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1951,7 +1951,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             return []
 
         # apt-get no longer works on 2.x AMIs
-        if not (version_gte(self._opts['ami_version'], '3')):
+        if (self._opts['ami_version'] == 'latest' or
+            not version_gte(self._opts['ami_version'], '3')):
             return []
 
         if PY2:
@@ -2002,7 +2003,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         # bootstrap_python_packages
         if self._opts['bootstrap_python_packages']:
             if PY2:
-                if version_gte(self._opts['ami_version'], '3'):
+                if (self._opts['ami_version'] != 'latest' and
+                    version_gte(self._opts['ami_version'], '3')):
+
                     log.warning(
                         'bootstrap_python_packages is deprecated since v0.4.2'
                         ' and will be removed in v0.6.0. Consider using'

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3001,9 +3001,8 @@ class BootstrapPythonTestCase(MockBotoTestCase):
 
     if PY2:
         EXPECTED_BOOTSTRAP = [
-            ['sudo apt-get install -y python-pip || '
-             'sudo yum install -y python-pip'],
-             ['sudo pip install --upgrade ujson']]
+            ['sudo yum install -y python-pip'],
+            ['sudo pip install --upgrade ujson']]
     else:
         EXPECTED_BOOTSTRAP = [['sudo yum install -y python34']]
 
@@ -3033,8 +3032,8 @@ class BootstrapPythonTestCase(MockBotoTestCase):
             self.assertEqual(runner._bootstrap_python(), [])
             self.assertEqual(runner._bootstrap, [])
 
-    def _test_old_ami_version(self, ami_version):
-        mr_job = MRTwoStepJob(['-r', 'emr', '--ami-version', ami_version])
+    def test_ami_version_3_6_0(self):
+        mr_job = MRTwoStepJob(['-r', 'emr', '--ami-version', '3.6.0'])
 
         with no_handlers_for_logger('mrjob.emr'):
             stderr = StringIO()
@@ -3050,11 +3049,19 @@ class BootstrapPythonTestCase(MockBotoTestCase):
                 if not PY2:
                     self.assertIn('will probably not work', stderr.getvalue())
 
-    def test_ami_version_3_6_0(self):
-        self._test_old_ami_version('3.6.0')
+    def _test_2_x_ami(self, ami_version):
+        mr_job = MRTwoStepJob(['-r', 'emr', '--ami-version', ami_version])
+
+        with mr_job.make_runner() as runner:
+            self.assertEqual(runner._opts['bootstrap_python'], True)
+            self.assertEqual(runner._bootstrap_python(), [])
+            self.assertEqual(runner._bootstrap, [])
+
+    def test_ami_version_2_4_11(self):
+        self._test_2_x_ami('2.4.11')
 
     def test_ami_version_latest(self):
-        self._test_old_ami_version('latest')
+        self._test_2_x_ami('latest')
 
     def test_bootstrap_python_comes_before_bootstrap(self):
         mr_job = MRTwoStepJob(['-r', 'emr', '--bootstrap', 'true'])


### PR DESCRIPTION
This disables `bootstrap_python` and `bootstrap_python_packages` on the 2.x AMIs, since `apt-get` no longer works there (fixes #1248).

This doesn't yet update the docs (will do that when in a more literary frame of mind).