### PR TITLE
pick cheapest instance type (inc. for Spark)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 v0.5.?, 2016-??-?? -- Spark
  * JarStep.{INPUT,OUTPUT} are deprecated (use mrjob.step.{INPUT,OUTPUT})
+ * runners:
+   * EMR:
+     * default to cheapest instance type that will work (#1369)
 
 v0.5.5, 2016-09-05 -- missing ami_version option
  * EMR runner:

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -18,6 +18,7 @@ Guides
     guides/testing.rst
     guides/dataproc.rst
     guides/emr.rst
+    guides/spark.rst
     guides/py2-vs-py3.rst
     guides/contributing.rst
     guides/runner-job-interactions.rst

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -569,13 +569,26 @@ Number and type of instances
     :switch: --instance-type
     :type: :ref:`string <data-type-string>`
     :set: emr
-    :default: ``'m1.medium'``
+    :default: (automatic)
 
-    What sort of EC2 instance(s) to use on the nodes that actually run tasks
-    (see http://aws.amazon.com/ec2/instance-types/).  When you run multiple
-    instances (see :mrjob-opt:`num_core_instances`), the master node is just
-    coordinating the other nodes, so usually the default instance type
-    (``m1.medium``) is fine, and using larger instances is wasteful.
+    By default, mrjob picks the cheapest instance type that will work at all.
+    This is usually ``m1.medium``, with two exceptions:
+
+    * ``m1.large`` if you're running Spark (see :ref:`spark-auto-detection`)
+    * ``m1.small`` if you're running on the (deprecated) 2.x AMIs
+
+    Once you've tested a job and want to run it at scale, it's usually a good
+    idea to use instances larger than the default; see
+    http://aws.amazon.com/ec2/instance-types/ for options.
+
+    If you're running multiple nodes (see :mrjob-opt:`num_core_instances`),
+    this option *doesn't* apply to the master node because it's just
+    coordinating tasks, not running them. Use :mrjob-opt:`master_instance_type`
+    instead.
+
+    .. versionchanged:: 0.5.6
+
+       Used to default to ``m1.medium`` in all cases.
 
     .. versionchanged:: 0.5.4
 
@@ -586,7 +599,7 @@ Number and type of instances
     :switch: --core-instance-type
     :type: :ref:`string <data-type-string>`
     :set: emr
-    :default: ``'m1.medium'``
+    :default: value of :mrjob-opt:`instance_type`
 
     like :mrjob-opt:`instance_type`, but only for the core Hadoop nodes; these
     nodes run tasks and host HDFS. Usually you just want to use
@@ -617,11 +630,19 @@ Number and type of instances
     :switch: --master-instance-type
     :type: :ref:`string <data-type-string>`
     :set: emr
-    :default: ``'m1.medium'``
+    :default: (automatic)
 
     like :mrjob-opt:`instance_type`, but only for the master Hadoop node.
-    This node hosts the task tracker and HDFS, and runs tasks if there are no
-    other nodes. Usually you just want to use :mrjob-opt:`instance_type`.
+    This node hosts the task tracker/resource manager and HDFS, and runs tasks
+    if there are no other nodes.
+
+    If you're running a single node (no :mrjob-opt:`num_core_instances` or
+    :mrjob-opt:`num_task_instances`), this will default to the value of
+    :mrjob-opt:`instance_type`.
+
+    Otherwise, defaults to ``m1.medium`` (exception: ``m1.small`` on the
+    deprecated 2.x AMIs), which is usually adequate for all but the largest
+    jobs.
 
     .. versionchanged:: 0.5.4
 

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -300,7 +300,7 @@ Cluster creation and configuration
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``aws_region``.
+       This option used to be named *aws_region*.
 
 .. mrjob-opt::
     :config: release_label
@@ -366,7 +366,7 @@ Cluster creation and configuration
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``emr_tags``
+       This option used to be named *emr_tags*
 
     .. versionadded:: 0.4.5
 
@@ -402,7 +402,7 @@ Cluster creation and configuration
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``aws_availability_zone``
+       This option used to be named *aws_availability_zone*
 
 Bootstrapping
 -------------
@@ -592,7 +592,7 @@ Number and type of instances
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``ec2_instance_type``.
+       This option used to be named *ec2_instance_type*.
 
 .. mrjob-opt::
     :config: core_instance_type
@@ -623,7 +623,7 @@ Number and type of instances
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``ec2_core_instance_bid_price``.
+       This option used to be named *ec2_core_instance_bid_price*.
 
 .. mrjob-opt::
     :config: master_instance_type
@@ -646,7 +646,7 @@ Number and type of instances
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``ec2_master_instance_type``.
+       This option used to be named *ec2_master_instance_type*.
 
 .. mrjob-opt::
     :config: master_instance_bid_price
@@ -661,7 +661,7 @@ Number and type of instances
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``ec2_master_instance_bid_price``.
+       This option used to be named *ec2_master_instance_bid_price*.
 
 .. mrjob-opt::
     :config: task_instance_type
@@ -676,7 +676,7 @@ Number and type of instances
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``ec2_task_instance_type``.
+       This option used to be named *ec2_task_instance_type*.
 
 .. mrjob-opt::
     :config: task_instance_bid_price
@@ -691,7 +691,7 @@ Number and type of instances
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``ec2_task_instance_bid_price``.
+       This option used to be named *ec2_task_instance_bid_price*.
 
 .. mrjob-opt::
     :config: num_core_instances
@@ -705,7 +705,7 @@ Number and type of instances
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``num_ec2_core_instances``.
+       This option used to be named *num_ec2_core_instances*.
 
 .. mrjob-opt::
     :config: num_ec2_instances
@@ -834,7 +834,7 @@ MRJob uses boto to manipulate/access S3.
 
     .. versionchanged:: 0.5.4
 
-       This option used to be named ``s3_log_uri``
+       This option used to be named *s3_log_uri*
 
 .. mrjob-opt::
     :config: cloud_tmp_dir
@@ -954,7 +954,7 @@ SSH access and tunneling
 
     .. versionchanged:: 0.5.0
 
-       This option used to be named ``ssh_tunnel_to_job_tracker``.
+       This option used to be named *ssh_tunnel_to_job_tracker*.
 
 .. mrjob-opt::
     :config: ssh_tunnel_is_open

--- a/docs/guides/spark.rst
+++ b/docs/guides/spark.rst
@@ -1,0 +1,22 @@
+Spark
+=====
+
+
+.. _spark-auto-detection:
+
+Auto-detecting Spark jobs
+-------------------------
+
+When you use Spark on EMR, mrjob can generally detect when you're trying to
+use Spark and set up your cluster accordingly. This includes installing Spark
+(if needed) and picking an instance type large enough to run it (see
+:mrjob-opt:`instance_type`).
+
+In case you're curious, here's how mrjob determines you're using Spark:
+
+* any :py:class:`~mrjob.step.SparkStep` or
+  :py:class:`~mrjob.step.SparkScriptStep` in your job's steps (including
+  implicitly through the :py:class:`~mrjob.job.MRJob.spark` method)
+* "Spark" included in :mrjob-opt:`emr_applications` option
+* any bootstrap action (see :mrjob-opt:`bootstrap_actions`) ending in
+  ``/spark-install`` (this is how you install Spark on 3.x AMIs)

--- a/docs/job.rst
+++ b/docs/job.rst
@@ -28,6 +28,7 @@ One-step jobs
 .. automethod:: MRJob.mapper_pre_filter
 .. automethod:: MRJob.reducer_pre_filter
 .. automethod:: MRJob.combiner_pre_filter
+.. automethod:: MRJob.spark
 
 Multi-step jobs
 ---------------

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1416,6 +1416,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             return self._opts[role + '_instance_type']
 
         elif self._instance_is_worker(role):
+            # using *instance_type* here is defensive programming;
+            # if set, it should have already been popped into the worker
+            # instance type option(s) by _fix_instance_opts() above
             return (self._opts['instance_type'] or
                     self._cheapest_worker_instance_type())
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1609,6 +1609,11 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         else:
             return 'TERMINATE_CLUSTER'
 
+    def _has_spark_steps(self):
+        """Does the job have Spark steps? If so, we'll need more memory."""
+        return any(step['type'].startswith('spark')
+                   for step in self._get_steps())
+
     def _build_steps(self):
         """Return a list of boto Step objects corresponding to the
         steps we want to run."""

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3324,7 +3324,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         and EMR applications? If so, we'll need more memory."""
         return (self._has_spark_steps() or
                 self._has_spark_install_bootstrap_action() or
-                self._has_spark_emr_application())
+                self._has_spark_application())
 
     def _has_spark_steps(self):
         """Are any of our steps Spark steps (either spark or spark_script)"""
@@ -3337,7 +3337,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         return any(ba['path'].endswith('/install-spark')
                    for ba in self._bootstrap_actions)
 
-    def _has_spark_emr_application(self):
+    def _has_spark_application(self):
         """Does this runner have "Spark" in its *emr_applications* option?"""
         return any(a.lower() == 'spark'
                    for a in self._opts['emr_applications'])

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3328,8 +3328,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
     def _has_spark_steps(self):
         """Are any of our steps Spark steps (either spark or spark_script)"""
-        return (any(step['type'].split('_')[0] == 'spark')
-                for step in self._get_steps())
+        return any(step['type'].split('_')[0] == 'spark'
+                   for step in self._get_steps())
 
     def _has_spark_install_bootstrap_action(self):
         """Does it look like this runner has a spark bootstrap install

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -442,7 +442,7 @@ class SparkScriptStep(object):
                    can also be an ``s3://`` URI, or ``file://`` to reference a
                    jar on the local filesystem of your EMR instance(s).
     :param args: (optional) A list of arguments to the script. Use
-                  :py:data:`mrjob.step.INPUT` and :py:data:`OUTPUT` to
+                 :py:data:`mrjob.step.INPUT` and :py:data:`OUTPUT` to
                  interpolate input and output paths.
     :param spark_args: (optional) an array of arguments to pass to spark-submit
                        (e.g. ``['--executor-memory', '2G']``).

--- a/tests/mr_streaming_and_spark.py
+++ b/tests/mr_streaming_and_spark.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Job that runs (trivial) streaming and spark steps."""
+
+from mrjob.job import MRJob
+from mrjob.step import MRStep
+from mrjob.step import SparkStep
+
+class MRStreamingAndSpark(MRJob):
+
+    def mapper(self):
+        return
+
+    def spark(self):
+        pass
+
+    def steps(self):
+        return[
+            MRStep(mapper=self.mapper),
+            SparkStep(self.spark),
+        ]
+
+if __name__ == '__main__':
+    MRStreamingAndSpark.run()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -958,28 +958,28 @@ class EC2InstanceGroupTestCase(MockBotoTestCase):
     def test_2_x_ami_defaults_single_node(self):
         # m1.small still works with Hadoop 1, and it's cheaper
         self._test_instance_groups(
-            dict(ami_version='2.4.11'),
+            dict(image_version='2.4.11'),
             master=(1, 'm1.small', None))
 
     def test_2_x_ami_defaults_multiple_nodes(self):
         self._test_instance_groups(
-            dict(ami_version='2.4.11', num_core_instances=2),
+            dict(image_version='2.4.11', num_core_instances=2),
             core=(2, 'm1.small', None),
             master=(1, 'm1.small', None))
 
     def test_spark_defaults_single_node(self):
         # Spark needs at least m1.large
         self._test_instance_groups(
-            dict(ami_version='4.0.0', emr_applications=['Spark']),
+            dict(image_version='4.0.0', emr_applications=['Spark']),
             master=(1, 'm1.large', None))
 
     def test_spark_defaults_multiple_nodes(self):
         # Spark can get away with m1.medium for the resource manager
         self._test_instance_groups(
-            dict(ami_version='4.0.0',
+            dict(image_version='4.0.0',
                  emr_applications=['Spark'],
                  num_core_instances=2),
-            core=(1, 'm1.large', None),
+            core=(2, 'm1.large', None),
             master=(1, 'm1.medium', None))
 
     def test_explicit_instance_types_take_precedence(self):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5481,3 +5481,13 @@ class SetUpSSHTunnelTestCase(MockBotoTestCase):
 
         self.assertEqual(self.mock_Popen.call_count, 3)
         self.assertEqual(params['local_port'], 10003)
+
+
+class UsesSparkTestCase(MockBotoTestCase):
+
+    def test_default(self):
+        job = MRTwoStepJob(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertFalse(runner._uses_spark())

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -926,12 +926,12 @@ class EC2InstanceGroupTestCase(MockBotoTestCase):
             {},
             master=(1, 'm1.medium', None))
 
-    def test_single_instance(self):
+    def test_instance_type_single_instance(self):
         self._test_instance_groups(
             {'instance_type': 'c1.xlarge'},
             master=(1, 'c1.xlarge', None))
 
-    def test_multiple_instances(self):
+    def test_instance_type_multiple_instances(self):
         self._test_instance_groups(
             {'instance_type': 'c1.xlarge', 'num_core_instances': 2},
             core=(2, 'c1.xlarge', None),
@@ -954,6 +954,33 @@ class EC2InstanceGroupTestCase(MockBotoTestCase):
              'num_core_instances': 2},
             core=(2, 'm2.xlarge', None),
             master=(1, 'm1.large', None))
+
+    def test_2_x_ami_defaults_single_node(self):
+        # m1.small still works with Hadoop 1, and it's cheaper
+        self._test_instance_groups(
+            dict(ami_version='2.4.11'),
+            master=(1, 'm1.small', None))
+
+    def test_2_x_ami_defaults_multiple_nodes(self):
+        self._test_instance_groups(
+            dict(ami_version='2.4.11', num_core_instances=2),
+            core=(2, 'm1.small', None),
+            master=(1, 'm1.small', None))
+
+    def test_spark_defaults_single_node(self):
+        # Spark needs at least m1.large
+        self._test_instance_groups(
+            dict(ami_version='4.0.0', emr_applications=['Spark']),
+            master=(1, 'm1.large', None))
+
+    def test_spark_defaults_multiple_nodes(self):
+        # Spark can get away with m1.medium for the resource manager
+        self._test_instance_groups(
+            dict(ami_version='4.0.0',
+                 emr_applications=['Spark'],
+                 num_core_instances=2),
+            core=(1, 'm1.large', None),
+            master=(1, 'm1.medium', None))
 
     def test_explicit_instance_types_take_precedence(self):
         self._test_instance_groups(


### PR DESCRIPTION
This auto-detects when the user is running Spark, and if it is defaults `instance_type` to `m1.large` rather than `m1.medium`.

This also defaults `instance_type` to `m1.small` on 2.x AMIs, since they don't require `m1.medium`.

Updated the docs, including stub Spark docs

This does *not*:
 * auto-install Spark (the docs are a little ahead)
 * warn the user if they're using a too-small instance type