### PR TITLE
use (x)range for ssh_bind_ports default

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -770,7 +770,7 @@ SSH access and tunneling
     :switch: --ssh-bind-ports
     :type: special
     :set: emr
-    :default: ``[40001, ..., 40840]``
+    :default: ``range(40001, 40841)``
 
     A list of ports that are safe to listen on. The command line syntax looks
     like ``2000[:2001][,2003,2005:2008,etc]``, where commas separate ranges and

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -97,6 +97,7 @@ from mrjob.pool import _pool_hash_and_name
 from mrjob.py2 import PY2
 from mrjob.py2 import string_types
 from mrjob.py2 import urlopen
+from mrjob.py2 import xrange
 from mrjob.retry import RetryGoRound
 from mrjob.runner import MRJobRunner
 from mrjob.runner import RunnerOptionStore
@@ -408,7 +409,9 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             's3_upload_part_size': 100,  # 100 MB
             'sh_bin': ['/bin/sh', '-ex'],
             'ssh_bin': ['ssh'],
-            'ssh_bind_ports': list(range(40001, 40841)),
+             # don't use a list because it makes it hard to read option values
+             # when running in verbose mode. See #1284
+            'ssh_bind_ports': xrange(40001, 40841),
             'ssh_tunnel': False,
             'ssh_tunnel_is_open': False,
             'visible_to_all_users': True,

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -86,7 +86,7 @@ and ``.values()``.
 If you *do* have concerns about memory usage, ``for k in some_dict`` does not
 create a list in either version of Python.
 
-Same goes for ``xrange``; just use ``range``.
+Same goes for ``xrange``; plain-old `range`` is almost always fine.
 
 Miscellany
 ----------
@@ -128,6 +128,13 @@ if PY2:
 else:
     from io import StringIO
 StringIO  # quiet, pyflakes
+
+# ``xrange``. Plain old ``range`` is almost always fine
+if PY2:
+    xrange = xrange
+else:
+    xrange = range
+xrange  # quiet, pyflakes
 
 # urllib stuff
 # in most cases you should use ``mrjob.parse.urlparse()``


### PR DESCRIPTION
When you run a job on EMR in verbose mode (`-r emr -v`), `ssh_bind_ports` takes up several lines, making it difficult to read the values of other options.

This replaces the default list with a `range` object (`xrange` on Python 2). Hand-tested on Python 2 and Python 3. Fixes #1284