### PR TITLE
Whats new in mrjob 0.5.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,28 +1,48 @@
-v0.5.0, 2015-??-?? -- ???
+v0.5.0, 2016-03-?? -- the future is in the past
+ * supports Python 3 (#989)
  * requires boto 2.35.0 or newer (#980)
+   * removed many workarounds for S3 and EMR (#980), IAM (#1062)
  * jobs:
    * is_mapper_or_reducer() renamed to is_task() (#1072)
    * mr() no longer takes positional arguments (#814)
    * removed jar() (use mrjob.step.JarStep)
    * removed testing methods parse_counters() and parse_output()
+   * protocols:
+     * protocols are strict by default (#724)
+     * use ujson when available, drop simplejson (#1002)
+       * can explicitly choose Standard or Ultra JSON protocol
+     * raw protocols handle bytes or unicode depending on Python version
+       * can explicitly choose Text or Bytes protocol
    * mrjob.step:
       * JarStep only takes "args" and "main_class" keyword args
       * removed MRJobStep (use MRStep)
  * runners:
    * All runners:
+     * totally revamped log handling (#1123)
+     * runner status/log messages are less noisy (#1044)
+     * don't bootstrap mrjob if interpreter is set (#1041)
+     * fs methods path_exists() and path_join() are now exists() and join()
+     * deprecation warning: use runner.fs explicitly (#1146)
      * removed IS_SUCCESSFUL cleanup option (use ALL)
      * *SCRATCH cleanup options renamed to *TMP (#318)
      * base_tmp_dir option has been renamed to local_tmp_dir (#318)
-     * deprecation warning: use runner.fs explicitly (#1146)
-     * fs methods path_exists() and path_join() are now exists() and join()
+     * non-inline runners raise StepFailedException on step failure (#1219)
+     * steps_python_bin defaults to current python interpreter (#1038)
+     * _job_name is now _job_key (#982)
    * EMR:
      * default AWS region is us-west-2 (#1025)
+     * default instance type is m1.medium (#992)
+     * 4.x AMIs are supported (#1105)
+       * added --release-label switch (--ami-version 4.x.y also works)
+     * can fetch counters and probable cause of failure on 3.x and 4.x AMIs
+     * SSH tunnel now works on 3.x and 4.x AMIs (#1013)
+       * renamed ssh_tunnel_to_job_tracker option to ssh_tunnel
+     * correctly fetch step logs by step ID (#1117)
+     * bootstrap_python option
      * s3_scratch_uri option is now s3_tmp_dir (#318)
      * aws_region is no longer inferred from s3_tmp_dir
      * create/select temp bucket in same region as EMR jobs (#687)
      * added iam_endpoint option (#1067)
-     * SSH tunnel now works on 3.x and 4.x AMIs (#1013)
-       * renamed ssh_tunnel_to_job_tracker option to ssh_tunnel
      * removed s3_conn args from methods in EMRJobRunner and S3Filesystem
      * S3 Filesystem:
        * connect to each S3 bucket on appropriate endpoint (#1028)
@@ -31,22 +51,30 @@ v0.5.0, 2015-??-?? -- ???
        * recurse "subdirectories" even if uri lacks trailing / (#1183)
      * removed iam_job_flow_role option (use iam_instance_profile)
      * custom hadoop_streaming_jar gets properly uploaded
-     * 4.x AMIs are supported (#1105)
-       * added --release-label switch (--ami-version 4.x.y also works)
-     * don't try to clean up job when there's no cluster ID (#1170)
+     * job cleanup temporarily disabled (#1241)
+     * bootstrap_python_packages (deprecated) does nothing on 2.x AMIs (#1248)
+     * pooling respects key pair (#1230)
+     * idle cluster self-termination respects non-streaming jobs (#1145)
+     * visible_to_all_users defaults to true (#1016)
    * Hadoop
+     * works out-of the-box on most Hadoop setups (#1160)
+     * works out-of the box inside EMR (2.x, 3.x, and 4.x AMIs)
      * counters are parsed from Hadoop binary stderr in YARN (#1153)
      * can find logs and probable cause of failure in YARN (#1195)
        * will search in <output dir>/_logs, to support Cloudera (#565)
+     * HDFS Filesystem:
+       * use fs -ls -R and fs -rm -R in YARN (#1152)
+       * mkdir() now uses -p on YARN (#991)
+       * fs.du() now works on YARN (#1155)
+       * fs.du() now returns 0 for nonexistent files instead of erroring
+       * fs.rm() now uses -skipTrash
+     * dropped support for Hadoop prior to 0.20.203 (#1208)
      * added hadoop_log_dirs option
      * hdfs_scratch_dir option is now hadoop_tmp_dir (#318)
-     * use fs -ls -R and fs -rm -R in YARN (#1152)
-     * fs.du() now works on YARN (#1155)
-     * fs.du() now returns 0 for nonexistent files instead of erroring
-     * fs.rm() now uses -skipTrash
-     * dropped support for Hadoop prior to 0.20.203 (#1208)
+     * uses -D and correct property name when step has no reduces (#1213)
    * Inline/Local
      * runner.fs raises IOError if passed URIs (#1185)
+     * version-agnostic by default (#735)
  * removed mrjob.compat.get_jobconf_value() (use jobconf_from_env())
  * removed mrjob.compat methods to support Hadoop prior to 0.20.203:
    * supports_combiners_in_hadoop_streaming()
@@ -54,8 +82,9 @@ v0.5.0, 2015-??-?? -- ???
    * uses_generic_jobconf()
  * removed mrjob.conf.combine_cmd_lists()
  * removed fetch-logs tool (#1127)
- * Python-version-specific mrjob commands (#1104)
+ * Python-version-specific mrjobx and mrjobx.y commands (#1104)
  * use followlinks=True with os.walk()
+ * all internal constants/functions/methods explicitly start with _ (#681)
  * mrjob.util:
    * file_ext() takes filename, not path
    * random_identifier() moved here from mrjob.aws

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -17,5 +17,6 @@ Guides
     guides/hadoop-cookbook.rst
     guides/testing.rst
     guides/emr.rst
+    guides/py2-vs-py3.rst
     guides/contributing.rst
     guides/runner-job-interactions.rst

--- a/docs/guides/py2-vs-py3.rst
+++ b/docs/guides/py2-vs-py3.rst
@@ -1,0 +1,33 @@
+Python 2 vs. Python 3
+=====================
+
+Raw protocols
+-------------
+
+Both because we don't want to break mrjob for Python 2 users, and to make writing jobs simple, jobs read their input as ``str``\ s by default (even though ``str`` means bytes in Python 2 and unicode in Python 3).
+
+The way this works in mrjob is that :py:class:`~mrjob.protocol.RawValueProtocol` is actually an alias for one of two classes, :py:class:`~mrjob.protocol.BytesValueProtocol` if you're in Python 2, and :py:class:`~mrjob.protocol.TextValueProtocol` if you're in Python 3.
+
+If you care about this distinction, you probably want to explicitly set :py:attr:`~mrjob.job.MRJob.INPUT_PROTOCOL` to one of these. If your input has a well-defined encoding, probably you want :py:class:`~mrjob.protocol.BytesValueProtocol`, and if it's a bunch of text that's mostly ASCII, with like, some stuff that might be UTF-8? (i.e. most log files), you probably want :py:class:`~mrjob.protocol.TextValueProtocol`. But most of the time it'll just work without you having to think about it.
+
+Bytes vs. strings
+-----------------
+
+The following things are bytes in any version of Python (which means you need to use the ``bytes`` type and/or ``b'...'`` constant in Python 3):
+ - data read or written by :ref:`job-protocols`
+ - lines yielded by :py:meth:`~mrjob.runner.MRJobRunner.stream_output`
+ - anything read from :py:meth:`~mrjob.fs.base.Filesystem.cat`
+
+The :py:attr:`~mrjob.job.MRJob.stdin`, :py:attr:`~mrjob.job.MRJob.stdout`, and :py:attr:`~mrjob.job.MRJob.stderr` attributes of jobs are always bytestreams (so, for example, ``self.stderr`` defaults to ``sys.stderr.buffer`` in Python 3).
+
+Everything else (including file paths, URIs, arguments to commands, and logging messages) are strings; that is, ``str`` on Python 3, and either ``str`` or ``unicode`` on Python 2. Like with :py:class:`~mrjob.protocol.RawValueProtocol`, most of the time it'll just work even if you don't think about it.
+
+python_bin
+----------
+
+:mrjob-opt:`python_bin` (the name of the Python command when tasks run on your Hadoop cluster) defaults to :command:`python` in Python 2, and :command:`python3` in Python 3.
+
+Your Hadoop cluster
+-------------------
+
+Whatever version of Python you use, you'll have to have a compatible version of Python installed on your Hadoop cluster. mrjob does its best to make this work on Elastic MapReduce (see :mrjob-opt:`bootstrap_python`), but if you're running on your own Hadoop cluster, this is up to you.

--- a/docs/guides/py2-vs-py3.rst
+++ b/docs/guides/py2-vs-py3.rst
@@ -8,7 +8,7 @@ Both because we don't want to break mrjob for Python 2 users, and to make writin
 
 The way this works in mrjob is that :py:class:`~mrjob.protocol.RawValueProtocol` is actually an alias for one of two classes, :py:class:`~mrjob.protocol.BytesValueProtocol` if you're in Python 2, and :py:class:`~mrjob.protocol.TextValueProtocol` if you're in Python 3.
 
-If you care about this distinction, you probably want to explicitly set :py:attr:`~mrjob.job.MRJob.INPUT_PROTOCOL` to one of these. If your input has a well-defined encoding, probably you want :py:class:`~mrjob.protocol.BytesValueProtocol`, and if it's a bunch of text that's mostly ASCII, with like, some stuff that might be UTF-8? (i.e. most log files), you probably want :py:class:`~mrjob.protocol.TextValueProtocol`. But most of the time it'll just work without you having to think about it.
+If you care about this distinction, you may want to explicitly set :py:attr:`~mrjob.job.MRJob.INPUT_PROTOCOL` to one of these. If your input has a well-defined encoding, probably you want :py:class:`~mrjob.protocol.BytesValueProtocol`, and if it's a bunch of text that's mostly ASCII, with like, some stuff that... might be UTF-8? (i.e. most log files), you probably want :py:class:`~mrjob.protocol.TextValueProtocol`. But most of the time it'll just work.
 
 Bytes vs. strings
 -----------------
@@ -18,7 +18,7 @@ The following things are bytes in any version of Python (which means you need to
  - lines yielded by :py:meth:`~mrjob.runner.MRJobRunner.stream_output`
  - anything read from :py:meth:`~mrjob.fs.base.Filesystem.cat`
 
-The :py:attr:`~mrjob.job.MRJob.stdin`, :py:attr:`~mrjob.job.MRJob.stdout`, and :py:attr:`~mrjob.job.MRJob.stderr` attributes of jobs are always bytestreams (so, for example, ``self.stderr`` defaults to ``sys.stderr.buffer`` in Python 3).
+The :py:attr:`~mrjob.job.MRJob.stdin`, :py:attr:`~mrjob.job.MRJob.stdout`, and :py:attr:`~mrjob.job.MRJob.stderr` attributes of :py:class:`~mrjob.job.MRJob`\ s are always bytestreams (so, for example, ``self.stderr`` defaults to ``sys.stderr.buffer`` in Python 3).
 
 Everything else (including file paths, URIs, arguments to commands, and logging messages) are strings; that is, ``str`` on Python 3, and either ``str`` or ``unicode`` on Python 2. Like with :py:class:`~mrjob.protocol.RawValueProtocol`, most of the time it'll just work even if you don't think about it.
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -10,29 +10,28 @@ For a complete list of changes, see `CHANGES.txt
 -----
 
 Python 3
-========
+^^^^^^^^
 
-mrjob now fully supports Python 3.3+. We did this in a way that should be totally transparent to existing Python 2 users (you don't have to suddenly start handling ``unicode`` instead of ``str``). For more information, see :ref:`py2-vs-py3`.
+mrjob now fully supports Python 3.3+. We did this in a way that should be totally transparent to existing Python 2 users (you don't have to suddenly start handling ``unicode`` instead of ``str``). For more information, see :doc:`guides/py2-vs-py3`.
 
 If you run a job with Python 3, mrjob will automatically install Python 3 on ElasticMapreduce AMIs (see :mrjob-opt:`bootstrap_python`).
 
 The :command:`mrjob` command is now installed with Python-version-specific aliases (e.g. `mrjob3`, `mrjob3.4`), in case you install mrjob for multiple versions of Python.
 
 Hadoop
-======
+^^^^^^
 
-mrjob should now work out-of-the box on almost any Hadoop setup. If :command:`hadoop` is in your path, or you set any commonly-used :envvar:`$HADOOP_*` enivornment variable, mrjob will find the Hadoop binary, the streaming jar, and your logs, without any help on your part (see :mrjob-opt:`hadoop_bin` and :mrjob-opt:`hadoop_streaming_jar` for details).
+mrjob should now work out-of-the box on almost any Hadoop setup. If :command:`hadoop` is in your path, or you set any commonly-used :envvar:`$HADOOP_*` environment variable, mrjob will find the Hadoop binary, the streaming jar, and your logs, without any help on your part (see :mrjob-opt:`hadoop_bin` and :mrjob-opt:`hadoop_streaming_jar` for details).
 
 mrjob has been updated to probably support Hadoop 2 (YARN), and still supports Hadoop 1. This release *does* drop all support for Hadoop prior to 0.20.203 (mrjob is actually a few months older than Hadoop 0.20.203, so this used to matter).
 
 3.x and 4.x AMIs
-================
+^^^^^^^^^^^^^^^^
 
 mrjob now fully supports the 3.x and 4.x Elastic MapReduce AMIs, including fetching counters and finding probable cause of job failure.
 
-For the 4.x AMIs, you can either use the new :mrjob-opt:`release_label` option, or continue using :mrjob-opt:`ami_version`; both work.
-
 The default :mrjob-opt:`ami_version` is now ``3.11.0``. Our plan is to continue updating this to the lastest (non-broken) 3.x AMI for each 0.5.x release of mrjob.
+For the 4.x AMIs, you can either use the new :mrjob-opt:`release_label` option, or continue using :mrjob-opt:`ami_version`; both work.
 
 mrjob continues to support 2.x AMIs, however:
 
@@ -40,31 +39,36 @@ mrjob continues to support 2.x AMIs, however:
 
    2.x AMIs are officially deprecated by AWS because they are based on a very old version of Debian (squeeze), which breaks :command:`apt-get` and exposes you to security holes. If you're on a 2.x AMI, please, please switch in the near future.
 
-New default AWS Region
-======================
+AWS Regions
+^^^^^^^^^^^
 
-The new default :mrjob-opt:`aws_region` is ``us-west-2`` (Oregon). This both matches the default in the EMR console and, according to Amazon, is :ref:`carbon neutral <https://aws.amazon.com/about-aws/sustainability/>`__.
+The new default :mrjob-opt:`aws_region` is ``us-west-2`` (Oregon). This both matches the default in the EMR console and, according to Amazon, is `carbon neutral <https://aws.amazon.com/about-aws/sustainability/>`__.
 
-This change should be transparent to most users. However, EC2 key pairs (i.e. SSH credentials) are region-specific, so if you set up SSH but don't explicitly specify your AWS region, you should :ref:`create new SSH keys <ssh-tunneling>` for the ``us-west-2`` region.
+mrjob is much smarter about the way it handles regions when interacting with S3:
+ - automatically creates temp bucket in the same region as jobs
+ - connects to S3 buckets on the endpoint matching their region (no more 307 erros)
+ - no longer uses the temp bucket's location to choose where you run your job
 
-Log Interpretation
-==================
+An edge case that might affect you: EC2 key pairs (i.e. SSH credentials) are region-specific, so if you've set up SSH but not explicitly specified a region, you may get an error saying your key pair is invalid. You can fix this by :ref:`creating new SSH keys <ssh-tunneling>` for the ``us-west-2`` region (mrjob will tell you this as well).
+
+Log interpretation
+^^^^^^^^^^^^^^^^^^
 
 The part of mrjob that fetches counters and tells you what probably caused your job to fail was basically unmaintainable and has been totally rewritten. Not only do we now have solid support across Hadoop and EMR AMI versions, but if we missed anything, it should be straightforward to support it.
 
 Once casualty of this change was the :command:`mrjob fetch-logs` command, which means mrjob no longer offers a way to fetch or interpret logs from a *past* job (we do plan to re-introduce this functionality).
 
 ujson
-=====
+^^^^^
 
 By default, mrjob will use ``ujson`` (rather than ``simplejson``), if it is available, to encode intermediate and output data from your job
 
 mrjob will also try to install ``ujson`` on EMR by default when it can do so quickly and reliably (see :mrjob-opt:`bootstrap_python`).
 
-If you wish, you can now explicitly turn off ``ujson`` (e.g. :py:class:`mrjob.protocol.StandardJSONProtocol`) or require it (:py:class:`mrjob.protocol.UltraJSONProtocol).
+If you wish, you can now explicitly turn off ``ujson`` (e.g. :py:class:`~mrjob.protocol.StandardJSONProtocol`) or require it (:py:class:`~mrjob.protocol.UltraJSONProtocol`).
 
-Cleaner status messages
-=======================
+Status messages
+^^^^^^^^^^^^^^^
 
 The logging messages that mrjob prints as it runs your job kind of accreted over time without any real standard for what should be ``log.info()`` vs. ``log.debug()``. We've tried to cut these messages down to the basics (either useful info, like where a temp directory is, or something that tells you why you're waiting). If there are any messages you miss, try running your job with ``-v``.
 
@@ -72,7 +76,7 @@ Also, when a step in your job fails, mrjob no longer prints a useless stacktrace
 
 
 Deprecation
-===========
+^^^^^^^^^^^
 
 mrjob v0.4.6 contains many, many deprecation warnings about things being removed in v0.5.0. v0.5.0 is here, and they have been. If you have a specific problem, try searching `CHANGES.txt
 <https://github.com/Yelp/mrjob/blob/master/CHANGES.txt>`_, which calls these out specifically.

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -4,6 +4,81 @@ What's New
 For a complete list of changes, see `CHANGES.txt
 <https://github.com/Yelp/mrjob/blob/master/CHANGES.txt>`_
 
+.. _v0.5.0:
+
+0.5.0
+-----
+
+Python 3
+========
+
+mrjob now fully supports Python 3.3+. We did this in a way that should be totally transparent to existing Python 2 users (you don't have to suddenly start handling ``unicode`` instead of ``str``). For more information, see :ref:`py2-vs-py3`.
+
+If you run a job with Python 3, mrjob will automatically install Python 3 on ElasticMapreduce AMIs (see :mrjob-opt:`bootstrap_python`).
+
+The :command:`mrjob` command is now installed with Python-version-specific aliases (e.g. `mrjob3`, `mrjob3.4`), in case you install mrjob for multiple versions of Python.
+
+Hadoop
+======
+
+mrjob should now work out-of-the box on almost any Hadoop setup. If :command:`hadoop` is in your path, or you set any commonly-used :envvar:`$HADOOP_*` enivornment variable, mrjob will find the Hadoop binary, the streaming jar, and your logs, without any help on your part (see :mrjob-opt:`hadoop_bin` and :mrjob-opt:`hadoop_streaming_jar` for details).
+
+mrjob has been updated to probably support Hadoop 2 (YARN), and still supports Hadoop 1. This release *does* drop all support for Hadoop prior to 0.20.203 (mrjob is actually a few months older than Hadoop 0.20.203, so this used to matter).
+
+3.x and 4.x AMIs
+================
+
+mrjob now fully supports the 3.x and 4.x Elastic MapReduce AMIs, including fetching counters and finding probable cause of job failure.
+
+For the 4.x AMIs, you can either use the new :mrjob-opt:`release_label` option, or continue using :mrjob-opt:`ami_version`; both work.
+
+The default :mrjob-opt:`ami_version` is now ``3.11.0``. Our plan is to continue updating this to the lastest (non-broken) 3.x AMI for each 0.5.x release of mrjob.
+
+mrjob continues to support 2.x AMIs, however:
+
+.. warning::
+
+   2.x AMIs are officially deprecated by AWS because they are based on a very old version of Debian (squeeze), which breaks :command:`apt-get` and exposes you to security holes. If you're on a 2.x AMI, please, please switch in the near future.
+
+New default AWS Region
+======================
+
+The new default :mrjob-opt:`aws_region` is ``us-west-2`` (Oregon). This both matches the default in the EMR console and, according to Amazon, is :ref:`carbon neutral <https://aws.amazon.com/about-aws/sustainability/>`__.
+
+This change should be transparent to most users. However, EC2 key pairs (i.e. SSH credentials) are region-specific, so if you set up SSH but don't explicitly specify your AWS region, you should :ref:`create new SSH keys <ssh-tunneling>` for the ``us-west-2`` region.
+
+Log Interpretation
+==================
+
+The part of mrjob that fetches counters and tells you what probably caused your job to fail was basically unmaintainable and has been totally rewritten. Not only do we now have solid support across Hadoop and EMR AMI versions, but if we missed anything, it should be straightforward to support it.
+
+Once casualty of this change was the :command:`mrjob fetch-logs` command, which means mrjob no longer offers a way to fetch or interpret logs from a *past* job (we do plan to re-introduce this functionality).
+
+ujson
+=====
+
+By default, mrjob will use ``ujson`` (rather than ``simplejson``), if it is available, to encode intermediate and output data from your job
+
+mrjob will also try to install ``ujson`` on EMR by default when it can do so quickly and reliably (see :mrjob-opt:`bootstrap_python`).
+
+If you wish, you can now explicitly turn off ``ujson`` (e.g. :py:class:`mrjob.protocol.StandardJSONProtocol`) or require it (:py:class:`mrjob.protocol.UltraJSONProtocol).
+
+Cleaner status messages
+=======================
+
+The logging messages that mrjob prints as it runs your job kind of accreted over time without any real standard for what should be ``log.info()`` vs. ``log.debug()``. We've tried to cut these messages down to the basics (either useful info, like where a temp directory is, or something that tells you why you're waiting). If there are any messages you miss, try running your job with ``-v``.
+
+Also, when a step in your job fails, mrjob no longer prints a useless stacktrace telling you where in the code the runner raised an exception about your step failing. This is thanks to the :py:class:`~mrjob.step.StepFailedException`, which you can also catch and interpret if you're :ref:`running jobs programmatically <runners-programmatically>`.
+
+
+Deprecation
+===========
+
+mrjob v0.4.6 contains many, many deprecation warnings about things being removed in v0.5.0. v0.5.0 is here, and they have been. If you have a specific problem, try searching `CHANGES.txt
+<https://github.com/Yelp/mrjob/blob/master/CHANGES.txt>`_, which calls these out specifically.
+
+mrjob also contained a number of constants, functions, and methods that didn't appear in the documentation but still might have seemed generally useful. This created a huge maintenance headache (Does anyone use this? Can we mess with it, or do we need to issue a deprecation warning for several mrjob versions first?). Thus, we've prepended an ``_`` to the name of anything that mrjob isn't really meant to provide as a library. If you find that, say, a regex you used to important isn't available, try prepending an ``_`` to its name (and know that you're using something that isn't officially supported and might go away).
+
 
 0.4.6
 -----


### PR DESCRIPTION
Updated `CHANGES.txt` and `whats-new.rst`. Also added a document summarizing the differences between Python 2 and Python 3 (fixes #1033).
