### PR TITLE
stop log parsing from erroring on fs.exists()

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -43,6 +43,7 @@ from mrjob.logs.errors import _format_error
 from mrjob.logs.mixin import LogInterpretationMixin
 from mrjob.logs.step import _interpret_hadoop_jar_command_stderr
 from mrjob.logs.step import _is_counter_log4j_record
+from mrjob.logs.wrap import _logs_exist
 from mrjob.parse import is_uri
 from mrjob.py2 import to_string
 from mrjob.runner import MRJobRunner
@@ -587,7 +588,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
     def _stream_history_log_dirs(self, output_dir=None):
         """Yield lists of directories to look for the history log in."""
         for log_dir in unique(self._hadoop_log_dirs(output_dir=output_dir)):
-            if self.fs.exists(log_dir):
+            if _logs_exist(self.fs, log_dir):
                 log.info('Looking for history log in %s...' % log_dir)
                 # logs aren't always in a subdir named history/
                 yield [log_dir]
@@ -603,7 +604,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             else:
                 path = self.fs.join(log_dir, 'userlogs')
 
-            if self.fs.exists(path):
+            if _logs_exist(self.fs, path):
                 log.info('Looking for task syslogs in %s...' % path)
                 yield [path]
 

--- a/mrjob/logs/wrap.py
+++ b/mrjob/logs/wrap.py
@@ -80,3 +80,11 @@ def _ls_logs(fs, log_dir_stream, matcher, **kwargs):
             return _sort_by_recency(matches)
 
     return []
+
+
+def _logs_exist(fs, path):
+    """Do ``fs.exists(path)``, and return ``None`` if it raises ``IOError``"""
+    try:
+        return fs.exists(path)
+    except IOError:
+        return None

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -482,6 +482,17 @@ class StreamHistoryLogDirsTestCase(StreamingLogDirsTestCase):
 
         self.assertRaises(StopIteration, next, results)
 
+    def test_io_error_from_fs_exists(self):
+        self.runner._hadoop_log_dirs.return_value = [
+            'hdfs:///tmp/output/_logs',
+        ]
+
+        self.runner.fs.exists.side_effect = IOError
+
+        results = self.runner._stream_history_log_dirs()
+
+        self.assertRaises(StopIteration, next, results)
+
 
 class StreamTaskLogDirsTestCase(StreamingLogDirsTestCase):
 
@@ -539,6 +550,18 @@ class StreamTaskLogDirsTestCase(StreamingLogDirsTestCase):
         results = self.runner._stream_task_log_dirs()
 
         self.assertRaises(StopIteration, next, results)
+
+    def test_io_error_from_fs_exists(self):
+        self.runner._hadoop_log_dirs.return_value = [
+            'hdfs:///tmp/output/_logs',
+        ]
+
+        self.runner.fs.exists.side_effect = IOError
+
+        results = self.runner._stream_task_log_dirs()
+
+        self.assertRaises(StopIteration, next, results)
+
 
 
 class MockHadoopTestCase(SandboxedTestCase):


### PR DESCRIPTION
Swallow `IOError` from `fs.exists()` during log parsing (fixes #1355).