### PR TITLE
fixes to partitioner and SORT_VALUES

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -43,6 +43,25 @@ and ``inline`` runners to some degree.
     'KEY1=VALUE1', '-D', 'KEY2=VALUE2', ...]`` to
     :mrjob-opt:`hadoop_extra_args`
 
+.. mrjob-opt::
+    :config: partitioner
+    :switch: --partitioner
+    :type: :ref:`string <data-type-string>`
+    :set: no_mrjob_conf
+    :default: ``None``
+
+    .. deprecated:: 0.5.1
+
+    Name of a Hadoop partitioner class, e.g.
+    ``'org.apache.hadoop.mapred.lib.HashPartitioner'``. Hadoop Streaming will
+    use this to determine how mapper output should be sorted and distributed
+    to reducers.
+
+    The recommended way to specify partitioner is in your job, with the
+    :py:attr:`~mrjob.job.MRJob.PARTITIONER` attribute or the
+    :py:meth:`~mrjob.job.MRJob.partitioner` method.
+
+
 
 Options available to hadoop and emr runners
 -------------------------------------------
@@ -105,20 +124,6 @@ Options available to hadoop and emr runners
     :default: :py:func:`getpass.getuser`, or ``no_user`` if that fails
 
     Who is running this job (if different from the current user)
-
-.. mrjob-opt::
-    :config: partitioner
-    :switch: --partitioner
-    :type: :ref:`string <data-type-string>`
-    :set: no_mrjob_conf
-    :default: ``None``
-
-    Optional name of a Hadoop partitioner class, e.g.
-    ``'org.apache.hadoop.mapred.lib.HashPartitioner'``. Hadoop Streaming will
-    use this to determine how mapper output should be sorted and distributed
-    to reducers. You can also set this option on your job class with the
-    :py:attr:`~mrjob.job.MRJob.PARTITIONER` attribute or the
-    :py:meth:`~mrjob.job.MRJob.partitioner` method.
 
 .. mrjob-opt::
     :config: check_input_paths

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -40,13 +40,17 @@ log = logging.getLogger(__name__)
 
 
 # jobconf options for implementing SORT_VALUES
+#
+# This includes both the Hadoop 1 and Hadoop 2 names of the options.
+# The options that are set to None exist to override mrjob.conf.
 _SORT_VALUES_JOBCONF = {
-    'stream.num.map.output.key.fields': 2,
     'mapred.text.key.partitioner.options': '-k1,1',
-    # Hadoop's defaults for these actually work fine; we just want to
-    # prevent interference from mrjob.conf.
     'mapred.output.key.comparator.class': None,
     'mapred.text.key.comparator.options': None,
+    'mapreduce.partition.keypartitioner.options': '-k1,1',
+    'mapreduce.job.output.key.comparator.class': None,
+    'mapreduce.partition.keycomparator.options': None,
+    'stream.num.map.output.key.fields': 2,
 }
 
 # partitioner for sort_values

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -485,7 +485,7 @@ class MRJobLauncher(object):
             'label': self.options.label,
             'output_dir': self.options.output_dir,
             'owner': self.options.owner,
-            'partitioner': self.partitioner(),
+            'partitioner': self.partitioner() or self.options.partitioner,
             'python_archives': self.options.python_archives,
             'python_bin': self.options.python_bin,
             'setup': self.options.setup,

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -151,6 +151,11 @@ def _add_runner_opts(opt_group, default_runner='local'):
             'and must be empty'),
 
         opt_group.add_option(
+            '--partitioner', dest='partitioner', default=None,
+            help=('Hadoop partitioner class. Deprecated as of v0.5.1 and'
+                  ' will be removed in v0.6.0 (specify in your job instead)')),
+
+        opt_group.add_option(
             '--python-archive', dest='python_archives', default=[],
             action='append',
             help=('Archive to unpack and add to the PYTHONPATH of the mr_job'
@@ -236,12 +241,6 @@ def _add_hadoop_emr_opts(opt_group):
         opt_group.add_option(
             '--owner', dest='owner', default=None,
             help='user who ran the job (if different from the current user)'),
-
-        opt_group.add_option(
-            '--partitioner', dest='partitioner', default=None,
-            help=('Hadoop partitioner class to use to determine how mapper'
-                  ' output should be sorted and distributed to reducers. For'
-                  ' example: org.apache.hadoop.mapred.lib.HashPartitioner')),
 
         opt_group.add_option(
             '--check-input-paths', dest='check_input_paths',

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -33,7 +33,7 @@ from subprocess import Popen
 from subprocess import PIPE
 from subprocess import check_call
 
-from mrjob.compat import translate_jobconf
+from mrjob.compat import translate_jobconf_dict
 from mrjob.conf import combine_cmds
 from mrjob.conf import combine_dicts
 from mrjob.conf import combine_envs

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1153,37 +1153,11 @@ class MRJobRunner(object):
         jobconf = combine_dicts(self._opts['jobconf'], step.get('jobconf'))
 
         # if user is using the wrong jobconfs, add in the correct ones
-        self._update_jobconf_for_hadoop_version(
-            jobconf, self.get_hadoop_version())
+        version = self.get_hadoop_version()
+        if version:
+            jobconf = translate_jobconf_dict(jobconf, hadoop_version=version)
 
         return jobconf
-
-    def _update_jobconf_for_hadoop_version(self, jobconf, hadoop_version):
-        """If *jobconf* (a dict) contains jobconf variables from the wrong
-        version of Hadoop, add variables for the right one.
-
-        If *hadoop_version* is empty, do nothing.
-        """
-        if not hadoop_version:  # this happens for sim runner
-            return
-
-        translations = {}  # for warning, below
-
-        for key, value in sorted(jobconf.items()):
-            new_key = translate_jobconf(key, hadoop_version)
-            if new_key not in jobconf:
-                jobconf[new_key] = value
-                translations[key] = new_key
-
-        if translations:
-            log.warning(
-                "Detected hadoop configuration property names that"
-                " do not match hadoop version %s:"
-                "\nThey have been translated as follows\n %s",
-                hadoop_version,
-                '\n'.join([
-                    "%s: %s" % (key, new_key) for key, new_key
-                    in sorted(translations.items())]))
 
     # TODO: this is only used by non-local runners, and could
     # conceivably be moved to some intermediary class (RealMRJobRunner?)

--- a/tests/mr_sort_values.py
+++ b/tests/mr_sort_values.py
@@ -1,0 +1,27 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Job to test if runners respect SORT_VALUES."""
+from mrjob.job import MRJob
+
+
+class MRSortValues(MRJob):
+    SORT_VALUES = True
+
+    # need to define a mapper or reducer
+    def mapper_init(self):
+        pass
+
+
+if __name__ == '__main__':
+    MRSortValues.run()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -72,7 +72,6 @@ from tests.quiet import no_handlers_for_logger
 from tests.sandbox import mrjob_conf_patcher
 from tests.sandbox import patch_fs_s3
 from tests.test_hadoop import HadoopExtraArgsTestCase
-from tests.test_job import MRSortValues
 
 try:
     import boto

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -59,6 +59,7 @@ from tests.mr_hadoop_format_job import MRHadoopFormatJob
 from tests.mr_jar_and_streaming import MRJarAndStreaming
 from tests.mr_just_a_jar import MRJustAJar
 from tests.mr_no_mapper import MRNoMapper
+from tests.mr_sort_values import MRSortValues
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
 from tests.py2 import Mock
@@ -71,6 +72,7 @@ from tests.quiet import no_handlers_for_logger
 from tests.sandbox import mrjob_conf_patcher
 from tests.sandbox import patch_fs_s3
 from tests.test_hadoop import HadoopExtraArgsTestCase
+from tests.test_job import MRSortValues
 
 try:
     import boto
@@ -3683,3 +3685,26 @@ class GetStepLogInterpretationTestCase(MockBotoTestCase):
 # for the EMR runner
 class HadoopExtraArgsOnEMRTestCase(HadoopExtraArgsTestCase, MockBotoTestCase):
     pass
+
+
+# make sure we don't override the partitioner on EMR (tests #1294)
+class SortValuesTestCase(MockBotoTestCase):
+
+    def setUp(self):
+        super(SortValuesTestCase, self).setUp()
+        # _hadoop_args_for_step() needs this
+        self.start(patch(
+            'mrjob.emr.EMRJobRunner.get_hadoop_version',
+            return_value='2.4.0'))
+
+    def test_options(self):
+        job = MRSortValues(['-r', 'emr'])
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._hadoop_args_for_step(0), [
+                    '-D', 'mapred.text.key.partitioner.options=-k1,1',
+                    '-D', 'stream.num.map.output.key.fields=2',
+                    '-partitioner',
+                    'org.apache.hadoop.mapred.lib.KeyFieldBasedPartitioner',
+                ])

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3704,6 +3704,7 @@ class PartitionerTestCase(MockBotoTestCase):
             self.assertEqual(
                 runner._hadoop_args_for_step(0), [
                     '-D', 'mapred.text.key.partitioner.options=-k1,1',
+                    '-D', 'mapreduce.partition.keypartitioner.options=-k1,1',
                     '-D', 'stream.num.map.output.key.fields=2',
                     '-partitioner',
                     'org.apache.hadoop.mapred.lib.KeyFieldBasedPartitioner',
@@ -3716,6 +3717,7 @@ class PartitionerTestCase(MockBotoTestCase):
             self.assertEqual(
                 runner._hadoop_args_for_step(0), [
                     '-D', 'mapred.text.key.partitioner.options=-k1,1',
+                    '-D', 'mapreduce.partition.keypartitioner.options=-k1,1',
                     '-D', 'stream.num.map.output.key.fields=2',
                     '-partitioner', 'java.lang.Object',
                 ])

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -40,6 +40,7 @@ from mrjob.step import JarStep
 from mrjob.step import MRStep
 from mrjob.util import log_to_stream
 from tests.mr_hadoop_format_job import MRHadoopFormatJob
+from tests.mr_sort_values import MRSortValues
 from tests.mr_tower_of_powers import MRTowerOfPowers
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.py2 import TestCase
@@ -656,15 +657,7 @@ class JobConfTestCase(TestCase):
                          {'mapred.baz': 'bar'})
 
 
-class MRSortValuesJob(MRJob):
-    SORT_VALUES = True
-
-    # need to define a mapper or reducer
-    def mapper_init(self):
-        pass
-
-
-class MRSortValuesAndMoreJob(MRSortValuesJob):
+class MRSortValuesAndMore(MRSortValues):
     PARTITIONER = 'org.apache.hadoop.mapred.lib.HashPartitioner'
 
     JOBCONF = {
@@ -678,14 +671,14 @@ class MRSortValuesAndMoreJob(MRSortValuesJob):
 class SortValuesTestCase(TestCase):
 
     def test_sort_values_sets_partitioner(self):
-        mr_job = MRSortValuesJob()
+        mr_job = MRSortValues()
 
         self.assertEqual(
             mr_job.partitioner(),
             'org.apache.hadoop.mapred.lib.KeyFieldBasedPartitioner')
 
     def test_sort_values_sets_jobconf(self):
-        mr_job = MRSortValuesJob()
+        mr_job = MRSortValues()
 
         self.assertEqual(
             mr_job.jobconf(),
@@ -695,7 +688,7 @@ class SortValuesTestCase(TestCase):
              'mapred.text.key.comparator.options': None})
 
     def test_can_override_sort_values_from_job(self):
-        mr_job = MRSortValuesAndMoreJob()
+        mr_job = MRSortValuesAndMore()
 
         self.assertEqual(
             mr_job.partitioner(),
@@ -710,7 +703,7 @@ class SortValuesTestCase(TestCase):
              'mapred.text.key.comparator.options': '-k1 -k2nr'})
 
     def test_can_override_sort_values_from_cmd_line(self):
-        mr_job = MRSortValuesJob(
+        mr_job = MRSortValues(
             ['--partitioner', 'org.pants.FancyPantsPartitioner',
              '--jobconf', 'stream.num.map.output.key.fields=lots'])
 
@@ -735,7 +728,7 @@ class SortValuesRunnerTestCase(SandboxedTestCase):
     }}}}
 
     def test_cant_override_sort_values_from_mrjob_conf(self):
-        runner = MRSortValuesJob().make_runner()
+        runner = MRSortValues().make_runner()
 
         self.assertEqual(
             runner._hadoop_args_for_step(0),

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -21,9 +21,11 @@ from io import BytesIO
 from subprocess import Popen
 from subprocess import PIPE
 
+from mrjob.conf import combine_dicts
 from mrjob.conf import combine_envs
 from mrjob.job import MRJob
 from mrjob.job import UsageError
+from mrjob.job import _SORT_VALUES_JOBCONF
 from mrjob.job import _im_func
 from mrjob.parse import parse_mr_job_stderr
 from mrjob.protocol import JSONProtocol
@@ -680,12 +682,7 @@ class SortValuesTestCase(TestCase):
     def test_sort_values_sets_jobconf(self):
         mr_job = MRSortValues()
 
-        self.assertEqual(
-            mr_job.jobconf(),
-            {'stream.num.map.output.key.fields': 2,
-             'mapred.text.key.partitioner.options': '-k1,1',
-             'mapred.output.key.comparator.class': None,
-             'mapred.text.key.comparator.options': None})
+        self.assertEqual(mr_job.jobconf(), _SORT_VALUES_JOBCONF)
 
     def test_can_override_sort_values_from_job(self):
         mr_job = MRSortValuesAndMore()
@@ -696,11 +693,7 @@ class SortValuesTestCase(TestCase):
 
         self.assertEqual(
             mr_job.jobconf(),
-            {'stream.num.map.output.key.fields': 3,
-             'mapred.text.key.partitioner.options': '-k1,1',
-             'mapred.output.key.comparator.class':
-                'org.apache.hadoop.mapred.lib.KeyFieldBasedComparator',
-             'mapred.text.key.comparator.options': '-k1 -k2nr'})
+            combine_dicts(_SORT_VALUES_JOBCONF, MRSortValuesAndMore.JOBCONF))
 
     def test_can_override_sort_values_from_cmd_line(self):
         mr_job = MRSortValues(
@@ -713,10 +706,8 @@ class SortValuesTestCase(TestCase):
 
         self.assertEqual(
             mr_job.jobconf(),
-            {'stream.num.map.output.key.fields': 'lots',
-             'mapred.text.key.partitioner.options': '-k1,1',
-             'mapred.output.key.comparator.class': None,
-             'mapred.text.key.comparator.options': None})
+            combine_dicts(_SORT_VALUES_JOBCONF,
+                          {'stream.num.map.output.key.fields': 'lots'}))
 
 
 class SortValuesRunnerTestCase(SandboxedTestCase):
@@ -736,6 +727,7 @@ class SortValuesRunnerTestCase(SandboxedTestCase):
             # blanked out so as not to mess up SORT_VALUES
             ['-D', 'foo=bar',
              '-D', 'mapred.text.key.partitioner.options=-k1,1',
+             '-D', 'mapreduce.partition.keypartitioner.options=-k1,1',
              '-D', 'stream.num.map.output.key.fields=2',
              '-partitioner',
                 'org.apache.hadoop.mapred.lib.KeyFieldBasedPartitioner'])

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -25,7 +25,6 @@ import tempfile
 from io import BytesIO
 from subprocess import CalledProcessError
 
-from mrjob.conf import combine_dicts
 from mrjob.hadoop import HadoopJobRunner
 from mrjob.inline import InlineMRJobRunner
 from mrjob.local import LocalMRJobRunner


### PR DESCRIPTION
This patches a major bug that was disabling `SORT_VALUES` (see #1294).

`SORT_VALUES` now sets both Hadoop 1 and Hadoop 2 jobconf variables, to avoid translation warnings (see #1286)

I also noticed that a method in `mrjob.runner` was doing almost the same thing as `mrjob.compat.translate_jobconf_dict()` so I removed it and added (missing) tests for `translate_jobconf_dict()`.