### PR TITLE
Check current directory for config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,7 @@ other advanced mrjob features, you'll need to set up ``mrjob.conf``. mrjob looks
 for its conf file in:
 
 * The contents of ``$MRJOB_CONF``
+* ``./mrjob.conf``
 * ``~/.mrjob.conf``
 * ``/etc/mrjob.conf``
 

--- a/docs/guides/configs-basics.rst
+++ b/docs/guides/configs-basics.rst
@@ -6,6 +6,7 @@ Config file format and location
 We look for :file:`mrjob.conf` in these locations:
 
 - The location specified by :envvar:`MRJOB_CONF`
+- :file:`./mrjob.conf`
 - :file:`~/.mrjob.conf`
 - :file:`/etc/mrjob.conf`
 

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -138,6 +138,7 @@ def find_mrjob_conf():
     """Look for :file:`mrjob.conf`, and return its path. Places we look:
 
     - The location specified by :envvar:`MRJOB_CONF`
+    - :file:`./mrjob.conf`
     - :file:`~/.mrjob.conf`
     - :file:`/etc/mrjob.conf`
 
@@ -146,6 +147,8 @@ def find_mrjob_conf():
     def candidates():
         if 'MRJOB_CONF' in os.environ:
             yield expand_path(os.environ['MRJOB_CONF'])
+
+        yield expand_path(os.path.join('.', 'mrjob.conf'))
 
         # $HOME isn't necessarily set on Windows, but ~ works
         # use os.path.join() so we don't end up mixing \ and /

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -90,6 +90,11 @@ class MRJobBasicConfTestCase(MRJobConfTestCase):
         open(dot_mrjob_path, 'w').close()
         self.assertEqual(find_mrjob_conf(), dot_mrjob_path)
 
+    def test_mrjob_in_current_dir(self):
+        dot_mrjob_path = os.path.join('.', 'mrjob.conf')
+        open(dot_mrjob_path, 'w').close()
+        self.assertEqual(find_mrjob_conf(), dot_mrjob_path)
+
     def test_mrjob_conf_in_home_dir(self):
         # ~/mrjob.conf is not a place we look (should be ~/.mrjob)
         os.environ['HOME'] = self.tmp_dir


### PR DESCRIPTION
Different projects may require different configuration. I find dropping a config file in my git repository is easier than setting an environment variable.

This PR adds the ability to create a file in the current directory called `mrjob.conf` which will be taken before `~/.mrjob.conf` but after `MRJOB_CONF`.