### PR TITLE
Hadoop runner spark support

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -142,9 +142,9 @@ Options available to hadoop runner only
     :set: hadoop
     :default: (automatic)
 
-    Name/path of your hadoop program (may include arguments).
+    Name/path of your :command:`hadoop` binary (may include arguments).
 
-    mrjob tries its best to find your hadoop binary, checking all of the
+    mrjob tries its best to find :command:`hadoop`, checking all of the
     following places for an executable file named ``hadoop``:
 
     * :mrjob-opt:`hadoop_home`/``bin`` (deprecated)
@@ -217,3 +217,26 @@ Options available to hadoop runner only
     .. versionchanged:: 0.5.0
 
        This option used to be named ``hdfs_scratch_dir``.
+
+.. mrjob-opt::
+    :config: spark_submit_bin
+    :switch: --spark-submit-bin
+    :type: :ref:`command <data-type-command>`
+    :set: hadoop
+    :default: (automatic)
+
+    Name/path of your :command:`spark-submit` binary (may include arguments).
+
+    mrjob tries its best to find :command:`spark-submit`, checking all of the
+    following places for an executable file named ``spark-submit``:
+
+    * ``$SPARK_HOME/bin``
+    * ``$PATH``
+    * ``/usr/lib/spark/bin``
+    * ``/usr/local/spark/bin``
+    * ``/usr/local/lib/spark/bin``
+
+    If all else fails, we just use ``spark-submit`` and hope for the best.
+
+    .. TODO: update versionadded for spark release
+    .. versionadded:: 0.5.8

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1810,18 +1810,6 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         else:
             return self._upload_mgr.uri(path)
 
-    def _interpolate_input_and_output(self, args, step_num):
-
-        def interpolate(arg):
-            if arg == mrjob.step.INPUT:
-                return ','.join(self._step_input_uris(step_num))
-            elif arg == mrjob.step.OUTPUT:
-                return self._step_output_uri(step_num)
-            else:
-                return arg
-
-        return [interpolate(arg) for arg in args]
-
     def _build_master_node_setup_step(self):
         name = '%s: Master node setup' % self._job_key
         jar = self._script_runner_jar_uri()

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3306,10 +3306,6 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 self._has_spark_install_bootstrap_action() or
                 self._has_spark_application())
 
-    def _has_spark_steps(self):
-        """Are any of our steps Spark steps (either spark or spark_script)"""
-        return any(step['type'].split('_')[0] == 'spark'
-                   for step in self._get_steps())
 
     def _has_spark_install_bootstrap_action(self):
         """Does it look like this runner has a spark bootstrap install

--- a/mrjob/examples/mr_spark_wordcount_script.py
+++ b/mrjob/examples/mr_spark_wordcount_script.py
@@ -15,6 +15,8 @@ from os.path import dirname
 from os.path import join
 
 from mrjob.job import MRJob
+from mrjob.step import INPUT
+from mrjob.step import OUTPUT
 from mrjob.step import SparkScriptStep
 
 
@@ -24,7 +26,7 @@ class MRSparkScriptWordcount(MRJob):
         return [
             SparkScriptStep(
                 script=join(dirname(__file__), 'spark_wordcount_script.py'),
-                args=[SparkScriptStep.INPUT, SparkScriptStep.OUTPUT],
+                args=[INPUT, OUTPUT],
             ),
         ]
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -124,6 +124,7 @@ class HadoopRunnerOptionStore(RunnerOptionStore):
         'hadoop_log_dirs',
         'hadoop_streaming_jar',
         'hadoop_tmp_dir',
+        'spark_submit_bin',
     ]))
 
     COMBINERS = combine_dicts(RunnerOptionStore.COMBINERS, {

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -504,6 +504,10 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             return self._args_for_streaming_step(step_num)
         elif step['type'] == 'jar':
             return self._args_for_jar_step(step_num)
+        elif step['type'] == 'spark':
+            return self._args_for_spark_step(step_num)
+        elif step['type'] == 'spark_script':
+            return self._args_for_spark_script_step(step_num)
         else:
             raise AssertionError('Bad step type: %r' % (step['type'],))
 
@@ -590,6 +594,12 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             args.extend(interpolate(arg) for arg in step['args'])
 
         return args
+
+    def _args_for_spark_step(self, step_num):
+        pass
+
+    def _args_for_spark_script_step(self, step_num):
+        pass
 
     def _hdfs_step_input_files(self, step_num):
         """Get the hdfs:// URI for input for the given step."""

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -193,6 +193,10 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         self._hadoop_streaming_jar = self._opts['hadoop_streaming_jar']
         self._searched_for_hadoop_streaming_jar = False
 
+        # Keep track of where the spark-submit binary is
+        self._spark_submit_bin = self._opts['spark_submit_bin']
+        self._searched_for_spark_submit_bin = False
+
         # List of dicts (one for each step) potentially containing
         # the keys 'history', 'step', and 'task' ('step' will always
         # be filled because it comes from the hadoop jar command output,
@@ -328,6 +332,31 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
 
         for path in _FALLBACK_HADOOP_LOG_DIRS:
             yield path
+
+    def get_spark_submit_bin(self):
+        # TODO: this is almost identical to get_hadoop_bin()
+        if not (self._spark_submit_bin or
+                self._searched_for_spark_submit_bin):
+
+            self._spark_submit_bin = self._find_spark_submit_bin()
+
+            if self._spark_submit_bin:
+                log.info('Found Hadoop streaming jar: %s' %
+                         self._spark_submit_bin)
+            else:
+                log.warning('Hadoop streaming jar not found. Use'
+                            ' --hadoop-streaming-jar')
+
+            self._searched_for_spark_submit_bin = True
+
+        return self._spark_submit_bin
+
+    # TODO: fill these methods (see #1366)
+    def _find_spark_submit_bin(self):
+        pass
+
+    def _spark_submit_bin_dirs(self):
+        return ()
 
     def _run(self):
         self._check_input_exists()

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -136,6 +136,7 @@ class HadoopRunnerOptionStore(RunnerOptionStore):
         'hadoop_home': combine_paths,
         'hadoop_log_dirs': combine_path_lists,
         'hadoop_tmp_dir': combine_paths,
+        'spark_submit_bin': combine_cmds,
     })
 
     DEPRECATED_ALIASES = combine_dicts(RunnerOptionStore.DEPRECATED_ALIASES, {

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -26,7 +26,6 @@ try:
 except ImportError:
     pty = None
 
-import mrjob.step
 from mrjob.compat import translate_jobconf
 from mrjob.compat import uses_yarn
 from mrjob.conf import combine_cmds
@@ -581,17 +580,9 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         if step.get('main_class'):
             args.append(step['main_class'])
 
-        # TODO: merge with logic in mrjob/emr.py
-        def interpolate(arg):
-            if arg == mrjob.step.INPUT:
-                return ','.join(self._step_input_uris(step_num))
-            elif arg == mrjob.step.OUTPUT:
-                return self._step_output_uri(step_num)
-            else:
-                return arg
-
         if step.get('args'):
-            args.extend(interpolate(arg) for arg in step['args'])
+            args.extend(
+                self._interpolate_input_and_output(step['args'], step_num))
 
         return args
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -369,11 +369,27 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         yield '/usr/local/lib/spark/bin'
 
     def _run(self):
+        self._find_binaries_and_jars()
         self._check_input_exists()
         self._create_setup_wrapper_script()
         self._add_job_files_for_upload()
         self._upload_local_files_to_hdfs()
         self._run_job_in_hadoop()
+
+    def _find_binaries_and_jars(self):
+        """Find hadoop and (if needed) spark-submit bin up-front, before
+        continuing with the job.
+
+        (This is just for user-interaction purposes; these would otherwise
+        lazy-load as needed.)
+        """
+        self.get_hadoop_bin()
+
+        if self._has_streaming_steps():
+            self.get_hadoop_streaming_jar()
+
+        if self._has_spark_steps():
+            self.get_spark_submit_bin()
 
     def _check_input_exists(self):
         """Make sure all input exists before continuing with our job.

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -384,7 +384,8 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         (This is just for user-interaction purposes; these would otherwise
         lazy-load as needed.)
         """
-        self.get_hadoop_bin()
+        # this triggers looking for Hadoop binary
+        self.get_hadoop_version()
 
         if self._has_streaming_steps():
             self.get_hadoop_streaming_jar()

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -359,7 +359,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         # $SPARK_HOME
         spark_home = os.environ.get('SPARK_HOME')
         if spark_home:
-            yield spark_home
+            yield os.path.join(spark_home, 'bin')
 
         yield None  # use $PATH
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -346,7 +346,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             log.info('Looking for spark-submit binary in %s...' % (
                 path or '$PATH'))
 
-            spark_submit_bin = which('hadoop', path=path)
+            spark_submit_bin = which('spark-submit', path=path)
 
             if spark_submit_bin:
                 log.info('Found spark-submit binary: %s' % spark_submit_bin)

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -290,6 +290,10 @@ def _add_hadoop_opts(opt_group):
             '--hdfs-scratch-dir', dest='hadoop_tmp_dir',
             default=None,
             help='Deprecated alias for --hadoop-tmp-dir'),
+
+        opt_group.add_option(
+            '--spark-submit-bin', dest='spark_submit_bin', default=None,
+            help='path to spark-submit binary'),
     ]
 
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -773,6 +773,16 @@ class MRJobRunner(object):
         """Get the number of steps (calls :py:meth:`get_steps`)."""
         return len(self._get_steps())
 
+    def _has_streaming_steps(self):
+        """Are any of our steps Hadoop streaming steps?"""
+        return any(step['type'] == 'streaming'
+                   for step in self._get_steps())
+
+    def _has_spark_steps(self):
+        """Are any of our steps Spark steps (either spark or spark_script)"""
+        return any(step['type'].split('_')[0] == 'spark'
+                   for step in self._get_steps())
+
     def _interpreter(self, steps=False):
         if steps:
             return (self._opts['steps_interpreter'] or

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -33,6 +33,7 @@ from subprocess import Popen
 from subprocess import PIPE
 from subprocess import check_call
 
+import mrjob.step
 from mrjob.compat import translate_jobconf_dict
 from mrjob.conf import combine_cmds
 from mrjob.conf import combine_dicts
@@ -1132,6 +1133,25 @@ class MRJobRunner(object):
             return self._output_dir
         else:
             return self._intermediate_output_uri(step_num)
+
+    def _interpolate_input_and_output(self, args, step_num):
+        """Replace :py:data:`~mrjob.step.INPUT` and
+        :py:data:`~mrjob.step.OUTPUT` in arguments to a jar or Spark
+        step.
+
+        If there are multiple input paths (i.e. on the first step), they'll
+        be joined with a comma.
+        """
+
+        def interpolate(arg):
+            if arg == mrjob.step.INPUT:
+                return ','.join(self._step_input_uris(step_num))
+            elif arg == mrjob.step.OUTPUT:
+                return self._step_output_uri(step_num)
+            else:
+                return arg
+
+        return [interpolate(arg) for arg in args]
 
     def _create_mrjob_tar_gz(self):
         """Make a tarball of the mrjob library, without .pyc or .pyo files,

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1282,8 +1282,8 @@ class FindBinariesAndJARsTestCase(SandboxedTestCase):
     def setUp(self):
         super(FindBinariesAndJARsTestCase, self).setUp()
 
-        self.get_hadoop_bin = self.start(patch(
-            'mrjob.hadoop.HadoopJobRunner.get_hadoop_bin'))
+        self.get_hadoop_version = self.start(patch(
+            'mrjob.hadoop.HadoopJobRunner.get_hadoop_version'))
 
         self.get_hadoop_streaming_jar = self.start(patch(
             'mrjob.hadoop.HadoopJobRunner.get_hadoop_streaming_jar'))
@@ -1291,12 +1291,12 @@ class FindBinariesAndJARsTestCase(SandboxedTestCase):
         self.get_spark_submit_bin = self.start(patch(
             'mrjob.hadoop.HadoopJobRunner.get_spark_submit_bin'))
 
-    def test_always_call_get_hadoop_bin(self):
+    def test_always_call_get_hadoop_version(self):
         runner = HadoopJobRunner()
 
         runner._find_binaries_and_jars()
 
-        self.assertTrue(self.get_hadoop_bin.called)
+        self.assertTrue(self.get_hadoop_version.called)
         self.assertFalse(self.get_hadoop_streaming_jar.called)
         self.assertFalse(self.get_spark_submit_bin.called)
 
@@ -1307,7 +1307,7 @@ class FindBinariesAndJARsTestCase(SandboxedTestCase):
         with job.make_runner() as runner:
             runner._find_binaries_and_jars()
 
-            self.assertTrue(self.get_hadoop_bin.called)
+            self.assertTrue(self.get_hadoop_version.called)
             self.assertTrue(self.get_hadoop_streaming_jar.called)
             self.assertFalse(self.get_spark_submit_bin.called)
 
@@ -1318,7 +1318,7 @@ class FindBinariesAndJARsTestCase(SandboxedTestCase):
         with job.make_runner() as runner:
             runner._find_binaries_and_jars()
 
-            self.assertTrue(self.get_hadoop_bin.called)
+            self.assertTrue(self.get_hadoop_version.called)
             self.assertFalse(self.get_hadoop_streaming_jar.called)
             self.assertTrue(self.get_spark_submit_bin.called)
 
@@ -1329,6 +1329,6 @@ class FindBinariesAndJARsTestCase(SandboxedTestCase):
         with job.make_runner() as runner:
             runner._find_binaries_and_jars()
 
-            self.assertTrue(self.get_hadoop_bin.called)
+            self.assertTrue(self.get_hadoop_version.called)
             self.assertTrue(self.get_hadoop_streaming_jar.called)
             self.assertTrue(self.get_spark_submit_bin.called)


### PR DESCRIPTION
Hadoop runner can now find the `spark-submit` binary and run ``spark`` and ``spark_script`` steps. Fixes #1366.

Hadoop runner now also looks for the hadoop binary, streaming jar (if needed), and spark-submit binary (if needed) up-front, rather than waiting until the last minute.