### PR TITLE
very basic throttling for audit-emr-usage

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -196,9 +196,18 @@ def _repeat(api_call, *args, **kwargs):
 
     Yields one or more responses.
     """
+    # the _delay kwarg sleeps that many seconds before each API call
+    # (including the first). This was added for audit-emr-usage; should
+    # re-visit if we need to use more generally. See #1091
+
     marker = None
 
+    _delay = kwargs.pop('_delay', None)
+
     while True:
+        if _delay:
+            time.sleep(_delay)
+
         resp = api_call(*args, marker=marker, **kwargs)
         yield resp
 


### PR DESCRIPTION
This adds a one-second delay before each API call made by `mrjob audit-emr-usage`, which seems to be enough in practice. (Fixes #1091)

Implemented this as a keyword arg to `mrjob.emr._repeat()` that simply calls `sleep()` before each API call. Fancier sorts of wrappers are possible, but I want to know this is more generally useful first. Also may have to re-implement this once we use boto3 (see #1304), so don't want to get too fancy.