### PR TITLE
Clean up status logging

### DIFF
--- a/docs/runners-emr.rst
+++ b/docs/runners-emr.rst
@@ -11,8 +11,9 @@ Job Runner
 EMR Utilities
 -------------
 
-.. automethod:: EMRJobRunner.make_emr_conn
 .. automethod:: EMRJobRunner.get_ami_version
+.. automethod:: EMRJobRunner.get_cluster_id
+.. automethod:: EMRJobRunner.make_emr_conn
 
 S3 Utilities
 ------------

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -415,7 +415,7 @@ def load_opts_from_mrjob_confs(runner_alias, conf_paths=None):
         from multiple paths due to symlinks.
     """
     if conf_paths is None:
-        return load_opts_from_mrjob_conf(runner_alias, find_mrjob_conf())
+        return load_opts_from_mrjob_conf(runner_alias)
     else:
         # don't include conf files that were loaded earlier in conf_paths
         already_loaded = []

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1081,7 +1081,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         # delete all the files we created
         if self._s3_tmp_dir:
             try:
-                log.info('Removing all files in %s' % self._s3_tmp_dir)
+                log.info('Removing s3 temp directory %s...' % self._s3_tmp_dir)
                 self.fs.rm(self._s3_tmp_dir)
                 self._s3_tmp_dir = None
             except Exception as e:
@@ -1095,7 +1095,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         if self._s3_log_dir() and not self._opts['cluster_id'] \
                 and not self._opts['pool_clusters']:
             try:
-                log.info('Removing all files in %s' % self._s3_log_dir())
+                log.info('Removing log files in %s...' % self._s3_log_dir())
                 self.fs.rm(self._s3_log_dir())
             except Exception as e:
                 log.exception(e)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1694,16 +1694,16 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                     for path in self._get_input_paths()]
         else:
             # put intermediate data in HDFS
-            return ['hdfs:///tmp/mrjob/%s/step-output/%s/' % (
-                self._job_key, step_num)]
+            return ['hdfs:///tmp/mrjob/%s/step-output/%04d/' % (
+                self._job_key, step_num - 1)]
 
     def _step_output_uri(self, step_num):
         if step_num == len(self._get_steps()) - 1:
             return self._output_dir
         else:
             # put intermediate data in HDFS
-            return 'hdfs:///tmp/mrjob/%s/step-output/%s/' % (
-                self._job_key, step_num + 1)
+            return 'hdfs:///tmp/mrjob/%s/step-output/%04d/' % (
+                self._job_key, step_num)
 
     ### LOG PARSING (implementation of LogInterpretationMixin) ###
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1709,11 +1709,20 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
     def _stream_history_log_dirs(self, output_dir=None):
         """Yield lists of directories to look for the history log in."""
-        if version_gte(self.get_ami_version(), '4'):
-            # denied access on some 4.x AMIs by the yarn user, see #1244
-            dir_name = 'hadoop-mapreduce/history'
-            s3_dir_name = 'hadoop-mapreduce/history'
-        elif version_gte(self.get_ami_version(), '3'):
+        # History logs have different paths on the 4.x AMIs.
+        #
+        # Disabling until we can effectively fetch these logs over SSH;
+        # on 4.3.0 there are permissions issues (see #1244), and
+        # on 4.0.0 the logs aren't on the filesystem at all (see #1253).
+        #
+        # Unlike on 3.x, the history logs *are* available on S3, but they're
+        # not useful enough to justify the wait when SSH is set up
+
+        #if version_gte(self.get_ami_version(), '4'):
+        #    # denied access on some 4.x AMIs by the yarn user, see #1244
+        #    dir_name = 'hadoop-mapreduce/history'
+        #    s3_dir_name = 'hadoop-mapreduce/history'
+        if version_gte(self.get_ami_version(), '3'):
             # on the 3.x AMIs, the history log lives inside HDFS and isn't
             # copied to S3. We don't need it anyway; everything relevant
             # is in the step log

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -107,11 +107,12 @@ class HadoopFilesystem(Filesystem):
                     yield os.path.join(path, 'bin')
 
         for path in unique(yield_paths()):
-            log.info('Looking for hadoop binary in %s' % (path or '$PATH'))
+            log.info('Looking for hadoop binary in %s...' % (path or '$PATH'))
 
             hadoop_bin = which('hadoop', path=path)
 
             if hadoop_bin:
+                log.info('Found hadoop binary: %s' % hadoop_bin)
                 return [hadoop_bin]
         else:
             log.info("Falling back to 'hadoop'")

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -227,7 +227,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         """Search for the hadoop streaming jar. See
         :py:meth:`_hadoop_streaming_jar_dirs` for where we search."""
         for path in unique(self._hadoop_streaming_jar_dirs()):
-            log.info('Looking for Hadoop streaming jar in %s' % path)
+            log.info('Looking for Hadoop streaming jar in %s...' % path)
 
             streaming_jars = []
             for path in self.fs.ls(path):
@@ -343,12 +343,12 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         """
         self.fs.mkdir(self._upload_mgr.prefix)
 
-        log.info('Copying local files into %s' % self._upload_mgr.prefix)
+        log.info('Copying local files to %s...' % self._upload_mgr.prefix)
         for path, uri in self._upload_mgr.path_to_uri().items():
             self._upload_to_hdfs(path, uri)
 
     def _upload_to_hdfs(self, path, target):
-        log.debug('Uploading %s -> %s on HDFS' % (path, target))
+        log.debug('  %s -> %s' % (path, target))
         self.fs._put(path, target)
 
     def _dump_stdin_to_local_file(self):
@@ -357,7 +357,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
          # prompt user, so they don't think the process has stalled
         log.info('reading from STDIN')
 
-        log.debug('dumping stdin to local file %s' % stdin_path)
+        log.debug('dumping stdin to local file %s...' % stdin_path)
         stdin_file = open(stdin_path, 'wb')
         for line in self._stdin:
             stdin_file.write(line)
@@ -370,7 +370,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
 
             # log this *after* _args_for_step(), which can start a search
             # for the Hadoop streaming jar
-            log.info('Running step %d of %d' %
+            log.info('Running step %d of %d...' %
                       (step_num + 1, self._num_steps()))
             log.debug('> %s' % cmd_line(step_args))
 
@@ -548,7 +548,8 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         super(HadoopJobRunner, self)._cleanup_local_tmp()
 
         if self._hadoop_tmp_dir:
-            log.info('deleting %s from HDFS' % self._hadoop_tmp_dir)
+            log.info('Removing HDFS temp directory %s...' %
+                     self._hadoop_tmp_dir)
             try:
                 self.fs.rm(self._hadoop_tmp_dir)
             except Exception as e:
@@ -614,11 +615,11 @@ def _hadoop_prefix_from_bin(hadoop_bin):
 
 
 def _log_line_from_hadoop(line, level=None):
-    """Log ``'HADOOP: <line>'``. *line* should be a string.
+    """Log ``'  <line>'``. *line* should be a string.
 
     Optionally specify a logging level (default is logging.INFO).
     """
-    log.log(level or logging.INFO, 'HADOOP: %s' % line)
+    log.log(level or logging.INFO, '  %s' % line)
 
 
 def _log_record_from_hadoop(record):

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -625,7 +625,7 @@ def _log_line_from_hadoop(line, level=None):
 def _log_record_from_hadoop(record):
     """Log log4j record parsed from hadoop stderr."""
     if _is_counter_log4j_record(record):
-        log.info('(parsing counters)')
+        log.info('  (parsing counters)')
     else:
         level = getattr(logging, record.get('level') or '', None)
         _log_line_from_hadoop(record['message'], level=level)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -535,14 +535,19 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
                     for p in self._get_input_paths()]
         else:
             return [posixpath.join(
-                self._hadoop_tmp_dir, 'step-output', str(step_num))]
+                self._hadoop_tmp_dir,
+                'step-output/%04d' % (step_num - 1)
+            )]
+
 
     def _hdfs_step_output_dir(self, step_num):
         if step_num == len(self._get_steps()) - 1:
             return self._output_dir
         else:
             return posixpath.join(
-                self._hadoop_tmp_dir, 'step-output', str(step_num + 1))
+                self._hadoop_tmp_dir,
+                'step-output/%04d' % step_num
+            )
 
     def _cleanup_local_tmp(self):
         super(HadoopJobRunner, self)._cleanup_local_tmp()

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -629,8 +629,6 @@ def _log_line_from_hadoop(line, level=None):
 
 def _log_record_from_hadoop(record):
     """Log log4j record parsed from hadoop stderr."""
-    if _is_counter_log4j_record(record):
-        log.info('  (parsing counters)')
-    else:
+    if not _is_counter_log4j_record(record):  # counters are printed separately
         level = getattr(logging, record.get('level') or '', None)
         _log_line_from_hadoop(record['message'], level=level)

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -226,7 +226,7 @@ class LocalMRJobRunner(SimMRJobRunner):
 
         :return: dict(proc=Popen, args=[process args], write_to=file)
         """
-        log.info('> %s > %s' % (' | '.join(
+        log.debug('> %s > %s' % (' | '.join(
             args if isinstance(args, string_types) else cmd_line(args)
             for args in procs_args), output_path))
 
@@ -284,10 +284,10 @@ class LocalMRJobRunner(SimMRJobRunner):
             # in practice there's only going to be at most one line in
             # one of these lists, but the code is cleaner this way
             for status in parsed['statuses']:
-                log.info('status: %s' % status)
+                log.info('Status: %s' % status)
 
             for line in parsed['other']:
-                log.error('STDERR: %s' % line.rstrip('\r\n'))
+                log.debug('STDERR: %s' % line.rstrip('\r\n'))
                 yield line
 
     def _default_python_bin(self, local=False):

--- a/mrjob/logs/wrap.py
+++ b/mrjob/logs/wrap.py
@@ -57,8 +57,9 @@ def _ls_logs(fs, log_dir_stream, matcher, **kwargs):
     # wrapper for fs.ls() that turns IOErrors into warnings
     def _fs_ls(path):
         try:
-            for path in fs.ls(log_dir):
-                yield path
+            if fs.exists(log_dir):
+                for path in fs.ls(log_dir):
+                    yield path
         except IOError as e:
             log.warning("couldn't ls() %s: %r" % (log_dir, e))
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -481,7 +481,7 @@ class MRJobRunner(object):
                 'WARNING! Trying to stream output from a closed runner, output'
                 ' will probably be empty.')
 
-        log.info('Streaming final output from %s' % output_dir)
+        log.info('Streaming final output from %s...' % output_dir)
 
         def split_path(path):
             while True:
@@ -519,7 +519,7 @@ class MRJobRunner(object):
         This won't remove output_dir if it's outside of our tmp dir.
         """
         if self._local_tmp_dir:
-            log.info('removing tmp directory %s' % self._local_tmp_dir)
+            log.info('Removing tmp directory %s...' % self._local_tmp_dir)
             try:
                 shutil.rmtree(self._local_tmp_dir)
             except OSError as e:
@@ -929,7 +929,7 @@ class MRJobRunner(object):
             return
 
         path = os.path.join(self._get_local_tmp_dir(), dest)
-        log.info('writing wrapper script to %s' % path)
+        log.debug('Writing wrapper script to %s' % path)
 
         contents = self._setup_wrapper_script_content(setup)
         for line in contents:
@@ -1266,7 +1266,7 @@ class MRJobRunner(object):
         env['TMPDIR'] = self._opts['local_tmp_dir']
         env['TEMP'] = self._opts['local_tmp_dir']
 
-        log.info('writing to %s' % output_path)
+        log.debug('Writing to %s' % output_path)
 
         err_path = os.path.join(self._get_local_tmp_dir(), 'sort-stderr')
 
@@ -1275,7 +1275,7 @@ class MRJobRunner(object):
             with open(output_path, 'wb') as output:
                 with open(err_path, 'wb') as err:
                     args = ['sort'] + list(input_paths)
-                    log.info('> %s' % cmd_line(args))
+                    log.debug('> %s' % cmd_line(args))
                     try:
                         check_call(args, stdout=output, stderr=err, env=env)
                         return
@@ -1285,11 +1285,11 @@ class MRJobRunner(object):
         # Looks like we're using Windows sort
         self._sort_is_windows_sort = True
 
-        log.info('Piping files into sort for Windows compatibility')
+        log.debug('Piping files into sort for Windows compatibility')
         with open(output_path, 'wb') as output:
             with open(err_path, 'wb') as err:
                 args = ['sort']
-                log.info('> %s' % cmd_line(args))
+                log.debug('> %s' % cmd_line(args))
                 proc = Popen(args, stdin=PIPE, stdout=output, stderr=err,
                              env=env)
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -519,7 +519,7 @@ class MRJobRunner(object):
         This won't remove output_dir if it's outside of our tmp dir.
         """
         if self._local_tmp_dir:
-            log.info('Removing tmp directory %s...' % self._local_tmp_dir)
+            log.info('Removing temp directory %s...' % self._local_tmp_dir)
             try:
                 shutil.rmtree(self._local_tmp_dir)
             except OSError as e:

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -496,8 +496,7 @@ class SimMRJobRunner(MRJobRunner):
             ','.join(cache_local_archives))
 
         # task and attempt IDs
-        # TODO: these are a crappy imitation of task/attempt IDs
-        #       see mrjob.logs.ids for examples
+        # TODO: these are a crappy imitation of task/attempt IDs (see #1254)
         j['mapreduce.task.id'] = 'task_%s_%s_%04d%d' % (
             self._job_key, step_type.lower(), step_num, task_num)
         # (we only have one attempt)

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -185,7 +185,7 @@ class SimMRJobRunner(MRJobRunner):
                 # of self._prev_outfiles
                 sort_output_path = os.path.join(
                     self._get_local_tmp_dir(),
-                    'step-%d-mapper-sorted' % step_num)
+                    'step-%04d-mapper-sorted' % step_num)
 
                 self._invoke_sort(self._step_input_paths(), sort_output_path)
                 self._prev_outfiles = [sort_output_path]
@@ -210,7 +210,7 @@ class SimMRJobRunner(MRJobRunner):
 
         jobconf = self._jobconf_for_step(step_num)
 
-        outfile_prefix = 'step-%d-%s' % (step_num, step_type)
+        outfile_prefix = 'step-%04d-%s' % (step_num, step_type)
 
         # allow setting number of tasks from jobconf
         if step_type == 'reducer':
@@ -496,10 +496,12 @@ class SimMRJobRunner(MRJobRunner):
             ','.join(cache_local_archives))
 
         # task and attempt IDs
-        j['mapreduce.task.id'] = 'task_%s_%s_%05d%d' % (
+        # TODO: these are a crappy imitation of task/attempt IDs
+        #       see mrjob.logs.ids for examples
+        j['mapreduce.task.id'] = 'task_%s_%s_%04d%d' % (
             self._job_key, step_type.lower(), step_num, task_num)
         # (we only have one attempt)
-        j['mapreduce.task.attempt.id'] = 'attempt_%s_%s_%05d%d_0' % (
+        j['mapreduce.task.attempt.id'] = 'attempt_%s_%s_%04d%d_0' % (
             self._job_key, step_type.lower(), step_num, task_num)
 
         # not actually sure what's correct for combiners here. It'll definitely

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -172,6 +172,9 @@ class SimMRJobRunner(MRJobRunner):
 
         # run mapper, combiner, sort, reducer for each step
         for step_num, step in enumerate(self._get_steps()):
+            log.info('Running step %d of %d...' % (
+                step_num + 1, self._num_steps()))
+
             self._check_step_works_with_runner(step)
             self._counters.append({})
 
@@ -193,7 +196,7 @@ class SimMRJobRunner(MRJobRunner):
         # move final output to output directory
         for i, outfile in enumerate(self._prev_outfiles):
             final_outfile = os.path.join(self._output_dir, 'part-%05d' % i)
-            log.info('Moving %s -> %s' % (outfile, final_outfile))
+            log.debug('Moving %s -> %s' % (outfile, final_outfile))
             shutil.move(outfile, final_outfile)
 
     def _invoke_step(self, step_num, step_type):
@@ -259,7 +262,7 @@ class SimMRJobRunner(MRJobRunner):
             output_path = os.path.join(
                 self._get_local_tmp_dir(),
                 outfile_prefix + '_part-%05d' % task_num)
-            log.info('writing to %s' % output_path)
+            log.debug('Writing to %s' % output_path)
 
             self._run_step(step_num, step_type, input_path, output_path,
                            working_dir, env)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3381,10 +3381,15 @@ class StreamLogDirsTestCase(MockBotoTestCase):
         self.assertRaises(StopIteration, next, results)
 
     def test_stream_history_log_dirs_from_4_x_amis(self):
-        self._test_stream_history_log_dirs(
-            ssh=True, ami_version='4.3.0',
-            expected_dir_name='hadoop-mapreduce/history',
-            expected_s3_dir_name='hadoop-mapreduce/history')
+        # history log fetching is disabled until we fix
+        # #1244 and #1253
+        runner = EMRJobRunner(ami_version='4.3.0')
+        results = runner._stream_history_log_dirs()
+        self.assertRaises(StopIteration, next, results)
+        #self._test_stream_history_log_dirs(
+        #    ssh=True, ami_version='4.3.0',
+        #    expected_dir_name='hadoop-mapreduce/history',
+        #    expected_s3_dir_name='hadoop-mapreduce/history')
 
     def _test_stream_step_log_dirs(self, ssh):
         ec2_key_pair_file = '/path/to/EMR.pem' if ssh else None

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -313,9 +313,9 @@ class InlineMRJobRunnerJobConfTestCase(SandboxedTestCase):
         self.assertEqual(results['mapreduce.map.input.length'], '4')
         self.assertEqual(results['mapreduce.map.input.start'], '0')
         self.assertEqual(results['mapreduce.task.attempt.id'],
-                       'attempt_%s_mapper_000000_0' % runner._job_key)
+                       'attempt_%s_mapper_00000_0' % runner._job_key)
         self.assertEqual(results['mapreduce.task.id'],
-                       'task_%s_mapper_000000' % runner._job_key)
+                       'task_%s_mapper_00000' % runner._job_key)
         self.assertEqual(results['mapreduce.task.ismap'], 'true')
         self.assertEqual(results['mapreduce.task.output.dir'],
                          runner._output_dir)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -326,7 +326,7 @@ class LargeAmountsOfStderrTestCase(TestCase):
         signal.signal(signal.SIGALRM, self._old_alarm_handler)
 
     def test_large_amounts_of_stderr(self):
-        mr_job = MRVerboseJob(['--no-conf', '-r', 'local'])
+        mr_job = MRVerboseJob(['--no-conf', '-r', 'local', '-v'])
         mr_job.sandbox()
 
         try:
@@ -342,9 +342,9 @@ class LargeAmountsOfStderrTestCase(TestCase):
             stderr = mr_job.stderr.getvalue()
             self.assertIn(
                 b"Counters: 1\n\tFoo\n\t\tBar=10000", stderr)
-            self.assertIn(b'status: 0\n', stderr)
-            self.assertIn(b'status: 99\n', stderr)
-            self.assertNotIn(b'status: 100\n', stderr)
+            self.assertIn(b'Status: 0\n', stderr)
+            self.assertIn(b'Status: 99\n', stderr)
+            self.assertNotIn(b'Status: 100\n', stderr)
             self.assertIn(b'STDERR: Qux\n', stderr)
             # exception should appear in exception message
             self.assertIn(b'BOOM', stderr)
@@ -390,7 +390,7 @@ class PythonBinTestCase(EmptyMrjobConfTestCase):
     def test_python_dash_v_as_python_bin(self):
         python_cmd = cmd_line([sys.executable or 'python', '-v'])
         mr_job = MRTwoStepJob(['--python-bin', python_cmd, '--no-conf',
-                               '-r', 'local'])
+                               '-r', 'local', '-v'])
         mr_job.sandbox(stdin=[b'bar\n'])
 
         with no_handlers_for_logger():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -833,7 +833,7 @@ class SetupTestCase(SandboxedTestCase):
 
         with no_handlers_for_logger('mrjob.local'):
             stderr = StringIO()
-            log_to_stream('mrjob.local', stderr)
+            log_to_stream('mrjob.local', stderr, debug=True)
 
             with job.make_runner() as r:
                 r.run()


### PR DESCRIPTION
Went over every `log.*()` call that runners make, and make them as consistent and non-noisy as possible (see #1044).

Also checked off the last few items on my pre-release TODO list (see #1233)

This is (hopefully) the last feature change before the v0.5.0 release.