### PR TITLE
use localhost, not *host*, for destination of SSH tunnel (fixes #1311)

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1048,7 +1048,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 '-o', 'StrictHostKeyChecking=no',
                 '-o', 'ExitOnForwardFailure=yes',
                 '-o', 'UserKnownHostsFile=%s' % fake_known_hosts_file,
-                '-L', '%d:%s:%d' % (bind_port, host, tunnel_config['port']),
+                # don't use *host* in place of localhost; it causes
+                # issues on VPCs (see #1311)
+                '-L', '%d:localhost:%d' % (bind_port, tunnel_config['port']),
                 '-N', '-q',  # no shell, no output
                 '-i', self._opts['ec2_key_pair_file'],
             ]


### PR DESCRIPTION
Looks like accidentally broke SSH tunneling to VPCs when I added support for Hadoop 2 (see #1311).

This reverts my offhand, somewhat pedantic change to ssh tunneling back to the way it's always been.

