### PR TITLE
bootstrap Spark

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -504,6 +504,21 @@ and install another Python binary.
       no longer installs Python 3 on AMI version 4.6.0+ by default
 
 .. mrjob-opt::
+   :config: bootstrap_spark
+   :switch: --bootstrap-spark, --no-bootstrap-spark
+   :type: boolean
+   :set: emr
+   :default: (automatic)
+
+   Install Spark on the cluster. This works on AMI version 3.x and later.
+
+   By default, we automatically install Spark only if our job has Spark steps.
+
+   .. TODO: update versionadded for spark release
+   .. versionadded:: 0.5.8
+
+
+.. mrjob-opt::
     :config: bootstrap_python_packages
     :switch: --bootstrap-python-package
     :type: :ref:`path list <data-type-path-list>`

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2580,7 +2580,10 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 not self._opts['release_label']):
             if version_gte(self._opts['image_version'],
                            _MIN_SPARK_AMI_VERSION):
-                actions.append(_3_X_SPARK_BOOTSTRAP_ACTION)
+                # running this action twice apparently breaks Spark's
+                # ability to output to S3 (see #1367)
+                if not self._has_spark_install_bootstrap_action():
+                    actions.append(_3_X_SPARK_BOOTSTRAP_ACTION)
             else:
                 log.warning("Spark isn't available on AMI versions prior"
                             "to %s" % _MIN_SPARK_AMI_VERSION)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1846,7 +1846,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     def _get_spark_jar_and_step_arg_prefix(self):
         # TODO: add spark_submit_bin option
 
-        if version_gte(self.get_ami_version(), '4'):
+        if version_gte(self.get_image_version(), '4'):
             return (_4_X_INTERMEDIARY_JAR, ['spark-submit'])
         else:
             return (self._script_runner_jar_uri(), [_3_X_SPARK_SUBMIT])

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2593,10 +2593,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                                    _MIN_SPARK_AMI_VERSION):
                     log.warning(
                         "Bootstrapping Spark probably won't work; not"
-                        " available on AMI version less than %s" %
+                        " available AMIs before %s" %
                         _MIN_SPARK_AMI_VERSION)
-
-
 
         results = []
         for action in actions:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -386,6 +386,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         'bootstrap_python',
         'bootstrap_python_packages',
         'bootstrap_scripts',
+        'bootstrap_spark',
         'check_cluster_every',
         'cloud_fs_sync_secs',
         'cloud_log_dir',
@@ -2553,6 +2554,14 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             ]]
         else:
             return []
+
+    def _should_bootstrap_spark(self):
+        """Return *bootstrap_spark* option if set; otherwise return
+        true if our job has Spark steps."""
+        if self._opts['bootstrap_spark'] is None:
+            return self._has_spark_steps()
+        else:
+            return self._opts['bootstrap_spark']
 
     def _parse_bootstrap(self):
         """Parse the *bootstrap* option with

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1555,10 +1555,10 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         bootstrap_action_args = []
 
         for i, bootstrap_action in enumerate(self._bootstrap_actions()):
-            s3_uri = self._upload_mgr.uri(bootstrap_action['path'])
+            uri = self._upload_mgr.uri(bootstrap_action['path'])
             bootstrap_action_args.append(
                 boto.emr.BootstrapAction(
-                    'action %d' % i, s3_uri, bootstrap_action['args']))
+                    'action %d' % i, uri, bootstrap_action['args']))
 
         if self._master_bootstrap_script_path:
             master_bootstrap_script_args = []
@@ -2550,7 +2550,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         if self._opts['bootstrap_spark'] is None:
             return self._has_spark_steps()
         else:
-            return self._opts['bootstrap_spark']
+            return bool(self._opts['bootstrap_spark'])
 
     def _applications(self):
         """Returns applications (*emr_applications* option) as a set. Adds
@@ -2573,7 +2573,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
         (This doesn't handle the master bootstrap script.)
         """
-        actions = self._opts['bootstrap_actions']
+        actions = list(self._opts['bootstrap_actions'])
 
         # no release_label implies AMIs prior to 4.x
         if (include_spark and self._should_bootstrap_spark() and

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2566,7 +2566,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
         # patch in "Hadoop" unless applications is empty (e.g. 3.x AMIs)
         if applications:
-            applications.add('Hadoop')
+            # don't add both "Hadoop" and "hadoop"
+            if not any(a.lower() == 'hadoop' for a in applications):
+                applications.add('Hadoop')
 
         return applications
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -525,6 +525,16 @@ def _add_emr_launch_opts(opt_group):
             help='Deprecated alias for --zone'),
 
         opt_group.add_option(
+            '--bootstrap-spark', dest='bootstrap_spark',
+            action='store_true', default=None,
+            help="Auto-install Spark on the cluster (even if not needed)."),
+
+        opt_group.add_option(
+            '--no-bootstrap-spark', dest='bootstrap_spark',
+            action='store_false', default=None,
+            help="Don't auto-install Spark on the cluster."),
+
+        opt_group.add_option(
             '--cloud-log-dir', dest='cloud_log_dir', default=None,
             help='URI on remote FS to write logs into'),
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2569,6 +2569,55 @@ class PoolMatchingTestCase(MockBotoTestCase):
             cluster_id,
             ['-r', 'emr', '--pool-clusters'])
 
+    def test_dont_join_cluster_without_spark(self):
+        _, cluster_id = self.make_pooled_cluster()
+
+        self.assertDoesNotJoin(
+            cluster_id,
+            ['-r', 'emr', '--pool-clusters'],
+            job_class=MRNullSpark)
+
+    def test_join_cluster_with_spark_3_x_ami(self):
+        _, cluster_id = self.make_pooled_cluster(
+            image_version='3.11.0',
+            bootstrap_actions=[_3_X_SPARK_BOOTSTRAP_ACTION])
+
+        self.assertJoins(
+            cluster_id,
+            ['-r', 'emr', '--pool-clusters', '--image-version', '3.11.0'],
+            job_class=MRNullSpark)
+
+    def test_join_cluster_with_spark_4_x_ami(self):
+        _, cluster_id = self.make_pooled_cluster(
+            image_version='4.7.2',
+            emr_applications=['Spark'])
+
+        self.assertJoins(
+            cluster_id,
+            ['-r', 'emr', '--pool-clusters', '--image-version', '4.7.2'],
+            job_class=MRNullSpark)
+
+    def test_ignore_spark_bootstrap_action_on_4_x_ami(self):
+        _, cluster_id = self.make_pooled_cluster(
+            image_version='4.7.2',
+            bootstrap_actions=[_3_X_SPARK_BOOTSTRAP_ACTION])
+
+        self.assertDoesNotJoin(
+            cluster_id,
+            ['-r', 'emr', '--pool-clusters', '--image-version', '4.7.2'],
+            job_class=MRNullSpark)
+
+    def test_other_install_spark_bootstrap_action_on_3_x_ami(self):
+        # has to be exactly the install-spark bootstrap action we expected
+        _, cluster_id = self.make_pooled_cluster(
+            image_version='3.11.0',
+            bootstrap_actions=['s3://bucket/install-spark'])
+
+        self.assertDoesNotJoin(
+            cluster_id,
+            ['-r', 'emr', '--pool-clusters', '--image-version', '3.11.0'],
+            job_class=MRNullSpark)
+
 
 class PoolingRecoveryTestCase(MockBotoTestCase):
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4745,7 +4745,7 @@ class EMRApplicationsTestCase(MockBotoTestCase):
         job.sandbox()
 
         with job.make_runner() as runner:
-            self.assertEqual(runner._opts['emr_applications'], set())
+            self.assertEqual(runner._applications(), set())
 
             runner._launch()
             cluster = runner._describe_cluster()
@@ -4758,7 +4758,7 @@ class EMRApplicationsTestCase(MockBotoTestCase):
         job.sandbox()
 
         with job.make_runner() as runner:
-            self.assertEqual(runner._opts['emr_applications'], set())
+            self.assertEqual(runner._applications(), set())
 
             runner._launch()
             cluster = runner._describe_cluster()
@@ -4784,7 +4784,7 @@ class EMRApplicationsTestCase(MockBotoTestCase):
         job.sandbox()
 
         with job.make_runner() as runner:
-            self.assertEqual(runner._opts['emr_applications'],
+            self.assertEqual(runner._applications(),
                              set(['Hadoop', 'Mahout']))
 
             runner._launch()
@@ -4803,7 +4803,7 @@ class EMRApplicationsTestCase(MockBotoTestCase):
         with job.make_runner() as runner:
             # we explicitly add Hadoop so we can see Hadoop version in
             # the cluster description from the API
-            self.assertEqual(runner._opts['emr_applications'],
+            self.assertEqual(runner._applications(),
                              set(['Hadoop', 'Mahout']))
 
             runner._launch()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4059,6 +4059,49 @@ class BootstrapPythonTestCase(MockBotoTestCase):
                 self.EXPECTED_BOOTSTRAP + [['true']])
 
 
+class ShouldBoostrapSparkTestCase(MockBotoTestCase):
+
+    def test_default(self):
+        job = MRTwoStepJob(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._should_bootstrap_spark(), False)
+
+    def test_explicit_true(self):
+        job = MRTwoStepJob(['-r', 'emr', '--bootstrap-spark'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._should_bootstrap_spark(), True)
+
+    def test_spark_job(self):
+        job = MRNullSpark(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._should_bootstrap_spark(), True)
+
+    def test_spark_script_job(self):
+        job = MRSparkScript(['-r', 'emr'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._should_bootstrap_spark(), True)
+
+    def test_explicit_false(self):
+        job = MRNullSpark(['-r', 'emr', '--no-bootstrap-spark'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._should_bootstrap_spark(), False)
+
+
 class EMRTagsTestCase(MockBotoTestCase):
 
     def test_tags_option_dict(self):

--- a/tests/tools/emr/test_create_cluster.py
+++ b/tests/tools/emr/test_create_cluster.py
@@ -40,6 +40,7 @@ class ClusterInspectionTestCase(ToolTestCase):
                 'bootstrap_python': None,
                 'bootstrap_python_packages': [],
                 'bootstrap_scripts': [],
+                'bootstrap_spark': None,
                 'check_cluster_every': None,
                 'cloud_fs_sync_secs': None,
                 'cloud_log_dir': None,


### PR DESCRIPTION
This automatically installs Spark on EMR if it looks like your job has Spark steps. Fixes #1367 

You can currently only run a job if your Python version matches `python` on your EMR AMI (since we bootstrap mrjob for whatever version of python matches the local version); this will change with #1370.