### PR TITLE
handle unknown Dataproc image versions

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -40,6 +40,7 @@ except ImportError:
     import configparser
 
 import mrjob
+from mrjob.compat import map_version
 from mrjob.conf import combine_dicts
 from mrjob.conf import combine_lists
 from mrjob.conf import combine_paths
@@ -837,8 +838,10 @@ class DataprocJobRunner(MRJobRunner):
         cluster = self._api_cluster_get(self._cluster_id)
         self._image_version = (
             cluster['config']['softwareConfig']['imageVersion'])
-        self._hadoop_version = (
-            _DATAPROC_IMAGE_TO_HADOOP_VERSION[self._image_version])
+        # protect against new versions, including patch versions
+        # we didn't explicitly request. See #1428
+        self._hadoop_version = map_version(
+            self._image_version, _DATAPROC_IMAGE_TO_HADOOP_VERSION)
 
     ### Bootstrapping ###
 

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -100,9 +100,16 @@ _DATAPROC_JOB_STATES_ACTIVE = frozenset(
 
 _DATAPROC_JOB_STATES_INACTIVE = frozenset(['CANCELLED', 'DONE', 'ERROR'])
 
+# Dataproc images where Hadoop version changed (we use map_version() on this)
+#
+# This will need to be updated by hand if we want it to be fully accurate
+# (it doesn't really matter to mrjob though, which only cares about
+# major version)
+#
+# See https://cloud.google.com/dataproc/docs/concepts/dataproc-versions
+# for the full list.
 _DATAPROC_IMAGE_TO_HADOOP_VERSION = {
     '0.1': '2.7.1',
-    '0.2': '2.7.1',
     '1.0': '2.7.2'
 }
 

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -341,6 +341,13 @@ class CloudAndHadoopVersionTestCase(MockGoogleAPITestCase):
     def test_image_1_0(self):
         self._assert_cloud_hadoop_version('1.0', '2.7.2')
 
+    def test_image_1_0_11(self):
+        # regression test for #1428
+        self._assert_cloud_hadoop_version('1.0.11', '2.7.2')
+
+    def test_future_proofing(self):
+        self._assert_cloud_hadoop_version('5.0', '2.7.2')
+
     def _assert_cloud_hadoop_version(self, image_version, hadoop_version):
         with self.make_runner('--image-version', image_version) as runner:
             runner.run()


### PR DESCRIPTION
The dataproc runner used a static mapping from image version to Hadoop version, to power `get_hadoop_version()`. (This information isn't available from the API.) This caused a crash when the API reported an unexpected patch version. See #1428 for details.

This uses `map_version()` rather than a dictionary lookup. If we encounter an unknown image version, we'll just return the Hadoop version for the previous known image version.