### PR TITLE
tunnel to correct host for resource tracker

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -769,9 +769,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         # - ami_version
         # - hadoop_version
         # - master_public_dns
-        # - master_public_ip
         # - master_private_ip
-        self._cluster_cache = defaultdict(defaultdict)
+        self._cluster_to_cache = defaultdict(dict)
 
         # List of dicts (one for each step) potentially containing
         # the keys 'history', 'step', and 'task'. These will also always
@@ -3076,15 +3075,15 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     def _get_cluster_info(self, key):
         if not self._cluster_id:
             raise AssertionError('cluster has not yet been created')
-        cache = self._cluster_cache[self._cluster_id]
+        cache = self._cluster_to_cache[self._cluster_id]
 
-        if not cache[key]:
+        if not cache.get(key):
             if key == 'master_private_ip':
                 self._store_master_instance_info()
             else:
                 self._store_cluster_info()
 
-        return cache[key]
+        return cache.get(key)
 
     def _store_cluster_info(self):
         """Describe our cluster, and cache ami_version, hadoop_version,
@@ -3092,7 +3091,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         if not self._cluster_id:
             raise AssertionError('cluster has not yet been created')
 
-        cache = self._cluster_cache[self._cluster_id]
+        cache = self._cluster_to_cache[self._cluster_id]
 
         cluster = self._describe_cluster()
 
@@ -3117,7 +3116,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         if not self._cluster_id:
             raise AssertionError('cluster has not yet been created')
 
-        cache = self._cluster_cache[self._cluster_id]
+        cache = self._cluster_to_cache[self._cluster_id]
 
         emr_conn = self.make_emr_conn()
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1136,7 +1136,6 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         return map_version(self.get_ami_version(),
                            _AMI_VERSION_TO_SSH_TUNNEL_CONFIG)
 
-    # TODO: this currently has no automated tests (see #1281)
     def _set_up_ssh_tunnel(self):
         """set up the ssh tunnel to the job tracker, if it's not currently
         running.
@@ -3121,7 +3120,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         emr_conn = self.make_emr_conn()
 
         instances = emr_conn.list_instances(
-            self._cluster_id, instance_group_types='MASTER').instances
+            self._cluster_id, instance_group_types=['MASTER']).instances
 
         if not instances:
             return

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -887,4 +887,5 @@ def _fix_custom_options(options, option_parser):
         except ValueError as e:
             option_parser.error('invalid port range list %r: \n%s' %
                                 (options.ssh_bind_ports, e.args[0]))
-            options.ssh_bind_ports = ports
+
+        options.ssh_bind_ports = ports

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -236,6 +236,7 @@ class MockBotoTestCase(SandboxedTestCase):
 
         # use fake hostname
         runner._address_of_master = MagicMock(return_value='testmaster')
+        runner._master_private_ip = MagicMock(return_value='172.172.172.172')
 
         # re-initialize fs
         runner._fs = None

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -231,8 +231,6 @@ class MockBotoTestCase(SandboxedTestCase):
 
         # Tell the runner to use the fake binary
         runner._opts['ssh_bin'] = [self.ssh_bin]
-        # Inject master node hostname so it doesn't try to 'emr --describe' it
-        runner._address = 'testmaster'
         # Also pretend to have an SSH key pair file
         runner._opts['ec2_key_pair_file'] = self.keyfile_path
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2880,11 +2880,11 @@ class TestCatFallback(MockBotoTestCase):
         mock_ssh_file('testmaster', 'etc/init.d', b'meow')
 
         ssh_cat_gen = runner.fs.cat(
-            'ssh://' + runner._address + '/etc/init.d')
+            'ssh://testmaster/etc/init.d')
         self.assertEqual(list(ssh_cat_gen)[0].rstrip(), b'meow')
         self.assertRaises(
             IOError, list,
-            runner.fs.cat('ssh://' + runner._address + '/does_not_exist'))
+            runner.fs.cat('ssh://testmaster/does_not_exist'))
 
     def test_ssh_cat_errlog(self):
         # A file *containing* an error message shouldn't cause an error.
@@ -2894,7 +2894,7 @@ class TestCatFallback(MockBotoTestCase):
         error_message = b'cat: logs/err.log: No such file or directory\n'
         mock_ssh_file('testmaster', 'logs/err.log', error_message)
         self.assertEqual(
-            list(runner.fs.cat('ssh://' + runner._address + '/logs/err.log')),
+            list(runner.fs.cat('ssh://testmaster/logs/err.log')),
             [error_message])
 
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -65,6 +65,7 @@ from tests.mr_no_mapper import MRNoMapper
 from tests.mr_sort_values import MRSortValues
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
+from tests.py2 import MagicMock
 from tests.py2 import Mock
 from tests.py2 import TestCase
 from tests.py2 import call
@@ -5113,3 +5114,144 @@ class UseSudoOverSshTestCase(MockBotoTestCase):
             runner._launch()
 
             self.assertIsNone(runner._ssh_fs)
+
+
+class MasterPrivateIPTestCase(MockBotoTestCase):
+
+    # logic for runner._master_private_ip()
+
+    def test_master_private_ip(self):
+        job = MRTwoStepJob(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            # no cluster yet
+            self.assertRaises(AssertionError, runner._master_private_ip)
+
+            runner._launch()
+
+            self.assertIsNone(runner._master_private_ip())
+
+            self.connect_emr().simulate_progress(runner.get_cluster_id())
+            self.assertIsNotNone(runner._master_private_ip())
+
+
+class SetUpSSHTunnelTestCase(MockBotoTestCase):
+
+    def setUp(self, *args):
+        super(SetUpSSHTunnelTestCase, self).setUp()
+
+        self.mock_Popen = self.start(patch('mrjob.emr.Popen'))
+        # simulate successfully binding port
+        self.mock_Popen.return_value.returncode = None
+        self.mock_Popen.return_value.pid = 99999
+
+        self.start(patch('os.kill'))  # don't clean up fake SSH proc
+
+    def get_ssh_args(self, *args):
+        job_args = [
+            '-r', 'emr',
+            '--ssh-tunnel',
+            '--ec2-key-pair', 'EMR',
+            '--ec2-key-pair-file', '/path/to/EMR.pem'] + list(args)
+
+        job = MRTwoStepJob(job_args)
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._launch()
+
+            cluster_id = runner.get_cluster_id()
+
+            cluster = self.mock_emr_clusters[cluster_id]
+            while cluster.status.state in ('STARTING', 'BOOTSTRAPPING'):
+                self.connect_emr().simulate_progress(cluster_id)
+
+            runner._set_up_ssh_tunnel()
+
+            ssh_args = self.mock_Popen.call_args[0][0]
+
+            return ssh_args
+
+    def parse_ssh_args(self, ssh_args):
+        local_port, remote_host, remote_port = (
+            ssh_args[ssh_args.index('-L') + 1].split(':'))
+
+        local_port = int(local_port)
+        remote_port = int(remote_port)
+
+        user, host = ssh_args[-1].split('@')
+
+        return dict(
+            host=host,
+            local_port=local_port,
+            remote_host=remote_host,
+            remote_port=remote_port,
+            user=user)
+
+    def test_basic(self):
+        # test things that don't depend on AMI
+        ssh_args = self.get_ssh_args()
+        params = self.parse_ssh_args(ssh_args)
+
+        self.assertEqual(params['user'], 'hadoop')
+        self.assertNotEqual(params['host'], params['remote_host'])
+
+        self.assertEqual(self.mock_Popen.call_count, 1)
+
+        self.assertNotIn('-g', ssh_args)
+        self.assertNotIn('-4', ssh_args)
+
+    def test_2_x_ami(self):
+        ssh_args = self.get_ssh_args('--ami-version', '2.4.11')
+        params = self.parse_ssh_args(ssh_args)
+
+        self.assertEqual(params['remote_port'], 9100)
+        self.assertEqual(params['remote_host'], 'localhost')
+
+    def test_3_x_ami(self):
+        ssh_args = self.get_ssh_args('--ami-version', '3.11.0')
+        params = self.parse_ssh_args(ssh_args)
+
+        self.assertEqual(params['remote_port'], 9026)
+        self.assertEqual(len(params['remote_host'].split('.')), 4)
+
+    def test_4_x_ami(self):
+        ssh_args = self.get_ssh_args('--ami-version', '4.7.2')
+        params = self.parse_ssh_args(ssh_args)
+
+        self.assertEqual(params['remote_port'], 8088)
+        self.assertEqual(len(params['remote_host'].split('.')), 4)
+
+    def test_ssh_tunnel_is_open(self):
+        # this is the same on all AMIs
+        ssh_args = self.get_ssh_args('--ssh-tunnel-is-open')
+
+        self.assertIn('-g', ssh_args)
+        self.assertIn('-4', ssh_args)
+
+    def test_ssh_bind_ports(self):
+        ssh_args = self.get_ssh_args('--ssh-bind-ports', '12345')
+        params = self.parse_ssh_args(ssh_args)
+
+        self.assertEqual(params['local_port'], 12345)
+
+    def test_retry_ports(self):
+        returncodes = [None, 255, 255]  # in reverse order
+
+        def popen_side_effect(*args, **kwargs):
+            return_value = Mock()
+            return_value.pid = 99999
+            return_value.returncode = returncodes.pop()
+            return return_value
+
+        self.mock_Popen.side_effect = popen_side_effect
+
+        self.start(patch('mrjob.emr.EMRJobRunner._pick_ssh_bind_ports',
+                   return_value=[10001, 10002, 10003, 10004]))
+
+        ssh_args = self.get_ssh_args()
+        params = self.parse_ssh_args(ssh_args)
+
+        self.assertEqual(self.mock_Popen.call_count, 3)
+        self.assertEqual(params['local_port'], 10003)

--- a/tests/tools/emr/test_mrboss.py
+++ b/tests/tools/emr/test_mrboss.py
@@ -22,7 +22,6 @@ from mrjob.emr import EMRJobRunner
 from mrjob.tools.emr.mrboss import _run_on_all_nodes
 from tests.mockssh import mock_ssh_file
 from tests.mockboto import MockBotoTestCase
-from tests.py2 import MagicMock
 from tests.test_emr import BUCKET_URI
 from tests.test_emr import LOG_DIR
 
@@ -46,7 +45,6 @@ class MRBossTestCase(MockBotoTestCase):
         self.runner._s3_log_dir_uri = BUCKET_URI + LOG_DIR
         self.prepare_runner_for_ssh(self.runner)
         self.output_dir = tempfile.mkdtemp(prefix='mrboss_wd')
-        self.runner._address_of_master = MagicMock(return_value='testmaster')
 
     def cleanup_runner(self):
         """This method assumes ``prepare_runner_for_ssh()`` was called. That

--- a/tests/tools/emr/test_mrboss.py
+++ b/tests/tools/emr/test_mrboss.py
@@ -22,6 +22,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.tools.emr.mrboss import _run_on_all_nodes
 from tests.mockssh import mock_ssh_file
 from tests.mockboto import MockBotoTestCase
+from tests.py2 import MagicMock
 from tests.test_emr import BUCKET_URI
 from tests.test_emr import LOG_DIR
 
@@ -45,6 +46,7 @@ class MRBossTestCase(MockBotoTestCase):
         self.runner._s3_log_dir_uri = BUCKET_URI + LOG_DIR
         self.prepare_runner_for_ssh(self.runner)
         self.output_dir = tempfile.mkdtemp(prefix='mrboss_wd')
+        self.runner._address_of_master = MagicMock(return_value='testmaster')
 
     def cleanup_runner(self):
         """This method assumes ``prepare_runner_for_ssh()`` was called. That


### PR DESCRIPTION
On the 3.x and 4.x AMIs, the SSH tunnel now connects to the (internal) IP that the resource tracker actually listens on. While more correct, the old behavior doesn't seem to have been a problem except for certain VPC setups (see #1397, which this fixes).

Also fixed a bug that made the `--ssh-bin-ports` switch unusable since v0.4.5; apparently no one cared? (see #1402)

Refactored the way we cache information about clusters (e.g. AMI version), so that we don't have to worry about a bunch of attributes.

Finally, added good tests for the core ssh tunneling code, which was formerly completely without tests (see #1281).