### PR TITLE
deprecate hadoop_streaming_jar_on_emr

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -68,8 +68,7 @@ Options available to hadoop and emr runners
     Path to a custom hadoop streaming jar.
 
     On EMR, this can be either a local path or a URI (``s3://...``). If you
-    want to use a jar at a path on the master node, use
-    :mrjob-opt:`hadoop_streaming_jar_on_emr`.
+    want to use a jar at a path on the master node, use a ``file://`` URI.
 
     On Hadoop, mrjob tries its best to find your hadoop streaming jar,
     searching these directories (recursively) for a ``.jar`` file with

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -183,9 +183,10 @@ Cluster creation and configuration
     :set: emr
     :default: AWS default
 
-    Like :mrjob-opt:`hadoop_streaming_jar`, except that it points to a path on
-    the EMR instance, rather than to a local file or one on S3. Rarely
-    necessary to set this by hand.
+    .. deprecated:: 0.5.4
+
+       Prepend ``file://`` and pass that to :mrjob-opt:`hadoop_streaming_jar`
+       instead.
 
 .. mrjob-opt::
     :config: iam_endpoint

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -237,7 +237,9 @@ def _add_hadoop_emr_opts(opt_group):
         opt_group.add_option(
             '--hadoop-streaming-jar', dest='hadoop_streaming_jar',
             default=None,
-            help='Path of your hadoop streaming jar (locally, or on S3/HDFS)'),
+            help='Path of your hadoop streaming jar (locally, or on S3/HDFS).'
+                 ' In EMR, use a file:// URI to refer to a jar on the master'
+                 ' node of your cluster.'),
 
         opt_group.add_option(
             '--label', dest='label', default=None,
@@ -453,8 +455,9 @@ def _add_emr_run_opts(opt_group):
         opt_group.add_option(
             '--hadoop-streaming-jar-on-emr',
             dest='hadoop_streaming_jar_on_emr', default=None,
-            help=('Local path of the hadoop streaming jar on the EMR node.'
-                  ' Rarely necessary.')),
+            help=("Deprecated: prepend 'file://' and pass that to"
+                  ' --hadoop-streaming-jar instead'),
+        ),
 
         opt_group.add_option(
             '--no-ssh-tunnel', dest='ssh_tunnel',


### PR DESCRIPTION
Deprecates the `hadoop_streaming_jar_on_emr` option (fixes #1405). You can now accomplish the same thing by passing a `file://` URI as `hadoop_streaming_jar`.