### PR TITLE
Hide credentials from debug log

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -601,7 +601,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             else:
                 # don't expose aws_access_key_id if it was accidentally
                 # put in a list or something
-                return type(opt_value)
+                return '...'
         else:
             return opt_value
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -587,6 +587,24 @@ class EMRRunnerOptionStore(RunnerOptionStore):
                 not self['release_label']):
             self['release_label'] = 'emr-' + self['ami_version']
 
+    def _obfuscate(self, opt_key, opt_value):
+        # don't need to obfuscate empty values
+        if not opt_value:
+            return opt_value
+
+        if opt_key in ('aws_secret_access_key', 'aws_security_token'):
+            # don't expose any part of secret credentials
+            return '...'
+        elif opt_key == 'aws_access_key_id':
+            if isinstance(opt_value, string_types):
+                return '...' + opt_value[-4:]
+            else:
+                # don't expose aws_access_key_id if it was accidentally
+                # put in a list or something
+                return type(opt_value)
+        else:
+            return opt_value
+
 
 class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     """Runs an :py:class:`~mrjob.job.MRJob` on Amazon Elastic MapReduce.

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -186,7 +186,9 @@ class RunnerOptionStore(OptionStore):
         self.populate_values_from_cascading_dicts()
 
         log.debug('Active configuration:')
-        log.debug(pprint.pformat(self))
+        log.debug(pprint.pformat(
+            dict((opt_key, self._obfuscate(opt_key, opt_value))
+                 for opt_key, opt_value in self.items())))
 
     def default_options(self):
         super_opts = super(RunnerOptionStore, self).default_options()
@@ -246,6 +248,11 @@ class RunnerOptionStore(OptionStore):
         opt_list = [handle_cleanup_opt(opt) for opt in opt_list]
 
         opts[opt_key] = opt_list
+
+    def _obfuscate(self, opt_key, opt_value):
+        """Return value of opt to show in debug printout. Used to obfuscate
+        credentials, etc."""
+        return opt_value
 
 
 class MRJobRunner(object):

--- a/tests/test_option_store.py
+++ b/tests/test_option_store.py
@@ -526,3 +526,75 @@ class OptionStoreSanityCheckTestCase(TestCase):
 
     def test_sim_runner_option_store_is_sane(self):
         self.assert_option_store_is_sane(SimRunnerOptionStore)
+
+
+class OptionStoreDebugPrintoutTestCase(ConfigFilesTestCase):
+
+    def get_debug_printout(self, opt_store_class, alias, opts):
+        stderr = StringIO()
+
+        with no_handlers_for_logger():
+            log_to_stream('mrjob.runner', stderr, debug=True)
+
+            # debug printout happens in constructor
+            opt_store_class(alias, opts, [])
+
+        return stderr.getvalue()
+
+    def test_option_debug_printout(self):
+        printout = self.get_debug_printout(
+            RunnerOptionStore, 'inline', dict(owner='dave'))
+
+        self.assertIn("'owner'", printout)
+        self.assertIn("'dave'", printout)
+
+    def test_non_obfuscated_option_on_emr(self):
+        printout = self.get_debug_printout(
+            EMRRunnerOptionStore, 'emr', dict(owner='dave'))
+
+        self.assertIn("'owner'", printout)
+        self.assertIn("'dave'", printout)
+
+    def test_aws_access_key_id(self):
+        printout = self.get_debug_printout(
+            EMRRunnerOptionStore, 'emr', dict(
+                aws_access_key_id='AKIATOPQUALITYSALESEVENT'))
+
+        self.assertIn("'aws_access_key_id'", printout)
+        self.assertIn("'...VENT'", printout)
+
+    def test_aws_access_key_id_with_wrong_type(self):
+        printout = self.get_debug_printout(
+            EMRRunnerOptionStore, 'emr', dict(
+                aws_access_key_id=['AKIATOPQUALITYSALESEVENT']))
+
+        self.assertIn("'aws_access_key_id'", printout)
+        self.assertNotIn('VENT', printout)
+        self.assertIn("'list'", printout)
+
+    def test_aws_secret_access_key(self):
+        printout = self.get_debug_printout(
+            EMRRunnerOptionStore, 'emr', dict(
+                aws_secret_access_key='PASSWORD'))
+
+        self.assertIn("'aws_secret_access_key'", printout)
+        self.assertNotIn('PASSWORD', printout)
+        self.assertIn("'...'", printout)
+
+    def test_aws_security_token(self):
+        printout = self.get_debug_printout(
+            EMRRunnerOptionStore, 'emr', dict(
+                aws_security_token='TOKEN'))
+
+        self.assertIn("'aws_security_token'", printout)
+        self.assertNotIn('TOKEN', printout)
+        self.assertIn("'...'", printout)
+
+    def test_dont_obfuscate_empty_opts(self):
+        printout = self.get_debug_printout(
+            EMRRunnerOptionStore, 'emr', {})
+
+        self.assertNotIn("'...'", printout)
+        self.assertIn("'aws_access_key_id'", printout)
+        self.assertIn("'aws_secret_access_key'", printout)
+        self.assertIn("'aws_security_token'", printout)

--- a/tests/test_option_store.py
+++ b/tests/test_option_store.py
@@ -570,7 +570,7 @@ class OptionStoreDebugPrintoutTestCase(ConfigFilesTestCase):
 
         self.assertIn("'aws_access_key_id'", printout)
         self.assertNotIn('VENT', printout)
-        self.assertIn("'list'", printout)
+        self.assertIn("'...'", printout)
 
     def test_aws_secret_access_key(self):
         printout = self.get_debug_printout(


### PR DESCRIPTION
This prevents the value `aws_secret_access_key` and `aws_security_token` from being debug-logged when in verbose mode, instead showing `'...``.

This also only shows the last 4 characters of `aws_access_key_id` (e.g. `'...WXYZ'`).

Fixes #1353.

None of the other runners seem to have credentials worth obfuscating (`dataproc` does it solely through environment variables), but the `_obfuscate()` method is there to redefine if anyone needs it.