### PR TITLE
respect strict_protocols: False in config

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+v0.5.1, 2016-05-?? -- ???
+ * strict_protocols in mrjob.conf is no longer ignored (#1302)
+ * check_input_paths in mrjob.conf is no longer ignored
+ * partitioner() is no longer ignored, fixing SORT_VALUES (#1294)
+ * improved probably cause of error from pre-YARN logs (#1288)
+ * ssh_bind_ports now defaults to (x)range, not list (#1284)
+
 v0.5.0, 2016-03-28 -- the future is in the past
  * supports Python 3 (#989)
  * requires boto 2.35.0 or newer (#980)

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -676,7 +676,9 @@ class MRJob(MRJobLauncher):
                     key, value = read(line.rstrip(b'\r\n'))
                     yield key, value
                 except Exception as e:
-                    if self.options.strict_protocols:
+                    # the strict_protocols option has to default to None
+                    # because it's used by runners, so treat None as true
+                    if self.options.strict_protocols != False:
                         raise
                     else:
                         self.increment_counter(
@@ -687,7 +689,8 @@ class MRJob(MRJobLauncher):
                 self.stdout.write(write(key, value))
                 self.stdout.write(b'\n')
             except Exception as e:
-                if self.options.strict_protocols:
+                # None counts as true, see above
+                if self.options.strict_protocols != False:
                     raise
                 else:
                     self.increment_counter(

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -244,12 +244,12 @@ def _add_hadoop_emr_opts(opt_group):
 
         opt_group.add_option(
             '--check-input-paths', dest='check_input_paths',
-            default=True, action='store_true',
+            default=None, action='store_true',
             help='Check input paths exist before running (the default)'),
 
         opt_group.add_option(
             '--no-check-input-paths', dest='check_input_paths',
-            default=True, action='store_false',
+            default=None, action='store_false',
             help='Skip the checks to ensure all input paths exist'),
     ]
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -44,11 +44,11 @@ def _add_protocol_opts(opt_group):
     """
     return [
         opt_group.add_option(
-            '--strict-protocols', dest='strict_protocols', default=True,
+            '--strict-protocols', dest='strict_protocols', default=None,
             action='store_true', help='If something violates an input/output '
             'protocol then raise an exception (the default)'),
         opt_group.add_option(
-            '--no-strict-protocols', dest='strict_protocols', default=True,
+            '--no-strict-protocols', dest='strict_protocols', default=None,
             action='store_false', help='If something violates an input/output '
             'protocol then increment a counter and continue'),
     ]

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -400,33 +400,6 @@ class StrictProtocolsTestCase(EmptyMrjobConfTestCase):
             ['--no-strict-protocols'])
 
 
-class StrictProtocolsInConfTestCase(TestCase):
-    # regression tests for #1302, where command-line option's default
-    # overrode configs
-
-    STRICT_MRJOB_CONF = {'runners': {'inline': {'strict_protocols': True}}}
-
-    LOOSE_MRJOB_CONF = {'runners': {'inline': {'strict_protocols': False}}}
-
-    def test_default(self):
-        job = MRJob()
-        with job.make_runner() as runner:
-            self.assertEqual(runner._opts['strict_protocols'], True)
-
-    def test_strict_mrjob_conf(self):
-        job = MRJob()
-        with mrjob_conf_patcher(self.STRICT_MRJOB_CONF):
-            with job.make_runner() as runner:
-                self.assertEqual(runner._opts['strict_protocols'], True)
-
-    def test_loose_mrjob_conf(self):
-        job = MRJob()
-        with mrjob_conf_patcher(self.LOOSE_MRJOB_CONF):
-            with job.make_runner() as runner:
-                self.assertEqual(runner._opts['strict_protocols'], False)
-
-
-
 class PickProtocolsTestCase(TestCase):
 
     def _yield_none(self, *args, **kwargs):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -328,11 +328,7 @@ class StrictProtocolsTestCase(EmptyMrjobConfTestCase):
                               b'set()\n' +
                               b"'bar'\n")
 
-    STRICT_MRJOB_CONF = {'runners': {'inline': {'strict_protocols': True}}}
-
-    LOOSE_MRJOB_CONF = {'runners': {'inline': {'strict_protocols': False}}}
-
-    def assertJobHandlesUndecodableInput(self, job_args):
+    def assertJobHandlesUndecodableInput(self, job_args=()):
         job = self.MRBoringJSONJob(job_args)
         job.sandbox(stdin=BytesIO(self.BAD_JSON_INPUT))
 
@@ -349,14 +345,14 @@ class StrictProtocolsTestCase(EmptyMrjobConfTestCase):
             self.assertEqual(
                 sum(counters['Undecodable input'].values()), 3)
 
-    def assertJobRaisesExceptionOnUndecodableInput(self, job_args):
+    def assertJobRaisesExceptionOnUndecodableInput(self, job_args=()):
         job = self.MRBoringJSONJob(job_args)
         job.sandbox(stdin=BytesIO(self.BAD_JSON_INPUT))
 
         with job.make_runner() as r:
             self.assertRaises(Exception, r.run)
 
-    def assertJobHandlesUnencodableOutput(self, job_args):
+    def assertJobHandlesUnencodableOutput(self, job_args=()):
         job = self.MRBoringReprAndJSONJob(job_args)
         job.sandbox(stdin=BytesIO(self.UNENCODABLE_REPR_INPUT))
 
@@ -374,7 +370,7 @@ class StrictProtocolsTestCase(EmptyMrjobConfTestCase):
             self.assertEqual(list(counters), ['Unencodable output'])
             self.assertEqual(list(counters['Unencodable output'].values()), [1])
 
-    def assertJobRaisesExceptionOnUnencodableOutput(self, job_args):
+    def assertJobRaisesExceptionOnUnencodableOutput(self, job_args=()):
         job = self.MRBoringReprAndJSONJob(job_args)
         job.sandbox(stdin=BytesIO(self.UNENCODABLE_REPR_INPUT))
 
@@ -382,44 +378,53 @@ class StrictProtocolsTestCase(EmptyMrjobConfTestCase):
             self.assertRaises(Exception, r.run)
 
     def test_undecodable_input(self):
-        self.assertJobRaisesExceptionOnUndecodableInput(job_args=[])
+        self.assertJobRaisesExceptionOnUndecodableInput()
 
-    def test_undecodable_input_strict(self):
+    def test_undecodable_input_strict_protocols(self):
         self.assertJobRaisesExceptionOnUndecodableInput(
-            job_args=['--strict-protocols'])
-
-    def test_undecodable_input_strict_in_mrjob_conf(self):
-        with mrjob_conf_patcher(self.STRICT_MRJOB_CONF):
-            self.assertJobRaisesExceptionOnUndecodableInput(
-                job_args=['--strict-protocols'])
+            ['--strict-protocols'])
 
     def test_undecodable_input_no_strict_protocols(self):
-        with mrjob_conf_patcher(self.STRICT_MRJOB_CONF):
-            self.assertJobHandlesUndecodableInput(
-                job_args=['--no-strict-protocols'])
+        self.assertJobHandlesUndecodableInput(
+            ['--no-strict-protocols'])
 
     def test_unencodable_output(self):
-        self.assertJobRaisesExceptionOnUnencodableOutput(job_args=[])
+        self.assertJobRaisesExceptionOnUnencodableOutput()
 
     def test_unencodable_output_strict(self):
         self.assertJobRaisesExceptionOnUnencodableOutput(
-            job_args=['--strict-protocols'])
-
-    def test_unencodable_output_strict_in_mrjob_conf(self):
-        with mrjob_conf_patcher(self.STRICT_MRJOB_CONF):
-            self.assertJobRaisesExceptionOnUnencodableOutput(
-                job_args=['--strict-protocols'])
+            ['--strict-protocols'])
 
     def test_unencodable_output_no_strict_protocols(self):
-        with mrjob_conf_patcher(self.STRICT_MRJOB_CONF):
-            self.assertJobHandlesUnencodableOutput(
-                job_args=['--no-strict-protocols'])
+        self.assertJobHandlesUnencodableOutput(
+            ['--no-strict-protocols'])
 
-    def test_loose_protocols_in_conf(self):
-        # regression test for #1302; config file was being overriden
-        # by option default of True
+
+class StrictProtocolsInConfTestCase(TestCase):
+    # regression tests for #1302, where command-line option's default
+    # overrode configs
+
+    STRICT_MRJOB_CONF = {'runners': {'inline': {'strict_protocols': True}}}
+
+    LOOSE_MRJOB_CONF = {'runners': {'inline': {'strict_protocols': False}}}
+
+    def test_default(self):
+        job = MRJob()
+        with job.make_runner() as runner:
+            self.assertEqual(runner._opts['strict_protocols'], True)
+
+    def test_strict_mrjob_conf(self):
+        job = MRJob()
+        with mrjob_conf_patcher(self.STRICT_MRJOB_CONF):
+            with job.make_runner() as runner:
+                self.assertEqual(runner._opts['strict_protocols'], True)
+
+    def test_loose_mrjob_conf(self):
+        job = MRJob()
         with mrjob_conf_patcher(self.LOOSE_MRJOB_CONF):
-            self.assertJobHandlesUndecodableInput([])
+            with job.make_runner() as runner:
+                self.assertEqual(runner._opts['strict_protocols'], False)
+
 
 
 class PickProtocolsTestCase(TestCase):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -328,7 +328,9 @@ class StrictProtocolsTestCase(EmptyMrjobConfTestCase):
                               b'set()\n' +
                               b"'bar'\n")
 
-    STRICT_MRJOB_CONF ={'runners': {'inline': {'strict_protocols': True}}}
+    STRICT_MRJOB_CONF = {'runners': {'inline': {'strict_protocols': True}}}
+
+    LOOSE_MRJOB_CONF = {'runners': {'inline': {'strict_protocols': False}}}
 
     def assertJobHandlesUndecodableInput(self, job_args):
         job = self.MRBoringJSONJob(job_args)
@@ -412,6 +414,12 @@ class StrictProtocolsTestCase(EmptyMrjobConfTestCase):
         with mrjob_conf_patcher(self.STRICT_MRJOB_CONF):
             self.assertJobHandlesUnencodableOutput(
                 job_args=['--no-strict-protocols'])
+
+    def test_loose_protocols_in_conf(self):
+        # regression test for #1302; config file was being overriden
+        # by option default of True
+        with mrjob_conf_patcher(self.LOOSE_MRJOB_CONF):
+            self.assertJobHandlesUndecodableInput([])
 
 
 class PickProtocolsTestCase(TestCase):


### PR DESCRIPTION
This fixes #1302.

The default for the `--strict-protocols` switch was set to `True` rather than `None`, which would result in mrjob.conf being overridden even if no switches were used.

*However* there was a good reason to default  to `True`; the job itself uses it, and by default, the runner doesn't pass `--strict-protocols` to jobs (it only passes `--no-strict-protocols` to indicate "loose" protocols).

The fix was to have jobs enforce strict protocols whenever `self.options.strict_protocols != False` (so `None` is treated the same as `True`, the default).

Also noticed that `check_input_files` was also defaulting its command-line option to `True` (which would override the config file). Fixed and added tests.