### PR TITLE
ami_version alias

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -357,7 +357,6 @@ class EMRRunnerOptionStore(RunnerOptionStore):
 
     ALLOWED_KEYS = RunnerOptionStore.ALLOWED_KEYS.union(set([
         'additional_emr_info',
-        'image_version',
         'aws_access_key_id',
         'aws_secret_access_key',
         'aws_security_token',
@@ -391,6 +390,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         'iam_endpoint',
         'iam_instance_profile',
         'iam_service_role',
+        'image_version',
         'instance_type',
         'master_instance_bid_price',
         'master_instance_type',
@@ -436,6 +436,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
     })
 
     DEPRECATED_ALIASES = combine_dicts(RunnerOptionStore.DEPRECATED_ALIASES, {
+        'ami_version': 'image_version',
         'aws_availability_zone': 'zone',
         'aws_region': 'region',
         'check_emr_status_every': 'check_cluster_every',

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5256,3 +5256,20 @@ class SetUpSSHTunnelTestCase(MockBotoTestCase):
 
         self.assertEqual(self.mock_Popen.call_count, 3)
         self.assertEqual(params['local_port'], 10003)
+
+
+class DeprecatedAMIVersionKeywordOptionTestCase(MockBotoTestCase):
+    # regression test for #1421
+
+    def test_ami_version_4_0_0(self):
+        runner = EMRJobRunner(ami_version='4.0.0')
+        runner.make_persistent_cluster()
+
+        self.assertEqual(runner.get_image_version(), '4.0.0')
+
+        cluster = runner._describe_cluster()
+        self.assertEqual(cluster.releaselabel, 'emr-4.0.0')
+        self.assertFalse(hasattr(cluster, 'runningamiversion'))
+
+        self.assertEqual(runner._opts['image_version'], '4.0.0')
+        self.assertEqual(runner._opts['release_label'], 'emr-4.0.0')


### PR DESCRIPTION
This restores the `ami_version` alias as a deprecated alias for `image_version` (accidentally removed it entirely in v0.5.4).