### PR TITLE
improve error picking

### DIFF
--- a/mrjob/logs/errors.py
+++ b/mrjob/logs/errors.py
@@ -57,8 +57,15 @@ def _merge_and_sort_errors(errors, container_to_attempt_id=None):
         key_to_error.setdefault(key, {})
         key_to_error[key].update(error)
 
+    # wrap sort key to prioritize task errors. See #1429
+    def sort_key(key_and_error):
+        key, error = key_and_error
+
+        # key[0] is step number
+        return (key[0], bool(error.get('task_error')), key[1:])
+
     return [error for key, error in
-            sorted(key_to_error.items(), reverse=True)]
+            sorted(key_to_error.items(), key=sort_key, reverse=True)]
 
 
 def _format_error(error):

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -99,7 +99,8 @@ def _match_task_syslog_path(path, application_id=None, job_id=None):
 def _interpret_task_logs(fs, matches, partial=True, stderr_callback=None):
     """Look for errors in task syslog/stderr.
 
-    If *partial* is true (the default), stop when we find the first error.
+    If *partial* is true (the default), stop when we find the first error
+    that includes a *task_error*.
 
     If *stderr_callback* is set, every time we're about to parse a stderr
         file, call it with a single argument, the path of that file
@@ -158,7 +159,7 @@ def _interpret_task_logs(fs, matches, partial=True, stderr_callback=None):
         result.setdefault('errors', [])
         result['errors'].append(error)
 
-        if partial:
+        if partial and task_error:
             result['partial'] = True
             break
 

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -46,6 +46,12 @@ _PRE_YARN_TASK_SYSLOG_PATH_RE = re.compile(
 # ignore warnings about initializing log4j in task stderr
 _TASK_STDERR_IGNORE_RE = re.compile(r'^log4j:WARN .*$')
 
+# this is the start of a Java stacktrace that Hadoop 1 always logs to
+# stderr when tasks fail (see #1430)
+_SUBPROCESS_FAILED_STACK_TRACE_START = re.compile(
+    r'^java\.lang\.RuntimeException: PipeMapRed\.waitOutputThreads\(\):'
+    r' subprocess failed with code .*$')
+
 # message telling us about a (input) split. Looks like this:
 #
 # Processing split: hdfs://ddf64167693a:9000/path/to/bootstrap.sh:0+335
@@ -236,9 +242,23 @@ def _parse_task_stderr(lines):
     num_lines: how may lines the message takes up
     """
     task_error = None
+    stack_trace_start_line = None
 
     for line_num, line in enumerate(lines):
         line = line.rstrip('\r\n')
+
+        # ignore "subprocess failed" stack trace
+        if _SUBPROCESS_FAILED_STACK_TRACE_START.match(line):
+            stack_trace_start_line = line_num
+            continue
+
+        # once we detect a stack trace, keep ignoring lines until
+        # we find a non-indented one
+        if stack_trace_start_line is not None:
+            if line.lstrip() != line:
+                continue
+            else:
+                stack_trace_start_line = None
 
         # ignore warnings about initializing log4j
         if _TASK_STDERR_IGNORE_RE.match(line):
@@ -255,7 +275,8 @@ def _parse_task_stderr(lines):
 
     if task_error:
         if 'num_lines' not in task_error:
-            task_error['num_lines'] = line_num + 1 - task_error['start_line']
+            end_line = stack_trace_start_line or (line_num + 1)
+            task_error['num_lines'] = end_line - task_error['start_line']
         return task_error
     else:
         return None

--- a/tests/logs/test_errors.py
+++ b/tests/logs/test_errors.py
@@ -47,7 +47,7 @@ class PickErrorTestCase(TestCase):
             dict(
                 container_id='container_1450486922681_0005_01_000004',
                 hadoop_error=dict(message='elephant problems'),
-            ),
+            )
         )
 
     def test_task_error_beats_recency(self):
@@ -73,7 +73,32 @@ class PickErrorTestCase(TestCase):
                 container_id='container_1450486922681_0005_01_000003',
                 hadoop_error=dict(message='BOOM'),
                 task_error=dict(message='things exploding'),
+            )
+        )
+
+    def test_timestamp_beats_task_error(self):
+        log_interpretation = dict(
+            history=dict(
+                errors=[
+                    dict(
+                        container_id='container_1450486922681_0005_01_000003',
+                        hadoop_error=dict(message='BOOM'),
+                        task_error=dict(message='things exploding'),
+                    ),
+                    dict(
+                        container_id='container_1450489999999_0005_01_000004',
+                        hadoop_error=dict(message='elephant problems'),
+                    ),
+                ],
             ),
+        )
+
+        self.assertEqual(
+            _pick_error(log_interpretation),
+            dict(
+                container_id='container_1450489999999_0005_01_000004',
+                hadoop_error=dict(message='elephant problems'),
+            )
         )
 
     def test_merge_order(self):
@@ -129,7 +154,7 @@ class PickErrorTestCase(TestCase):
                     message='exploding snakes, now?!',
                     path='some_stderr',
                 ),
-            ),
+            )
         )
 
     def test_container_to_attempt_id(self):

--- a/tests/logs/test_errors.py
+++ b/tests/logs/test_errors.py
@@ -33,7 +33,6 @@ class PickErrorTestCase(TestCase):
                     dict(
                         container_id='container_1450486922681_0005_01_000003',
                         hadoop_error=dict(message='BOOM'),
-                        task_error=dict(message='things exploding'),
                     ),
                     dict(
                         container_id='container_1450486922681_0005_01_000004',
@@ -48,6 +47,32 @@ class PickErrorTestCase(TestCase):
             dict(
                 container_id='container_1450486922681_0005_01_000004',
                 hadoop_error=dict(message='elephant problems'),
+            ),
+        )
+
+    def test_task_error_beats_recency(self):
+        log_interpretation = dict(
+            history=dict(
+                errors=[
+                    dict(
+                        container_id='container_1450486922681_0005_01_000003',
+                        hadoop_error=dict(message='BOOM'),
+                        task_error=dict(message='things exploding'),
+                    ),
+                    dict(
+                        container_id='container_1450486922681_0005_01_000004',
+                        hadoop_error=dict(message='elephant problems'),
+                    ),
+                ],
+            ),
+        )
+
+        self.assertEqual(
+            _pick_error(log_interpretation),
+            dict(
+                container_id='container_1450486922681_0005_01_000003',
+                hadoop_error=dict(message='BOOM'),
+                task_error=dict(message='things exploding'),
             ),
         )
 
@@ -195,10 +220,6 @@ class MergeAndSortErrorsTestCase(TestCase):
             _merge_and_sort_errors(errors),
             [
                 dict(
-                    container_id='container_1450486922681_0005_01_000004',
-                    hadoop_error=dict(message='bad stuff, maybe?')
-                ),
-                dict(
                     container_id='container_1450486922681_0005_01_000003',
                     hadoop_error=dict(
                         message='BOOM\n',
@@ -209,7 +230,11 @@ class MergeAndSortErrorsTestCase(TestCase):
                         message='it was probably snakes',
                         path='some_stderr'
                     ),
-                )
+                ),
+                dict(
+                    container_id='container_1450486922681_0005_01_000004',
+                    hadoop_error=dict(message='bad stuff, maybe?')
+                ),
             ])
 
     def test_can_merge_with_incomplete_ids(self):

--- a/tests/logs/test_task.py
+++ b/tests/logs/test_task.py
@@ -189,7 +189,6 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
                     task_id='task_201512232143_0008_m_000001',
                 ),
             ],
-            partial=True,
         ))
 
     def test_syslog_with_error_and_split(self):
@@ -214,7 +213,6 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
                     task_id='task_201512232143_0008_m_000001',
                 ),
             ],
-            partial=True,
         ))
 
     def test_syslog_with_corresponding_stderr(self):
@@ -274,7 +272,6 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
                     ),
                 ),
             ],
-            partial=True,
         ))
 
     def test_error_in_stderr_only(self):


### PR DESCRIPTION
Update our error picking logic to prioritize task errors (e.g. Python stacktraces), see #1429. Also strip the ever-present `subprocess failed` java stacktrace from task stderr log (see #1430), which makes for less noise and prevents us from showing otherwise empty stderr file contents to the user.