### PR TITLE
recover from pooled cluster self-termination

### DIFF
--- a/mrjob/bootstrap/terminate_idle_cluster.sh
+++ b/mrjob/bootstrap/terminate_idle_cluster.sh
@@ -51,6 +51,8 @@ if [ -z "$MAX_SECS_IDLE" ]; then MAX_SECS_IDLE=1800; fi
 MIN_SECS_TO_END_OF_HOUR=$2
 if [ -z "$MIN_SECS_TO_END_OF_HOUR" ]; then MIN_SECS_TO_END_OF_HOUR=300; fi
 
+# exit if this isn't the master node
+grep -q 'isMaster.*false' /mnt/var/lib/info/instance.json && exit 0
 
 (
 while true  # the only way out is to SHUT DOWN THE MACHINE

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -926,6 +926,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
     def _run(self):
         self._launch()
+        self._finish_run()
+
+    def _finish_run(self):
         while True:
             try:
                 self._wait_for_steps_to_complete()

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -189,7 +189,8 @@ _S3_LOG_WAIT_MINUTES = 10
 class _PooledClusterSelfTerminatedException(Exception):
     pass
 
-# mildly flexible regex to detect cluster self-termination
+# mildly flexible regex to detect cluster self-termination. Termination of
+# non-master nodes won't shut down the cluster, so don't need to match that.
 _CLUSTER_SELF_TERMINATED_RE = re.compile(
     '^.*The master node was terminated.*$', re.I)
 
@@ -2012,6 +2013,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         # code.
 
         # cluster should have stopped because master node failed
+        # could also check for
+        # cluster.status.statechangereason.code == 'INSTANCE_FAILURE'
         if not _CLUSTER_SELF_TERMINATED_RE.match(_get_reason(cluster)):
             return
 

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -846,7 +846,7 @@ class MockEmrConnection(object):
             id=cluster_id,
             loguri=log_uri,
             # TODO: set this later, once cluster is running
-            masterpublicdnsname='mockmaster',
+            masterpublicdnsname='mockmaster%d' % len(self.mock_emr_clusters),
             name=name,
             normalizedinstancehours='0',
             releaselabel=release_label,

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -152,7 +152,7 @@ class MockBotoTestCase(SandboxedTestCase):
     def setUp(self):
         # patch boto
         self.mock_emr_failures = {}
-        self.mock_emr_self_termination = {}
+        self.mock_emr_self_termination = set()
         self.mock_emr_clusters = {}
         self.mock_emr_output = {}
         self.mock_iam_instance_profiles = {}
@@ -1318,6 +1318,8 @@ class MockEmrConnection(object):
             for step in cluster._steps:
                 if step.status.state in ('PENDING', 'RUNNING'):
                     step.status.state = 'CANCELLED'  # not INTERRUPTED
+
+            return
 
         # try to find the next step, and advance it
 

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -151,7 +151,7 @@ class MockBotoTestCase(SandboxedTestCase):
 
     def setUp(self):
         # patch boto
-        self.mock_emr_failures = {}
+        self.mock_emr_failures = set()
         self.mock_emr_self_termination = set()
         self.mock_emr_clusters = {}
         self.mock_emr_output = {}

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2644,26 +2644,8 @@ class PoolingRecoveryTestCase(MockBotoTestCase):
 
             self.assertRaises(StepFailedException, runner._finish_run)
 
-    def test_recover_if_our_cluster_self_terminates(self):
+    def test_dont_recover_from_created_cluster_self_terminating(self):
         job = MRTwoStepJob(['-r', 'emr'])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            runner._launch()
-
-            cluster_id = runner.get_cluster_id()
-            self.assertEqual(self.num_steps(cluster_id), 2)
-            self.mock_emr_self_termination.add(cluster_id)
-
-            runner._finish_run()
-
-            self.assertNotEqual(runner.get_cluster_id(), cluster_id)
-            self.assertEqual(self.num_steps(runner.get_cluster_id()), 2)
-
-    def test_dont_recover_when_no_pooling(self):
-        # kind of odd that our own cluster would idle-time-out, but whatever
-
-        job = MRTwoStepJob(['-r', 'emr', '--no-pool-clusters'])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2532,6 +2532,119 @@ class PoolMatchingTestCase(MockBotoTestCase):
             ['-r', 'emr', '--pool-clusters'])
 
 
+
+class PoolingRecoveryTestCase(MockBotoTestCase):
+
+    MRJOB_CONF_CONTENTS = {'runners': {'emr': {'pool_clusters': True}}}
+
+    # for multiple failover test
+    MAX_EMR_CONNECTIONS = 1000
+
+    def make_pooled_cluster(self, **kwargs):
+        cluster_id = EMRJobRunner(**kwargs).make_persistent_cluster()
+
+        mock_cluster = self.mock_emr_clusters[cluster_id]
+        mock_cluster.status.state = 'WAITING'
+
+        return cluster_id
+
+    def num_steps(self, cluster_id):
+        return len(self.mock_emr_clusters[cluster_id]._steps)
+
+    def test_join_healthy_cluster(self):
+        cluster_id = self.make_pooled_cluster()
+
+        job = MRTwoStepJob(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            self.assertEqual(self.num_steps(cluster_id), 2)
+            self.assertEqual(runner.get_cluster_id(), cluster_id)
+
+    def test_launch_new_cluster_after_self_termination(self):
+        cluster_id = self.make_pooled_cluster()
+        self.mock_emr_self_termination.add(cluster_id)
+
+        job = MRTwoStepJob(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            # tried to add steps to pooled cluster, had to try again
+            self.assertEqual(self.num_steps(cluster_id), 2)
+
+            self.assertNotEqual(runner.get_cluster_id(), cluster_id)
+            self.assertEqual(self.num_steps(runner.get_cluster_id()), 2)
+
+    def test_join_pooled_cluster_after_self_termination(self):
+        # cluster 1 should be preferable
+        cluster1_id = self.make_pooled_cluster(num_ec2_instances=20)
+        self.mock_emr_self_termination.add(cluster1_id)
+        cluster2_id = self.make_pooled_cluster()
+
+        job = MRTwoStepJob(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            self.assertEqual(self.num_steps(cluster1_id), 2)
+
+            self.assertEqual(runner.get_cluster_id(), cluster2_id)
+            self.assertEqual(self.num_steps(cluster2_id), 2)
+
+    def test_multiple_failover(self):
+        cluster_ids = []
+        for _ in range(10):
+            cluster_id = self.make_pooled_cluster()
+            self.mock_emr_self_termination.add(cluster_id)
+
+        job = MRTwoStepJob(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            for cluster_id in cluster_ids:
+                self.assertEqual(self.num_steps(cluster_id), 2)
+
+            self.assertNotIn(runner.get_cluster_id(), cluster_ids)
+            self.assertEqual(self.num_steps(runner.get_cluster_id()), 2)
+
+    def test_dont_recover_with_explicit_cluster_id(self):
+        cluster_id = self.make_pooled_cluster()
+        self.mock_emr_self_termination.add(cluster_id)
+
+        job = MRTwoStepJob(['-r', 'emr', '--cluster-id', cluster_id])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertRaises(StepFailedException, runner.run)
+
+            self.assertEqual(self.num_steps(cluster_id), 2)
+
+    def test_dont_recover_from_user_termination(self):
+        cluster_id = self.make_pooled_cluster()
+
+        job = MRTwoStepJob(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            # don't have a mockboto hook for termination of cluster
+            # during run(), so running the two halves of run() separately
+            runner._launch()
+
+            self.assertEqual(runner.get_cluster_id(), cluster_id)
+            self.assertEqual(self.num_steps(cluster_id), 2)
+
+            self.connect_emr().terminate_jobflow(cluster_id)
+
+            self.assertRaises(StepFailedException, runner._finish_run)
+
+
 class PoolingDisablingTestCase(MockBotoTestCase):
 
     MRJOB_CONF_CONTENTS = {'runners': {'emr': {

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2657,6 +2657,25 @@ class PoolingRecoveryTestCase(MockBotoTestCase):
 
             self.assertRaises(StepFailedException, runner._finish_run)
 
+    def test_cluster_info_cache_gets_cleared(self):
+        cluster_id = self.make_pooled_cluster()
+
+        self.mock_emr_self_termination.add(cluster_id)
+
+        job = MRTwoStepJob(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._launch()
+
+            self.assertEqual(runner.get_cluster_id(), cluster_id)
+            addr = runner._address_of_master()
+
+            runner._finish_run()
+
+            self.assertNotEqual(runner.get_cluster_id(), cluster_id)
+            self.assertNotEqual(runner._address_of_master(), addr)
+
 
 class PoolingDisablingTestCase(MockBotoTestCase):
 


### PR DESCRIPTION
This change makes pooling and cluster idle self-termination play well together by having pooled jobs relaunch if they chose a cluster that was in the process of shutting itself down (fixes #708). (There's a window of a minute or two where this can happen because the EMR API is rather slow to notice.)

Also updated the idle termination script to *only* run on the master node, since if you only have one task node, and it terminates itself, EMR interprets that as a step failure, not a cluster failure.