### PR TITLE
Use sudo over SSH

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -895,7 +895,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             if self._opts['ec2_key_pair_file']:
                 ssh_fs = SSHFilesystem(
                     ssh_bin=self._opts['ssh_bin'],
-                    ec2_key_pair_file=self._opts['ec2_key_pair_file'])
+                    ec2_key_pair_file=self._opts['ec2_key_pair_file'],
+                    sudo=True)
 
                 self._fs = CompositeFilesystem(
                     ssh_fs, s3_fs, LocalFilesystem())

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -898,7 +898,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                     ec2_key_pair_file=self._opts['ec2_key_pair_file'])
 
                 self._fs = CompositeFilesystem(
-                    ssh_fs, s3_fs, LocalFilesystem())
+                    self._ssh_fs, s3_fs, LocalFilesystem())
             else:
                 self._ssh_fs = None
                 self._fs = CompositeFilesystem(s3_fs, LocalFilesystem())

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -893,14 +893,14 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 s3_endpoint=self._opts['s3_endpoint'])
 
             if self._opts['ec2_key_pair_file']:
-                ssh_fs = SSHFilesystem(
+                self._ssh_fs = SSHFilesystem(
                     ssh_bin=self._opts['ssh_bin'],
-                    ec2_key_pair_file=self._opts['ec2_key_pair_file'],
-                    sudo=True)
+                    ec2_key_pair_file=self._opts['ec2_key_pair_file'])
 
                 self._fs = CompositeFilesystem(
                     ssh_fs, s3_fs, LocalFilesystem())
             else:
+                self._ssh_fs = None
                 self._fs = CompositeFilesystem(s3_fs, LocalFilesystem())
 
         return self._fs
@@ -1717,6 +1717,10 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                      ', '.join('%s=%s' % (tag, value)
                                for tag, value in tags.items()))
             emr_conn.add_tags(self._cluster_id, tags)
+
+        # SSH FS uses sudo if we're on AMI 4.3.0+ (see #1244)
+        if self._ssh_fs and version_gte(self.get_ami_version(), '4.3.0'):
+            self._ssh_fs.use_sudo_over_ssh()
 
     def _job_steps(self, max_steps=None):
         """Get the steps we submitted for this job in chronological order,

--- a/mrjob/fs/ssh.py
+++ b/mrjob/fs/ssh.py
@@ -158,3 +158,8 @@ class SSHFilesystem(Filesystem):
                 self._ssh_bin, host, self._ec2_key_pair_file)
 
         return self._host_to_slave_hosts[host]
+
+    def use_sudo_over_ssh(self, sudo=True):
+        """Use this to turn on *sudo* (we do this depending on the AMI
+        version on EMR)."""
+        self._sudo = sudo

--- a/mrjob/fs/ssh.py
+++ b/mrjob/fs/ssh.py
@@ -38,7 +38,7 @@ class SSHFilesystem(Filesystem):
     :py:class:`~mrjob.fs.local.LocalFilesystem`.
     """
 
-    def __init__(self, ssh_bin, ec2_key_pair_file, sudo=False):
+    def __init__(self, ssh_bin, ec2_key_pair_file):
         """
         :param ssh_bin: path to ``ssh`` binary
         :param ec2_key_pair_file: path to an SSH keyfile
@@ -56,8 +56,8 @@ class SSHFilesystem(Filesystem):
         # keep track of the slave hosts accessible through each host
         self._host_to_slave_hosts = {}
 
-        # should we use sudo? (for EMR)
-        self._sudo = sudo
+        # should we use sudo (for EMR)? Enable with use_sudo_over_ssh()
+        self._sudo = False
 
     def can_handle_path(self, path):
         return _SSH_URI_RE.match(path) is not None

--- a/mrjob/fs/ssh.py
+++ b/mrjob/fs/ssh.py
@@ -38,7 +38,7 @@ class SSHFilesystem(Filesystem):
     :py:class:`~mrjob.fs.local.LocalFilesystem`.
     """
 
-    def __init__(self, ssh_bin, ec2_key_pair_file):
+    def __init__(self, ssh_bin, ec2_key_pair_file, sudo=False):
         """
         :param ssh_bin: path to ``ssh`` binary
         :param ec2_key_pair_file: path to an SSH keyfile
@@ -55,6 +55,9 @@ class SSHFilesystem(Filesystem):
 
         # keep track of the slave hosts accessible through each host
         self._host_to_slave_hosts = {}
+
+        # should we use sudo? (for EMR)
+        self._sudo = sudo
 
     def can_handle_path(self, path):
         return _SSH_URI_RE.match(path) is not None
@@ -105,6 +108,7 @@ class SSHFilesystem(Filesystem):
             self._ec2_key_pair_file,
             m.group('filesystem_path'),
             keyfile,
+            sudo=self._sudo,
         )
 
         for line in output:
@@ -127,6 +131,7 @@ class SSHFilesystem(Filesystem):
             self._ec2_key_pair_file,
             ssh_match.group('filesystem_path'),
             keyfile,
+            sudo=self._sudo,
         )
         return read_file(filename, fileobj=BytesIO(output))
 

--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -248,3 +248,17 @@ class SSHFSTestCase(MockSubprocessTestCase):
     def test_md5sum(self):
         # not implemented
         self.assertRaises(IOError, self.fs.md5sum, 'ssh://testmaster/d')
+
+    def test_ssh_slave_hosts(self):
+        self.add_slave()
+        self.add_slave()
+
+        self.assertEquals(self.fs.ssh_slave_hosts('testmaster'),
+                          ['testslave1', 'testslave2'])
+
+    def test_ssh_no_slave_hosts(self):
+        self.assertEquals(self.fs.ssh_slave_hosts('testmaster'), [])
+
+    def test_ssh_slave_hosts_doesnt_care_about_sudo(self):
+        self.require_sudo()
+        self.test_ssh_slave_hosts()

--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -54,6 +54,9 @@ class SSHFSTestCase(MockSubprocessTestCase):
         self.env['MOCK_SSH_ROOTS'] += (':testmaster!testslave%d=%s'
                                        % (slave_num, new_dir))
 
+    def require_sudo(self):
+        self.env['MOCK_SSH_REQUIRES_SUDO'] = '1'
+
     def make_master_file(self, path, contents):
         return self.makefile(os.path.join(self.master_ssh_root, path),
                              contents)
@@ -82,6 +85,51 @@ class SSHFSTestCase(MockSubprocessTestCase):
         self.assertEqual(sorted(self.fs.ls('ssh://testmaster/')),
                          ['ssh://testmaster/d/f2', 'ssh://testmaster/f'])
 
+    def test_ls_without_required_sudo(self):
+        self.make_master_file('f', 'contents')
+        self.require_sudo()
+
+        self.assertRaises(IOError, list, self.fs.ls('ssh://testmaster/'))
+
+    def test_ls_with_required_sudo(self):
+        self.make_master_file('f', 'contents')
+        self.require_sudo()
+
+        self.fs.use_sudo_over_ssh()
+
+        self.assertEqual(list(self.fs.ls('ssh://testmaster/')),
+                         ['ssh://testmaster/f'])
+
+
+    def test_slave_ls(self):
+        self.add_slave()
+        self.make_slave_file(1, 'f', 'foo\nfoo\n')
+        remote_path = 'ssh://testmaster!testslave1/'
+
+        self.assertEqual(list(self.fs.ls(remote_path)),
+                         ['ssh://testmaster!testslave1/f'])
+
+    def test_slave_ls_without_required_sudo(self):
+        self.add_slave()
+        self.make_slave_file(1, 'f', 'foo\nfoo\n')
+        remote_path = 'ssh://testmaster!testslave1/'
+
+        self.require_sudo()
+
+        self.assertRaises(IOError, list, self.fs.ls(remote_path))
+
+    def test_slave_ls_with_required_sudo(self):
+        self.add_slave()
+        self.make_slave_file(1, 'f', 'foo\nfoo\n')
+        remote_path = 'ssh://testmaster!testslave1/'
+
+        self.require_sudo()
+
+        self.fs.use_sudo_over_ssh()
+
+        self.assertEqual(list(self.fs.ls(remote_path)),
+                         ['ssh://testmaster!testslave1/f'])
+
     def test_cat_uncompressed(self):
         self.make_master_file(os.path.join('data', 'foo'), 'foo\nfoo\n')
         remote_path = self.fs.join('ssh://testmaster/data', 'foo')
@@ -105,6 +153,25 @@ class SSHFSTestCase(MockSubprocessTestCase):
         self.assertEqual(list(self.fs._cat_file(remote_path)),
                          [b'foo\n'] * 10000)
 
+    def test_cat_without_required_sudo(self):
+        self.make_master_file(os.path.join('data', 'foo'), 'foo\nfoo\n')
+        remote_path = self.fs.join('ssh://testmaster/data', 'foo')
+
+        self.require_sudo()
+
+        self.assertRaises(IOError, self.fs._cat_file, remote_path)
+
+    def test_cat_with_required_sudo(self):
+        self.make_master_file(os.path.join('data', 'foo'), 'foo\nfoo\n')
+        remote_path = self.fs.join('ssh://testmaster/data', 'foo')
+
+        self.require_sudo()
+
+        self.fs.use_sudo_over_ssh()
+
+        self.assertEqual(list(self.fs._cat_file(remote_path)),
+                         [b'foo\n', b'foo\n'])
+
     def test_slave_cat(self):
         self.add_slave()
         self.make_slave_file(1, 'f', 'foo\nfoo\n')
@@ -113,13 +180,24 @@ class SSHFSTestCase(MockSubprocessTestCase):
         self.assertEqual(list(self.fs._cat_file(remote_path)),
                          [b'foo\n', b'foo\n'])
 
-    def test_slave_ls(self):
+    def test_slave_cat_without_required_sudo(self):
         self.add_slave()
         self.make_slave_file(1, 'f', 'foo\nfoo\n')
-        remote_path = 'ssh://testmaster!testslave1/'
+        remote_path = 'ssh://testmaster!testslave1/f'
+        self.require_sudo()
 
-        self.assertEqual(list(self.fs.ls(remote_path)),
-                         ['ssh://testmaster!testslave1/f'])
+        self.assertRaises(IOError, self.fs._cat_file, remote_path)
+
+    def test_slave_cat_with_required_sudo(self):
+        self.add_slave()
+        self.make_slave_file(1, 'f', 'foo\nfoo\n')
+        remote_path = 'ssh://testmaster!testslave1/f'
+        self.require_sudo()
+
+        self.fs.use_sudo_over_ssh()
+
+        self.assertEqual(list(self.fs._cat_file(remote_path)),
+                         [b'foo\n', b'foo\n'])
 
     def test_du(self):
         self.make_master_file('f', 'contents')
@@ -137,6 +215,25 @@ class SSHFSTestCase(MockSubprocessTestCase):
     def test_exists_yes(self):
         self.make_master_file('f', 'contents')
         path = 'ssh://testmaster/f'
+        self.assertEqual(self.fs.exists(path), True)
+
+    def test_exists_without_required_sudo(self):
+        # apparently we just swallow IOErrors over SSH? See #1388
+        self.make_master_file('f', 'contents')
+        path = 'ssh://testmaster/f'
+
+        self.require_sudo()
+
+        self.assertEqual(self.fs.exists(path), False)
+
+    def test_exists_with_required_sudo(self):
+        self.make_master_file('f', 'contents')
+        path = 'ssh://testmaster/f'
+
+        self.require_sudo()
+
+        self.fs.use_sudo_over_ssh()
+
         self.assertEqual(self.fs.exists(path), True)
 
     def test_rm(self):

--- a/tests/mockssh.py
+++ b/tests/mockssh.py
@@ -180,6 +180,14 @@ def main(stdin, stdout, stderr, args, environ):
         """
         remote_arg_pos = 0
 
+        # handle sudo
+        if remote_args[0] == 'sudo':
+            remote_args = remote_args[1:]
+        elif environ.get('MOCK_SSH_REQUIRES_SUDO'):
+            if remote_args[0] in ('find', 'cat'):
+                print('sudo required')
+                return 1
+
         # Get slave addresses (this is 'bash -c "hadoop dfsadmn ...')
         if remote_args[0].startswith('bash -c "hadoop'):
             return slave_addresses()

--- a/tests/mockssh.py
+++ b/tests/mockssh.py
@@ -20,6 +20,9 @@ MOCK_SSH_ROOTS -- specify directories for hosts in the form:
 MOCK_SSH_VERIFY_KEY_FILE -- set to 'true' if the script should print an error
                             when the key file does not exist
 
+You can optionally set MOCK_SSH_REQUIRES_SUDO to 1 (or any nonempty value)
+to raise an error unless ls and cat are preceded by sudo.
+
 This is designed to run as: python -m tests.mockssh <ssh args>
 
 mrjob requires a single binary (no args) to stand in for ssh, so
@@ -185,7 +188,7 @@ def main(stdin, stdout, stderr, args, environ):
             remote_args = remote_args[1:]
         elif environ.get('MOCK_SSH_REQUIRES_SUDO'):
             if remote_args[0] in ('find', 'cat'):
-                print('sudo required')
+                print('sudo required', file=stderr)
                 return 1
 
         # Get slave addresses (this is 'bash -c "hadoop dfsadmn ...')
@@ -231,7 +234,7 @@ def main(stdin, stdout, stderr, args, environ):
 
             # build bang path
             return run(slave_host, remote_args[remote_arg_pos + 1:],
-                       stdin, stdout, stderr, slave_key_file)
+                       stdout, stderr, environ, slave_key_file)
 
         print(("Command line not recognized: %s" %
                ' '.join(remote_args)), file=stderr)

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -13,8 +13,4 @@
 # limitations under the License.
 """Tests for mrjob.ssh"""
 
-# *chirp*
-
-# *chirp*
-
-# *chirp*
+# this is mostly tested indirectly through fs/test_ssh.py.


### PR DESCRIPTION
This uses `sudo cat` and `sudo ls` over SSH on AMI 4.3.0+, to get around permissions issues for the container logs (fixes #1244).