### PR TITLE
fix deprecated tools modules

### DIFF
--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -75,7 +75,7 @@ _STEP_NAME_RE = re.compile(
 log = logging.getLogger(__name__)
 
 
-def main(args):
+def main(args=None):
     # parser command-line args
     option_parser = _make_option_parser()
     options, args = option_parser.parse_args(args)
@@ -827,4 +827,4 @@ def _percent(x, total, default=0.0):
 
 
 if __name__ == '__main__':
-    main(None)
+    main()

--- a/mrjob/tools/emr/create_job_flow.py
+++ b/mrjob/tools/emr/create_job_flow.py
@@ -19,7 +19,7 @@ from sys import stderr
 from .create_cluster import main as real_main
 
 
-def main(args):
+def main(args=None):
     print('create-job-flow is a deprecated alias for create-cluster'
           ' and will be removed in v0.6.0', file=stderr)
     real_main(args)

--- a/mrjob/tools/emr/report_long_jobs.py
+++ b/mrjob/tools/emr/report_long_jobs.py
@@ -66,9 +66,8 @@ DEFAULT_MIN_HOURS = 24.0
 log = logging.getLogger(__name__)
 
 
-def main(args=None, now=None):
-    if now is None:
-        now = datetime.utcnow()
+def main(args=None):
+    now = datetime.utcnow()
 
     option_parser = _make_option_parser()
     options, args = option_parser.parse_args(args)

--- a/mrjob/tools/emr/report_long_jobs.py
+++ b/mrjob/tools/emr/report_long_jobs.py
@@ -49,7 +49,6 @@ from datetime import datetime
 from datetime import timedelta
 import logging
 from optparse import OptionParser
-import sys
 
 from mrjob.emr import EMRJobRunner
 from mrjob.emr import _yield_all_clusters
@@ -67,7 +66,7 @@ DEFAULT_MIN_HOURS = 24.0
 log = logging.getLogger(__name__)
 
 
-def main(args, now=None):
+def main(args=None, now=None):
     if now is None:
         now = datetime.utcnow()
 
@@ -240,4 +239,4 @@ def _make_option_parser():
 
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    main()

--- a/mrjob/tools/emr/terminate_idle_job_flows.py
+++ b/mrjob/tools/emr/terminate_idle_job_flows.py
@@ -19,7 +19,7 @@ from sys import stderr
 from .terminate_idle_clusters import main as real_main
 
 
-def main(args):
+def main(args=None):
     print(
         'terminate-idle-job-flows is a deprecated alias for'
         ' terminate-idle-clusters and will be removed in v0.6.0',

--- a/mrjob/tools/emr/terminate_job_flow.py
+++ b/mrjob/tools/emr/terminate_job_flow.py
@@ -19,7 +19,7 @@ from sys import stderr
 from .terminate_cluster import main as real_main
 
 
-def main(args):
+def main(args=None):
     print(
         'terminate-job-flow is a deprecated alias for'
         ' terminate-cluster and will be removed in v0.6.0',


### PR DESCRIPTION
This makes it possible to run deprecated tools modules (e.g. `python -m mrjob.tools.emr.create_job_flow`), which was broken by a silly argument-defaulting issue.

Also made the `main()` method in *every* tool take a single argument (named `args` or `cl_args`), which is defaulted to `None`. This removes the `now` keyword argument in `report_long_jobs`, which appears to be unused.