### PR TITLE
Restore simplejson

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,8 +9,8 @@ v0.5.0, 2016-03-?? -- the future is in the past
    * removed testing methods parse_counters() and parse_output()
    * protocols:
      * protocols are strict by default (#724)
-     * use ujson when available, drop simplejson (#1002)
-       * can explicitly choose Standard or Ultra JSON protocol
+     * JSON protocols use ujson when available, then simplejson (#1002, #1266)
+       * can explicitly choose Standard, Simple or Ultra JSON protocol
      * raw protocols handle bytes or unicode depending on Python version
        * can explicitly choose Text or Bytes protocol
    * mrjob.step:

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -353,7 +353,11 @@ Job execution context
 
     .. warning::
 
-        "Loose" protocols are going away in v0.6.0.
+       Non-strict protocols are going away in v0.6.0. There is no limit on
+       how much data on-strict protocols can silently swallow (potentially
+       *all* of it). If you have a problem caused by character encoding in
+       log files, consider using
+       :py:class:`~mrjob.protocol.TextValueProtocol` instead.
 
 Other
 =====

--- a/docs/guides/emr-bootstrap-cookbook.rst
+++ b/docs/guides/emr-bootstrap-cookbook.rst
@@ -24,6 +24,8 @@ tasks on EMR apparently have access to :command:`sudo`).
 Installing Python packages with pip
 -----------------------------------
 
+.. _installing-ujson:
+
 :command:`pip` is the standard way to install Python packages.
 
 on Python 2

--- a/docs/protocols.rst
+++ b/docs/protocols.rst
@@ -40,38 +40,27 @@ JSON
     between steps.**
 
     This is an alias for :py:class:`UltraJSONProtocol` if :py:mod:`ujson`
-    is installed, and :py:class:`StandardJSONProtocol` otherwise.
+    is installed, :py:class:`SimpleJSONProtocol` if :py:mod:`simplejson`
+    is installed and :py:mod:`ujson` is not and
+    :py:class:`StandardJSONProtocol` if neither is installed.
 
-    .. warning::
-
-        :py:mod:`ujson` is about five times faster than the standard
-        implementation, but is more willing to encode things that aren't
-        strictly JSON-encodable, including sets, dictionaries with
-        tuples as keys, UTF-8 encoded bytes, and objects (!). Relying on this
-        behavior won't stop your job from working, but it can
-        make your job *dependent* on :py:mod:`ujson`, rather than just using
-        it as a speedup.
-
-    .. note::
-
-        :py:mod:`ujson` also differs from the standard implementation in that
-        it doesn't  add spaces to its JSONs (``{"foo":"bar"}`` versus
-        ``{"foo": "bar"}``). This probably won't affect anything but test
-        cases.
-
-.. autoclass:: StandardJSONProtocol
 .. autoclass:: UltraJSONProtocol
+.. autoclass:: SimpleJSONProtocol
+.. autoclass:: StandardJSONProtocol
 
 .. py:class:: JSONValueProtocol
 
    Encode ``value`` as a JSON and discard ``key`` (``key`` is read in as
    ``None``).
 
-   This is an alias for :py:class:`UltraJSONValueProtocol` if :py:mod:`ujson`
-   is installed, and :py:class:`StandardJSONValueProtocol` otherwise.
+    This is an alias for :py:class:`UltraJSONValueProtocol` if :py:mod:`ujson`
+    is installed, :py:class:`SimpleJSONValueProtocol` if :py:mod:`simplejson`
+    is installed and :py:mod:`ujson` is not and
+    :py:class:`StandardJSONValueProtocol` if neither is installed.
 
-.. autoclass:: StandardJSONValueProtocol
 .. autoclass:: UltraJSONValueProtocol
+.. autoclass:: SimpleJSONValueProtocol
+.. autoclass:: StandardJSONValueProtocol
 
 Repr
 ----

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -71,14 +71,24 @@ The part of mrjob that fetches counters and tells you what probably caused your 
 
 Once casualty of this change was the :command:`mrjob fetch-logs` command, which means mrjob no longer offers a way to fetch or interpret logs from a *past* job. We do plan to re-introduce this functionality.
 
-ujson
-^^^^^
+Protocols
+^^^^^^^^^
 
-By default, mrjob will use ``ujson`` (rather than ``simplejson``), if it is available, to encode intermediate and output data from your job.
+Protocols are now strict by default (they simply raise an exception on
+unencodable data). "Loose" protocols can be re-enabled with the
+``--no-strict-protocols`` switch; see :mrjob-opt:`strict_protocols` for
+why this is a bad idea.
 
-mrjob will also try to install ``ujson`` on EMR by default when it can do so quickly and reliably (see :mrjob-opt:`bootstrap_python`).
+Protocols will now use the much faster :py:mod:`ujson` library, if installed,
+to encode and decode JSON. This is especially recommended for simple jobs that
+spend a significant fraction of their time encoding and data (if
+you're using EMR, see :ref:`Installing ujson <installing-ujson>`).
 
-If you wish, you can now explicitly turn off ``ujson`` (e.g. :py:class:`~mrjob.protocol.StandardJSONProtocol`) or require it (:py:class:`~mrjob.protocol.UltraJSONProtocol`).
+mrjob will fall back to the :py:mod:`simplejson` library if :py:mod:`ujson`
+is not installed, and use the built-in ``json`` module if neither is installed.
+
+You can now explicitly specify which JSON implementation you wish to use
+(e.g. :py:class:`~mrjob.protocol.StandardJSONProtocol`, :py:class:`~mrjob.protocol.SimpleJSONProtocol`, :py:class:`~mrjob.protocol.UltraJSONProtocol`).
 
 Status messages
 ^^^^^^^^^^^^^^^

--- a/mrjob/protocol.py
+++ b/mrjob/protocol.py
@@ -110,9 +110,11 @@ class StandardJSONProtocol(_KeyCachingProtocol):
     """Implements :py:class:`JSONProtocol` using Python's built-in JSON
     library.
 
-    Note that the built-in library is (appropriately) strict about the JSON
-    standard; it won't accept dictionaries with non-string keys, sets, or
-    (on Python 3) bytestrings.
+    .. note::
+
+        The built-in ``json`` library is (appropriately) strict about the JSON
+        standard; it won't accept dictionaries with non-string keys, sets, or
+        (on Python 3) bytestrings.
     """
     if PY2:
         def _loads(self, value):
@@ -181,6 +183,23 @@ class SimpleJSONValueProtocol(object):
 
 class UltraJSONProtocol(_KeyCachingProtocol):
     """Implements :py:class:`JSONProtocol` using the :py:mod:`ujson` library.
+
+    .. warning::
+
+        :py:mod:`ujson` is about five times faster than the standard
+        implementation, but is more willing to encode things that aren't
+        strictly JSON-encodable, including sets, dictionaries with
+        tuples as keys, UTF-8 encoded bytes, and objects (!). Relying on this
+        behavior won't stop your job from working, but it can
+        make your job *dependent* on :py:mod:`ujson`, rather than just using
+        it as a speedup.
+
+    .. note::
+
+        :py:mod:`ujson` also differs from the standard implementation in that
+        it doesn't  add spaces to its JSONs (``{"foo":"bar"}`` versus
+        ``{"foo": "bar"}``). This probably won't affect anything but test
+        cases.
     """
     def _loads(self, value):
         # ujson can handle bytes even in Python 3

--- a/mrjob/protocol.py
+++ b/mrjob/protocol.py
@@ -199,7 +199,7 @@ class UltraJSONProtocol(_KeyCachingProtocol):
         :py:mod:`ujson` also differs from the standard implementation in that
         it doesn't  add spaces to its JSONs (``{"foo":"bar"}`` versus
         ``{"foo": "bar"}``). This probably won't affect anything but test
-        cases.
+        cases and readability.
     """
     def _loads(self, value):
         # ujson can handle bytes even in Python 3

--- a/mrjob/protocol.py
+++ b/mrjob/protocol.py
@@ -40,6 +40,13 @@ except ImportError:
 from mrjob.py2 import PY2
 from mrjob.util import safeeval
 
+
+try:
+    import simplejson
+    simplejson  # quiet "redefinition of unused ..." warning from pyflakes
+except ImportError:
+    simplejson = None
+
 try:
     import ujson
     ujson  # quiet "redefinition of unused ..." warning from pyflakes
@@ -141,6 +148,37 @@ class StandardJSONValueProtocol(object):
             return json.dumps(value).encode('utf_8')
 
 
+class SimpleJSONProtocol(_KeyCachingProtocol):
+    """Implements :py:class:`JSONProtocol` using the :py:mod:`simplejson` library.
+    """
+    def _loads(self, value):
+        # simplejson can handle bytes even in Python 3
+        return simplejson.loads(value)
+
+    if PY2:
+        def _dumps(self, value):
+            return simplejson.dumps(value)
+    else:
+        def _dumps(self, value):
+            return simplejson.dumps(value).encode('utf_8')
+
+
+class SimpleJSONValueProtocol(object):
+    """Implements :py:class:`JSONValueProtocol` using the :py:mod:`simplejson`
+    library.
+    """
+    def read(self, line):
+        # simplejson can handle bytes even in Python 3
+        return (None, simplejson.loads(line))
+
+    if PY2:
+        def write(self, key, value):
+            return simplejson.dumps(value)
+    else:
+        def write(self, key, value):
+            return simplejson.dumps(value).encode('utf_8')
+
+
 class UltraJSONProtocol(_KeyCachingProtocol):
     """Implements :py:class:`JSONProtocol` using the :py:mod:`ujson` library.
     """
@@ -176,6 +214,10 @@ class UltraJSONValueProtocol(object):
 if ujson:
     JSONProtocol = UltraJSONProtocol
     JSONValueProtocol = UltraJSONValueProtocol
+# if no ujson, try simplejson
+elif simplejson:
+    JSONProtocol = SimpleJSONProtocol
+    JSONValueProtocol = SimpleJSONValueProtocol
 else:
     JSONProtocol = StandardJSONProtocol
     JSONValueProtocol = StandardJSONValueProtocol

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -24,12 +24,15 @@ from mrjob.protocol import RawProtocol
 from mrjob.protocol import RawValueProtocol
 from mrjob.protocol import ReprProtocol
 from mrjob.protocol import ReprValueProtocol
+from mrjob.protocol import SimpleJSONProtocol
+from mrjob.protocol import SimpleJSONValueProtocol
 from mrjob.protocol import StandardJSONProtocol
 from mrjob.protocol import StandardJSONValueProtocol
 from mrjob.protocol import TextProtocol
 from mrjob.protocol import TextValueProtocol
 from mrjob.protocol import UltraJSONProtocol
 from mrjob.protocol import UltraJSONValueProtocol
+from mrjob.protocol import simplejson
 from mrjob.protocol import ujson
 from mrjob.py2 import PY2
 
@@ -106,10 +109,15 @@ class ProtocolTestCase(TestCase):
 
 class JSONProtocolAliasesTestCase(TestCase):
 
-    def test_use_ujson_if_installed(self):
+    def test_use_ujson_or_simplejson_if_installed(self):
+        # these aliases are determined at compile time, so there
+        # isn't a straightforward way to test this through patches
         if ujson:
             self.assertEqual(JSONProtocol, UltraJSONProtocol)
             self.assertEqual(JSONValueProtocol, UltraJSONValueProtocol)
+        elif simplejson:
+            self.assertEqual(JSONProtocol, SimpleJSONProtocol)
+            self.assertEqual(JSONValueProtocol, SimpleJSONValueProtocol)
         else:
             self.assertEqual(JSONProtocol, StandardJSONProtocol)
             self.assertEqual(JSONValueProtocol, StandardJSONValueProtocol)
@@ -162,6 +170,12 @@ class StandardJSONProtocolTestCase(ProtocolTestCase):
 
         # Point class has no representation in JSON
         self.assertCantEncode(self.PROTOCOL, Point(2, 3), Point(1, 4))
+
+
+@skipIf(simplejson is None, 'simplejson module not installed')
+class SimpleJSONProtocolTestCase(StandardJSONProtocolTestCase):
+
+    PROTOCOL = SimpleJSONProtocol()
 
 
 @skipIf(ujson is None, 'ujson module not installed')
@@ -228,6 +242,12 @@ class StandardJSONValueProtocolTestCase(ProtocolTestCase):
 
         # Point class has no representation in JSON
         self.assertCantEncode(self.PROTOCOL, None, Point(1, 4))
+
+
+@skipIf(simplejson is None, 'simplejson module not installed')
+class SimpleJSONValueProtocolTestCase(StandardJSONValueProtocolTestCase):
+
+    PROTOCOL = SimpleJSONValueProtocol()
 
 
 @skipIf(ujson is None, 'ujson module not installed')
@@ -400,7 +420,6 @@ class TextProtocolTestCase(ProtocolTestCase):
         # we fall back to latin-1 for the whole line, not individual fields
         self.assertEqual(TextProtocol().read(b'caf\xe9\tol\xc3\xa9'),
                          (u'caf\xe9', u'ol\xc3\xa9'))
-
 
 
 class ReprProtocolTestCase(ProtocolTestCase):


### PR DESCRIPTION
Restore support for ``simplejson``, and use it if ``ujson`` isn't installed (fixes #1266).