### PR TITLE
add spark_args option

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -54,9 +54,7 @@ Options available to hadoop and emr runners
     :set: all
     :default: ``[]``
 
-    Extra arguments to pass to hadoop streaming. This option is called
-    **extra_args** when passed as a keyword argument to
-    :py:class:`~mrjob.runner.MRJobRunner`.
+    Extra arguments to pass to hadoop streaming.
 
 .. mrjob-opt::
     :config: hadoop_streaming_jar
@@ -217,6 +215,18 @@ Options available to hadoop runner only
     .. versionchanged:: 0.5.0
 
        This option used to be named ``hdfs_scratch_dir``.
+
+.. mrjob-opt::
+    :config: spark_args
+    :switch: --spark-arg
+    :type: :ref:`string list <data-type-string-list>`
+    :set: all
+    :default: ``[]``
+
+    Extra arguments to pass to :command:`spark-submit`.
+
+    .. TODO: update versionadded for spark release
+    .. versionadded:: 0.5.8
 
 .. mrjob-opt::
     :config: spark_submit_bin

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1015,6 +1015,16 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    spark_args=dict(
+        combiner=combine_lists,
+        switches=[
+            (['--spark-arg'], dict(
+                action='append',
+                help=('Argument of any type to pass to spark-submit.'
+                      ' You can use --spark-arg multiple times.'),
+            )),
+        ],
+    ),
     spark_submit_bin=dict(
         combiner=combine_cmds,
         switches=[

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1206,6 +1206,9 @@ class MRJobRunner(object):
             if value is not None:
                 args.extend(['--conf', '%s=%s' % (key, value)])
 
+        # spark_args option
+        args.extend(self._opts['spark_args'])
+
         # step spark_args
         args.extend(step['spark_args'])
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -634,7 +634,20 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
                 )
             )
 
-    def test_custom_spark_args(self):
+    def test_option_spark_args(self):
+        job = MRNullSpark(['--spark-arg', '--name', '--spark-arg', 'Dave'])
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_args_for_step(0), (
+                    self._expected_conf_args(
+                        cmdenv=dict(PYSPARK_PYTHON='mypy')) +
+                    ['--name', 'Dave']
+                )
+            )
+
+    def test_job_spark_args(self):
+        # --extra-spark-arg is a passthrough option for MRNullSpark
         job = MRNullSpark(['--extra-spark-arg', '-v'])
 
         with job.make_runner() as runner:
@@ -646,6 +659,19 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
                 )
             )
 
+    def test_job_spark_args_come_after_option_spark_args(self):
+        job = MRNullSpark(
+            ['--extra-spark-arg', '-v',
+             '--spark-arg', '--name', '--spark-arg', 'Dave'])
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_args_for_step(0), (
+                    self._expected_conf_args(
+                        cmdenv=dict(PYSPARK_PYTHON='mypy')) +
+                    ['--name', 'Dave', '-v']
+                )
+            )
 
 
 


### PR DESCRIPTION
Add a `spark_args` runner option and `--spark-args` switch.

(This is way easier now that runner options are just a big data structure; see #1460.)

This fixes #1373.