### PR TITLE
determine cause of bootstrap script failure

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2008,7 +2008,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         # TODO: If the failure is on the master node, we could just look in
         # /mnt/var/log/bootstrap-actions. However, if it's on a slave node,
         # we'd have to look up its internal IP using the ListInstances
-        # API call. This *would* be a bit faster though.
+        # API call. This *would* be a bit faster though. See #1346.
         return self._stream_log_dirs(
             'bootstrap logs',
             dir_name=None,  # don't SSH in

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2000,15 +2000,16 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             s3_dir_name = posixpath.join(
                 'node', node_id, 'bootstrap-actions', str(action_num + 1))
 
-            # dir_name=None means don't try to SSH in.
-            # TODO: If the failure is on the master node, we just look in
-            # /mnt/var/log/bootstrap-actions. However, if it's on a slave node,
-            # we have to look up its internal IP using the ListInstances
-            # API call. This *would* be a bit faster though.
-            return self._stream_log_dirs(
-                'bootstrap stderr log',
-                dir_name=None,  # don't SSH in
-                s3_dir_name=s3_dir_name)
+        # dir_name=None means don't try to SSH in.
+        #
+        # TODO: If the failure is on the master node, we could just look in
+        # /mnt/var/log/bootstrap-actions. However, if it's on a slave node,
+        # we'd have to look up its internal IP using the ListInstances
+        # API call. This *would* be a bit faster though.
+        return self._stream_log_dirs(
+            'bootstrap logs',
+            dir_name=None,  # don't SSH in
+            s3_dir_name=s3_dir_name)
 
     def _stream_history_log_dirs(self, output_dir=None):
         """Yield lists of directories to look for the history log in."""

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1970,7 +1970,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         # this doesn't really correspond to a step, so
         # don't bother storing it in self._log_interpretations
         bootstrap_interpretation = _interpret_emr_bootstrap_stderr(
-            self.fs, self._ls_bootstrap_stderr_logs(*action_num_and_node_id))
+            self.fs, self._ls_bootstrap_stderr_logs(**action_num_and_node_id))
 
         # should be 0 or 1 errors, since we're checking a single stderr file
         error = _pick_error(bootstrap_interpretation)

--- a/mrjob/logs/bootstrap.py
+++ b/mrjob/logs/bootstrap.py
@@ -23,31 +23,47 @@ from .wrap import _ls_logs
 #
 # On the master instance (i-96c21a39), bootstrap action 1 returned a non-zero
 # return code
-#
-# This correponds to a path like
-# <s3_log_dir>/node/i-96c21a39/bootstrap-actions/1/stderr.gz
-#
-# (may or may not actually be gzipped)
 _BOOTSTRAP_NONZERO_RETURN_CODE_RE = re.compile(
     r'^.*\((?P<node_id>i-[0-9a-f]+)\)'
     r'.*bootstrap action (?P<action_num>\d+)'
     r'.*non-zero return code'
     r'.*$')
 
+# match a path like:
+# <s3_log_dir>/node/i-96c21a39/bootstrap-actions/1/stderr.gz
+#
+# (may or may not actually be gzipped)
+_EMR_BOOTSTRAP_STDERR_PATH_RE = re.compile(
+    r'^(?P<prefix>.*?/)'
+    r'node/'
+    r'(?P<node_id>i-[0-9a-f]+)/'
+    r'bootstrap-actions/'
+    r'(?P<action_num>\d+)/'
+    r'syslog(?P<suffix>\.\w+)?')
+
 
 def _check_for_nonzero_return_code(reason):
+    """Given a reason for cluster termination, check if it's because
+    a bootstrap action terminated with an error.
+
+    If it is, return a dictionary with the keys action_num (0-indexed
+    bootstrap action number) and node_id (a string). Otherwise return None.
+    """
     m = _BOOTSTRAP_NONZERO_RETURN_CODE_RE.match(reason)
 
     if m:
-        return dict(action_num=int(m.group('action_num')),
-                    node_id=m.group('node_id'))
+        return _extract_action_num_and_node_id(m)
     else:
         return None
 
 
-def _ls_emr_bootstrap_stderr_paths(
+def _ls_emr_bootstrap_stderr_logs(
         fs, log_dir_stream, action_num=None, node_id=None):
+    """Find all stderr from bootstrap actions in the given dir. Sort
+    so the most recent one comes first, using node ID as a tiebreaker.
 
+    (In practice, we look at a single a action on a single node anyway.)
+    """
     matches = _ls_logs(fs, log_dir_stream, _match_emr_bootstrap_stderr_path,
                        action_num=None, node_id=None)
 
@@ -55,10 +71,60 @@ def _ls_emr_bootstrap_stderr_paths(
 
 
 def _match_emr_bootstrap_stderr_path(path, node_id=None, action_num=None):
-    # write a regex for this
-    pass
+    """If *path* corresponds to a bootstrap stderr file, return a dict
+    with the keys *action_num* (an 0-indexed int) and *node_id*. Otherwise
+    return None.
+
+    Optionally, filter by *action_num* and *node_id*.
+    """
+    m = _EMR_BOOTSTRAP_STDERR_PATH_RE.match(path)
+    if not m:
+        return
+
+    result = _extract_action_num_and_node_id(m)
+
+    if action_num is not None and action_num != result['action_num']:
+        return None
+
+    if node_id is not None and node_id != result['node_id']:
+        return None
+
+    return m
 
 
-def _interpret_emr_bootstrap_stderr(fs, matches):
-    # cat logs, pass them to _parse_task_stderr
-    pass
+def _interpret_emr_bootstrap_stderr(fs, matches, partial=True):
+    """Extract errors from bootstrap stderr.
+
+    If *partial* is true, stop when we find the first match.
+
+    (In practice, we usually target a single file anyway.)
+    """
+    result = {}
+
+    for match in matches:
+        stderr_path = match['path']
+
+        task_error = _parse_task_stderr(_cat_log(fs, stderr_path))
+        if task_error:
+            task_error['path'] = stderr_path
+            error = dict(
+                action_num=match['action_num'],
+                node_id=match['node_id'],
+                task_error=task_error)
+            result.setdefault('errors', [])
+            result['errors'].append(error)
+
+            if partial:
+                result['partial'] = True
+                break
+
+    return result
+
+
+def _extract_action_num_and_node_id(m):
+    """Helper method: Extract *action_num* and *node_id* from the given regex
+    match. Convert *action_num* to a 0-indexed integer."""
+    return dict(
+        action_num=(int(m.group('action_num')) - 1),
+        node_id=m.group('node_id'),
+    )

--- a/mrjob/logs/bootstrap.py
+++ b/mrjob/logs/bootstrap.py
@@ -24,7 +24,7 @@ from .wrap import _ls_logs
 # On the master instance (i-96c21a39), bootstrap action 1 returned a non-zero
 # return code
 _BOOTSTRAP_NONZERO_RETURN_CODE_RE = re.compile(
-    r'^.*\((?P<node_id>i-[0-9a-f]+)\)'
+    r'^.*\(.*?(?P<node_id>i-[0-9a-f]+).*\)'
     r'.*bootstrap action (?P<action_num>\d+)'
     r'.*non-zero return code'
     r'.*$')

--- a/mrjob/logs/bootstrap.py
+++ b/mrjob/logs/bootstrap.py
@@ -23,6 +23,12 @@ from .wrap import _ls_logs
 #
 # On the master instance (i-96c21a39), bootstrap action 1 returned a non-zero
 # return code
+#
+# On 2 slave instances (including i-105af6bf and i-b659f519), bootstrap action
+# 1 returned a non-zero return code
+#
+# (EMR doesn't seem to return errors that include both master and slave
+# instances)
 _BOOTSTRAP_NONZERO_RETURN_CODE_RE = re.compile(
     r'^.*\(.*?(?P<node_id>i-[0-9a-f]+).*\)'
     r'.*bootstrap action (?P<action_num>\d+)'

--- a/mrjob/logs/bootstrap.py
+++ b/mrjob/logs/bootstrap.py
@@ -39,7 +39,7 @@ _EMR_BOOTSTRAP_STDERR_PATH_RE = re.compile(
     r'(?P<node_id>i-[0-9a-f]+)/'
     r'bootstrap-actions/'
     r'(?P<action_num>\d+)/'
-    r'syslog(?P<suffix>\.\w+)?')
+    r'stderr(?P<suffix>\.\w+)?')
 
 
 def _check_for_nonzero_return_code(reason):
@@ -89,7 +89,7 @@ def _match_emr_bootstrap_stderr_path(path, node_id=None, action_num=None):
     if node_id is not None and node_id != result['node_id']:
         return None
 
-    return m
+    return result
 
 
 def _interpret_emr_bootstrap_stderr(fs, matches, partial=True):

--- a/mrjob/logs/bootstrap.py
+++ b/mrjob/logs/bootstrap.py
@@ -123,6 +123,7 @@ def _interpret_emr_bootstrap_stderr(fs, matches, partial=True):
 
         task_error = _parse_task_stderr(_cat_log(fs, stderr_path))
         if task_error:
+            task_error = dict(task_error)  # make a copy
             task_error['path'] = stderr_path
             error = dict(
                 action_num=match['action_num'],

--- a/mrjob/logs/bootstrap.py
+++ b/mrjob/logs/bootstrap.py
@@ -1,0 +1,64 @@
+# Copyright 2015-2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Parse logs from EMR bootstrap actions (and, eventually, Dataproc
+initialization actions)."""
+import re
+
+from .task import _parse_task_stderr
+from .wrap import _cat_log
+from .wrap import _ls_logs
+
+# match cause of failure when there's a problem with bootstrap script. Example:
+#
+# On the master instance (i-96c21a39), bootstrap action 1 returned a non-zero
+# return code
+#
+# This correponds to a path like
+# <s3_log_dir>/node/i-96c21a39/bootstrap-actions/1/stderr.gz
+#
+# (may or may not actually be gzipped)
+_BOOTSTRAP_NONZERO_RETURN_CODE_RE = re.compile(
+    r'^.*\((?P<node_id>i-[0-9a-f]+)\)'
+    r'.*bootstrap action (?P<action_num>\d+)'
+    r'.*non-zero return code'
+    r'.*$')
+
+
+def _check_for_nonzero_return_code(reason):
+    m = _BOOTSTRAP_NONZERO_RETURN_CODE_RE.match(reason)
+
+    if m:
+        return dict(action_num=int(m.group('action_num')),
+                    node_id=m.group('node_id'))
+    else:
+        return None
+
+
+def _ls_emr_bootstrap_stderr_paths(
+        fs, log_dir_stream, action_num=None, node_id=None):
+
+    matches = _ls_logs(fs, log_dir_stream, _match_emr_bootstrap_stderr_path,
+                       action_num=None, node_id=None)
+
+    return sorted(matches, key=lambda m: (-m['action_num'], m['node_id']))
+
+
+def _match_emr_bootstrap_stderr_path(path, node_id=None, action_num=None):
+    # write a regex for this
+    pass
+
+
+def _interpret_emr_bootstrap_stderr(fs, matches):
+    # cat logs, pass them to _parse_task_stderr
+    pass

--- a/mrjob/logs/bootstrap.py
+++ b/mrjob/logs/bootstrap.py
@@ -98,6 +98,17 @@ def _match_emr_bootstrap_stderr_path(path, node_id=None, action_num=None):
     return result
 
 
+# This strategy assumes we can ask the EMR API which node(s) the error
+# occurred on. This is true even after the cluster has shut down, so it's
+# a pretty reasonable assumption, even for after-the-fact log parsing.
+#
+# If we *had* to figure out from logs alone whether a node had an error,
+# we'd want to first check the controller file for a line like:
+#
+# 2016-07-07T23:26:49.565Z ERROR Execution failed with code '1'
+#
+# and then look in the corresponding stderr file, much like how we handle
+# task logs. This seems like overkill at the moment.
 def _interpret_emr_bootstrap_stderr(fs, matches, partial=True):
     """Extract errors from bootstrap stderr.
 

--- a/mrjob/logs/step.py
+++ b/mrjob/logs/step.py
@@ -33,7 +33,8 @@ from .wrap import _ls_logs
 _EMR_STEP_LOG_PATH_RE = re.compile(
     r'^(?P<prefix>.*?/)'
     r'(?P<step_id>s-[A-Z0-9]+)/'
-    r'(?P<log_type>syslog|stderr)(\.(?P<timestamp>[\d-]+))?(?P<suffix>\.\w+)?')
+    r'(?P<log_type>syslog|stderr)'
+    r'(\.(?P<timestamp>[\d-]+))?(?P<suffix>\.\w+)?$')
 
 # hadoop streaming always prints "packageJobJar..." to stdout,
 # and prints Streaming Command Failed! to stderr on failure

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -41,7 +41,7 @@ _PRE_YARN_TASK_SYSLOG_PATH_RE = re.compile(
     r'(?P<attempt_id>attempt_(?P<timestamp>\d+)_(?P<step_num>\d+)_'
     r'(?P<task_type>[mr])_(?P<task_num>\d+)_'
     r'(?P<attempt_num>\d+))/'
-    r'syslog(?P<suffix>\.\w+)?')
+    r'syslog(?P<suffix>\.\w+)?$')
 
 # ignore warnings about initializing log4j in task stderr
 _TASK_STDERR_IGNORE_RE = re.compile(r'^log4j:WARN .*$')
@@ -58,7 +58,7 @@ _YARN_TASK_SYSLOG_PATH_RE = re.compile(
     r'^(?P<prefix>.*?/)'
     r'(?P<application_id>application_\d+_\d{4})/'
     r'(?P<container_id>container(_\d+)+)/'
-    r'syslog(?P<suffix>\.\w+)?')
+    r'syslog(?P<suffix>\.\w+)?$')
 
 
 def _ls_task_syslogs(fs, log_dir_stream, application_id=None, job_id=None):

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -53,7 +53,6 @@ from mrjob.setup import parse_setup_cmd
 from mrjob.step import STEP_TYPES
 from mrjob.util import bash_wrap
 from mrjob.util import cmd_line
-from mrjob.util import file_ext
 from mrjob.util import tar_and_gzip
 
 
@@ -1129,7 +1128,8 @@ class MRJobRunner(object):
 
             def filter_path(path):
                 filename = os.path.basename(path)
-                return not(file_ext(filename).lower() in ('.pyc', '.pyo') or
+                return not(filename.lower().endswith('.pyc') or
+                           filename.lower().endswith('.pyo') or
                            # filter out emacs backup files
                            filename.endswith('~') or
                            # filter out emacs lock files

--- a/tests/logs/test_bootstrap.py
+++ b/tests/logs/test_bootstrap.py
@@ -82,3 +82,37 @@ class MatchEMRBootstrapStderrPathTestCase(TestCase):
                 'bootstrap-actions/1/syslog'),
             None
         )
+
+    def test_filter_by_action_num(self):
+        self.assertEqual(
+            _match_emr_bootstrap_stderr_path(
+                's3://bucket/tmp/logs/j-1EE0CL1O7FDXU/node/i-e647eb49/'
+                'bootstrap-actions/2/stderr',
+                action_num=1),
+            dict(action_num=1, node_id='i-e647eb49')
+        )
+
+        self.assertEqual(
+            _match_emr_bootstrap_stderr_path(
+                's3://bucket/tmp/logs/j-1EE0CL1O7FDXU/node/i-e647eb49/'
+                'bootstrap-actions/2/stderr',
+                action_num=0),
+            None
+        )
+
+    def test_filter_by_node_id(self):
+        self.assertEqual(
+            _match_emr_bootstrap_stderr_path(
+                's3://bucket/tmp/logs/j-1EE0CL1O7FDXU/node/i-e647eb49/'
+                'bootstrap-actions/2/stderr',
+                node_id='i-e647eb49'),
+            dict(action_num=1, node_id='i-e647eb49')
+        )
+
+        self.assertEqual(
+            _match_emr_bootstrap_stderr_path(
+                's3://bucket/tmp/logs/j-1EE0CL1O7FDXU/node/i-e647eb49/'
+                'bootstrap-actions/2/stderr',
+                node_id='i-105af6bf'),
+            None
+        )

--- a/tests/logs/test_bootstrap.py
+++ b/tests/logs/test_bootstrap.py
@@ -18,6 +18,7 @@ from tests.py2 import patch
 
 from mrjob.logs.bootstrap import _check_for_nonzero_return_code
 from mrjob.logs.bootstrap import _match_emr_bootstrap_stderr_path
+from mrjob.logs.bootstrap import _interpret_emr_bootstrap_stderr
 
 
 class CheckForNonzeroReturnCodeTestCase(TestCase):
@@ -116,3 +117,13 @@ class MatchEMRBootstrapStderrPathTestCase(TestCase):
                 node_id='i-105af6bf'),
             None
         )
+
+
+class InterpretEMRBootstrapStderrTestCase(PatcherTestCase):
+
+    def interpret_bootstrap_stderr(self, matches):
+        # implement this; see test_history.py
+        return {}
+
+    def test_empty(self):
+        self.assertEqual(self.interpret_bootstrap_stderr([]), {})

--- a/tests/logs/test_bootstrap.py
+++ b/tests/logs/test_bootstrap.py
@@ -59,10 +59,26 @@ class MatchEMRBootstrapStderrPathTestCase(TestCase):
             _match_emr_bootstrap_stderr_path(''),
             None)
 
-    def test_gz(self):
+    def test_stderr(self):
+        self.assertEqual(
+            _match_emr_bootstrap_stderr_path(
+                's3://bucket/tmp/logs/j-1EE0CL1O7FDXU/node/i-e647eb49/'
+                'bootstrap-actions/2/stderr'),
+            dict(action_num=1, node_id='i-e647eb49')
+        )
+
+    def test_stderr_gz(self):
         self.assertEqual(
             _match_emr_bootstrap_stderr_path(
                 's3://bucket/tmp/logs/j-1EE0CL1O7FDXU/node/i-e647eb49/'
                 'bootstrap-actions/1/stderr.gz'),
             dict(action_num=0, node_id='i-e647eb49')
+        )
+
+    def test_syslog(self):
+        self.assertEqual(
+            _match_emr_bootstrap_stderr_path(
+                's3://bucket/tmp/logs/j-1EE0CL1O7FDXU/node/i-e647eb49/'
+                'bootstrap-actions/1/syslog'),
+            None
         )

--- a/tests/logs/test_bootstrap.py
+++ b/tests/logs/test_bootstrap.py
@@ -36,7 +36,13 @@ class CheckForNonzeroReturnCodeTestCase(TestCase):
             dict(action_num=1, node_id='i-96c21a39'),
         )
 
-    # would be good to test this on other instances too
+    def test_nonzero_return_code_on_two_slave_instances(self):
+        self.assertEqual(
+            _check_for_nonzero_return_code(
+                'On 2 slave instances (including i-105af6bf and i-b659f519),'
+                ' bootstrap action 1 returned a non-zero return code'),
+            dict(action_num=0, node_id='i-105af6bf')
+        )
 
     def test_failed_to_download_bootstrap_action(self):
         self.assertEqual(

--- a/tests/logs/test_bootstrap.py
+++ b/tests/logs/test_bootstrap.py
@@ -1,0 +1,62 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from tests.sandbox import PatcherTestCase
+from tests.py2 import Mock
+from tests.py2 import TestCase
+from tests.py2 import patch
+
+from mrjob.logs.bootstrap import _check_for_nonzero_return_code
+from mrjob.logs.bootstrap import _match_emr_bootstrap_stderr_path
+
+
+class CheckForNonzeroReturnCodeTestCase(TestCase):
+
+    def test_empty(self):
+        self.assertEqual(
+            _check_for_nonzero_return_code(''),
+            None)
+
+    def test_nonzero_return_code_on_master_instance(self):
+        self.assertEqual(
+            _check_for_nonzero_return_code(
+                'On the master instance (i-96c21a39), bootstrap action 2'
+                ' returned a non-zero return code'),
+            # action_num is 0-indexed
+            dict(action_num=1, node_id='i-96c21a39'),
+        )
+
+    # would be good to test this on other instances too
+
+    def test_failed_to_download_bootstrap_action(self):
+        self.assertEqual(
+            _check_for_nonzero_return_code(
+                'Master instance (i-ec41ed43) failed attempting to download'
+                ' bootstrap action 1 file from S3'),
+            None)
+
+
+class MatchEMRBootstrapStderrPathTestCase(TestCase):
+
+    def test_empty(self):
+        self.assertEqual(
+            _match_emr_bootstrap_stderr_path(''),
+            None)
+
+    def test_gz(self):
+        self.assertEqual(
+            _match_emr_bootstrap_stderr_path(
+                's3://bucket/tmp/logs/j-1EE0CL1O7FDXU/node/i-e647eb49/'
+                'bootstrap-actions/1/stderr.gz'),
+            dict(action_num=0, node_id='i-e647eb49')
+        )

--- a/tests/logs/test_mixin.py
+++ b/tests/logs/test_mixin.py
@@ -373,7 +373,7 @@ class LsHistoryLogsTestCase(LogInterpretationMixinTestCase):
         self.runner._stream_history_log_dirs = Mock()
 
     def test_basic(self):
-        # the _ls_history_log() method is a very thin wrapper. Just
+        # the _ls_history_logs() method is a very thin wrapper. Just
         # verify that the keyword args get passed through and
         # that logging happens in the right order
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4412,7 +4412,7 @@ class WaitForStepsToCompleteTestCase(MockBotoTestCase):
             return_value=MockEmrObject(
                 id='j-CLUSTERID',
                 status=MockEmrObject(
-                    state='TERMINATED',
+                    state='TERMINATING',
                 ),
             ),
         ))
@@ -4422,9 +4422,10 @@ class WaitForStepsToCompleteTestCase(MockBotoTestCase):
         self.start(patch.object(
             runner, '_check_for_key_pair_from_wrong_region'))
         self.start(patch.object(
-            runner, '_check_for_failed_bootstrap_action'))
+            runner, '_check_for_failed_bootstrap_action',
+            side_effect=self.StopTest))
 
-        self.assertRaises(StepFailedException,
+        self.assertRaises(self.StopTest,
                           runner._wait_for_steps_to_complete)
 
         self.assertTrue(runner._check_for_missing_default_iam_roles.called)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3691,7 +3691,7 @@ class StreamLogDirsTestCase(MockBotoTestCase):
         self.assertTrue(
             self._wait_for_logs_on_s3.called)
         self.log.info.assert_called_once_with(
-            'Looking for bootstrap log in'
+            'Looking for bootstrap logs in'
             ' s3://bucket/logs/j-CLUSTERID/' +
             expected_s3_dir_name + '...')
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -203,6 +203,9 @@ class CreateMrjobTarGzTestCase(TestCase):
                     self.assertEqual(path[:6], 'mrjob/')
 
                 self.assertIn('mrjob/job.py', contents)
+                for filename in contents:
+                    self.assertFalse(filename.endswith('.pyc'),
+                                     msg="%s ends with '.pyc'" % filename)
 
 
 class TestStreamingOutput(TestCase):


### PR DESCRIPTION
Finally, mrjob will tell you why a bootstrap script failed (fixes #370).

Some other minor changes:
 * the master bootstrap script now redirects stdout to stderr, like the setup wrapper script
 * files with paths like `*.cpython-34.pyc` are no longer included in `mrjob.tar.gz`

Also, a small amount of cleanup to EMR runner and log parsing regexes.