### PR TITLE
SSH tunnel tweaks

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1665,6 +1665,10 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 reason = _get_reason(cluster)
                 reason_desc = (': %s' % reason) if reason else ''
 
+                # we can open the ssh tunnel if cluster is RUNNING (see #1115)
+                if cluster.state.state == 'RUNNING':
+                    self._set_up_ssh_tunnel()
+
                 log.info('  PENDING (cluster is %s%s)' % (
                     cluster.status.state, reason_desc))
                 continue
@@ -1678,7 +1682,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                     start = iso8601_to_timestamp(startdatetime)
                     time_running_desc = ' for %.1fs' % (time.time() - start)
 
-                # now is the time to tunnel if, if we haven't already
+                # now is the time to tunnel, if we haven't already
                 self._set_up_ssh_tunnel()
                 log.info('  RUNNING%s' % time_running_desc)
                 self._log_step_progress()

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1094,7 +1094,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 '-o', 'UserKnownHostsFile=%s' % fake_known_hosts_file,
                 '-L', '%d:%s:%d' % (
                     bind_port, tunnel_host, tunnel_config['port']),
-                '-N', '-q',  # no shell, no output
+                '-N', '-n', '-q',  # no shell, no input, no output
                 '-i', self._opts['ec2_key_pair_file'],
             ]
             if self._opts['ssh_tunnel_is_open']:

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1249,14 +1249,6 @@ class MockEmrConnection(object):
 
             return
 
-        # if job is BOOTSTRAPPING, move it along to RUNNING
-        if cluster.status.state == 'BOOTSTRAPPING':
-            cluster.status.state = 'RUNNING'
-            for ig in cluster._instancegroups:
-                ig.status.state = 'RUNNING'
-
-            return
-
         # if job is TERMINATING, move along to terminated
         if cluster.status.state == 'TERMINATING':
             code = getattr(getattr(cluster.status, 'statechangereason', None),
@@ -1272,6 +1264,12 @@ class MockEmrConnection(object):
         # if job is done, nothing to do
         if cluster.status.state in ('TERMINATED', 'TERMINATED_WITH_ERRORS'):
             return
+
+        # if job is BOOTSTRAPPING, move it along to RUNNING and continue
+        if cluster.status.state == 'BOOTSTRAPPING':
+            cluster.status.state = 'RUNNING'
+            for ig in cluster._instancegroups:
+                ig.status.state = 'RUNNING'
 
         # at this point, should be RUNNING or WAITING
         assert cluster.status.state in ('RUNNING', 'WAITING')


### PR DESCRIPTION
This uses `-n` (no stdin) with the SSH tunnel (hopefully fixes #1161) and opens the SSH tunnel as soon as we know the cluster is ready (fixes #1115).