### PR TITLE
Debug jar issues

### DIFF
--- a/mrjob/tools/emr/terminate_idle_clusters.py
+++ b/mrjob/tools/emr/terminate_idle_clusters.py
@@ -84,11 +84,11 @@ from mrjob.util import strip_microseconds
 
 log = logging.getLogger(__name__)
 
-DEFAULT_MAX_HOURS_IDLE = 1
-DEFAULT_MAX_MINUTES_LOCKED = 1
+_DEFAULT_MAX_HOURS_IDLE = 1
+_DEFAULT_MAX_MINUTES_LOCKED = 1
 
-DEBUG_JAR_RE = re.compile(
-    r's3n://.*\.elasticmapreduce/libs/state-pusher/[^/]+/fetch')
+_DEBUG_JAR_ARG_RE = re.compile(
+    r's3n?://.*\.elasticmapreduce/libs/state-pusher/[^/]+/fetch')
 
 
 def main(cl_args=None):
@@ -141,7 +141,7 @@ def _maybe_terminate_clusters(dry_run=False,
 
     # old default behavior
     if max_hours_idle is None and mins_to_end_of_hour is None:
-        max_hours_idle = DEFAULT_MAX_HOURS_IDLE
+        max_hours_idle = _DEFAULT_MAX_HOURS_IDLE
 
     runner = EMRJobRunner(**kwargs)
     emr_conn = runner.make_emr_conn()
@@ -270,7 +270,7 @@ def _is_cluster_non_streaming(steps):
             if arg.value == '-mapper':
                 return False
             # This is a debug jar associated with hadoop streaming
-            if DEBUG_JAR_RE.match(arg.value):
+            if _DEBUG_JAR_ARG_RE.match(arg.value):
                 return False
     else:
         # job has at least one step, and none are streaming steps
@@ -389,7 +389,7 @@ def _make_option_parser():
               ' your jobs can take to start instances and bootstrap.'))
     option_parser.add_option(
         '--max-mins-locked', dest='max_mins_locked',
-        default=DEFAULT_MAX_MINUTES_LOCKED, type='float',
+        default=_DEFAULT_MAX_MINUTES_LOCKED, type='float',
         help='Max number of minutes a cluster can be locked while idle.')
     option_parser.add_option(
         '--mins-to-end-of-hour', dest='mins_to_end_of_hour',

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -90,13 +90,27 @@ AMI_HADOOP_VERSION_UPDATES = {
     '4.3.0': '2.7.1',
 }
 
+
+# hard-coded EmrConnection.DebuggingJar from boto 2.39.0. boto 2.40.0 more
+# correctly uses a template with the correct region (see #1306), but
+# mockboto's EMR stuff doesn't have any other reason to be region-aware.
+DEBUGGING_JAR = (
+    's3n://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar')
+
+# likewise, this is EmrConnection.DebuggingArgs from boto 2.39.0
+DEBUGGING_ARGS = (
+    's3n://us-east-1.elasticmapreduce/libs/state-pusher/0.1/fetch')
+
 # extra step to use when debugging_step=True is passed to run_jobflow()
 DEBUGGING_STEP = JarStep(
     name='Setup Hadoop Debugging',
     action_on_failure='TERMINATE_CLUSTER',
     main_class=None,
-    jar=EmrConnection.DebuggingJar,
-    step_args=EmrConnection.DebuggingArgs)
+    jar=DEBUGGING_JAR,
+    step_args=DEBUGGING_ARGS)
+
+
+
 
 
 ### Errors ###


### PR DESCRIPTION
This fixes failing tests, and an edge case where a cluster started with boto 2.40.0 with debugging but no steps will be considered a non-streaming step and not marked idle by `terminate_idle_clusters` (see #1306).
