### PR TITLE
Steps ordering

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -229,6 +229,9 @@ def _yield_all_steps(emr_conn, cluster_id, *args, **kwargs):
 
     Calls :py:func:`~mrjob.patched_boto._patched_list_steps`, to work around
     `boto's StartDateTime bug <https://github.com/boto/boto/issues/3268>`__.
+
+    Note that this returns steps in *reverse* order, because that's what
+    the ``ListSteps`` API call does. See #1316.
     """
     for resp in _repeat(_patched_list_steps, emr_conn, cluster_id,
                         *args, **kwargs):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -217,6 +217,11 @@ def _yield_all_bootstrap_actions(emr_conn, cluster_id, *args, **kwargs):
 
 
 def _yield_all_instance_groups(emr_conn, cluster_id, *args, **kwargs):
+    """Get all instance groups for the given cluster.
+
+    Not sure what order the API returns instance groups in (see #1316);
+    please treat it as undefined (make a dictionary, etc.)
+    """
     for resp in _repeat(emr_conn.list_instance_groups,
                         cluster_id, *args, **kwargs):
         for group in getattr(resp, 'instancegroups', []):
@@ -2384,6 +2389,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             # check memory and compute units, bailing out if we hit
             # an instance with too little memory
             for ig in list(_yield_all_instance_groups(emr_conn, cluster.id)):
+                # if you edit this code, please don't rely on any particular
+                # ordering of instance groups (see #1316)
                 role = ig.instancegrouptype.lower()
 
                 # unknown, new kind of role; bail out!

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -240,9 +240,12 @@ def _yield_all_steps(emr_conn, cluster_id, *args, **kwargs):
 
 
 def _step_ids_for_job(steps, job_key):
-    """Return a list of the (EMR) step IDs for the job with the given key.
+    """Given a list of steps for a cluster, return a list of the (EMR) step
+    IDs for the job with the given key, in the same order.
 
-    *steps* is the result of _yield_all_steps().
+    Note that :py:func:`_yield_all_steps` returns steps in reverse order;
+    you probably want to use the value returned by
+    :py:meth:`EMRJobRunner._list_steps_for_cluster` for *steps*.
     """
     step_ids = []
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2585,10 +2585,14 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         return _patched_describe_cluster(emr_conn, self._cluster_id)
 
     def _list_steps_for_cluster(self):
-        """Get all steps for our cluster, potentially making multiple API calls
+        """Get all steps for our cluster in the order they were added.
+
+        Potentially make multiple API calls.
         """
         emr_conn = self.make_emr_conn()
-        return list(_yield_all_steps(emr_conn, self._cluster_id))
+        # the ListSteps API call returns steps in reverse order, see #1316
+        return list(reversed(list(
+            _yield_all_steps(emr_conn, self._cluster_id))))
 
     def get_hadoop_version(self):
         if self._hadoop_version is None:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1596,7 +1596,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                                for tag, value in tags.items()))
             emr_conn.add_tags(self._cluster_id, tags)
 
-    def _steps_for_job(self):
+    def _job_steps(self):
         """Get the steps we submitted for this job in chronological order,
         ignoring steps from other jobs, and making as few API calls as
         possible.
@@ -1613,7 +1613,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
     def _wait_for_steps_to_complete(self):
         """Wait for every step of the job to complete, one by one."""
-        job_steps = self._steps_for_job()
+        job_steps = self._job_steps()
         num_steps = len(self._get_steps())
 
         if len(job_steps) != num_steps:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2590,14 +2590,6 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         emr_conn = self.make_emr_conn()
         return list(_yield_all_steps(emr_conn, self._cluster_id))
 
-    def _step_num_to_id(self):
-        if self._cluster_id is None:
-            return {}
-
-        return dict((step_num, step.id)
-                    for step_num, step in
-                    enumerate(self._list_steps_for_cluster(), start=1))
-
     def get_hadoop_version(self):
         if self._hadoop_version is None:
             self._store_cluster_info()

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -613,7 +613,8 @@ def _yield_clusters(max_days_ago=None, now=None, **runner_kwargs):
         cluster_id = cluster_summary.id
 
         cluster = _patched_describe_cluster(emr_conn, cluster_id)
-        cluster.steps = list(_yield_all_steps(emr_conn, cluster_id))
+        cluster.steps = list(reversed(list(
+            _yield_all_steps(emr_conn, cluster_id))))
         cluster.bootstrapactions = list(
             _yield_all_bootstrap_actions(emr_conn, cluster_id))
 

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -54,9 +54,9 @@ import re
 from optparse import OptionParser
 
 from mrjob.emr import EMRJobRunner
+from mrjob.emr import _list_all_steps
 from mrjob.emr import _yield_all_clusters
 from mrjob.emr import _yield_all_bootstrap_actions
-from mrjob.emr import _yield_all_steps
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_opts
 from mrjob.options import _add_emr_connect_opts
@@ -613,8 +613,7 @@ def _yield_clusters(max_days_ago=None, now=None, **runner_kwargs):
         cluster_id = cluster_summary.id
 
         cluster = _patched_describe_cluster(emr_conn, cluster_id)
-        cluster.steps = list(reversed(list(
-            _yield_all_steps(emr_conn, cluster_id))))
+        cluster.steps = _list_all_steps(emr_conn, cluster_id)
         cluster.bootstrapactions = list(
             _yield_all_bootstrap_actions(emr_conn, cluster_id))
 

--- a/mrjob/tools/emr/report_long_jobs.py
+++ b/mrjob/tools/emr/report_long_jobs.py
@@ -146,7 +146,8 @@ def _find_long_running_jobs(emr_conn, cluster_summaries, min_time, now=None):
         if cs.status.state != 'RUNNING':
             continue
 
-        steps = list(_yield_all_steps(emr_conn, cs.id))
+        # _yield_all_steps() is in reverse order, see #1316
+        steps = list(reversed(list(_yield_all_steps(emr_conn, cs.id))))
 
         running_steps = [
             step for step in steps if step.status.state == 'RUNNING']

--- a/mrjob/tools/emr/report_long_jobs.py
+++ b/mrjob/tools/emr/report_long_jobs.py
@@ -51,8 +51,8 @@ import logging
 from optparse import OptionParser
 
 from mrjob.emr import EMRJobRunner
+from mrjob.emr import _list_all_steps
 from mrjob.emr import _yield_all_clusters
-from mrjob.emr import _yield_all_steps
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_opts
 from mrjob.options import _add_emr_connect_opts
@@ -146,8 +146,7 @@ def _find_long_running_jobs(emr_conn, cluster_summaries, min_time, now=None):
         if cs.status.state != 'RUNNING':
             continue
 
-        # _yield_all_steps() is in reverse order, see #1316
-        steps = list(reversed(list(_yield_all_steps(emr_conn, cs.id))))
+        steps = _list_all_steps(emr_conn, cs.id)
 
         running_steps = [
             step for step in steps if step.status.state == 'RUNNING']

--- a/mrjob/tools/emr/terminate_idle_clusters.py
+++ b/mrjob/tools/emr/terminate_idle_clusters.py
@@ -175,7 +175,7 @@ def _maybe_terminate_clusters(dry_run=False,
             continue
 
         # need steps to learn more about cluster
-        steps = list(_yield_all_steps(emr_conn, cluster_id))
+        steps = list(reversed(list(_yield_all_steps(emr_conn, cluster_id))))
 
         # we can't really tell if non-streaming jobs are idle or not, so
         # let them be (see Issue #60)

--- a/mrjob/tools/emr/terminate_idle_clusters.py
+++ b/mrjob/tools/emr/terminate_idle_clusters.py
@@ -70,9 +70,9 @@ import re
 
 from mrjob.emr import _attempt_to_acquire_lock
 from mrjob.emr import EMRJobRunner
+from mrjob.emr import _list_all_steps
 from mrjob.emr import _yield_all_bootstrap_actions
 from mrjob.emr import _yield_all_clusters
-from mrjob.emr import _yield_all_steps
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_opts
 from mrjob.options import _add_emr_connect_opts
@@ -175,7 +175,7 @@ def _maybe_terminate_clusters(dry_run=False,
             continue
 
         # need steps to learn more about cluster
-        steps = list(reversed(list(_yield_all_steps(emr_conn, cluster_id))))
+        steps = _list_all_steps(emr_conn, cluster_id)
 
         # we can't really tell if non-streaming jobs are idle or not, so
         # let them be (see Issue #60)

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1138,6 +1138,8 @@ class MockEmrConnection(object):
     def list_steps(self, cluster_id, step_states=None, marker=None):
         self._enforce_strict_ssl()
 
+        # ListSteps also allows you to filter by StepIds, but we don't use that
+
         # make sure that we only call list_steps() when we've patched
         # around https://github.com/boto/boto/issues/3268
         if 'StartDateTime' not in boto.emr.emrobject.ClusterTimeline.Fields:
@@ -1151,8 +1153,7 @@ class MockEmrConnection(object):
 
         steps_listed = []
 
-        # TODO: ListSteps lists steps in *reverse* order (see #1316).
-        for step in cluster._steps:
+        for step in reversed(cluster._steps):
             if step_states is None or step.status.state in step_states:
                 steps_listed.append(step)
 

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -653,6 +653,7 @@ class MockEmrConnection(object):
         self.mock_emr_failures = combine_values({}, mock_emr_failures)
         self.mock_emr_output = combine_values({}, mock_emr_output)
         self.max_clusters_returned = max_clusters_returned
+        self.max_steps_returned = max_steps_returned
 
         if region is not None:
             self.host = region.endpoint
@@ -1171,6 +1172,9 @@ class MockEmrConnection(object):
             step = steps[index]
             if step_states is None or step.status.state in step_states:
                 steps_listed.append(step)
+
+            if len(steps_listed) >= self.max_steps_returned:
+                break
         else:
             index = None  # listed all steps, no need to call again
 

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1100,7 +1100,7 @@ class MockEmrConnection(object):
             self.mock_emr_clusters.values(),
             key=cluster_sort_key, reverse=True)
 
-        for cluster in sorted(self.mock_emr_clusters.values()):
+        for cluster in sorted_clusters:
             # skip ahead to marker (marker is just cluster ID)
             cluster_id = cluster.id
             if marker is not None and cluster_id < marker:

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1217,6 +1217,8 @@ class MockEmrConnection(object):
         :type now: py:class:`datetime.datetime`
         :param now: alternate time to use as the current time (should be UTC)
         """
+        # TODO: this doesn't actually update steps to CANCELLED when
+        # cluster is shut down
         if now is None:
             now = datetime.utcnow()
 

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1145,11 +1145,13 @@ class MockEmrConnection(object):
 
         if marker is not None:
             raise NotImplementedError(
-                'marker not simulated for ListBootstrapActions')
+                'marker not simulated for ListSteps')
 
         cluster = self._get_mock_cluster(cluster_id)
 
         steps_listed = []
+
+        # TODO: ListSteps lists steps in *reverse* order (see #1316).
         for step in cluster._steps:
             if step_states is None or step.status.state in step_states:
                 steps_listed.append(step)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -582,7 +582,7 @@ class EMRAPIParamsTestCase(MockBotoTestCase):
         }}}
 
         job = MRWordCount(['-r', 'emr'])
-        job.sandbox(stdin=BytesIO(b''))
+        job.sandbox()
 
         with mrjob_conf_patcher(API_PARAMS_MRJOB_CONF):
             with job.make_runner() as runner:
@@ -3787,7 +3787,7 @@ class EmrApplicationsTestCase(MockBotoTestCase):
 
     def test_default(self):
         job = MRTwoStepJob(['-r', 'emr', '--ami-version', '4.3.0'])
-        job.sandbox(stdin=BytesIO(b''))
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(runner._opts['emr_applications'], set())
@@ -3803,7 +3803,7 @@ class EmrApplicationsTestCase(MockBotoTestCase):
             ['-r', 'emr', '--ami-version', '4.3.0',
              '--emr-application', 'Hadoop',
              '--emr-application', 'Mahout'])
-        job.sandbox(stdin=BytesIO(b''))
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(runner._opts['emr_applications'],
@@ -3820,7 +3820,7 @@ class EmrApplicationsTestCase(MockBotoTestCase):
         job = MRTwoStepJob(
             ['-r', 'emr', '--ami-version', '4.3.0',
              '--emr-application', 'Mahout'])
-        job.sandbox(stdin=BytesIO(b''))
+        job.sandbox()
 
         with job.make_runner() as runner:
             # we explicitly add Hadoop so we can see Hadoop version in
@@ -3840,7 +3840,7 @@ class EmrApplicationsTestCase(MockBotoTestCase):
             ['-r', 'emr', '--ami-version', '4.3.0',
              '--emr-application', 'Hadoop',
              '--emr-application', 'Mahout'])
-        job.sandbox(stdin=BytesIO(b''))
+        job.sandbox()
 
         with job.make_runner() as runner:
             runner._launch()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -37,6 +37,7 @@ from mrjob.emr import _lock_acquire_step_2
 from mrjob.emr import _yield_all_bootstrap_actions
 from mrjob.emr import _yield_all_clusters
 from mrjob.emr import _yield_all_instance_groups
+from mrjob.emr import _yield_all_steps
 from mrjob.emr import filechunkio
 from mrjob.job import MRJob
 from mrjob.parse import parse_s3_uri
@@ -3872,3 +3873,11 @@ class ListStepsForClusterTestCase(MockBotoTestCase):
             self.assertEqual(len(steps), 2)
             self.assertIn('Step 1', steps[0].name)
             self.assertIn('Step 2', steps[1].name)
+
+            # double-check that API returns steps in reverse order
+            steps_from_api = list(_yield_all_steps(
+                runner.make_emr_conn(), runner.get_cluster_id()))
+
+            self.assertEqual(len(steps_from_api), 2)
+            self.assertIn('Step 2', steps_from_api[0].name)
+            self.assertIn('Step 1', steps_from_api[1].name)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -37,7 +37,6 @@ from mrjob.emr import _lock_acquire_step_2
 from mrjob.emr import _yield_all_bootstrap_actions
 from mrjob.emr import _yield_all_clusters
 from mrjob.emr import _yield_all_instance_groups
-from mrjob.emr import _yield_all_steps
 from mrjob.emr import filechunkio
 from mrjob.job import MRJob
 from mrjob.parse import parse_s3_uri
@@ -156,8 +155,7 @@ class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
             # make sure our input and output formats are attached to
             # the correct steps
             emr_conn = runner.make_emr_conn()
-            steps = list(reversed(list(
-                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
+            steps = runner._list_steps_for_cluster()
 
             step_0_args = [a.value for a in steps[0].config.args]
             step_1_args = [a.value for a in steps[1].config.args]
@@ -686,8 +684,7 @@ class EnableDebuggingTestCase(MockBotoTestCase):
             runner.run()
 
             emr_conn = runner.make_emr_conn()
-            steps = list(reversed(list(
-                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
+            steps = runner._list_steps_for_cluster()
 
             self.assertEqual(steps[0].name, 'Setup Hadoop Debugging')
 
@@ -2910,8 +2907,7 @@ class JarStepTestCase(MockBotoTestCase):
             self.assertTrue(runner.fs.ls(jar_uri))
 
             emr_conn = runner.make_emr_conn()
-            steps = list(reversed(list(
-                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
+            steps = runner._list_steps_for_cluster()
 
             self.assertEqual(len(steps), 1)
             self.assertEqual(steps[0].config.jar, jar_uri)
@@ -2927,8 +2923,7 @@ class JarStepTestCase(MockBotoTestCase):
             runner.run()
 
             emr_conn = runner.make_emr_conn()
-            steps = list(reversed(list(
-                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
+            steps = runner._list_steps_for_cluster()
 
             self.assertEqual(len(steps), 1)
             self.assertEqual(steps[0].config.jar, JAR_URI)
@@ -2942,8 +2937,7 @@ class JarStepTestCase(MockBotoTestCase):
             runner.run()
 
             emr_conn = runner.make_emr_conn()
-            steps = list(reversed(list(
-                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
+            steps = runner._list_steps_for_cluster()
 
             self.assertEqual(len(steps), 1)
             self.assertEqual(steps[0].config.jar,
@@ -2965,8 +2959,7 @@ class JarStepTestCase(MockBotoTestCase):
             runner.run()
 
             emr_conn = runner.make_emr_conn()
-            steps = list(reversed(list(
-                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
+            steps = runner._list_steps_for_cluster()
 
             self.assertEqual(len(steps), 2)
             jar_step, streaming_step = steps

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -805,7 +805,9 @@ class EC2InstanceGroupTestCase(MockBotoTestCase):
         instance_groups = list(
             _yield_all_instance_groups(emr_conn, cluster_id))
 
-        # convert actual instance groups to dicts
+        # convert actual instance groups to dicts. (This gets around any
+        # assumptions about the order the API returns instance groups in;
+        # see #1316)
         role_to_actual = {}
         for ig in instance_groups:
             info = dict(

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -156,7 +156,8 @@ class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
             # make sure our input and output formats are attached to
             # the correct steps
             emr_conn = runner.make_emr_conn()
-            steps = list(_yield_all_steps(emr_conn, runner.get_cluster_id()))
+            steps = list(reversed(list(
+                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
 
             step_0_args = [a.value for a in steps[0].config.args]
             step_1_args = [a.value for a in steps[1].config.args]
@@ -685,7 +686,8 @@ class EnableDebuggingTestCase(MockBotoTestCase):
             runner.run()
 
             emr_conn = runner.make_emr_conn()
-            steps = list(_yield_all_steps(emr_conn, runner.get_cluster_id()))
+            steps = list(reversed(list(
+                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
 
             self.assertEqual(steps[0].name, 'Setup Hadoop Debugging')
 
@@ -2908,7 +2910,8 @@ class JarStepTestCase(MockBotoTestCase):
             self.assertTrue(runner.fs.ls(jar_uri))
 
             emr_conn = runner.make_emr_conn()
-            steps = list(_yield_all_steps(emr_conn, runner.get_cluster_id()))
+            steps = list(reversed(list(
+                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
 
             self.assertEqual(len(steps), 1)
             self.assertEqual(steps[0].config.jar, jar_uri)
@@ -2924,7 +2927,8 @@ class JarStepTestCase(MockBotoTestCase):
             runner.run()
 
             emr_conn = runner.make_emr_conn()
-            steps = list(_yield_all_steps(emr_conn, runner.get_cluster_id()))
+            steps = list(reversed(list(
+                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
 
             self.assertEqual(len(steps), 1)
             self.assertEqual(steps[0].config.jar, JAR_URI)
@@ -2938,7 +2942,8 @@ class JarStepTestCase(MockBotoTestCase):
             runner.run()
 
             emr_conn = runner.make_emr_conn()
-            steps = list(_yield_all_steps(emr_conn, runner.get_cluster_id()))
+            steps = list(reversed(list(
+                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
 
             self.assertEqual(len(steps), 1)
             self.assertEqual(steps[0].config.jar,
@@ -2960,7 +2965,8 @@ class JarStepTestCase(MockBotoTestCase):
             runner.run()
 
             emr_conn = runner.make_emr_conn()
-            steps = list(_yield_all_steps(emr_conn, runner.get_cluster_id()))
+            steps = list(reversed(list(
+                _yield_all_steps(emr_conn, runner.get_cluster_id()))))
 
             self.assertEqual(len(steps), 2)
             jar_step, streaming_step = steps

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -943,7 +943,7 @@ class SetupLineEncodingTestCase(MockHadoopTestCase):
 
     def test_setup_wrapper_script_uses_local_line_endings(self):
         job = MRTwoStepJob(['-r', 'hadoop', '--setup', 'true'])
-        job.sandbox(stdin=BytesIO(b''))
+        job.sandbox()
 
         add_mock_hadoop_output([b''])
         add_mock_hadoop_output([b''])


### PR DESCRIPTION
Update code to correctly reflect that the `ListSteps` and `ListClusters` EMR API calls return in reverse chronological order. This was a serious issue with `ListSteps` (the change fixes #1316). It didn't seem to matter at all for `ListClusters`, but now `mockboto` is correct (we were previously ordering by cluster ID).

Our code doesn't rely on any particular order from `ListInstanceGroups` (basically treats it as a dictionary), so rather than trying to make `mockboto` correct, just added comments to warn about relying on ordering.

Also confirmed that `ListBootstrapActions` lists them in the order they were added (not reverse) and documented that in our code. This is what we expected all along, so our code didn't need to be updated.