### PR TITLE
Fix job crash during cleanup on local hadoop cluster

### DIFF
--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -267,7 +267,7 @@ class HadoopFilesystem(Filesystem):
         def cleanup():
             # there shouldn't be any stderr
             for line in cat_proc.stderr:
-                log.error('STDERR: ' + line)
+                log.error('STDERR: ' + line.decode('utf-8'))
 
             cat_proc.stdout.close()
             cat_proc.stderr.close()


### PR DESCRIPTION
When running a word count on local Hadoop cluster, program crashed during cleanup step causing this stack trace:
```
Traceback (most recent call last):
  File "word_count.py", line 23, in <module>
    MRWordFreqCount.run()
  File "/Users/etiennebatise/.virtualenvs/ENV-MRJ/lib/python3.5/site-packages/mrjob/job.py", line 430, in run
    mr_job.execute()
  File "/Users/etiennebatise/.virtualenvs/ENV-MRJ/lib/python3.5/site-packages/mrjob/job.py", line 448, in execute
    super(MRJob, self).execute()
  File "/Users/etiennebatise/.virtualenvs/ENV-MRJ/lib/python3.5/site-packages/mrjob/launch.py", line 160, in execute
    self.run_job()
  File "/Users/etiennebatise/.virtualenvs/ENV-MRJ/lib/python3.5/site-packages/mrjob/launch.py", line 238, in run_job
    for line in runner.stream_output():
  File "/Users/etiennebatise/.virtualenvs/ENV-MRJ/lib/python3.5/site-packages/mrjob/runner.py", line 507, in stream_output
    for line in self.fs._cat_file(filename):
  File "/Users/etiennebatise/.virtualenvs/ENV-MRJ/lib/python3.5/site-packages/mrjob/fs/composite.py", line 72, in _cat_file
    for line in self._do_action('_cat_file', path):
  File "/Users/etiennebatise/.virtualenvs/ENV-MRJ/lib/python3.5/site-packages/mrjob/util.py", line 416, in read_file
    cleanup()
  File "/Users/etiennebatise/.virtualenvs/ENV-MRJ/lib/python3.5/site-packages/mrjob/fs/hadoop.py", line 270, in cleanup
    log.error('STDERR: ' + line)
TypeError: Can't convert 'bytes' object to str implicitly
```

Looking rapidly into the test case for this function, I realized this statement was never called, and coverage confirmed it: 
<img width="383" alt="screen shot 2016-08-10 at 16 41 23" src="https://cloud.githubusercontent.com/assets/5644956/17557979/769689f4-5f19-11e6-9a57-53d9fc793b34.png">

I haven't figured out what causes the error in my case.

OSX El Capitan, Python3.5, Hadoop 2.7.2