### PR TITLE
add emr_configurations option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,11 @@
 v0.5.3, 2016-07-?? -- ???
  * runners:
+   * all:
+     * .cpython-3*.pyc files no longer included when bootstrapping mrjob
    * EMR:
      * determine cause of failure of bootstrap scripts (#370)
        * master bootstrap script now redirects stdout to stderr
- * .cpython-3x.pyc files no longer included when bootstrapping mrjob
+ * combine_lists() treats lists as values, not sequences
 
 v0.5.2, 2016-05-23 -- initial Cloud Dataproc support
  * basic support for Google Cloud Dataproc (#1243)

--- a/docs/guides/emr-advanced.rst
+++ b/docs/guides/emr-advanced.rst
@@ -68,6 +68,7 @@ join:
 * :mrjob-opt:`ami_version`\/:mrjob-opt:`release_label`: must match
 * :mrjob-opt:`emr_applications`: require *at least* these applications
   (extra ones okay)
+* :mrjob-opt:`emr_configurations`: must match
 * :mrjob-opt:`ec2_key_pair`: if specified, only join clusters with the same key
   pair
 * :mrjob-opt:`subnet`: only join clusters with the same EC2 subnet ID (or

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -176,6 +176,34 @@ Cluster creation and configuration
 
    See `Applications <http://docs.aws.amazon.com/ElasticMapReduce/latest/ReleaseGuide/emr-release-components.html>`_ in the EMR docs for more details.
 
+   .. versionadded:: 0.5.2
+
+.. mrjob-opt::
+    :config: emr_configurations
+    :switch: --emr-configuration
+    :type: list of dicts
+    :set: emr
+    :default: ``[]``
+
+    Configurations for 4.x AMIs. For example:
+
+    .. code-block:: yaml
+
+        runners:
+          emr:
+            emr_configurations:
+            - Classification: core-site
+              Properties:
+                hadoop.security.groups.cache.secs: 250
+
+    On the command line, configurations should be JSON-encoded:
+
+    .. code-block:: sh
+
+        --emr-configuration '{"Classification": "core-site", ...}
+
+    See `Configuring Applications <http://docs.aws.amazon.com/ElasticMapReduce/latest/ReleaseGuide/emr-configure-apps.html>`_ in the EMR docs for more details.
+
 .. mrjob-opt::
     :config: emr_endpoint
     :switch: --emr-endpoint

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -495,6 +495,9 @@ def combine_lists(*seqs):
     .. versionchanged:: 0.4.6
        Strings, bytes, and non-sequence objects (e.g. numbers) are treated as
        single-item lists.
+
+    .. versionchanged:: 0.5.3
+       Dicts are treated as single-item lists
     """
     result = []
 
@@ -502,7 +505,7 @@ def combine_lists(*seqs):
         if seq is None:
             continue
 
-        if isinstance(seq, (bytes, string_types)):
+        if isinstance(seq, (bytes, string_types, dict)):
             result.append(seq)
         else:
             try:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1481,7 +1481,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         if self._opts['emr_api_params']:
             api_params.update(self._opts['emr_api_params'])
 
-        args['api_params'] = _unpack_emr_api_params(api_params)
+        args['api_params'] = _encode_emr_api_params(api_params)
 
         if steps:
             args['steps'] = steps
@@ -2985,7 +2985,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
         return wrap_aws_conn(raw_iam_conn)
 
-def _unpack_emr_api_params(x):
+
+def _encode_emr_api_params(x):
     """Recursively unpack parameters to the EMR API."""
     # recursively unpack values, and flatten into main dict
     if isinstance(x, dict):
@@ -2998,7 +2999,7 @@ def _unpack_emr_api_params(x):
                 value = [{'Key': k, 'Value': v}
                          for k, v in sorted(value.items())]
 
-            unpacked_value = _unpack_emr_api_params(value)
+            unpacked_value = _encode_emr_api_params(value)
             if isinstance(unpacked_value, dict):
                 for subkey, subvalue in unpacked_value.items():
                     result['%s.%s' % (key, subkey)] = subvalue
@@ -3009,7 +3010,7 @@ def _unpack_emr_api_params(x):
 
     # treat lists like dicts mapping "member.N" (1-indexed) to value
     if isinstance(x, (list, tuple)):
-        return _unpack_emr_api_params(dict(
+        return _encode_emr_api_params(dict(
             ('member.%d' % (i + 1), item)
             for i, item in enumerate(x)))
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3016,3 +3016,27 @@ def _encode_emr_api_params(x):
 
     # base case, not a dict or list
     return x
+
+
+def _decode_configurations_from_api(configurations):
+    """Recursively convert configurations object from describe_cluster()
+    back into simple data structure."""
+    results = []
+
+    for c in configurations:
+        result = {}
+
+        if hasattr(configuration, 'classification'):
+            result['Classification'] = c.classification
+
+        if hasattr(configuration, 'configurations'):
+            result['Configurations'] = _decode_configurations_from_api(
+                c.configurations)
+
+        if hasattr(configuration, 'properties'):
+            result['Properties'] = dict(
+                (kv.key, kv.value) for kv in c.properties)
+
+        results.append(result)
+
+    return results

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3015,19 +3015,3 @@ def _unpack_emr_api_params(x):
 
     # base case, not a dict or list
     return x
-
-
-# not currently used; should use in mrjob.options to unpack --emr-api-param
-def _maybe_unpack_json(x):
-    """If *x* is a string starting with ``{`` or ``[``,
-    try to JSON-decode it. Otherwise, return *x* as-is.
-
-    This allows us to read in JSON from the command line.
-    """
-    if isinstance(x, string_types) and x[:1] in ('{', '['):
-        try:
-            return json.loads(x)
-        except:
-            log.warning("tried to decode %r but it isn't valid JSON" % x)
-
-    return x

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3088,14 +3088,14 @@ def _decode_configurations_from_api(configurations):
     for c in configurations:
         result = {}
 
-        if hasattr(configuration, 'classification'):
+        if hasattr(c, 'classification'):
             result['Classification'] = c.classification
 
-        if hasattr(configuration, 'configurations'):
+        if hasattr(c, 'configurations'):
             result['Configurations'] = _decode_configurations_from_api(
                 c.configurations)
 
-        if hasattr(configuration, 'properties'):
+        if hasattr(c, 'properties'):
             result['Properties'] = dict(
                 (kv.key, kv.value) for kv in c.properties)
 

--- a/mrjob/patched_boto.py
+++ b/mrjob/patched_boto.py
@@ -85,7 +85,7 @@ class _Configuration(EmrObject):
         self.properties = None
 
     def startElement(self, name, attrs, connection):
-        if name == 'Configuration':
+        if name == 'Configurations':
             # configurations can contain themselves
             self.configurations = ResultSet([('member', _Configuration)])
             return self.configurations

--- a/mrjob/patched_boto.py
+++ b/mrjob/patched_boto.py
@@ -90,8 +90,16 @@ class _Configuration(EmrObject):
             self.configurations = ResultSet([('member', _Configuration)])
             return self.configurations
         elif name == 'Properties':
-            self.properties = ResultSet([('member', KeyValue)])
+            self.properties = ResultSet([('entry', _KeyValueEntry)])
             return self.properties
+
+
+class _KeyValueEntry(EmrObject):
+    """Like KeyValue, but used for Properties in _Configurations."""
+    Fields = set([
+        'key',
+        'value',
+    ])
 
 
 class _PatchedCluster(Cluster):

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -694,6 +694,9 @@ class MockEmrConnection(object):
         if now is None:
             now = datetime.utcnow()
 
+        # convert api_params into MockEmrObject
+        api_params_obj = _api_params_to_emr_object(api_params or {})
+
         # default fields that can be set from api_params
         if job_flow_role is None:
             job_flow_role = (api_params or {}).get('JobFlowRole')
@@ -769,11 +772,8 @@ class MockEmrConnection(object):
         # TODO: could raise an exception if applications are set for
         # pre-4.x AMI
         if version_gte(ami_version, '4'):
-            application_names = set()
-            for key, value in api_params.items():
-                if (key.startswith('Applications.member.') and
-                        key.endswith('.Name')):
-                    application_names.add(value)
+            application_objs = getattr(api_params_obj, 'applications', [])
+            application_names = set(a.name for a in application_objs)
 
             # if Applications is set but doesn't include Hadoop, the
             # cluster description won't either! (Even though Hadoop is
@@ -809,6 +809,7 @@ class MockEmrConnection(object):
         cluster = MockEmrObject(
             applications=applications,
             autoterminate=('false' if keep_alive else 'true'),
+            configurations=getattr(api_params_obj, 'configurations', None),
             ec2instanceattributes=MockEmrObject(
                 ec2availabilityzone=availability_zone,
                 ec2keyname=ec2_keyname,
@@ -1673,3 +1674,44 @@ class MockIAMConnection(object):
        # could add response_metadata to result_dict, but we don't use it
 
         return {prefix + '_response': result_dict}
+
+
+def _api_params_to_emr_object(params):
+    """Convert emr_api_params into a MockEmrObject."""
+    result = MockEmrObject()
+
+    # iteratively set value, creating MockEmrObjects as needed
+    for key, value in params.items():
+        # boto converts attrs to lowercase
+        attrs = [a.lower() for a in key.split('.')]
+
+        obj = result
+        for attr in attrs[:-1]:
+            if not hasattr(obj, attr):
+                setattr(obj, attr, MockEmrObject())
+            obj = getattr(obj, attr)
+
+        setattr(obj, attrs[-1], str(value))
+
+    # convert objects with "member" key to lists
+    def _convert_lists(x):
+        # base case
+        if not isinstance(x, MockEmrObject):
+            return x
+
+        # recursively convert sub-objects
+        if not hasattr(x, 'member'):
+            for k, v in x.__dict__.items():
+                setattr(x, k, _convert_lists(v))
+            return x
+
+        # special case: this object was meant to be a list
+        result = []
+
+        for k in sorted(x.member.__dict__, key=lambda k: int(k)):
+            assert(len(result) == int(k) - 1)  # verify correct numbering
+            result.append(_convert_lists(getattr(x.member, k)))
+
+        return result
+
+    return _convert_lists(result)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -582,6 +582,10 @@ class CombineListsTestCase(TestCase):
         self.assertEqual(combine_lists('one', None, 'two', u'three'),
                          ['one', 'two', u'three'])
 
+    def test_dicts(self):
+        self.assertEqual(combine_lists({1: 2}, None, {}),
+                         [{1: 2}, {}])
+
     def test_scalars(self):
         self.assertEqual(combine_lists(None, False, b'\x00', 42, 3.14),
                          [False, b'\x00', 42, 3.14])
@@ -589,6 +593,7 @@ class CombineListsTestCase(TestCase):
     def test_mix_lists_and_scalars(self):
         self.assertEqual(combine_lists([1, 2], 3, (4, 5), 6),
                          [1, 2, 3, 4, 5, 6])
+
 
 
 class CombineOptsTestCase(TestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4275,6 +4275,10 @@ class EmrApplicationsTestCase(MockBotoTestCase):
             self.assertNotIn('Applications.member.0.Name', cluster._api_params)
 
 
+class EmrConfigurationsTestCase(MockBotoTestCase):
+    pass
+
+
 class JobStepsTestCase(MockBotoTestCase):
 
     def setUp(self):

--- a/tests/tools/emr/test_create_cluster.py
+++ b/tests/tools/emr/test_create_cluster.py
@@ -55,6 +55,7 @@ class ClusterInspectionTestCase(ToolTestCase):
              'ec2_task_instance_type': None,
              'emr_api_params': {},
              'emr_applications': [],
+             'emr_configurations': [],
              'emr_endpoint': None,
              'emr_tags': {},
              'enable_emr_debugging': None,


### PR DESCRIPTION
This adds the emr_configurations option (fixing #1276), including pooling support.

This would have been much simpler to code in `boto3` (see #1304).
