### PR TITLE
bootstrap_python simplification

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -57,7 +57,6 @@ v0.5.0, 2016-03-?? -- the future is in the past
      * removed iam_job_flow_role option (use iam_instance_profile)
      * custom hadoop_streaming_jar gets properly uploaded
      * job cleanup temporarily disabled (#1241)
-     * bootstrap_python_packages (deprecated) does nothing on 2.x AMIs (#1248)
      * pooling respects key pair (#1230)
      * idle cluster self-termination respects non-streaming jobs (#1145)
      * deprecated "latest" AMI version not passed through to EMR (#1269)

--- a/docs/guides/emr-bootstrap-cookbook.rst
+++ b/docs/guides/emr-bootstrap-cookbook.rst
@@ -29,9 +29,10 @@ Installing Python packages with pip
 on Python 2
 ^^^^^^^^^^^
 
-mrjob installs :command:`pip` by default in Python 2 (see
-:mrjob-opt:`bootstrap_mrjob`), so all you have to do is run it with
-:command:`sudo`:
+As long as you're using AMI version 3.0.0 or later, mrjob automatically
+installs :command:`pip` by default in Python 2 (see
+:mrjob-opt:`bootstrap_mrjob`). All you have to do is run it with
+:command:`sudo`. For example:
 
 .. code-block:: yaml
 
@@ -40,9 +41,10 @@ mrjob installs :command:`pip` by default in Python 2 (see
         bootstrap:
         - sudo pip install dateglob mr3po
 
-(Just using ``dateglob`` and ``mr3po`` as examples.)
+See `PyPI <https://pypi.python.org/pypi>`_ for a the full list of available
+Python packages.
 
-You can also install packages from a requirements file:
+You can also install packages from a `requirements <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`__ file:
 
 .. code-block:: yaml
 
@@ -59,6 +61,10 @@ Or a tarball:
       emr:
         bootstrap:
         - sudo pip install /local/path/of/tarball.tar.gz#
+
+If you *must* run on the (deprecated) 2.x AMIs, see
+:ref:`below <using-ujson-py2-ami-v2>` for what it takes to get :command:`pip`
+working.
 
 If you turned off :mrjob-opt:`bootstrap_mrjob` but still want :command:`pip`,
 the relevant package is ``python-pip``; see :ref:`bootstrap-system-packages`.
@@ -105,12 +111,33 @@ Installing ujson
 ``ujson`` is a fast, pure-C library; if installed, mrjob will automatically
 use it to turbocharge JSON-serialization.
 
-on Python 2
-^^^^^^^^^^^
+on Python 2 (3.x AMIs and later)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On Python 2, mrjob automatically installs ``ujson`` for you. Done! (If you
-turned off :mrjob-opt:`bootstrap_mrjob`, the relevant Python package is
-``ujson``; see :ref:`using-pip`.)
+On Python 2, mrjob automatically installs ``ujson`` for you as long as you're
+using AMI version 3.0.0 or later. Done!
+
+.. _using-ujson-py2-ami-v2:
+
+on Python 2 (2.x AMIs)
+^^^^^^^^^^^^^^^^^^^^^^
+
+The 2.x AMI series is based on version of Debian
+(`Squeeze <http://www.debian.org/News/2011/20110625>`_) that is so old it
+has been "archived", which means that you need to update
+``/etc/apt/sources.list`` before you can install packages.
+
+Here's how to update ``sources.list``, install ``pip``,
+and then :command:`pip install` the ``ujson`` library:
+
+.. code-block:: yaml
+
+    runners:
+      emr:
+        bootstrap:
+        - sudo echo "deb http://archive.debian.org/debian/ squeeze main contrib non-free" > /etc/apt/sources.list
+        - sudo apt-get install -y python-pip
+        - sudo pip install ujson
 
 .. _using-ujson-py3:
 
@@ -141,7 +168,6 @@ what's faster.
 
 The most efficient solution would be to build your own Python 3 RPM and just
 install that, but that's beyond the scope of this cookbook.
-
 
 .. _bootstrap-system-packages:
 
@@ -181,39 +207,14 @@ the ``python34`` and ``python34-docs`` packages themselves;
 2.x AMIs
 ^^^^^^^^
 
-The 2.x AMIs are based on `Debian 6.0.2 (Squeeze)
-<http://www.debian.org/News/2011/20110625>`_, and use :command:`apt-get`. For
-example, to install Cython:
+The 2.x AMIs are based on a very old version of Debian. You probably shouldn't
+be using them at all, but if you do, you'll need to apply a small fix
+before you can :command:`apt-get install -y` packages; see
+:ref:`above <using-ujson-py2-ami-v2>` for an example of how to do this.
 
-.. code-block:: yaml
-
-    runners:
-      emr:
-        bootstrap:
-        - sudo apt-get install -y cython
-
-Don't forget the ``-y``; otherwise your bootstrap script will hang waiting for
-user input that will never come.
-
-The full list of Squeeze packages is
-`here <https://packages.debian.org/squeeze/>`__. Squeeze was
-released in February 2011, so none of these packages are going to be
-super up-to-date.
-
-I don't know or care which AMI version I'm using
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Yeah, and a lot of packages probably have the same name in both distributions
-anyway, right?
-
-Here's a trick you can use to install, for example, ``python-pip`` on any AMI:
-
-.. code-block:: yaml
-
-    runners:
-      emr:
-        bootstrap:
-        - sudo apt-get install -y python-pip || sudo yum install -y python-pip
+See the `full list of Squeeze packages
+<https://packages.debian.org/squeeze/>`__ for all the (very old versions of)
+software you can install.
 
 .. _installing-python-from-source:
 

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -344,7 +344,9 @@ and install another Python binary.
     Passing expressions like ``path#name`` will cause
     *path* to be automatically uploaded to the task's working directory
     with the filename *name*, marked as executable, and interpolated into the
-    script by their absolute path on the machine running the script. *path*
+    script by their absolute path on the machine running the script.
+
+    *path*
     may also be a URI, and ``~`` and environment variables within *path*
     will be resolved based on the local environment. *name* is optional.
     For details of parsing, see :py:func:`~mrjob.setup.parse_setup_cmd`.
@@ -403,11 +405,12 @@ and install another Python binary.
    :default: ``True``
 
    Attempt to install a compatible version of Python at bootstrap time,
-   and, if possible, `ujson`.
+   and, if possible, :command:`pip` and the ``ujson`` library.
 
-   In Python 2, install :command:`pip` and the ``ujson`` library (Python 2
-   is already installed on all AMIs). This does nothing on the (deprecated)
-   2.x AMIs because :command:`apt-get` no longer works.
+   Every AMI has Python 2 installed. We install :command:`pip` and ``ujson``
+   on AMI version 3.0.0 and later. (See :ref:`this example
+   <using-ujson-py2-ami-v2>` for how to get :command:`pip` and ``ujson``
+   on the deprecated 2.x AMIs.)
 
    In Python 3, this option attempts to install Python 3.4 from a package
    (``sudo yum install -y python34``), which will work unless you've set
@@ -435,13 +438,16 @@ and install another Python binary.
     .. deprecated:: 0.4.2
 
     Paths of python modules tarballs to install on EMR. Pass
-    ``pip install path/to/tarballs/*.tar.gz#`` to :mrjob-opt:`bootstrap`
+    ``pip install path/to/tarballs/package.tar.gz#`` to :mrjob-opt:`bootstrap`
     instead.
 
-    In addition to being deprecated, this option only works in Python 2,
-    and only on the 3.x AMIs and later.
-    See :ref:`Installing packages with pip on Python 3 <using-pip-py3>`
-    to see how to do this on Python 3.
+    This option only works in Python 2. In addition, to make it work in the
+    deprecated 2.x AMIs, you'll also have to update ``sources.list`` to get
+    :command:`apt-get` working; see
+    :ref:`this example <using-ujson-py2-ami-v2>`.
+
+    For Python 3, see :ref:`Installing packages with pip on Python 3
+    <using-pip-py3>`.
 
 .. mrjob-opt::
     :config: bootstrap_scripts

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -426,24 +426,13 @@ and install another Python binary.
     .. deprecated:: 0.4.2
 
     Paths of python modules tarballs to install on EMR. Pass
-    ``pip install path/to/tarballs/package.tar.gz#`` to :mrjob-opt:`bootstrap`
-    instead.
+    ``sudo pip-x.y install path/to/package.tar.gz#`` to
+    :mrjob-opt:`bootstrap` instead.
 
-    .. _fixing-apt-get:
-
-    This option only works in Python 2. To make it work in the
-    deprecated 2.x AMIs, you'll also have to update ``sources.list`` to get
-    :command:`apt-get` working:
-
-    .. code-block:: yaml
-
-        runners:
-          emr:
-            bootstrap:
-            - sudo echo "deb http://archive.debian.org/debian/ squeeze main contrib non-free" > /etc/apt/sources.list
-
-    For Python 3, see :ref:`Installing packages with pip on Python 3
-    <using-pip-py3>`.
+    Also, please consider installing packages directly from
+    `PyPI <https://pypi.python.org/pypi>`_ instead (
+    ``sudo pip-x.y install package-name``); PyPI is much more
+    robust/production-ready than when this option was first created.
 
 .. mrjob-opt::
     :config: bootstrap_scripts

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -441,10 +441,18 @@ and install another Python binary.
     ``pip install path/to/tarballs/package.tar.gz#`` to :mrjob-opt:`bootstrap`
     instead.
 
-    This option only works in Python 2. In addition, to make it work in the
+    .. _fixing-apt-get:
+
+    This option only works in Python 2. To make it work in the
     deprecated 2.x AMIs, you'll also have to update ``sources.list`` to get
-    :command:`apt-get` working; see
-    :ref:`this example <using-ujson-py2-ami-v2>`.
+    :command:`apt-get` working:
+
+    .. code-block:: yaml
+
+        runners:
+          emr:
+            bootstrap:
+            - sudo echo "deb http://archive.debian.org/debian/ squeeze main contrib non-free" > /etc/apt/sources.list
 
     For Python 3, see :ref:`Installing packages with pip on Python 3
     <using-pip-py3>`.

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -137,7 +137,7 @@ Other changes
 
  - mrjob now requires ``boto`` 2.35.0 or newer (chances are you're already doing this). Later 0.5.x releases of mrjob may require newer versions of ``boto``.
  - :mrjob-opt:`visible_to_all_users` now defaults to ``True``
- - :py:meth:`~mrjob.fs.hadoop.HadoopFilesystem.rm` uses ``-skipTrash``
+ - ``HadoopFilesystem.rm()`` uses ``-skipTrash``
  - new :mrjob-opt:`iam_endpoint` option
  - custom :mrjob-opt:`hadoop_streaming_jar`\ s are properly uploaded
  - :py:data:`~mrjob.runner.JOB` :mrjob-opt:`cleanup` on EMR is temporarily disabled

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -108,7 +108,6 @@ Many things that were deprecated in 0.4.6 have been removed:
 
    - :py:data:`~mrjob.runner.IF_SUCCESSFUL` :mrjob-opt:`cleanup` option (use :py:data:`~mrjob.runner.ALL`)
    - *iam_job_flow_role* (use :mrjob-opt:`iam_instance_profile`)
-   - :mrjob-opt:`bootstrap_python_packages` is still around until mrjob 0.6.0, but no longer does anything on 2.x AMIs (because we can't :command:`apt-get install python-pip`)
 
  - functions and methods:
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1993,17 +1993,6 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
         self._master_bootstrap_script_path = path
 
-    # TODO: we may not need this
-    def _on_pre_3_x_ami(self):
-        """Are we on an AMI prior to 3.x (where apt-get no longer works)?
-
-        This just checks ``self._opts``; it doesn't require the cluster
-        to be running."""
-        if self._opts['release_label']:  # hides ami_version
-            return False
-        else:
-            return not version_gte(self._opts['ami_version'], '3')
-
     def _bootstrap_python(self):
         """Return a (possibly empty) list of parsed commands (in the same
         format as returned by parse_setup_cmd())'"""

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2022,25 +2022,27 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         # bootstrap_python_packages
         if self._opts['bootstrap_python_packages']:
             if PY2:
-                if self._on_pre_3_x_ami():
-                    log.warning(
-                        'bootstrap_python_packages is deprecated and is no'
-                        ' longer supported on the 2.x AMIs. See'
-                        ' https://pythonhosted.org/mrjob/guides/emr-bootstrap'
-                        '-cookbook.html#using-pip for an alternative.')
-                else:
-                    log.warning(
-                        'bootstrap_python_packages is deprecated since v0.4.2'
-                        ' and will be removed in v0.6.0. Consider using'
-                        ' bootstrap instead.')
+                log.warning(
+                    'bootstrap_python_packages is deprecated since v0.4.2'
+                    ' and will be removed in v0.6.0. Consider using'
+                    ' bootstrap instead.')
 
-                    bootstrap.append(['sudo yum install -y python-pip'])
+                if self._on_pre_3_x_ami() and not any(
+                        'sources.list' in b for b in self._opts['bootstrap']):
+                    log.warning(
+                        '\nIn addition, you need to update sources.list to'
+                        ' make bootstrap_python_packages work on 2.x AMIs;'
+                        ' see:\n\n'
+                        ' https://pythonhosted.org/mrjob/guides/emr-opts.html'
+                        '#fixing-apt-get\n')
 
-                    for path in self._opts['bootstrap_python_packages']:
-                        path_dict = parse_legacy_hash_path('file', path)
-                        # don't worry about inspecting the tarball; pip is
-                        # smart enough to deal with that
-                        bootstrap.append(['sudo pip install ', path_dict])
+                bootstrap.append(['sudo yum install -y python-pip'])
+
+                for path in self._opts['bootstrap_python_packages']:
+                    path_dict = parse_legacy_hash_path('file', path)
+                    # don't worry about inspecting the tarball; pip is
+                    # smart enough to deal with that
+                    bootstrap.append(['sudo pip install ', path_dict])
             else:
                 log.warning(
                     'bootstrap_python_packages is deprecated and is not'

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1371,9 +1371,8 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
         self.assertIn('sudo ' + expected_python_bin + ' -m compileall -f'
                       ' $__mrjob_PYTHON_LIB/mrjob && true', lines)
         # bootstrap_python_packages
-        if PY2:
-            self.assertIn('sudo yum install -y python-pip', lines)
-            self.assertIn('sudo pip install $__mrjob_PWD/yelpy.tar.gz', lines)
+        self.assertIn(('sudo ' + expected_python_bin +
+                       ' -m pip install $__mrjob_PWD/yelpy.tar.gz'), lines)
         # bootstrap_scripts
         self.assertIn('$__mrjob_PWD/speedups.sh', lines)
         self.assertIn('$__mrjob_PWD/s.sh', lines)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1286,8 +1286,7 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
 
         self.assertEqual(lines[0], '#!/usr/bin/env bash -e')
 
-    def _test_create_master_bootstrap_script(
-            self, ami_version=None, expect_bootstrap_python_packages=PY2):
+    def _test_create_master_bootstrap_script(self, ami_version=None):
         # create a fake src tarball
         foo_py_path = os.path.join(self.tmp_dir, 'foo.py')
         with open(foo_py_path, 'w'):
@@ -1340,7 +1339,7 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
         assertScriptDownloads(runner._mrjob_tar_gz_path)
         assertScriptDownloads('speedups.sh')
         assertScriptDownloads('/tmp/s.sh')
-        if expect_bootstrap_python_packages:
+        if PY2:
             assertScriptDownloads(yelpy_tar_gz_path)
 
         # check scripts get run
@@ -1363,7 +1362,7 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
         self.assertIn('sudo ' + PYTHON_BIN + ' -m compileall -f'
                       ' $__mrjob_PYTHON_LIB/mrjob && true', lines)
         # bootstrap_python_packages
-        if expect_bootstrap_python_packages:
+        if PY2:
             self.assertIn('sudo yum install -y python-pip', lines)
             self.assertIn('sudo pip install $__mrjob_PWD/yelpy.tar.gz', lines)
         # bootstrap_scripts
@@ -1375,11 +1374,11 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
 
     def test_create_master_bootstrap_script_on_2_4_11_ami(self):
         self._test_create_master_bootstrap_script(
-            ami_version='2.4.11', expect_bootstrap_python_packages=False)
+            ami_version='2.4.11')
 
     def test_create_master_bootstrap_script_on_latest_ami(self):
         self._test_create_master_bootstrap_script(
-            ami_version='latest', expect_bootstrap_python_packages=False)
+            ami_version='latest')
 
     def test_no_bootstrap_script_if_not_needed(self):
         runner = EMRJobRunner(conf_paths=[], bootstrap_mrjob=False,


### PR DESCRIPTION
The `bootstrap_python` option is now only responsible for installing Python, not `ujson`. It *does* now install headers and pip (hadn't realized these packages were available for Python 3 before). (Fixes #1264)

This also makes ``bootstrap_python_packages`` run regardless of Python version. We use `python -m pip ...` rather than `pip ...` because it's a little more straightforward to install packages for the correct version of Python. (Fixes #1263)