### PR TITLE
Respect key pairs when pooling

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2242,8 +2242,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             if (self._opts['ec2_key_pair'] and
                 self._opts['ec2_key_pair'] !=
                 getattr(getattr(cluster,
-                    'ec2instanceattributes',
-                    object()), 'ec2keyname', None)):
+                    'ec2instanceattributes', None), 'ec2keyname', None)):
                 return
 
             # this may be a retry due to locked clusters

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2152,6 +2152,34 @@ class PoolMatchingTestCase(MockBotoTestCase):
 
         self.assertJoins(cluster_id, ['-r', 'emr', '--pool-clusters'])
 
+    def test_can_join_cluster_with_same_key_pair(self):
+        _, cluster_id = self.make_pooled_cluster(ec2_key_pair='EMR')
+
+        self.assertJoins(
+            cluster_id,
+            ['-r', 'emr', '--ec2-key-pair', 'EMR', '--pool-clusters'])
+
+    def test_cant_join_cluster_with_different_key_pair(self):
+        _, cluster_id = self.make_pooled_cluster(ec2_key_pair='EMR')
+
+        self.assertDoesNotJoin(
+            cluster_id,
+            ['-r', 'emr', '--ec2-key-pair', 'EMR2', '--pool-clusters'])
+
+    def test_cant_join_cluster_with_missing_key_pair(self):
+        _, cluster_id = self.make_pooled_cluster()
+
+        self.assertDoesNotJoin(
+            cluster_id,
+            ['-r', 'emr', '--ec2-key-pair', 'EMR2', '--pool-clusters'])
+
+    def test_ignore_key_pair_if_we_have_none(self):
+        _, cluster_id = self.make_pooled_cluster(ec2_key_pair='EMR')
+
+        self.assertJoins(
+            cluster_id,
+            ['-r', 'emr', '--pool-clusters'])
+
 
 class PoolingDisablingTestCase(MockBotoTestCase):
 


### PR DESCRIPTION
If we have `ec2_key_pair` set and use pooling, we should only join clusters with the same key pair (see #1230).

This builds on pull request #1239.