### PR TITLE
EMR python_bin defaults

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,7 @@ v0.5.0, 2016-03-?? -- the future is in the past
      * default AWS region is us-west-2 (#1025)
      * default instance type is m1.medium (#992)
      * visible_to_all_users defaults to true (#1016)
+     * matches your minor version of Python 2 on 3.x and 4.x AMIs (#1265)
      * 4.x AMIs are supported (#1105)
        * added --release-label switch (--ami-version 4.x.y also works)
      * can fetch counters and probable cause of failure on 3.x and 4.x AMIs

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -35,6 +35,7 @@ v0.5.0, 2016-03-?? -- the future is in the past
    * EMR:
      * default AWS region is us-west-2 (#1025)
      * default instance type is m1.medium (#992)
+     * visible_to_all_users defaults to true (#1016)
      * 4.x AMIs are supported (#1105)
        * added --release-label switch (--ami-version 4.x.y also works)
      * can fetch counters and probable cause of failure on 3.x and 4.x AMIs
@@ -58,7 +59,7 @@ v0.5.0, 2016-03-?? -- the future is in the past
      * bootstrap_python_packages (deprecated) does nothing on 2.x AMIs (#1248)
      * pooling respects key pair (#1230)
      * idle cluster self-termination respects non-streaming jobs (#1145)
-     * visible_to_all_users defaults to true (#1016)
+     * deprecated "latest" AMI version not passed through to EMR (#1269)
    * Hadoop
      * works out-of the-box on most Hadoop setups (#1160)
      * works out-of the box inside EMR (2.x, 3.x, and 4.x AMIs)

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -228,8 +228,18 @@ Job execution context
     :default: (automatic)
 
     Name/path of alternate Python binary for wrapper scripts and
-    mappers/reducers (e.g. ``'python -v'``). This defaults to ``'python'`` if
-    you're in Python 2 and ``'python3'`` if you're in Python 3.
+    mappers/reducers (e.g. ``'python -v'``).
+
+    If you're on Python 3, this defaults to ``'python3'``.
+
+    If you're on Python 2, this defaults to ``'python'``, except on EMR,
+    where it will be either ``'python2.6'`` or ``'python2.7'``.
+
+    Generally, :py:class:`~mrjob.emr.EMRJobRunner` just matches whichever
+    version of Python you're running, but if you're on a (deprecated) 2.x AMI,
+    it defaults to ``python2.7`` if you're on AMI version 2.4.3 or later
+    (because it comes with :command:`pip`) and to ``python2.6``
+    otherwise (because Python 2.7 is unavailable).
 
     This option also affects which Python binary is used for file locking in
     :mrjob-opt:`setup` scripts, so it might be useful to set even if you're

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -22,6 +22,7 @@ import posixpath
 import random
 import signal
 import socket
+import sys
 import time
 from collections import defaultdict
 from datetime import datetime

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -690,17 +690,17 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             # on 3.x and 4.x AMIs, both versions of Python work, so just
             # match whatever version we're using locally
             if sys.version_info >= (2, 7):
-                return 'python2.7'
+                return ['python2.7']
             else:
-                return 'python2.6'
+                return ['python2.6']
         elif version_gte(self._opts['ami_version'], '2.4.3'):
             # on 2.4.3+, use python2.7 because the default python
             # doesn't have a working pip
-            return 'python2.7'
+            return ['python2.7']
         else:
             # prior to 2.4.3, Python 2.6 is the only version installed.
             # Use "python2.6" and not "python" for consistency
-            return 'python2.6'
+            return ['python2.6']
 
     def _fix_s3_tmp_and_log_uri_opts(self):
         """Fill in s3_tmp_dir and s3_log_uri (in self._opts) if they

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -146,6 +146,10 @@ _DEFAULT_AWS_REGION = 'us-west-2'
 # default AMI to use on EMR. This will be updated with each version
 _DEFAULT_AMI_VERSION = '3.11.0'
 
+# EMR translates the dead/deprecated "latest" AMI version to 2.4.2
+# (2.4.2 isn't actually the latest version by a long shot)
+_AMI_VERSION_LATEST = '2.4.2'
+
 # Hadoop streaming jar on 1-3.x AMIs
 _PRE_4_X_STREAMING_JAR = '/home/hadoop/contrib/streaming/hadoop-streaming.jar'
 
@@ -378,6 +382,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             self['aws_region'] = _DEFAULT_AWS_REGION
 
         self._fix_ec2_instance_opts()
+        self._fix_ami_version_latest()
         self._fix_release_label_opt()
 
     def default_options(self):
@@ -498,14 +503,20 @@ class EMRRunnerOptionStore(RunnerOptionStore):
                 except ValueError:
                     pass  # maybe EMR will accept non-floats?
 
+    def _fix_ami_version_latest(self):
+        """Translate the dead/deprecated *ami_version* value ``latest``
+        to ``2.4.2`` up-front, so our code doesn't have to deal with
+        non-numeric AMI versions."""
+        if self['ami_version'] == 'latest':
+            self['ami_version'] = _AMI_VERSION_LATEST
+
     def _fix_release_label_opt(self):
         """If *release_label* is not set and *ami_version* is set to version
         4 or higher (which the EMR API won't accept), set *release_label*
         to "emr-" plus *ami_version*. (Leave *ami_version* as-is;
         *release_label* overrides it anyway.)"""
-        if (not self['release_label'] and
-                self['ami_version'] != 'latest' and
-                version_gte(self['ami_version'], '4')):
+        if (version_gte(self['ami_version'], '4') and
+                not self['release_label']):
             self['release_label'] = 'emr-' + self['ami_version']
 
 
@@ -673,16 +684,21 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         if local or not PY2:
             return super(EMRJobRunner, self)._default_python_bin(local=local)
 
-        if self._opts['ami_version'] == 'latest':  # e.g. 2.4.9
-            return 'python2.7'
-        elif version_gte(self._opts['ami_version'], '3'):
-            if sys.version_info < (2, 7):
-                return 'python2.6'
-            else:
+        if self._opts['release_label'] or version_gte(
+                self._opts['ami_version'], '3'):
+            # on 3.x and 4.x AMIs, both versions of Python work, so just
+            # match whatever version we're using locally
+            if sys.version_info >= (2, 7):
                 return 'python2.7'
+            else:
+                return 'python2.6'
         elif version_gte(self._opts['ami_version'], '2.4.3'):
+            # on 2.4.3+, use python2.7 because the default python
+            # doesn't have a working pip
             return 'python2.7'
         else:
+            # prior to 2.4.3, Python 2.6 is the only version installed.
+            # Use "python2.6" and not "python" for consistency
             return 'python2.6'
 
     def _fix_s3_tmp_and_log_uri_opts(self):
@@ -1976,6 +1992,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
         self._master_bootstrap_script_path = path
 
+    # TODO: we may not need this
     def _on_pre_3_x_ami(self):
         """Are we on an AMI prior to 3.x (where apt-get no longer works)?
 
@@ -1983,11 +2000,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         to be running."""
         if self._opts['release_label']:  # hides ami_version
             return False
-
-        if self._opts['ami_version'] == 'latest':
-            return True
-
-        return not version_gte(self._opts['ami_version'], '3')
+        else:
+            return not version_gte(self._opts['ami_version'], '3')
 
     def _bootstrap_python(self):
         """Return a (possibly empty) list of parsed commands (in the same
@@ -2015,8 +2029,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             # see docs/guides/emr-bootstrap-cookbook.rst)
 
             # we have to have at least on AMI 3.7.0
-            if (self._opts['ami_version'] == 'latest' or
-                    not version_gte(self._opts['ami_version'], '3.7.0')):
+            if not (self._opts['release_label'] or
+                    version_gte(self._opts['ami_version'], '3.7.0')):
                 log.warning(
                     'bootstrapping Python 3 will probably not work on'
                     ' AMIs prior to 3.7.0. For an alternative, see:'
@@ -2294,10 +2308,6 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 release_label = getattr(cluster, 'releaselabel', '')
 
                 if release_label != self._opts['release_label']:
-                    return
-            elif self._opts['ami_version'] == 'latest':
-                # look for other clusters where "latest" was requested
-                if getattr(cluster, 'requestedamiversion', '') != 'latest':
                     return
             else:
                 # match actual AMI version

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -87,6 +87,7 @@ AMI_HADOOP_VERSION_UPDATES = {
     '3.0.0': '2.2.0',
     '3.1.0': '2.4.0',
     '4.0.0': '2.6.0',
+    '4.3.0': '2.7.1',
 }
 
 # extra step to use when debugging_step=True is passed to run_jobflow()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1383,13 +1383,13 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
     def test_create_master_bootstrap_script_on_2_4_11_ami(self):
         self._test_create_master_bootstrap_script(
             ami_version='2.4.11',
-            expected_python_bin='python2.7',
+            expected_python_bin=('python2.7' if PY2 else PYTHON_BIN),
             expect_bootstrap_python_packages=False)
 
     def test_create_master_bootstrap_script_on_2_4_2_ami(self):
         self._test_create_master_bootstrap_script(
             ami_version='2.4.2',
-            expected_python_bin='python2.6',
+            expected_python_bin=('python2.6' if PY2 else PYTHON_BIN),
             expect_bootstrap_python_packages=False)
 
     def test_no_bootstrap_script_if_not_needed(self):


### PR DESCRIPTION
This makes EMR choose `python2.6` or `python2.7` as appropriate when you're using Python 2 on EMR (fixes #1265).

Also, if the user sets `ami_version` to "latest", fix that up front so that the rest of the code can be simpler (see #1269).