### PR TITLE
more default hadoop log dir paths

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -194,6 +194,12 @@ Options available to hadoop runner only
    * ``$HADOOP_MAPRED_HOME/logs``
    * ``<dir containing hadoop bin>/logs`` (see :mrjob-opt:`hadoop_bin`), unless the hadoop binary is in ``/bin``, ``/usr/bin``, or ``/usr/local/bin``
    * ``$HADOOP_*_HOME/logs`` (in alphabetical order by environment variable name)
+   * ``/var/log/hadoop-yarn`` (on YARN only)
+   * ``/mnt/var/log/hadoop-yarn`` (on YARN only)
+   * ``/var/log/hadoop``
+   * ``/mnt/var/log/hadoop``
+
+   (The last path allows the Hadoop runner to work out-of-the box inside EMR.)
 
 .. mrjob-opt::
     :config: hadoop_tmp_dir

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -364,6 +364,9 @@ class HadoopLogDirsTestCase(SandboxedTestCase):
     def test_empty(self):
         self.assertEqual(list(self.runner._hadoop_log_dirs()),
                          ['hdfs:///tmp/hadoop-yarn/staging',
+                          '/var/log/hadoop-yarn',
+                          '/mnt/var/log/hadoop-yarn',
+                          '/var/log/hadoop',
                           '/mnt/var/log/hadoop'])
 
     def test_precedence(self):
@@ -380,6 +383,9 @@ class HadoopLogDirsTestCase(SandboxedTestCase):
              'hdfs:///output/_logs',
              '/path/to/hadoop-prefix/logs',
              '/path/to/hadoop-home/logs',
+             '/var/log/hadoop-yarn',
+             '/mnt/var/log/hadoop-yarn',
+             '/var/log/hadoop',
              '/mnt/var/log/hadoop'])
 
     def test_hadoop_log_dirs_opt(self):
@@ -399,11 +405,15 @@ class HadoopLogDirsTestCase(SandboxedTestCase):
         self.assertEqual(list(self.runner._hadoop_log_dirs()),
                          ['/path/to/yarn-log-dir',
                           'hdfs:///tmp/hadoop-yarn/staging',
+                          '/var/log/hadoop-yarn',
+                          '/mnt/var/log/hadoop-yarn',
+                          '/var/log/hadoop',
                           '/mnt/var/log/hadoop'])
 
         self.mock_hadoop_version = '1.0.3'
         self.assertEqual(list(self.runner._hadoop_log_dirs()),
-                         ['/mnt/var/log/hadoop'])
+                         ['/var/log/hadoop',
+                          '/mnt/var/log/hadoop'])
 
 
 class StreamingLogDirsTestCase(SandboxedTestCase):


### PR DESCRIPTION
mrjob now goes the extra mile to find your hadoop log dir. Fixes #1339.