### PR TITLE
Spark python bin, cmdenv, jobconf

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1739,11 +1739,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             action_on_failure=self._action_on_failure())
 
     def _build_spark_step(self, step_num):
-        step = self._get_step(step_num)
-
         return self._build_spark_step_helper(
             step_num=step_num,
-            spark_args=step['spark_args'],
             script=self._script_path,
             script_args=[
                 '--step-num=%d' % step_num,
@@ -1758,12 +1755,11 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
         return self._build_spark_step_helper(
             step_num=step_num,
-            spark_args=step['spark_args'],
             script=step['script'],
             script_args=step['args'])
 
     def _build_spark_step_helper(
-            self, step_num, spark_args, script, script_args):
+            self, step_num, script, script_args):
         """Common code for _build_spark_step() and _build_spark_script_step()
 
         Interpolates :py:data:`~mrjob.step.INPUT` and
@@ -1774,6 +1770,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         script_args = self._interpolate_input_and_output(script_args, step_num)
 
         jar, step_arg_prefix = self._get_spark_jar_and_step_arg_prefix()
+
+        spark_args = self._spark_args_for_step(step_num)
 
         # have to use `--deploy-mode cluster` to reference s3:// URIs
         step_args = (

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -629,8 +629,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             script_args=step['args']
         )
 
-    def _args_for_spark_step_helper(
-            self, step_num, spark_args, script, script_args):
+    def _args_for_spark_step_helper(self, step_num, script, script_args):
         """Common code for _args_for_spark_step() and
         _args_for_spark_script_step()."""
         spark_args = self._spark_args_for_step(step_num)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -609,11 +609,8 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         return args
 
     def _args_for_spark_step(self, step_num):
-        step = self._get_step(step_num)
-
         return self._args_for_spark_step_helper(
             step_num=step_num,
-            spark_args=step['spark_args'],
             script=self._script_path,
             script_args=[
                 '--step-num=%d' % step_num,
@@ -628,7 +625,6 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
 
         return self._args_for_spark_step_helper(
             step_num=step_num,
-            spark_args=step['spark_args'],
             script=step['script'],
             script_args=step['args']
         )
@@ -637,6 +633,8 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             self, step_num, spark_args, script, script_args):
         """Common code for _args_for_spark_step() and
         _args_for_spark_script_step()."""
+        spark_args = self._spark_args_for_step(step_num)
+
         script_args = self._interpolate_input_and_output(script_args, step_num)
 
         return (self.get_spark_submit_bin() +

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -36,7 +36,6 @@ from mrjob.py2 import string_types
 from mrjob.step import MRStep
 from mrjob.step import SparkStep
 from mrjob.step import _JOB_STEP_FUNC_PARAMS
-from mrjob.step import _SPARK_STEP_KWARGS
 from mrjob.util import expand_path
 from mrjob.util import read_input
 

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -993,10 +993,17 @@ class SparkStepArgsTestCase(SandboxedTestCase):
     MRJOB_CONF_CONTENTS = dict(runners=dict(hadoop=dict(
         spark_submit_bin='spark-submit')))
 
+    def setUp(self):
+        super(SparkStepArgsTestCase, self).setUp()
+
+        # _spark_args_for_step() is tested elsewhere
+        self.start(patch(
+            'mrjob.runner.MRJobRunner._spark_args_for_step',
+            return_value=['<spark args for step>']))
+
     def test_spark_step(self):
         job = MRNullSpark([
             '-r', 'hadoop',
-            '--extra-spark-arg', 'foo',
         ])
         job.sandbox()
 
@@ -1006,7 +1013,7 @@ class SparkStepArgsTestCase(SandboxedTestCase):
             self.assertEqual(runner._args_for_step(0), [
                 'spark-submit',
                 '--master', 'yarn',
-                'foo',
+                '<spark args for step>',
                 runner._script_path,
                 '--step-num=0',
                 '--spark',
@@ -1021,7 +1028,6 @@ class SparkStepArgsTestCase(SandboxedTestCase):
             '--script-arg', 'foo',
             '--script-arg', mrjob.step.OUTPUT,
             '--script-arg', mrjob.step.INPUT,
-            '--script-spark-arg', 'bar',
         ])
         job.sandbox()
 
@@ -1031,21 +1037,12 @@ class SparkStepArgsTestCase(SandboxedTestCase):
             self.assertEqual(runner._args_for_step(0), [
                 'spark-submit',
                 '--master', 'yarn',
-                'bar',
+                '<spark args for step>',
                 '/path/to/spark_script.py',
                 'foo',
                 runner._step_output_uri(0),
                 ','.join(runner._step_input_uris(0)),
             ])
-
-
-
-
-
-
-
-
-
 
 
 class SetupLineEncodingTestCase(MockHadoopTestCase):


### PR DESCRIPTION
Ensure that python binary (see #1370), cmdenv (see #1371), and jobconf (see #1372) are all passed to `spark-submit` with `--conf` options.