### PR TITLE
subnet option

### DIFF
--- a/docs/guides/emr-advanced.rst
+++ b/docs/guides/emr-advanced.rst
@@ -61,12 +61,20 @@ occasionally join clusters with out knowing they are about to self-terminate
 (this is better for development than production).
 
 Pooling is designed so that jobs run against the same :py:mod:`mrjob.conf` can
-share the same clusters. This means that the version of :py:mod:`mrjob`,
-bootstrap configuration, Hadoop version and AMI version all need to be exactly
-the same.
+share the same clusters. This means that the version of :py:mod:`mrjob` and
+bootstrap configuration. Other options that affect which cluster a job can
+join:
+
+* :mrjob-opt:`ami_version`\/:mrjob-opt:`release_label`: must match
+* :mrjob-opt:`emr_applications`: require *at least* these applications
+  (extra ones okay)
+* :mrjob-opt:`ec2_key_pair`: if specified, only join clusters with the same key
+  pair
+* :mrjob-opt:`subnet`: only join clusters with the same EC2 subnet ID (or
+  lack thereof)
 
 Pooled jobs will also only use clusters with the same **pool name**, so you
-can use the :option:`--pool-name` option to partition your clusters into
+can use the :mrjob-opt:`pool_name` to partition your clusters into
 separate pools.
 
 Pooling is flexible about instance type and number of instances; it will

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -314,6 +314,19 @@ Cluster creation and configuration
     .. versionadded:: 0.5.0
 
 .. mrjob-opt::
+   :config: subnet
+   :switch: --subnet
+   :type: :ref:`string <data-type-string>`
+   :set: emr
+   :default: ``None``
+
+   ID of Amazon VPC subnet to launch cluster in (e.g. ``'subnet-12345678'``).
+   If this is not set, or an empty string, cluster will be launched in the
+   normal AWS cloud.
+
+   .. versionadded:: 0.5.3
+
+.. mrjob-opt::
     :config: visible_to_all_users
     :switch: --visible-to-all-users, --no-visible-to-all-users
     :type: boolean

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -390,6 +390,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         'ssh_bind_ports',
         'ssh_tunnel',
         'ssh_tunnel_is_open',
+        'subnet',
         'visible_to_all_users',
     ]))
 
@@ -1460,6 +1461,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         if self._opts['emr_applications']:
             api_params['Applications'] = [
                 dict(Name=a) for a in sorted(self._opts['emr_applications'])]
+
+        if self._opts['subnet']:
+            api_params['Instances.Ec2SubnetId'] = self._opts['subnet']
 
         if self._opts['emr_api_params']:
             api_params.update(self._opts['emr_api_params'])

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2619,6 +2619,11 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 if not self._opts['emr_applications'] <= applications:
                     return
 
+            subnet = getattr(
+                cluster.ec2instanceattributes, 'ec2subnetid', None)
+            if subnet != (self._opts['subnet'] or None):
+                return
+
             steps = _list_all_steps(emr_conn, cluster.id)
 
             # there is a hard limit of 256 steps per cluster

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -525,6 +525,13 @@ def _add_emr_launch_opts(opt_group):
         ),
 
         opt_group.add_option(
+            '--no-emr-api-param', dest='no_emr_api_params',
+            default=[], action='append',
+            help='Parameters to be unset when calling EMR API.'
+                 ' You can use --no-emr-api-param multiple times.'
+        ),
+
+        opt_group.add_option(
             '--emr-application', dest='emr_applications',
             default=[], action='append',
             help='Additional applications to run on 4.x AMIs (e.g. Ganglia,'
@@ -626,11 +633,9 @@ def _add_emr_launch_opts(opt_group):
                   ' multipart uploading entirely.')),
 
         opt_group.add_option(
-            '--no-emr-api-param', dest='no_emr_api_params',
-            default=[], action='append',
-            help='Parameters to be unset when calling EMR API.'
-                 ' You can use --no-emr-api-param multiple times.'
-        ),
+            '--subnet', dest='subnet', default=None,
+            help=('ID of Amazon VPC subnet to launch cluster in (if not set,'
+                  ' cluster is launched in the normal AWS cloud)')),
 
         opt_group.add_option(
             '--visible-to-all-users', dest='visible_to_all_users',

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -634,8 +634,9 @@ def _add_emr_launch_opts(opt_group):
 
         opt_group.add_option(
             '--subnet', dest='subnet', default=None,
-            help=('ID of Amazon VPC subnet to launch cluster in (if not set,'
-                  ' cluster is launched in the normal AWS cloud)')),
+            help=('ID of Amazon VPC subnet to launch cluster in (if not set'
+                  ' or empty string, cluster is launched in the normal AWS'
+                  ' cloud)')),
 
         opt_group.add_option(
             '--visible-to-all-users', dest='visible_to_all_users',

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -797,7 +797,7 @@ class MockEmrConnection(object):
 
         # optional subnet (we don't do anything with this other than put it
         # in ec2instanceattributes)
-        ec2_subnet_id = api_params.get('Instances.Ec2SubnetId')
+        ec2_subnet_id = (api_params or {}).get('Instances.Ec2SubnetId')
 
         # create a MockEmrObject corresponding to the job flow. We only
         # need to fill in the fields that EMRJobRunner uses

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -795,6 +795,10 @@ class MockEmrConnection(object):
                 version=running_hadoop_version
             )]
 
+        # optional subnet (we don't do anything with this other than put it
+        # in ec2instanceattributes)
+        ec2_subnet_id = api_params.get('Instances.Ec2SubnetId')
+
         # create a MockEmrObject corresponding to the job flow. We only
         # need to fill in the fields that EMRJobRunner uses
         steps = steps or []
@@ -808,6 +812,7 @@ class MockEmrConnection(object):
             ec2instanceattributes=MockEmrObject(
                 ec2availabilityzone=availability_zone,
                 ec2keyname=ec2_keyname,
+                ec2subnetid=ec2_subnet_id,
                 iaminstanceprofile=job_flow_role,
             ),
             id=cluster_id,

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2096,7 +2096,7 @@ class PoolMatchingTestCase(MockBotoTestCase):
             '--ec2-task-instance-bid-price', '22.00'])
 
     def test_dont_join_full_cluster(self):
-        dummy_runner, cluster_id = self.make_pooled_cluster('pool1')
+        dummy_runner, cluster_id = self.make_pooled_cluster()
 
         # fill the cluster
         self.mock_emr_clusters[cluster_id]._steps = 255 * [
@@ -2113,12 +2113,11 @@ class PoolMatchingTestCase(MockBotoTestCase):
 
         # a two-step job shouldn't fit
         self.assertDoesNotJoin(cluster_id, [
-            '-r', 'emr', '-v', '--pool-clusters',
-            '--pool-name', 'pool1'],
+            '-r', 'emr', '-v', '--pool-clusters'],
             job_class=MRTwoStepJob)
 
     def test_join_almost_full_cluster(self):
-        dummy_runner, cluster_id = self.make_pooled_cluster('pool1')
+        dummy_runner, cluster_id = self.make_pooled_cluster()
 
         # fill the cluster
         self.mock_emr_clusters[cluster_id]._steps = 255 * [
@@ -2135,8 +2134,51 @@ class PoolMatchingTestCase(MockBotoTestCase):
 
         # a one-step job should fit
         self.assertJoins(cluster_id, [
+            '-r', 'emr', '-v', '--pool-clusters'],
+            job_class=MRWordCount)
+
+    def test_no_space_for_master_node_setup(self):
+        dummy_runner, cluster_id = self.make_pooled_cluster()
+
+        # fill the cluster
+        self.mock_emr_clusters[cluster_id]._steps = 255 * [
+            MockEmrObject(
+                actiononfailure='CANCEL_AND_WAIT',
+                config=MockEmrObject(args=[]),
+                id='s-FAKE',
+                name='dummy',
+                status=MockEmrObject(
+                    state='COMPLETED',
+                    timeline=MockEmrObject(
+                        enddatetime='definitely not none')))
+        ]
+
+        # --libjar makes this a two-step job, which won't fit
+        self.assertDoesNotJoin(cluster_id, [
             '-r', 'emr', '-v', '--pool-clusters',
-            '--pool-name', 'pool1'],
+            '--libjar', 's3:///poohs-house/HUNNY.jar'],
+            job_class=MRWordCount)
+
+    def test_bearly_space_for_master_node_setup(self):
+        dummy_runner, cluster_id = self.make_pooled_cluster()
+
+        # fill the cluster
+        self.mock_emr_clusters[cluster_id]._steps = 254 * [
+            MockEmrObject(
+                actiononfailure='CANCEL_AND_WAIT',
+                config=MockEmrObject(args=[]),
+                id='s-FAKE',
+                name='dummy',
+                status=MockEmrObject(
+                    state='COMPLETED',
+                    timeline=MockEmrObject(
+                        enddatetime='definitely not none')))
+        ]
+
+        # now there's space for two steps
+        self.assertJoins(cluster_id, [
+            '-r', 'emr', '-v', '--pool-clusters',
+            '--libjar', 's3:///poohs-house/HUNNY.jar'],
             job_class=MRWordCount)
 
     def test_dont_join_idle_with_pending_steps(self):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -402,6 +402,21 @@ class VisibleToAllUsersTestCase(MockBotoTestCase):
             self.assertEqual(visible_cluster.visibletoallusers, 'true')
 
 
+class SubnetTestCase(MockBotoTestCase):
+
+    def test_defaults(self):
+        cluster = self.run_and_get_cluster()
+        self.assertEqual(
+            getattr(cluster.ec2instanceattributes, 'ec2subnetid', None),
+            None)
+
+    def test_subnet_option(self):
+        cluster = self.run_and_get_cluster('--subnet', 'subnet-ffffffff')
+        self.assertEqual(
+            getattr(cluster.ec2instanceattributes, 'ec2subnetid', None),
+            'subnet-ffffffff')
+
+
 class IAMTestCase(MockBotoTestCase):
 
     def setUp(self):

--- a/tests/tools/emr/test_create_cluster.py
+++ b/tests/tools/emr/test_create_cluster.py
@@ -78,6 +78,7 @@ class ClusterInspectionTestCase(ToolTestCase):
              's3_sync_wait_time': None,
              's3_tmp_dir': None,
              's3_upload_part_size': None,
+             'subnet': None,
              'visible_to_all_users': None,
              })
 


### PR DESCRIPTION
This adds the `subnet` option to the EMR runner and makes pooling respect it.

Also refreshed the docs re: pooling rules and added a missing test of pooling's interaction with the master node setup script (which counts as an extra step).