### PR TITLE
Python on 4.x amis

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -458,19 +458,23 @@ and install another Python binary.
    :switch: --bootstrap-python, --no-bootstrap-python
    :type: boolean
    :set: emr
-   :default: ``True``
+   :default: (automatic)
 
    Attempt to install a compatible (major) version of Python at bootstrap time,
    including header files and :command:`pip` (see :ref:`using-pip`).
 
-   In Python 2, this currently does nothing (no need).
+   In Python 2, this never does anything.
 
    In Python 3, this runs
-   :command:`sudo yum install -y python34 python34-devel python34-pip`, which
-   will work unless you've set :mrjob-opt:`ami_version` to something earlier
-   than 3.7.0.
+   :command:`sudo yum install -y python34 python34-devel python34-pip`
+   by default on AMIs prior to 4.6.0 (starting with AMI 4.6.0, Python 3 is
+   pre-installed).
 
    .. versionadded:: 0.5.0
+
+   .. versionchanged:: 0.5.4
+
+      no longer installs Python 3 on AMI version 4.6.0+ by default
 
 .. mrjob-opt::
     :config: bootstrap_python_packages

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2323,9 +2323,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                     ' https://pythonhosted.org/mrjob/guides/emr-bootstrap'
                     '-cookbook.html#installing-python-from-source')
 
-                return [[
-                    'sudo yum install -y python34 python34-devel python34-pip'
-                ]]
+            return [[
+                'sudo yum install -y python34 python34-devel python34-pip'
+            ]]
         else:
             return []
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3616,6 +3616,29 @@ class BootstrapPythonTestCase(MockBotoTestCase):
         self._assert_tries_to_install_python3_on_py3(
             '--ami-version', '3.6.0')
 
+    def test_ami_version_3_7_0(self):
+        # the first version where Python 3 is available
+        self._assert_installs_python3_on_py3(
+            '--ami-version', '3.7.0')
+
+    def test_ami_version_4_5_0(self):
+        # the last version where Python 3 is not pre-installed
+        self._assert_installs_python3_on_py3(
+            '--ami-version', '4.5.0')
+
+    def test_ami_version_4_6_0(self):
+        # from this point on, Python 3 is already installed
+        self._assert_never_installs_python3(
+            '--ami-version', '4.6.0')
+
+    def test_force_booststrap_python(self):
+        self._assert_installs_python3_on_py3(
+            '--bootstrap-python', '--ami-version', '4.6.0')
+
+    def test_force_no_bootstrap_python(self):
+        self._assert_never_installs_python3(
+            '--no-bootstrap-python', '--ami-version', '3.7.0')
+
     def test_bootstrap_python_comes_before_bootstrap(self):
         mr_job = MRTwoStepJob(['-r', 'emr', '--bootstrap', 'true'])
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3568,7 +3568,6 @@ class BootstrapPythonTestCase(MockBotoTestCase):
     def _assert_installs_python3_on_py3(self, *args):
         mr_job = MRTwoStepJob(['-r', 'emr'] + list(args))
         with mr_job.make_runner() as runner:
-            self.assertEqual(runner._opts['bootstrap_python'], True)
             self.assertEqual(runner._bootstrap_python(),
                              self.EXPECTED_BOOTSTRAP)
             self.assertEqual(runner._bootstrap,
@@ -3582,7 +3581,6 @@ class BootstrapPythonTestCase(MockBotoTestCase):
             log_to_stream('mrjob.emr', stderr)
 
             with mr_job.make_runner() as runner:
-                self.assertEqual(runner._opts['bootstrap_python'], True)
                 self.assertEqual(runner._bootstrap_python(),
                                  self.EXPECTED_BOOTSTRAP)
                 self.assertEqual(runner._bootstrap,
@@ -3594,7 +3592,6 @@ class BootstrapPythonTestCase(MockBotoTestCase):
     def _assert_never_installs_python3(self, *args):
         mr_job = MRTwoStepJob(['-r', 'emr'] + list(args))
         with mr_job.make_runner() as runner:
-            self.assertEqual(runner._opts['bootstrap_python'], False)
             self.assertEqual(runner._bootstrap_python(), [])
             self.assertEqual(runner._bootstrap, [])
 


### PR DESCRIPTION
Stop installing Python 3 by default on AMI 4.6.0+, because it's already there.

The default for `bootstrap_python` is now `None` instead of `True`, so people can force `yum`-installing the Python 3 packages on 4.6.0+ if they want to (this appears to be harmless, as mrjob v0.5.3 is doing it, and you can still bootstrap successfully).