### PR TITLE
Spark on EMR

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v0.5.?, 2016-??-?? -- Spark
+ * JarStep.{INPUT,OUTPUT} are deprecated (use mrjob.step.{INPUT,OUTPUT})
+
+
 v0.5.3, 2016-07-15 -- libjars
  * jobs:
    * LIBJARS and libjars method (#1341)

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -570,8 +570,9 @@ For example, on EMR you can use a jar to run a script::
                 args=['s3://my_bucket/my_script.sh'])]
 
 More interesting is combining :py:class:`~mrjob.step.MRStep` and
-:py:class:`~mrjob.step.JarStep` in the same job. Use ``JarStep.INPUT`` and
-``JarStep.OUTPUT`` in *args* to stand for the input and output paths
+:py:class:`~mrjob.step.JarStep` in the same job. Use
+:py:data:`mrjob.step.INPUT` and :py:data:`mrjob.step.OUTPUT`
+in *args* to stand for the input and output paths
 for that step. For example::
 
     class NaiveBayesJob(MRJob):
@@ -581,7 +582,7 @@ for that step. For example::
                 MRStep(mapper=self.mapper, reducer=self.reducer),
                 JarStep(
                     jar='elephant-driver.jar',
-                    args=['naive-bayes', JarStep.INPUT, JarStep.OUTPUT]
+                    args=['naive-bayes', INPUT, OUTPUT]
                 )
             ]
 
@@ -600,8 +601,9 @@ before and after it by overriding :py:meth:`~mrjob.job.MRJob.pick_protocols`.
 .. warning::
 
     If the first step of your job is a :py:class:`~mrjob.step.JarStep` and you
-    pass in multiple input paths, mrjob will replace ``JarStep.INPUT`` with the
-    input paths joined together with a comma. Not all jars can handle this!
+    pass in multiple input paths, mrjob will replace
+    :py:data:`~mrjob.step.INPUT` with the input paths joined together with a
+    comma. Not all jars can handle this!
 
     Best practice in this case is to put all your input into a single
     directory and pass that as your input path.

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1639,7 +1639,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         upload URI of *script*
         """
         script = self._upload_uri_or_remote_path(script)
-        script_args = self._interpolate_input_and_output(script_args)
+        script_args = self._interpolate_input_and_output(script_args, step_num)
 
         # TODO: use script-runner and full spark-submit path on 3.x
         jar = _4_X_INTERMEDIARY_JAR

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -995,9 +995,11 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         if self._opts['hadoop_streaming_jar']:
             self._upload_mgr.add(self._opts['hadoop_streaming_jar'])
 
+        # upload JARs and (Python) scripts run by steps
         for step in self._get_steps():
-            if step.get('jar'):
-                self._upload_mgr.add(step['jar'])
+            for key in 'jar', 'script':
+                if step.get(key)
+                    self._upload_mgr.add(step[key])
 
     def _upload_local_files_to_s3(self):
         """Copy local files tracked by self._upload_mgr to S3."""

--- a/mrjob/examples/mr_jar_step_example.py
+++ b/mrjob/examples/mr_jar_step_example.py
@@ -21,8 +21,10 @@ of the example jar.
 """
 from mrjob.job import MRJob
 from mrjob.protocol import RawProtocol
+from mrjob.step import INPUT
 from mrjob.step import JarStep
 from mrjob.step import MRStep
+from mrjob.step import OUTPUT
 
 # use the file:// trick to access a jar hosted on the EMR machines
 HADOOP_EXAMPLES_JAR = 'file:///home/hadoop/hadoop-examples.jar'
@@ -36,7 +38,7 @@ class MRJarStepExample(MRJob):
         return [
             JarStep(
                 jar=HADOOP_EXAMPLES_JAR,
-                args=['wordcount', JarStep.INPUT, JarStep.OUTPUT]),
+                args=['wordcount', INPUT, OUTPUT]),
             MRStep(
                 mapper=self.mapper, combiner=self.reducer,
                 reducer=self.reducer)

--- a/mrjob/examples/mr_spark_wordcount.py
+++ b/mrjob/examples/mr_spark_wordcount.py
@@ -19,7 +19,7 @@ from mrjob.job import MRJob
 WORD_RE = re.compile(r"[\w']+")
 
 
-def MRSparkWordcount(MRJob):
+class MRSparkWordcount(MRJob):
 
     def spark(self, input_path, output_path):
         # Spark may not be available where script is launched

--- a/mrjob/examples/mr_spark_wordcount.py
+++ b/mrjob/examples/mr_spark_wordcount.py
@@ -1,0 +1,43 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+from operator import add
+
+from mrjob.job import MRJob
+
+WORD_RE = re.compile(r"[\w']+")
+
+
+def MRSparkWordcount(MRJob):
+
+    def spark(self, input_path, output_path):
+        # Spark may not be available where script is launched
+        from pyspark import SparkContext
+
+        sc = SparkContext(appName='mrjob Spark wordcount script')
+
+        lines = sc.textFile(inputPath)
+
+        counts = (
+            lines.flatMap(lambda line: WORD_RE.findall(line))
+            .map(lambda word: (word, 1))
+            .reduceByKey(add))
+
+        counts.saveAsTextFile(outputPath)
+
+        sc.stop()
+
+
+if __name__ == '__main__':
+    MRSparkWordcount.run()

--- a/mrjob/examples/mr_spark_wordcount.py
+++ b/mrjob/examples/mr_spark_wordcount.py
@@ -27,14 +27,14 @@ class MRSparkWordcount(MRJob):
 
         sc = SparkContext(appName='mrjob Spark wordcount script')
 
-        lines = sc.textFile(inputPath)
+        lines = sc.textFile(input_path)
 
         counts = (
             lines.flatMap(lambda line: WORD_RE.findall(line))
             .map(lambda word: (word, 1))
             .reduceByKey(add))
 
-        counts.saveAsTextFile(outputPath)
+        counts.saveAsTextFile(output_path)
 
         sc.stop()
 

--- a/mrjob/examples/mr_spark_wordcount_script.py
+++ b/mrjob/examples/mr_spark_wordcount_script.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from os.path import dirname
 from os.path import join
 
 from mrjob.job import MRJob
@@ -22,7 +23,7 @@ class MRSparkScriptWordcount(MRJob):
     def steps(self):
         return [
             SparkScriptStep(
-                script=join(__file__, 'spark_script_wordcount.py'),
+                script=join(dirname(__file__), 'spark_wordcount_script.py'),
                 args=[SparkScriptStep.INPUT, SparkScriptStep.OUTPUT],
             ),
         ]

--- a/mrjob/examples/mr_spark_wordcount_script.py
+++ b/mrjob/examples/mr_spark_wordcount_script.py
@@ -1,0 +1,32 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os.path import join
+
+from mrjob.job import MRJob
+from mrjob.step import SparkScriptStep
+
+
+class MRSparkScriptWordcount(MRJob):
+
+    def steps(self):
+        return [
+            SparkScriptStep(
+                script=join(__file__, 'spark_script_wordcount.py'),
+                args=[SparkScriptStep.INPUT, SparkScriptStep.OUTPUT],
+            ),
+        ]
+
+
+if __name__ == '__main__':
+    MRSparkScriptWordcount.run()

--- a/mrjob/examples/spark_wordcount_script.py
+++ b/mrjob/examples/spark_wordcount_script.py
@@ -1,0 +1,48 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+import sys
+from operator import add
+
+from pyspark import SparkContext
+
+
+WORD_RE = re.compile(r"[\w']+")
+
+
+def main():
+    # read in input, output path
+    args = sys.argv[1:]
+
+    if len(args) != 2:
+        raise ValueError
+
+    inputPath, outputPath = args
+
+    sc = SparkContext(appName='mrjob Spark wordcount script')
+
+    lines = sc.textFile(inputPath)
+
+    counts = (
+        lines.flatMap(WORD_RE.findall)
+        .map(lambda word: (word, 1))
+        .reduceByKey(add))
+
+    counts.saveAsTextFile(outputPath)
+
+    sc.stop()
+
+
+if __name__ == '__main__':
+    main()

--- a/mrjob/examples/spark_wordcount_script.py
+++ b/mrjob/examples/spark_wordcount_script.py
@@ -34,8 +34,10 @@ def main():
 
     lines = sc.textFile(inputPath)
 
+    # lines.flatMap(WORD_RE.findall) doesn't work on Spark 1.6.2; apparently
+    # it can't serialize instance methods?
     counts = (
-        lines.flatMap(WORD_RE.findall)
+        lines.flatMap(lambda line: WORD_RE.findall(line))
         .map(lambda word: (word, 1))
         .reduceByKey(add))
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -541,9 +541,9 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
 
         # TODO: merge with logic in mrjob/emr.py
         def interpolate(arg):
-            if arg == mrjob.step.JarStep.INPUT:
+            if arg == mrjob.step.INPUT:
                 return ','.join(self._hdfs_step_input_files(step_num))
-            elif arg == mrjob.step.JarStep.OUTPUT:
+            elif arg == mrjob.step.OUTPUT:
                 return self._hdfs_step_output_dir(step_num)
             else:
                 return arg

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -637,7 +637,17 @@ class MRJob(MRJobLauncher):
         Called from :py:meth:`run`. You'd probably only want to call this
         directly from automated tests.
         """
-        raise NotImplementedError
+        steps = self.steps()
+        if not 0 <= step_num < len(steps):
+            raise ValueError('Out-of-range step: %d' % step_num)
+        step = steps[step_num]
+
+        if len(self.args) != 2:
+            raise ValueError('Wrong number of args')
+        input_paths, output_path = self.args
+
+        spark_method = step['spark']
+        spark_method(input_paths, output_path)
 
     def show_steps(self):
         """Print information about how many steps there are, and whether

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -644,10 +644,10 @@ class MRJob(MRJobLauncher):
 
         if len(self.args) != 2:
             raise ValueError('Wrong number of args')
-        input_paths, output_path = self.args
+        input_path, output_path = self.args
 
         spark_method = step['spark']
-        spark_method(input_paths, output_path)
+        spark_method(input_path, output_path)
 
     def show_steps(self):
         """Print information about how many steps there are, and whether

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -886,14 +886,15 @@ class MRJob(MRJobLauncher):
         return super(MRJob, self).all_option_groups() + (self.mux_opt_group,)
 
     def is_task(self):
-        """True if this is a mapper, combiner, or reducer.
+        """True if this is a mapper, combiner, reducer, or Spark script.
 
         This is mostly useful inside :py:meth:`load_options`, to disable
-        loading options when we aren't running inside Hadoop Streaming.
+        loading options when we aren't running inside Hadoop.
         """
         return (self.options.run_mapper or
                 self.options.run_combiner or
-                self.options.run_reducer)
+                self.options.run_reducer or
+                self.options.run_spark)
 
     def _process_args(self, args):
         """mrjob.launch takes the first arg as the script path, but mrjob.job

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -501,6 +501,16 @@ class MRJob(MRJobLauncher):
 
         return super(MRJob, self).make_runner()
 
+    def _get_step(self, step_num, expected_type):
+        """Helper for run_* methods"""
+        steps = self.steps()
+        if not 0 <= step_num < len(steps):
+            raise ValueError('Out-of-range step: %d' % step_num)
+        step = steps[step_num]
+        if not isinstance(step, expected_type):
+            raise TypeError('Step %d is not a %s', expected_type.__name__)
+        return step
+
     def run_mapper(self, step_num=0):
         """Run the mapper and final mapper action for the given step.
 
@@ -515,10 +525,8 @@ class MRJob(MRJobLauncher):
         Called from :py:meth:`run`. You'd probably only want to call this
         directly from automated tests.
         """
-        steps = self.steps()
-        if not 0 <= step_num < len(steps):
-            raise ValueError('Out-of-range step: %d' % step_num)
-        step = steps[step_num]
+        step = self._get_step(step_num, MRStep)
+
         mapper = step['mapper']
         mapper_init = step['mapper_init']
         mapper_final = step['mapper_final']
@@ -553,10 +561,8 @@ class MRJob(MRJobLauncher):
         Called from :py:meth:`run`. You'd probably only want to call this
         directly from automated tests.
         """
-        steps = self.steps()
-        if not 0 <= step_num < len(steps):
-            raise ValueError('Out-of-range step: %d' % step_num)
-        step = steps[step_num]
+        step = self._get_step(step_num, MRStep)
+
         reducer = step['reducer']
         reducer_init = step['reducer_init']
         reducer_final = step['reducer_final']
@@ -598,10 +604,8 @@ class MRJob(MRJobLauncher):
         Called from :py:meth:`run`. You'd probably only want to call this
         directly from automated tests.
         """
-        steps = self.steps()
-        if not 0 <= step_num < len(steps):
-            raise ValueError('Out-of-range step: %d' % step_num)
-        step = steps[step_num]
+        step = self._get_step(step_num, MRStep)
+
         combiner = step['combiner']
         combiner_init = step['combiner_init']
         combiner_final = step['combiner_final']
@@ -638,10 +642,7 @@ class MRJob(MRJobLauncher):
         Called from :py:meth:`run`. You'd probably only want to call this
         directly from automated tests.
         """
-        steps = self.steps()
-        if not 0 <= step_num < len(steps):
-            raise ValueError('Out-of-range step: %d' % step_num)
-        step = steps[step_num]
+        step = self._get_step(step_num, SparkStep)
 
         if len(self.args) != 2:
             raise ValueError('Wrong number of args')

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -36,6 +36,7 @@ from mrjob.py2 import string_types
 from mrjob.step import MRStep
 from mrjob.step import SparkStep
 from mrjob.step import _JOB_STEP_FUNC_PARAMS
+from mrjob.step import _SPARK_STEP_KWARGS
 from mrjob.util import expand_path
 from mrjob.util import read_input
 
@@ -348,7 +349,7 @@ class MRJob(MRJobLauncher):
         # only include methods that have been redefined
         kwargs = dict(
             (func_name, getattr(self, func_name))
-            for func_name in _JOB_STEP_FUNC_PARAMS + ['spark']
+            for func_name in _JOB_STEP_FUNC_PARAMS + ('spark',)
             if (_im_func(getattr(self, func_name)) is not
                 _im_func(getattr(MRJob, func_name))))
 
@@ -358,9 +359,9 @@ class MRJob(MRJobLauncher):
             if sorted(kwargs) != ['spark']:
                 raise ValueError(
                     "Can't mix spark() and streaming functions")
-            return SparkStep(
+            return [SparkStep(
                 spark=kwargs['spark'],
-                spark_args=self.spark_args())
+                spark_args=self.spark_args())]
 
         # MRStep takes commands as strings, but the user defines them in the
         # class as functions that return strings, so call the functions.

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -629,7 +629,7 @@ class MRJob(MRJobLauncher):
             for out_key, out_value in combiner_final() or ():
                 write_line(out_key, out_value)
 
-    def run_spark(self):
+    def run_spark(self, step_num):
         """Run the Spark code for the given step.
 
         :type step_num: int
@@ -647,7 +647,7 @@ class MRJob(MRJobLauncher):
             raise ValueError('Wrong number of args')
         input_path, output_path = self.args
 
-        spark_method = step['spark']
+        spark_method = step.spark
         spark_method(input_path, output_path)
 
     def show_steps(self):

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -117,7 +117,7 @@ class StepFailedException(Exception):
                        if getattr(self, k) is not None)))
 
 
-# TODO: reduce enormous amount of boilerplate in these classes
+# TODO: reduce enormous amount of boilerplate in these classes (see #1368)
 
 class MRStep(object):
     """Represents steps handled by the script containing your job.
@@ -326,7 +326,11 @@ class JarStep(object):
 
     See :ref:`non-hadoop-streaming-jar-steps` for sample usage.
     """
-    # TODO: add deprecation warning, update docs
+    # these are deprecated and will be removed in v0.6.0; use
+    # mrjob.step.INPUT and mrjob.step.OUTPUT instead.
+    #
+    # Unfortunately, creating a "class property" to issue a deprecation
+    # warning for these is way more trouble than it's worth (metaclasses, etc.)
     INPUT = INPUT
     OUTPUT = OUTPUT
 

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -39,10 +39,10 @@ _JOB_STEP_PARAMS = _JOB_STEP_FUNC_PARAMS + _HADOOP_OPTS
 _JAR_STEP_KWARGS = ['args', 'main_class']
 
 # all allowable SparkScriptStep constructor keyword args
-_SPARK_SCRIPT_STEP_KWARGS = ['spark', 'spark_args']
+_SPARK_SCRIPT_STEP_KWARGS = ['args', 'script', 'spark_args']
 
-# all allowable SparkScriptStep constructor keyword args
-_SPARK_STEP_KWARGS = ['args', 'spark_args']
+# all allowable SparkStep constructor keyword args
+_SPARK_STEP_KWARGS = ['spark', 'spark_args']
 
 
 #: If passed as an argument to :py:class:`JarStep` or
@@ -438,21 +438,13 @@ class SparkScriptStep(object):
                    can also be an ``s3://`` URI, or ``file://`` to reference a
                    jar on the local filesystem of your EMR instance(s).
     :param args: (optional) A list of arguments to the script. Use
-                 :py:attr:`INPUT` and :py:attr:`OUTPUT` to interpolate
-                 input and output paths.
+                  :py:data:`mrjob.step.INPUT` and :py:data:`OUTPUT` to
+                 interpolate input and output paths.
     :param spark_args: (optional) an array of arguments to pass to spark-submit
                        (e.g. ``['--executor-memory', '2G']``).
 
     *script* can also be passed as a positional argument
     """
-    #: If this is passed as one of the step's arguments, it'll be replaced
-    #: with the step's input paths (if there are multiple paths, they'll
-    #: be joined with commas)
-    INPUT = '<input>'
-    #: If this is passed as one of the step's arguments, it'll be replaced
-    #: with the step's output path
-    OUTPUT = '<output>'
-
     def __init__(self, script, **kwargs):
         bad_kwargs = sorted(set(kwargs) - set(_SPARK_SCRIPT_STEP_KWARGS))
         if bad_kwargs:

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -42,7 +42,7 @@ _JAR_STEP_KWARGS = ['args', 'main_class']
 _SPARK_SCRIPT_STEP_KWARGS = ['spark', 'spark_args']
 
 # all allowable SparkScriptStep constructor keyword args
-_SPARK_SCRIPT_STEP_KWARGS = ['args', 'spark_args']
+_SPARK_STEP_KWARGS = ['args', 'spark_args']
 
 
 #: If passed as an argument to :py:class:`JarStep` or

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -19,7 +19,7 @@ from mrjob.py2 import string_types
 from mrjob.util import cmd_line
 
 
-STEP_TYPES = ('jar', 'spark_python', 'streaming')
+STEP_TYPES = ('jar', 'spark_script', 'streaming')
 
 # Function names mapping to mapper, reducer, and combiner operations
 _MAPPER_FUNCS = ('mapper', 'mapper_init', 'mapper_final', 'mapper_cmd',
@@ -38,8 +38,8 @@ _JOB_STEP_PARAMS = _JOB_STEP_FUNC_PARAMS + _HADOOP_OPTS
 # all allowable JarStep constructor keyword args
 _JAR_STEP_KWARGS = ['args', 'main_class']
 
-# all allowable SparkPythonStep constructor keyword args
-_SPARK_PYTHON_STEP_KWARGS = ['args', 'spark_args']
+# all allowable SparkScriptStep constructor keyword args
+_SPARK_SCRIPT_STEP_KWARGS = ['args', 'spark_args']
 
 
 log = logging.getLogger(__name__)
@@ -362,7 +362,7 @@ class JarStep(object):
         }
 
 
-class SparkPythonStep(object):
+class SparkScriptStep(object):
     """Represents a running a Python script through Spark
 
     Accepts the following keyword arguments:
@@ -387,10 +387,10 @@ class SparkPythonStep(object):
     OUTPUT = '<output>'
 
     def __init__(self, script, **kwargs):
-        bad_kwargs = sorted(set(kwargs) - set(_SPARK_PYTHON_STEP_KWARGS))
+        bad_kwargs = sorted(set(kwargs) - set(_SPARK_SCRIPT_STEP_KWARGS))
         if bad_kwargs:
             raise TypeError(
-                'SparkPythonStep() got an unexpected keyword argument %r' %
+                'SparkScriptStep() got an unexpected keyword argument %r' %
                 bad_kwargs[0])
 
         self.script = script
@@ -419,7 +419,7 @@ class SparkPythonStep(object):
         .. code-block:: js
 
             {
-                'type': 'spark_python',
+                'type': 'spark_script',
                 'script': <path of the Python script>,
                 'args': <list of strings, args to the spark script>,
                 'spark_args': <list of strings, args to spark-submit>
@@ -428,7 +428,7 @@ class SparkPythonStep(object):
         See :ref:`steps-format` for examples.
         """
         return {
-            'type': 'spark_python',
+            'type': 'spark_script',
             'args': self.args,
             'script': self.script,
             'spark_args': self.spark_args,

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -405,7 +405,7 @@ class SparkStep(object):
     def __repr__(self):
         repr_args = []
         repr_args.append(repr(self.spark))
-        if self.main_class:
+        if self.spark_args:
             repr_args.append('spark_args=' + repr(self.spark_args))
 
         return 'SparkStep(%s)' % ', '.join(repr_args)
@@ -466,7 +466,7 @@ class SparkScriptStep(object):
         repr_args.append(repr(self.script))
         if self.args:
             repr_args.append('args=' + repr(self.args))
-        if self.main_class:
+        if self.spark_args:
             repr_args.append('spark_args=' + repr(self.spark_args))
 
         return 'SparkScriptStep(%s)' % ', '.join(repr_args)

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -407,9 +407,9 @@ class SparkStep(object):
         return 'SparkStep(%s)' % ', '.join(repr_args)
 
     def __eq__(self, other):
-        return (isinstance(other, JarStep) and
+        return (isinstance(other, SparkStep) and
                 all(getattr(self, key) == getattr(other, key)
-                    for key in ('script', 'args', 'spark_args')))
+                    for key in ('spark', 'spark_args')))
 
     def description(self, step_num):
         """Returns a dictionary representation of this step:
@@ -476,7 +476,7 @@ class SparkScriptStep(object):
         return 'SparkScriptStep(%s)' % ', '.join(repr_args)
 
     def __eq__(self, other):
-        return (isinstance(other, JarStep) and
+        return (isinstance(other, SparkScriptStep) and
                 all(getattr(self, key) == getattr(other, key)
                     for key in ('script', 'args', 'spark_args')))
 

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -42,6 +42,18 @@ _JAR_STEP_KWARGS = ['args', 'main_class']
 _SPARK_SCRIPT_STEP_KWARGS = ['args', 'spark_args']
 
 
+#: If passed as an argument to :py:class:`JarStep` or
+#: py:class:`SparkScriptStep`, it'll be replaced with the step's input path(s)
+#: (if there are multiple paths, they'll be joined with commas)
+INPUT = '<input>'
+
+#: If this is passed as passed as an argument to :py:class:`JarStep` or
+#: py:class:`SparkScriptStep`, it'll be replaced
+#: with the step's output path
+OUTPUT = '<output>'
+
+
+
 log = logging.getLogger(__name__)
 
 
@@ -296,8 +308,8 @@ class JarStep(object):
                 ``s3://`` URI, or ``file://`` to reference a jar on
                 the local filesystem of your EMR instance(s).
     :param args: (optional) A list of arguments to the jar. Use
-                 :py:attr:`INPUT` and :py:attr:`OUTPUT` to interpolate
-                 input and output paths.
+                 :py:data:`mrjob.step.INPUT` and :py:data:`OUTPUT` to
+                 interpolate input and output paths.
     :param main_class: (optional) The main class to run from the jar. If
                        not specified, Hadoop will use the main class
                        in the jar's manifest file.
@@ -306,13 +318,9 @@ class JarStep(object):
 
     See :ref:`non-hadoop-streaming-jar-steps` for sample usage.
     """
-    #: If this is passed as one of the step's arguments, it'll be replaced
-    #: with the step's input paths (if there are multiple paths, they'll
-    #: be joined with commas)
-    INPUT = '<input>'
-    #: If this is passed as one of the step's arguments, it'll be replaced
-    #: with the step's output path
-    OUTPUT = '<output>'
+    # TODO: add deprecation warning, update docs
+    INPUT = INPUT
+    OUTPUT = OUTPUT
 
     def __init__(self, jar, **kwargs):
         bad_kwargs = sorted(set(kwargs) - set(_JAR_STEP_KWARGS))

--- a/tests/mr_jar_and_streaming.py
+++ b/tests/mr_jar_and_streaming.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from mrjob.job import MRJob
+from mrjob.step import INPUT
 from mrjob.step import JarStep
 from mrjob.step import MRStep
+from mrjob.step import OUTPUT
 
 
 class MRJarAndStreaming(MRJob):
@@ -27,7 +29,7 @@ class MRJarAndStreaming(MRJob):
         return [
             JarStep(
                 jar=self.options.jar,
-                args=['stuff', JarStep.INPUT, JarStep.OUTPUT]
+                args=['stuff', INPUT, OUTPUT]
             ),
             MRStep(mapper=self.mapper, reducer=self.reducer)
         ]

--- a/tests/mr_null_spark.py
+++ b/tests/mr_null_spark.py
@@ -12,33 +12,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Job that runs a single spark script, specified on the command line."""
+"""Job that runs an empty spark() method."""
 
 from mrjob.job import MRJob
-from mrjob.step import SparkScriptStep
 
 
-class MRSparkScript(MRJob):
+class MRNullSpark(MRJob):
 
     def configure_options(self):
-        super(MRSparkScript, self).configure_options()
+        super(MRNullSpark, self).configure_options()
 
         self.add_passthrough_option(
-            '--script', dest='script')
-        self.add_passthrough_option(
-            '--script-arg', dest='script_args',
-            action='append', default=[])
-        self.add_passthrough_option(
-            '--script-spark-arg', dest='script_spark_args',
+            '--extra-spark-arg', dest='extra_spark_args',
             action='append', default=[])
 
-    def steps(self):
-        return [SparkScriptStep(
-            script=self.options.script,
-            args=self.options.script_args,
-            spark_args=self.options.script_spark_args,
-        )]
+    def spark(self):
+        pass
+
+    def spark_args(self):
+        return self.options.extra_spark_args
 
 
 if __name__ == '__main__':
-    MRSparkScript.run()
+    MRNullSpark.run()

--- a/tests/mr_spark_script.py
+++ b/tests/mr_spark_script.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright 2009-2013 Yelp and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Job that runs a single jar, specified on the command line."""
+
+from mrjob.job import MRJob
+from mrjob.step import SparkScriptStep
+
+
+class MRSparkScript(MRJob):
+
+    def configure_options(self):
+        super(MRSparkScript, self).configure_options()
+
+        self.add_passthrough_option(
+            '--script', dest='script')
+        self.add_passthrough_option(
+            '--script-arg', dest='script_args',
+            action='append', default=[])
+        self.add_passthrough_option(
+            '--script-spark-arg', dest='script_spark_args',
+            action='append', default=[])
+
+    def steps(self):
+        return [SparkScriptStep(
+            script=self.options.script,
+            args=self.options.script_args,
+            spark_args=self.options.script_spark_args,
+        )]
+
+
+if __name__ == '__main__':
+    MRSparkScript.run()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -28,8 +28,10 @@ from io import BytesIO
 import mrjob
 import mrjob.emr
 from mrjob.emr import EMRJobRunner
+from mrjob.emr import _3_X_SPARK_SUBMIT
 from mrjob.emr import _4_X_INTERMEDIARY_JAR
 from mrjob.emr import _DEFAULT_AMI_VERSION
+from mrjob.emr import _EMR_SPARK_ARGS
 from mrjob.emr import _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH
 from mrjob.emr import _PRE_4_X_STREAMING_JAR
 from mrjob.emr import _attempt_to_acquire_lock
@@ -46,7 +48,10 @@ from mrjob.parse import parse_s3_uri
 from mrjob.pool import _pool_hash_and_name
 from mrjob.py2 import PY2
 from mrjob.py2 import StringIO
+from mrjob.step import INPUT
+from mrjob.step import OUTPUT
 from mrjob.step import StepFailedException
+from mrjob.step import SparkScriptStep
 from mrjob.tools.emr.audit_usage import _JOB_KEY_RE
 from mrjob.util import bash_wrap
 from mrjob.util import log_to_stream
@@ -63,6 +68,7 @@ from tests.mr_jar_and_streaming import MRJarAndStreaming
 from tests.mr_just_a_jar import MRJustAJar
 from tests.mr_no_mapper import MRNoMapper
 from tests.mr_sort_values import MRSortValues
+from tests.mr_spark_script import MRSparkScript
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
 from tests.py2 import Mock
@@ -3376,6 +3382,127 @@ class JarStepTestCase(MockBotoTestCase):
             self.assertEqual(jar_output_arg, streaming_input_arg)
 
 
+class SparkScriptTestCase(MockBotoTestCase):
+
+    def setUp(self):
+        super(SparkScriptTestCase, self).setUp()
+
+        self.fake_script = os.path.join(self.tmp_dir, 'fake.py')
+        open(self.fake_script, 'w').close()
+
+    def test_script_gets_uploaded(self):
+        job = MRSparkScript(['-r', 'emr', '--script', self.fake_script])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            self.assertIn(self.fake_script, runner._upload_mgr.path_to_uri())
+            script_uri = runner._upload_mgr.uri(self.fake_script)
+            self.assertTrue(runner.fs.ls(script_uri))
+
+            emr_conn = runner.make_emr_conn()
+            steps = _list_all_steps(emr_conn, runner.get_cluster_id())
+
+            self.assertEqual(len(steps), 1)
+            step_args = [a.value for a in steps[0].config.args]
+            # the first arg is spark-submit and varies by AMI
+            self.assertEqual(step_args[1:], _EMR_SPARK_ARGS + [script_uri])
+
+    # TODO: test warning for for AMIs prior to 3.8.0, which don't offer Spark
+
+    def test_3_x_ami(self):
+        job = MRSparkScript(['-r', 'emr', '--script', self.fake_script,
+                             '--ami-version', '3.11.0'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            emr_conn = runner.make_emr_conn()
+            steps = _list_all_steps(emr_conn, runner.get_cluster_id())
+
+            self.assertEqual(len(steps), 1)
+            self.assertEqual(
+                steps[0].config.jar, runner._script_runner_jar_uri())
+            self.assertEqual(
+                steps[0].config.args[0].value,
+                _3_X_SPARK_SUBMIT)
+
+    def test_4_x_ami(self):
+        job = MRSparkScript(['-r', 'emr', '--script', self.fake_script,
+                             '--ami-version', '4.7.2'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            emr_conn = runner.make_emr_conn()
+            steps = _list_all_steps(emr_conn, runner.get_cluster_id())
+
+            self.assertEqual(len(steps), 1)
+            self.assertEqual(
+                steps[0].config.jar, _4_X_INTERMEDIARY_JAR)
+            self.assertEqual(
+                steps[0].config.args[0].value, 'spark-submit')
+
+    def test_arg_interpolation(self):
+        input1 = os.path.join(self.tmp_dir, 'input1')
+        open(input1, 'w').close()
+        input2 = os.path.join(self.tmp_dir, 'input2')
+        open(input2, 'w').close()
+
+        job = MRSparkScript(['-r', 'emr', '--script', self.fake_script,
+                             '--script-arg', INPUT,
+                             '--script-arg', '-o',
+                             '--script-arg', OUTPUT,
+                             input1, input2])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            script_uri = runner._upload_mgr.uri(self.fake_script)
+            input1_uri = runner._upload_mgr.uri(input1)
+            input2_uri = runner._upload_mgr.uri(input2)
+
+            emr_conn = runner.make_emr_conn()
+            steps = _list_all_steps(emr_conn, runner.get_cluster_id())
+
+            step_args = [a.value for a in steps[0].config.args]
+            # the first arg is spark-submit and varies by AMI
+            self.assertEqual(
+                step_args[1:],
+                _EMR_SPARK_ARGS +
+                [
+                    script_uri,
+                    input1_uri + ',' + input2_uri,
+                    '-o',
+                    runner._output_dir,
+                ]
+            )
+
+    def test_spark_args_in_step(self):
+        job = MRSparkScript(['-r', 'emr', '--script', self.fake_script,
+                             '--script-spark-arg', 'ARGH'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            script_uri = runner._upload_mgr.uri(self.fake_script)
+
+            emr_conn = runner.make_emr_conn()
+            steps = _list_all_steps(emr_conn, runner.get_cluster_id())
+
+            step_args = [a.value for a in steps[0].config.args]
+            # the first arg is spark-submit and varies by AMI
+            self.assertEqual(
+                step_args[1:],
+                _EMR_SPARK_ARGS + ['ARGH', script_uri]
+            )
+
+
 class BuildMasterNodeSetupStep(MockBotoTestCase):
 
     def test_build_master_node_setup_step(self):
@@ -3394,6 +3521,8 @@ class BuildMasterNodeSetupStep(MockBotoTestCase):
         self.assertEqual(step['step_args'], [master_node_setup_uri])
         self.assertEqual(step['action_on_failure'],
                          runner._action_on_failure())
+
+
 
 
 class ActionOnFailureTestCase(MockBotoTestCase):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -873,6 +873,7 @@ class IsTaskTestCase(TestCase):
         self.assertEqual(MRJob(['--mapper']).is_task(), True)
         self.assertEqual(MRJob(['--reducer']).is_task(), True)
         self.assertEqual(MRJob(['--combiner']).is_task(), True)
+        self.assertEqual(MRJob(['--spark']).is_task(), True)
         self.assertEqual(MRJob(['--steps']).is_task(), False)
 
     def test_deprecated_alias(self):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -941,6 +941,14 @@ class StepNumTestCase(TestCase):
         self.assertRaises(ValueError, mr_job.run_mapper, 2)
         self.assertRaises(ValueError, mr_job.run_reducer, -1)
 
+    def test_wrong_type_of_step(self):
+        mr_job = MRJob()
+        mr_job.spark = MagicMock()
+
+        self.assertRaises(TypeError, mr_job.run_mapper)
+        self.assertRaises(TypeError, mr_job.run_combiner)
+        self.assertRaises(TypeError, mr_job.run_reducer)
+
 
 class FileOptionsTestCase(SandboxedTestCase):
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -386,7 +386,7 @@ class MRStepDescriptionTestCase(TestCase):
 class SparkStepTestCase(TestCase):
 
     def test_empty(self):
-        self.assertRaises(SparkStep)
+        self.assertRaises(TypeError, SparkStep)
 
     def test_defaults(self):
         step = SparkStep(spark=spark_func)
@@ -419,7 +419,7 @@ class SparkStepTestCase(TestCase):
 class SparkScriptStepTestCase(TestCase):
 
     def test_empty(self):
-        self.assertRaises(SparkScriptStep)
+        self.assertRaises(TypeError, SparkScriptStep)
 
     def test_defaults(self):
         step = SparkScriptStep(script='macbeth.py')

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -403,4 +403,55 @@ class SparkStepTestCase(TestCase):
         )
 
     def test_positional_spark_arg(self):
-        self.assertEqual(SparkStep(spark_func), SparkStep(spark=spark_func))
+        step1 = SparkStep(spark_func)
+        step2 = SparkStep(spark=spark_func)
+
+        self.assertEqual(step1, step2)
+        self.assertEqual(step1.description(0), step2.description(0))
+
+
+class SparkScriptStepTestCase(TestCase):
+
+    def test_empty(self):
+        self.assertRaises(SparkScriptStep)
+
+    def test_defaults(self):
+        step = SparkScriptStep(script='macbeth.py')
+
+        self.assertEqual(step.script, 'macbeth.py')
+        self.assertEqual(step.args, [])
+        self.assertEqual(step.spark_args, [])
+        self.assertEqual(
+            step.description(0),
+            dict(
+                type='spark_script',
+                script='macbeth.py',
+                args=[],
+                spark_args=[],
+             )
+        )
+
+    def test_all_args(self):
+        step = SparkScriptStep(script='macbeth.py',
+                               args=['ARGH', 'ARGH'],
+                               spark_args=['argh', 'argh'])
+
+        self.assertEqual(step.script, 'macbeth.py')
+        self.assertEqual(step.args, ['ARGH', 'ARGH'])
+        self.assertEqual(step.spark_args, ['argh', 'argh'])
+        self.assertEqual(
+            step.description(0),
+            dict(
+                type='spark_script',
+                script='macbeth.py',
+                args=['ARGH', 'ARGH'],
+                spark_args=['argh', 'argh'],
+             )
+        )
+
+    def test_positional_spark_arg(self):
+        step1 = SparkScriptStep('macbeth.py')
+        step2 = SparkScriptStep(script='macbeth.py')
+
+        self.assertEqual(step1, step2)
+        self.assertEqual(step1.description(0), step2.description(0))

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 """Tests for mrjob.step"""
 from mrjob.step import _IDENTITY_MAPPER
+from mrjob.step import INPUT
 from mrjob.step import JarStep
 from mrjob.step import MRStep
+from mrjob.step import OUTPUT
 from mrjob.step import SparkStep
 from mrjob.step import SparkScriptStep
 from mrjob.step import StepFailedException
@@ -103,6 +105,10 @@ class JarStepTestCase(TestCase):
             'args': [],
         })
         self.assertEqual(JarStep(**kwargs).description(0), expected)
+
+    def test_deprecated_INPUT_and_OUTPUT_attrs(self):
+        self.assertEqual(JarStep.INPUT, INPUT)
+        self.assertEqual(JarStep.OUTPUT, OUTPUT)
 
 
 class MRStepInitTestCase(TestCase):

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -17,6 +17,8 @@
 from mrjob.step import _IDENTITY_MAPPER
 from mrjob.step import JarStep
 from mrjob.step import MRStep
+from mrjob.step import SparkStep
+from mrjob.step import SparkScriptStep
 from mrjob.step import StepFailedException
 
 from tests.py2 import TestCase
@@ -31,6 +33,10 @@ def identity_mapper(k=None, v=None):
 def identity_reducer(k, vals):
     for v in vals:
         yield k, v
+
+
+def spark_func(input_path, output_path):
+    pass
 
 
 class StepFailedExceptionTestCase(TestCase):
@@ -369,3 +375,32 @@ class MRStepDescriptionTestCase(TestCase):
                 }
             }
         )
+
+
+class SparkStepTestCase(TestCase):
+
+    def test_empty(self):
+        self.assertRaises(SparkStep)
+
+    def test_defaults(self):
+        step = SparkStep(spark=spark_func)
+
+        self.assertEqual(step.spark, spark_func)
+        self.assertEqual(step.spark_args, [])
+        self.assertEqual(
+            step.description(0),
+            dict(type='spark', spark_args=[]),
+        )
+
+    def test_all_args(self):
+        step = SparkStep(spark=spark_func, spark_args=['argh', 'argh'])
+
+        self.assertEqual(step.spark, spark_func)
+        self.assertEqual(step.spark_args, ['argh', 'argh'])
+        self.assertEqual(
+            step.description(0),
+            dict(type='spark', spark_args=['argh', 'argh']),
+        )
+
+    def test_positional_spark_arg(self):
+        self.assertEqual(SparkStep(spark_func), SparkStep(spark=spark_func))


### PR DESCRIPTION
This defines `SparkScriptStep` and makes it possible to run spark scripts on EMR (with the correct command-line switches, anyway, see https://github.com/Yelp/mrjob/issues/1320#issuecomment-236282396). Fixes #1320.

This also defines `SparkStep` and the machinery for defining spark code right in the `MRJob` class. (Fixes #1360)

Also moved the `INPUT` and `OUTPUT` arg interpolation constants from `mrjob.step.JarStep` to `mrjob.step` because they're generally useful (they're still available from `JarStep` until v0.6.0).