### PR TITLE
pass_through_option()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+v0.5.4, 2016-08-??? -- ???
+ * jobs:
+   * pass_through_option(), for existing command-line options (#1075)
+     * MRJob.options.runner now defaults to None, not 'inline' or 'local'
+
 v0.5.3, 2016-07-15 -- libjars
  * jobs:
    * LIBJARS and libjars method (#1341)

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -657,6 +657,37 @@ command string.
     don't need to limit yourself to certain option types. However, your default
     values need to be compatible with :py:func:`copy.deepcopy`.
 
+Passing through existing options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Occasionally, it'll be useful for mappers, reducers, etc. to be able to see
+the value of other command-line options. For this, use
+:py:meth:`~mrjob.job.MRJob.pass_through_option` with the corresponding
+command-line switch.
+
+For example, you might wish to fetch supporting data for your job from
+different locations, depending on whether your job is running on EMR or
+locally::
+
+    class MRRunnerAwareJob(MRJob):
+
+        def configure_options(self):
+            super(MRRunnerAwareJob, self).configure_options()
+
+            self.pass_through_option('--runner')
+
+        def mapper_init(self):
+            if self.options.runner == 'emr':
+                self.data = ...  # load from S3
+            else:
+                self.data = ... # load from local FS
+
+.. note::
+
+   Keep in mind that ``self.options.runner`` (and the values of most options)
+   will be ``None`` unless the user explicitly set them with a command-line
+   switch.
+
 .. _writing-file-options:
 
 File options

--- a/docs/job.rst
+++ b/docs/job.rst
@@ -79,10 +79,14 @@ configuration options.
 .. automethod:: MRJob.configure_options
 .. automethod:: MRJob.add_passthrough_option
 .. automethod:: MRJob.add_file_option
+.. automethod:: MRJob.pass_through_option
 .. automethod:: MRJob.load_options
 .. automethod:: MRJob.is_task
 
 .. autoattribute:: MRJob.OPTION_CLASS
+
+   Redefine this if you want to use a subclass of :py:class:`optparse.Option`
+   for option parsing.
 
 .. _job-configuration:
 

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -463,7 +463,8 @@ class MRJob(MRJobLauncher):
         # support inline runner when running from the MRJob itself
         from mrjob.inline import InlineMRJobRunner
 
-        if self.options.runner == 'inline':
+        # inline is the default, not local
+        if not self.options.runner or self.options.runner == 'inline':
             return InlineMRJobRunner(mrjob_cls=self.__class__,
                                      **self.inline_job_runner_kwargs())
 

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -794,6 +794,20 @@ class MRJob(MRJobLauncher):
     ### Command-line arguments ###
 
     def configure_options(self):
+        """Define arguments for this script. Called from :py:meth:`__init__()`.
+
+        Re-define to define custom command-line arguments or pass
+        through existing ones::
+
+            def configure_options(self):
+                super(MRYourJob, self).configure_options()
+
+                self.add_passthrough_option(...)
+                self.add_file_option(...)
+                self.pass_through_option(...)
+                ...
+        """
+
         super(MRJob, self).configure_options()
 
         # To run mappers or reducers

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -79,10 +79,6 @@ class MRJob(MRJobLauncher):
     """The base class for all MapReduce jobs. See :py:meth:`__init__`
     for details."""
 
-    # inline can be the default because we have the class object in the same
-    # process as the launcher
-    _DEFAULT_RUNNER = 'inline'
-
     def __init__(self, args=None):
         """Entry point for running your job from other Python code.
 

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -68,8 +68,6 @@ class MRJobLauncher(object):
     #: :py:class:`optparse.OptionParser` instance.
     OPTION_CLASS = Option
 
-    _DEFAULT_RUNNER = 'local'
-
     def __init__(self, script_path=None, args=None, from_cl=False):
         """
         :param script_path: Path to script unless it's the first item of *args*
@@ -294,7 +292,7 @@ class MRJobLauncher(object):
             self.option_parser, 'Running the entire job')
         self.option_parser.add_option_group(self.runner_opt_group)
 
-        _add_runner_opts(self.runner_opt_group, self._DEFAULT_RUNNER)
+        _add_runner_opts(self.runner_opt_group)
         _add_basic_opts(self.runner_opt_group)
 
         # options for inline/local runners

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -383,6 +383,9 @@ class MRJobLauncher(object):
 
         If you want to pass files through to the mapper/reducer, use
         :py:meth:`add_file_option` instead.
+
+        If you want to pass through a built-in option (e.g. ``--runner``, use
+        :py:meth:`pass_through_option` instead.
         """
         if 'opt_group' in kwargs:
             pass_opt = kwargs.pop('opt_group').add_option(*args, **kwargs)
@@ -390,6 +393,13 @@ class MRJobLauncher(object):
             pass_opt = self.option_parser.add_option(*args, **kwargs)
 
         self._passthrough_options.append(pass_opt)
+
+    def pass_through_option(self, opt_str):
+        """Pass through a built-in option to tasks. For example:
+        ``job.pass_through_option('--runner')``.
+        """
+        self._passthrough_options.append(
+            self.option_parser.get_option(opt_str))
 
     def add_file_option(self, *args, **kwargs):
         """Add a command-line option that sends an external file

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -242,15 +242,15 @@ class MRJobLauncher(object):
     def configure_options(self):
         """Define arguments for this script. Called from :py:meth:`__init__()`.
 
-        Run ``python -m mrjob.job.MRJob --help`` to see all options.
-
-        Re-define to define custom command-line arguments::
+        Re-define to define custom command-line arguments or pass
+        through existing ones::
 
             def configure_options(self):
                 super(MRYourJob, self).configure_options
 
                 self.add_passthrough_option(...)
                 self.add_file_option(...)
+                self.pass_through_option(...)
                 ...
         """
         self.option_parser.add_option(
@@ -395,9 +395,22 @@ class MRJobLauncher(object):
         self._passthrough_options.append(pass_opt)
 
     def pass_through_option(self, opt_str):
-        """Pass through a built-in option to tasks. For example:
-        ``job.pass_through_option('--runner')``.
-        """
+        """Pass through a built-in option to tasks. For example, for
+        tasks to see which runner launched them::
+
+            def configure_options(self):
+                super(MRYourJob, self).configure_options()
+                self.pass_through_option('--runner')
+
+            def mapper_init(self):
+                if self.options.runner == 'emr':
+                    ...
+
+         *opt_str* can be a long option switch like ``--runner`` or a short
+         one like ``-r``.
+
+         .. versionadded:: 0.5.4
+         """
         self._passthrough_options.append(
             self.option_parser.get_option(opt_str))
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -79,7 +79,7 @@ def _add_basic_opts(opt_group):
     ]
 
 
-def _add_runner_opts(opt_group, default_runner='local'):
+def _add_runner_opts(opt_group):
     """Options for all runners."""
     return [
         opt_group.add_option(
@@ -176,12 +176,10 @@ def _add_runner_opts(opt_group, default_runner='local'):
                   ' include arguments, e.g. --python-bin "python -v"')),
 
         opt_group.add_option(
-            '-r', '--runner', dest='runner', default=default_runner,
+            '-r', '--runner', dest='runner', default=None,
             choices=('local', 'hadoop', 'emr', 'inline', 'dataproc'),
-            help=('Where to run the job: local to run locally, hadoop to run'
-                  ' on your Hadoop cluster, emr to run on Amazon'
-                  ' ElasticMapReduce, and inline for local debugging. Default'
-                  ' is %s.' % default_runner)),
+            help=('Where to run the job; one of dataproc, emr, hadoop, inline,'
+                  ' or local')),
 
         opt_group.add_option(
             '--setup', dest='setup', action='append',

--- a/tests/mr_no_runner.py
+++ b/tests/mr_no_runner.py
@@ -1,0 +1,28 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mrjob.job import MRJob
+
+
+class MRNoRunner(MRJob):
+    """Print out ``self.options.runner`` (which should be ``None``) in tasks.
+    """
+    def mapper(self, key, value):
+        return
+
+    def mapper_final(self):
+        yield None, self.options.runner
+
+
+if __name__ == '__main__':
+    MRNoRunner.run()

--- a/tests/mr_runner.py
+++ b/tests/mr_runner.py
@@ -1,0 +1,33 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mrjob.job import MRJob
+
+
+class MRRunner(MRJob):
+    """Print out ``self.option.runner`` in tasks."""
+
+    def configure_options(self):
+        super(MRRunner, self).configure_options()
+
+        self.pass_through_option('--runner')
+
+    def mapper(self, key, value):
+        return
+
+    def mapper_final(self):
+        yield None, self.options.runner
+
+
+if __name__ == '__main__':
+    MRRunner.run()

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -65,6 +65,8 @@ class MRCustomJobLauncher(MRJobLauncher):
             '--extra-special-arg', '-S', action='append',
             dest='extra_special_args', default=[])
 
+        self.pass_through_option('--runner')
+
         self.add_file_option('--foo-config', dest='foo_config', default=None)
         self.add_file_option('--accordian-file', dest='accordian_files',
                              action='append', default=[])
@@ -171,6 +173,7 @@ class CommandLineArgsTestCase(TestCase):
         self.assertEqual(mr_job.options.pill_type, 'blue')
         self.assertEqual(mr_job.options.planck_constant, 6.626068e-34)
         self.assertEqual(mr_job.options.extra_special_args, [])
+        self.assertEqual(mr_job.options.runner, None)
         # should include all --protocol options
         # should include default value of --num-items
         # should use long option names (--protocol, not -p)
@@ -190,6 +193,7 @@ class CommandLineArgsTestCase(TestCase):
             '--planck-constant', '42',
             '--extra-special-arg', 'you',
             '--extra-special-arg', 'me',
+            '--runner', 'inline',
         ])
 
         self.assertEqual(mr_job.options.foo_size, 9)
@@ -211,6 +215,7 @@ class CommandLineArgsTestCase(TestCase):
                 '--planck-constant', '1',
                 '--planck-constant', '42',
                 '--disable-quuxing',
+                '--runner', 'inline',
             ]
         )
 
@@ -221,6 +226,7 @@ class CommandLineArgsTestCase(TestCase):
             '-F9', '-BAlembic', '-MQ', '-T', 'red', '-C1', '-C42',
             '--extra-special-arg', 'you',
             '--extra-special-arg', 'me',
+            '-r', 'inline',
         ])
 
         self.assertEqual(mr_job.options.foo_size, 9)
@@ -242,6 +248,7 @@ class CommandLineArgsTestCase(TestCase):
                 '-C', '1',
                 '-C', '42',
                 '-Q',
+                '-r', 'inline',
             ]
         )
 


### PR DESCRIPTION
Allow passing through existing options, such as `--runner`. Includes documentation.

Also spruced up existing documentation for option-setting methods (for example, the entry for`configure_options()` was empty).