### PR TITLE
4.x resource tracker

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ v0.5.2, 2016-05-2? -- initial Cloud Dataproc support
  * correctly handle ~ in include path in mrjob.conf (#1308)
  * new emr_applications option (#1293)
  * fix running deprecated tools with python -m (#1312)
- * fix ssh tunneling to EMR VPCs (#1311)
+ * fix ssh tunneling to 2.x AMIs on EMR in VPCs (#1311)
 
 v0.5.1, 2016-04-29 -- post-release bugfixes
  * strict_protocols in mrjob.conf is no longer ignored (#1302)

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -19,8 +19,8 @@ Added the :mrjob-opt:`emr_applications` option, which helps you configure
 4.x AMIs.
 
 Fixed a bug in SSH tunneling (introduced in v0.5.0) that made connections
-to the job tracker/resource manager on EMR time out when running inside
-a VPC (Virtual Private Cluster).
+to the job tracker/resource manager on EMR time out when running on a 2.x
+AMI inside a VPC (Virtual Private Cluster).
 
 Fixed a bug (introduced in v0.4.6) that kept mrjob from interpreting ``~``
 (home directory) in includes in :file:`mrjob.conf`.

--- a/mrjob/ssh.py
+++ b/mrjob/ssh.py
@@ -23,6 +23,7 @@ from subprocess import Popen
 from subprocess import PIPE
 
 from mrjob.py2 import to_string
+from mrjob.util import cmd_line
 
 log = logging.getLogger(__name__)
 
@@ -67,7 +68,7 @@ def _ssh_run(ssh_bin, address, ec2_key_pair_file, cmd_args, stdin=''):
     :return: (stdout, stderr)
     """
     args = _ssh_args(ssh_bin, address, ec2_key_pair_file) + list(cmd_args)
-    log.debug('Run SSH command: %s' % args)
+    log.debug('> %s' % cmd_line(args))
     p = Popen(args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
     return p.communicate(stdin)
 


### PR DESCRIPTION
This walks back #1313 so that it only affects 2.x AMIs. Looks like using *host* and not `localhost` was the right thing to do for everything but the (deprecated) 2.x AMIs.

Also, tangentially related, updated debugging logging for `SSHFilesystem` so that it logs a command line like the SSH tunneling code, rather than a raw array of arguments (this turned out to be a nuisance when diagnosing #1287).