### PR TITLE
Add --ssh-socks-proxy

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -802,3 +802,12 @@ SSH access and tunneling
     if True, any host can connect to the job tracker through the SSH tunnel
     you open.  Mostly useful if your browser is running on a different machine
     from your job runner.
+
+.. mrjob-opt::
+    :config: ssh_socks_proxy
+    :switch: --ssh-socks-proxy
+    :type: boolean
+    :set: emr
+    :default: ``False``
+
+    if True, mrjob will setup another SSH tunnel with dynamic forwarding.

--- a/mrjob/__init__.py
+++ b/mrjob/__init__.py
@@ -117,4 +117,4 @@ __credits__ = [
     'Andrea Zonca <andrea.zonca@gmail.com>',
 ]
 
-__version__ = '0.5.0'
+__version__ = '0.5.0+x0'

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1004,8 +1004,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 '  Failed to open ssh SOCKS proxy to %s' % tunnel_config['name'])
         else:
             log.info(
-                '  Connect to %s using SOCKS proxy at :%d, and navigate to http://%s:8088/cluster' % (
-                tunnel_config['name'], bind_port, host))
+                '  Connect to %s using SOCKS proxy at :%d, and navigate to http://%s:%d/cluster' % (
+                    tunnel_config['name'], bind_port, host, tunnel_config['port']))
 
     def _set_up_ssh_tunnel(self):
         """set up the ssh tunnel to the job tracker, if it's not currently
@@ -1102,6 +1102,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             # still running. We are golden
             if ssh_proc.returncode is None:
                 self._ssh_procs[pname] = ssh_proc
+                break
             else:
                 ssh_proc.stdin.close()
                 ssh_proc.stdout.close()

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -350,6 +350,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         'ssh_bind_ports',
         'ssh_tunnel',
         'ssh_tunnel_is_open',
+        'ssh_socks_proxy',
         'visible_to_all_users',
     ]))
 
@@ -411,6 +412,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'ssh_bind_ports': list(range(40001, 40841)),
             'ssh_tunnel': False,
             'ssh_tunnel_is_open': False,
+            'ssh_socks_proxy': False,
             'visible_to_all_users': True,
         })
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -644,7 +644,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         self._emr_job_start = None
 
         # ssh state
-        self._ssh_proc = None
+        self._ssh_procs = {}
         self._gave_cant_ssh_warning = False
         # we don't upload the ssh key to master until it's needed
         self._ssh_key_is_copied = False
@@ -980,10 +980,61 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         return map_version(self.get_ami_version(),
                            _AMI_VERSION_TO_SSH_TUNNEL_CONFIG)
 
+    def _set_up_ssh_socks_proxy(self):
+        """set up a SOCKS proxy to the job tracker, if it's not currently running.
+        """
+        pname = 'dynamic-forward'
+
+        # look up what we're supposed to do on this AMI version
+        tunnel_config = self._ssh_tunnel_config()
+        ssh_args = ['-D', '%d']
+        log.info('  Opening ssh SOCKS proxy through %s...' % tunnel_config['name'])
+
+        bind_port = self._setup_ssh(pname, ssh_args)
+        if not bind_port:
+            return
+
+        if pname not in self._ssh_procs:
+            log.warning(
+                '  Failed to open ssh SOCKS proxy to %s' % tunnel_config['name'])
+        else:
+            log.info('  Connect to %s using SOCKS proxy at :%d' % (
+                tunnel_config['name'], bind_port))
+
     def _set_up_ssh_tunnel(self):
         """set up the ssh tunnel to the job tracker, if it's not currently
         running.
         """
+        pname = 'local-forward'
+
+        host = self._address_of_master()
+        if not host:
+            return
+
+        # look up what we're supposed to do on this AMI version
+        tunnel_config = self._ssh_tunnel_config()
+        ssh_args = ['-L', '%d' + ':%s:%d' % (host, tunnel_config['port'])]
+        log.info('  Opening ssh tunnel to %s...' % tunnel_config['name'])
+
+        bind_port = self._setup_ssh(pname, ssh_args)
+        if not bind_port:
+            return
+
+        if pname not in self._ssh_procs:
+            log.warning(
+                '  Failed to open ssh tunnel to %s' % tunnel_config['name'])
+        else:
+            if self._opts['ssh_tunnel_is_open']:
+                bind_host = socket.getfqdn()
+            else:
+                bind_host = 'localhost'
+            self._tunnel_url = 'http://%s:%d%s' % (
+                bind_host, bind_port, tunnel_config['path'])
+            self._show_tracker_progress = True
+            log.info('  Connect to %s at: %s' % (
+                tunnel_config['name'], self._tunnel_url))
+
+    def _setup_ssh(self, pname, ssh_args):
         if not self._opts['ssh_tunnel']:
             return
 
@@ -996,25 +1047,20 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             if not self._opts[opt_name]:
                 if not self._gave_cant_ssh_warning:
                     log.warning(
-                        "  You must set %s in order to set up the SSH tunnel!"
+                        "  You must set %s in order to set up the SSH tunnel/proxy!"
                         % opt_name)
                     self._gave_cant_ssh_warning = True
                 return
 
         # if there was already a tunnel, make sure it's still up
-        if self._ssh_proc:
-            self._ssh_proc.poll()
-            if self._ssh_proc.returncode is None:
+        if pname in self._ssh_procs:
+            self._ssh_procs[pname].poll()
+            if self._ssh_procs[pname].returncode is None:
                 return
             else:
                 log.warning('  Oops, ssh subprocess exited with return code'
-                            ' %d, restarting...' % self._ssh_proc.returncode)
-                self._ssh_proc = None
-
-        # look up what we're supposed to do on this AMI version
-        tunnel_config = self._ssh_tunnel_config()
-
-        log.info('  Opening ssh tunnel to %s...' % tunnel_config['name'])
+                            ' %d, restarting...' % self._ssh_procs[pname].returncode)
+                del self._ssh_procs[pname]
 
         # if ssh detects that a host key has changed, it will silently not
         # open the tunnel, so make a fake empty known_hosts file and use that.
@@ -1035,10 +1081,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 '-o', 'StrictHostKeyChecking=no',
                 '-o', 'ExitOnForwardFailure=yes',
                 '-o', 'UserKnownHostsFile=%s' % fake_known_hosts_file,
-                '-L', '%d:%s:%d' % (bind_port, host, tunnel_config['port']),
                 '-N', '-q',  # no shell, no output
                 '-i', self._opts['ec2_key_pair_file'],
-            ]
+            ] + ssh_args
             if self._opts['ssh_tunnel_is_open']:
                 args.extend(['-g', '-4'])  # -4: listen on IPv4 only
             args.append('hadoop@' + host)
@@ -1049,26 +1094,14 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             ssh_proc.poll()
             # still running. We are golden
             if ssh_proc.returncode is None:
-                self._ssh_proc = ssh_proc
+                self._ssh_procs[pname] = ssh_proc
                 break
             else:
                 ssh_proc.stdin.close()
                 ssh_proc.stdout.close()
                 ssh_proc.stderr.close()
 
-        if not self._ssh_proc:
-            log.warning(
-                '  Failed to open ssh tunnel to %s' % tunnel_config['name'])
-        else:
-            if self._opts['ssh_tunnel_is_open']:
-                bind_host = socket.getfqdn()
-            else:
-                bind_host = 'localhost'
-            self._tunnel_url = 'http://%s:%d%s' % (
-                bind_host, bind_port, tunnel_config['path'])
-            self._show_tracker_progress = True
-            log.info('  Connect to %s at: %s' % (
-                tunnel_config['name'], self._tunnel_url))
+        return bind_port
 
     def _pick_ssh_bind_ports(self):
         """Pick a list of ports to try binding our SSH tunnel to.
@@ -1092,21 +1125,22 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         super(EMRJobRunner, self).cleanup(mode=mode)
 
         # always stop our SSH tunnel if it's still running
-        if self._ssh_proc:
-            self._ssh_proc.poll()
-            if self._ssh_proc.returncode is None:
-                log.info('Killing our SSH tunnel (pid %d)' %
-                         self._ssh_proc.pid)
+        if self._ssh_procs:
+            for pname, ssh_proc in self._ssh_procs.iteritems():
+                ssh_proc.poll()
+                if ssh_proc.returncode is None:
+                    log.info('Killing our SSH tunnel (pid %d)' %
+                             ssh_proc.pid)
 
-                self._ssh_proc.stdin.close()
-                self._ssh_proc.stdout.close()
-                self._ssh_proc.stderr.close()
+                    ssh_proc.stdin.close()
+                    ssh_proc.stdout.close()
+                    ssh_proc.stderr.close()
 
-                try:
-                    os.kill(self._ssh_proc.pid, signal.SIGKILL)
-                    self._ssh_proc = None
-                except Exception as e:
-                    log.exception(e)
+                    try:
+                        os.kill(ssh_proc.pid, signal.SIGKILL)
+                        del self._ssh_procs[pname]
+                    except Exception as e:
+                        log.exception(e)
 
         # stop the cluster if it belongs to us (it may have stopped on its
         # own already, but that's fine)
@@ -1240,7 +1274,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         cluster_id = emr_conn.run_jobflow(
             self._job_key, self._opts['s3_log_uri'], **args)
 
-         # keep track of when we started our job
+        # keep track of when we started our job
         self._emr_job_start = time.time()
 
         log.debug('Cluster created with ID: %s' % cluster_id)
@@ -1604,6 +1638,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
                 # now is the time to tunnel if, if we haven't already
                 self._set_up_ssh_tunnel()
+                self._set_up_ssh_socks_proxy()
                 log.info('  RUNNING%s' % time_running_desc)
                 self._log_step_progress()
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -392,6 +392,11 @@ def _add_emr_run_opts(opt_group):
                   ' localhost).')),
 
         opt_group.add_option(
+            '--ssh-socks-proxy', dest='ssh_socks_proxy',
+            default=None, action='store_true',
+            help=('Use DynamicForward to create a SOCKS proxy.')),
+
+        opt_group.add_option(
             '--ssh-tunnel-to-job-tracker', dest='ssh_tunnel_to_job_tracker',
             default=None, action='store_true',
             help='Deprecated alias for --ssh-tunnel'),


### PR DESCRIPTION
Tests to come after I get some initial feedback!

This adds a `--ssh-socks-proxy` option to set up a SOCKS proxy using `ssh -D`. Note that this does not replace the existing SSH tunnel functionality, since having a `tunnel_url` to query is extremely useful.