### PR TITLE
Wrong task error

### DIFF
--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -191,7 +191,7 @@ def _parse_yarn_history_log(lines):
         if record_type.endswith('_ATTEMPT_FAILED'):
             for event in events:
                 err_msg = event.get('error')
-                if not isinstance(err_msg, string_types):
+                if not (err_msg and isinstance(err_msg, string_types)):
                     continue
 
                 error = dict(

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -312,8 +312,11 @@ def _parse_pre_yarn_history_log(lines):
 
             task_to_counters[task_id] = counters
 
+        # only want FAILED (not KILLED) tasks with non-blank errors
         elif (record['type'] in ('MapAttempt', 'ReduceAttempt') and
-              'TASK_ATTEMPT_ID' in fields and 'ERROR' in fields):
+              'TASK_ATTEMPT_ID' in fields and
+              fields.get('TASK_STATUS') == 'FAILED' and
+              fields.get('ERROR')):
             result.setdefault('errors', [])
             result['errors'].append(dict(
                 hadoop_error=dict(

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -450,6 +450,50 @@ class ParsePreYARNHistoryLogTestCase(TestCase):
                     ),
                 ]))
 
+    def test_ignore_killed_task_with_empty_error(self):
+        # regression test for #1288
+        lines = [
+            'MapAttempt TASK_TYPE="MAP"'
+            ' TASKID="task_201603252302_0001_m_000003"'
+            ' TASK_ATTEMPT_ID="attempt_201603252302_0001_m_000003_3"'
+            ' TASK_STATUS="KILLED" FINISH_TIME="1458947137998"'
+            ' HOSTNAME="172\.31\.18\.180" ERROR="" .\n',
+        ]
+
+        self.assertEqual(_parse_pre_yarn_history_log(lines), {})
+
+    def test_ignore_killed_task(self):
+        # not sure if this actually happens, but just to be safe
+        lines = [
+            'MapAttempt TASK_TYPE="MAP"'
+            ' TASKID="task_201601081945_0005_m_000001"'
+            ' TASK_ATTEMPT_ID='
+            '"attempt_201601081945_0005_m_00000_2"'
+            ' TASK_STATUS="KILLED"'
+            ' ERROR="java\.lang\.RuntimeException:'
+            ' PipeMapRed\.waitOutputThreads():'
+            ' subprocess failed with code 1\n',
+            '        at org\\.apache\\.hadoop\\.streaming\\.PipeMapRed'
+            '\\.waitOutputThreads(PipeMapRed\\.java:372)\n',
+            '        at org\\.apache\\.hadoop\\.streaming\\.PipeMapRed'
+            '\\.mapRedFinished(PipeMapRed\\.java:586)\n',
+            '" .\n',
+        ]
+
+        self.assertEqual(_parse_pre_yarn_history_log(lines), {})
+
+    def test_ignore_blank_error(self):
+        lines = [
+            'MapAttempt TASK_TYPE="MAP"'
+            ' TASKID="task_201601081945_0005_m_000001"'
+            ' TASK_ATTEMPT_ID='
+            '"attempt_201601081945_0005_m_00000_2"'
+            ' TASK_STATUS="FAILED"'
+            ' ERROR="" .\n',
+        ]
+
+        self.assertEqual(_parse_pre_yarn_history_log(lines), {})
+
 
 # edge cases in pre-YARN history record parsing
 class ParsePreYARNHistoryRecordsTestCase(TestCase):


### PR DESCRIPTION
This fixes #1288 by only parsing errors from the history file if they have non-blank error messages and correspond to `FAILED` (not `KILLED`) task attempts.
