### PR TITLE
Tilde in include

### DIFF
--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -305,11 +305,9 @@ class MRJobBasicConfTestCase(MRJobConfTestCase):
 
     def test_tilde_in_include(self):
         # regression test for #1308
+
         os.environ['HOME'] = self.tmp_dir
-
         base_conf_path = os.path.join(self.tmp_dir, 'mrjob.base.conf')
-        real_base_conf_path = os.path.realpath(base_conf_path)
-
         conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
 
         with open(base_conf_path, 'w') as f:
@@ -320,7 +318,7 @@ class MRJobBasicConfTestCase(MRJobConfTestCase):
 
         self.assertEqual(
             load_opts_from_mrjob_conf('foo', conf_path),
-            [(real_base_conf_path, {}), (conf_path, {})])
+            [(base_conf_path, {}), (conf_path, {})])
 
     def _test_round_trip(self, conf):
         conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -303,6 +303,25 @@ class MRJobBasicConfTestCase(MRJobConfTestCase):
             load_opts_from_mrjob_conf('foo', conf_symlink_path),
             [(real_base_conf_path, {}), (conf_symlink_path, {})])
 
+    def test_tilde_in_include(self):
+        # regression test for #1308
+        os.environ['HOME'] = self.tmp_dir
+
+        base_conf_path = os.path.join(self.tmp_dir, 'mrjob.base.conf')
+        real_base_conf_path = os.path.realpath(base_conf_path)
+
+        conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
+
+        with open(base_conf_path, 'w') as f:
+            dump_mrjob_conf({}, f)
+
+        with open(conf_path, 'w') as f:
+            dump_mrjob_conf({'include': '~/mrjob.base.conf'}, f)
+
+        self.assertEqual(
+            load_opts_from_mrjob_conf('foo', conf_path),
+            [(real_base_conf_path, {}), (conf_path, {})])
+
     def _test_round_trip(self, conf):
         conf_path = os.path.join(self.tmp_dir, 'mrjob.conf')
 


### PR DESCRIPTION
When we changed over to making includes relative to the including file (see #1179), we forgot that a path like `~/your.mrjob.conf` would get joined *before* the `~` could be expanded, so we get nonsense like `/including/dir/~/your.mrjob.conf` rather than `/home/you/your.mrjob.conf`.

This fix moves the call to `expand_path()` to the correct place. Fixes #1308.