### PR TITLE
Spark file support

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -231,6 +231,11 @@ Job execution context
 
         --cmdenv PYTHONPATH=$HOME/stuff,TZ=America/Los_Angeles
 
+    .. versionchanged:: 0.5.8.spark
+
+       This works with Spark too. In client mode (hadoop runner), these
+       environment variables are passed directly to :command:`spark-submit`.
+
 .. mrjob-opt::
     :config: interpreter
     :switch: --interpreter

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -48,6 +48,35 @@ options related to file uploading.
     Hadoop cluster or install it by some other method.
 
 .. mrjob-opt::
+   :config: py_files
+   :switch: --py-file
+   :type: :ref:`path list <data-type-path-list>`
+   :set: all
+   :default: ``[]``
+
+   List of ``.egg`` or ``.zip`` files to add to your job's ``PYTHONPATH``.
+
+   This is based on a Spark feature, but it works just as well with streaming
+   jobs.
+
+   .. versionadded:: 0.5.8.spark0
+
+.. mrjob-opt::
+    :config: python_archives
+    :switch: --python-archive
+    :type: :ref:`path list <data-type-path-list>`
+    :set: all
+    :default: ``[]``
+
+    Same as upload_archives, except they get added to the job's
+    :envvar:`PYTHONPATH`.
+
+    .. deprecated:: 0.5.8.spark0
+
+       Try :mrjob-opt:`py_files` with a `.zip` or `.egg` file instead. If you
+       must use an archive, see :ref:`cookbook-src-tree-pythonpath`.
+
+.. mrjob-opt::
     :config: upload_files
     :switch: --file
     :type: :ref:`path list <data-type-path-list>`
@@ -68,6 +97,10 @@ options related to file uploading.
 
         --file file_1.txt --file file_2.sqlite
 
+    .. versionchanged:: 0.5.8.spark0
+
+       This works with Spark as well.
+
 .. mrjob-opt::
     :config: upload_archives
     :switch: --archive
@@ -82,15 +115,10 @@ options related to file uploading.
     ``foo.tar.gz/``, and ``foo.tar.gz#stuff`` is unpacked to the directory
     ``stuff/``).
 
-.. mrjob-opt::
-    :config: python_archives
-    :switch: --python-archive
-    :type: :ref:`path list <data-type-path-list>`
-    :set: all
-    :default: ``[]``
+    .. versionchanged:: 0.5.8.spark0
 
-    Same as upload_archives, except they get added to the job's
-    :envvar:`PYTHONPATH`.
+       This works with Spark as well.
+
 
 Temp files and cleanup
 ======================

--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -225,8 +225,7 @@ Options available to hadoop runner only
 
     Extra arguments to pass to :command:`spark-submit`.
 
-    .. TODO: update versionadded for spark release
-    .. versionadded:: 0.5.8
+    .. versionadded:: 0.5.8.spark0
 
 .. mrjob-opt::
     :config: spark_submit_bin
@@ -248,5 +247,4 @@ Options available to hadoop runner only
 
     If all else fails, we just use ``spark-submit`` and hope for the best.
 
-    .. TODO: update versionadded for spark release
-    .. versionadded:: 0.5.8
+    .. versionadded:: 0.5.8.spark0

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2887,7 +2887,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 expected_applications = set(
                     a.lower() for a in applications)
 
-                if not expected_applications <= applications:
+                if not expected_applications <= cluster_applications:
                     log.debug('    missing applications: %s' % ', '.join(
                         sorted(expected_applications - cluster_applications)))
                     return

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1684,7 +1684,11 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     def _spark_py_files(self):
         """In cluster mode, py_files can be anywhere, so point to their
         uploaded URIs."""
-        return self._arg_hash_paths('file', self._opts['py_files'])
+        # don't use hash paths with --py-files; see #1375
+        return [
+            self._upload_mgr.uri(path)
+            for path in sorted(self._opts['py_files'])
+        ]
 
     def _step_name(self, step_num):
         """Return something like: ``'mr_your_job Step X of Y'``"""

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3286,7 +3286,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         and EMR applications? If so, we'll need more memory."""
         return (self._has_spark_steps() or
                 self._has_spark_install_bootstrap_action() or
-                self._has_spark_application())
+                self._has_spark_application() or
+                self._opts['bootstrap_spark'])
 
     def _has_spark_install_bootstrap_action(self):
         """Does it look like this runner has a spark bootstrap install

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -961,6 +961,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         for path in self._working_dir_mgr.paths():
             self._upload_mgr.add(path)
 
+        for path in self._opts['py_files']:
+            self._upload_mgr.add(path)
+
         if self._opts['hadoop_streaming_jar']:
             self._upload_mgr.add(self._opts['hadoop_streaming_jar'])
 
@@ -1677,6 +1680,11 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             jar=jar,
             step_args=step_args,
             action_on_failure=self._action_on_failure())
+
+    def _spark_py_files(self):
+        """In cluster mode, py_files can be anywhere, so point to their
+        uploaded URIs."""
+        return self._arg_hash_paths('file', self._opts['py_files'])
 
     def _step_name(self, step_num):
         """Return something like: ``'mr_your_job Step X of Y'``"""

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -430,6 +430,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             log.info('Running step %d of %d...' %
                      (step_num + 1, self._num_steps()))
             log.debug('> %s' % cmd_line(step_args))
+            log.debug('  with environment: %r' % sorted(env.items()))
 
             log_interpretation = {}
             self._log_interpretations.append(log_interpretation)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -423,6 +423,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
     def _run_job_in_hadoop(self):
         for step_num in range(self._num_steps()):
             step_args = self._args_for_step(step_num)
+            env = self._env_for_step(step_num)
 
             # log this *after* _args_for_step(), which can start a search
             # for the Hadoop streaming jar
@@ -443,7 +444,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
                 # Hadoop is running
                 log.debug('No PTY available, using Popen() to invoke Hadoop')
 
-                step_proc = Popen(step_args, stdout=PIPE, stderr=PIPE)
+                step_proc = Popen(step_args, stdout=PIPE, stderr=PIPE, env=env)
 
                 step_interpretation = _interpret_hadoop_jar_command_stderr(
                     step_proc.stderr,
@@ -460,7 +461,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             else:
                 # we have PTYs
                 if pid == 0:  # we are the child process
-                    os.execvp(step_args[0], step_args)
+                    os.execvpe(step_args[0], step_args, env)
                 else:
                     log.debug('Invoking Hadoop via PTY')
 
@@ -620,6 +621,17 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
                 spark_args +
                 [script] +
                 self._interpolate_input_and_output(script_args, step_num))
+
+    def _env_for_step(self, step_num):
+        step = self._get_step(step_num)
+
+        env = dict(os.environ)
+
+        # when running spark-submit, set its environment directly. See #1464
+        if step['type'].split('_')[0] == 'spark':
+            env.update(self._spark_cmdenv())
+
+        return env
 
     def _intermediate_output_uri(self, step_num):
         return posixpath.join(self._hadoop_tmp_dir,

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -924,12 +924,13 @@ _RUNNER_OPTS = dict(
     ),
     python_archives=dict(
         combiner=combine_path_lists,
+        deprecated=True,
         switches=[
             (['--python-archive'], dict(
                 action='append',
                 help=('Archive to unpack and add to the PYTHONPATH of the'
-                      ' MRJob script when it runs. You can use'
-                      ' --python-archives multiple times.'),
+                      ' MRJob script when it runs. This is deprecated;'
+                      ' try --py-file instead'),
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -918,7 +918,7 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--py-file'], dict(
                 action='append',
-                help='.py file, .zip or .egg to add to PYTHONPATH'
+                help='.zip or .egg file to add to PYTHONPATH'
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -913,6 +913,15 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    py_files=dict(
+        combiner=combine_path_lists,
+        switches=[
+            (['--py-file'], dict(
+                action='append',
+                help='.py file, .zip or .egg to add to PYTHONPATH'
+            )),
+        ],
+    ),
     python_archives=dict(
         combiner=combine_path_lists,
         switches=[

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -305,7 +305,7 @@ class MRJobRunner(object):
         for path in self._opts['upload_archives']:
             ua = parse_legacy_hash_path('archive', path,
                                         must_name='upload_archives')
-            self._working_dir_mgr.add(*ua)
+            self._working_dir_mgr.add(**ua)
             self._spark_archives.append((ua['name'], ua['path']))
 
         # py_files, python_archives, setup, setup_cmds, and setup_scripts

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1251,10 +1251,6 @@ class MRJobRunner(object):
         return args
 
     def _spark_upload_args(self):
-        # Spark only supports a limited subset of files in the working dir
-        files = self._opts['upload_files']
-        archives = self._opts['upload_archives']
-
         return self._upload_args_helper('--files', self._spark_files,
                                         '--archives', self._spark_archives)
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1290,7 +1290,8 @@ class MRJobRunner(object):
         """Helper function for the *upload_args methods."""
         if named_paths is None:
             # just return everything managed by _working_dir_mgr
-            named_paths = self._working_dir_mgr.name_to_path(type).items()
+            named_paths = sorted(
+                self._working_dir_mgr.name_to_path(type).items())
 
         for name, path in named_paths:
             if not name:

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -920,6 +920,10 @@ class MRJobRunner(object):
 
         # py_files
         for path in self._opts['py_files']:
+            # Spark (at least v1.3.1) doesn't work with # and --py-files,
+            # see #1375
+            if '#' in path:
+                raise ValueError("py_files cannot contain '#'")
             path_dict = parse_legacy_hash_path('file', path)
             setup.append(['export PYTHONPATH=', path_dict, ':$PYTHONPATH'])
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -709,12 +709,6 @@ class MRJobRunner(object):
         return any(step['type'].split('_')[0] == 'spark'
                    for step in self._get_steps())
 
-    def _has_non_spark_steps(self):
-        """Are any of our steps non-Spark steps?"""
-        # if so, we don't need to upload py_files
-        return any(step['type'].split('_')[0] != 'spark'
-                   for step in self._get_steps())
-
     def _interpreter(self, steps=False):
         if steps:
             return (self._opts['steps_interpreter'] or

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -938,9 +938,12 @@ class MRJobRunner(object):
             setup.append(['export PYTHONPATH=', path_dict, ':$PYTHONPATH'])
 
         # python_archives
-        for path in self._opts['python_archives']:
-            path_dict = parse_legacy_hash_path('archive', path)
-            setup.append(['export PYTHONPATH=', path_dict, ':$PYTHONPATH'])
+        if self._opts['python_archives']:
+            log.warning('python_archives is deprecated and will be removed'
+                        ' in v0.6.0. Try py_files instead')
+            for path in self._opts['python_archives']:
+                path_dict = parse_legacy_hash_path('archive', path)
+                setup.append(['export PYTHONPATH=', path_dict, ':$PYTHONPATH'])
 
         # setup
         for cmd in self._opts['setup']:

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1208,6 +1208,14 @@ class MRJobRunner(object):
 
         return args
 
+    def _spark_cmdenv(self):
+        """Returns a dictionary mapping environment variable to value,
+        including mapping PYSPARK_PYTHON to self._python_bin()
+        """
+        cmdenv = dict(PYSPARK_PYTHON=cmd_line(self._python_bin()))
+        cmdenv.update(self._opts['cmdenv'])
+        return cmdenv
+
     def _spark_args_for_step(self, step_num):
         """Build a list of extra args to the spark-submit binary for
         the given spark or spark_script step."""
@@ -1217,11 +1225,8 @@ class MRJobRunner(object):
 
         # --conf arguments include python bin, cmdenv, jobconf. Make sure
         # that we can always override these manually
-        cmdenv = dict(PYSPARK_PYTHON=cmd_line(self._python_bin()))
-        cmdenv.update(self._opts['cmdenv'])
-
         jobconf = {}
-        for key, value in cmdenv.items():
+        for key, value in self._spark_cmdenv().items():
             jobconf['spark.executorEnv.%s' % key] = value
             jobconf['spark.yarn.appMasterEnv.%s' % key] = value
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -298,7 +298,7 @@ class MRJobRunner(object):
             self._working_dir_mgr.add(**parse_legacy_hash_path(
                 'archive', path, must_name='upload_archives'))
 
-        # python_archives, setup, setup_cmds, and setup_scripts
+        # py_files, python_archives, setup, setup_cmds, and setup_scripts
         # self._setup is a list of shell commands with path dicts
         # interleaved; see mrjob.setup.parse_setup_cmds() for details
         self._setup = self._parse_setup()
@@ -910,11 +910,18 @@ class MRJobRunner(object):
         true, create mrjob.tar.gz (if it doesn't exist already) and
         prepend a setup command that adds it to PYTHONPATH.
 
+        Patch in *py_files*.
+
         Also patch in the deprecated
         options *python_archives*, *setup_cmd*, and *setup_script*
         as setup commands.
         """
         setup = []
+
+        # py_files
+        for path in self._opts['py_files']:
+            path_dict = parse_legacy_hash_path('file', path)
+            setup.append(['export PYTHONPATH=', path_dict, ':$PYTHONPATH'])
 
         # python_archives
         for path in self._opts['python_archives']:

--- a/mrjob/setup.py
+++ b/mrjob/setup.py
@@ -425,12 +425,19 @@ class WorkingDirManager(object):
                     in self._name_to_typed_path.items()
                     if typed_path[0] == type)
 
-    def paths(self):
-        """Get a set of all paths tracked by this WorkingDirManager."""
+    def paths(self, type=None):
+        """Get a set of all paths tracked by this WorkingDirManager.
+
+        Optionally filter by type.
+        """
         paths = set()
 
-        paths.update(p for (t, p) in self._typed_path_to_auto_name)
-        paths.update(p for (t, p) in self._name_to_typed_path.values())
+        paths.update(
+            p for (t, p) in self._typed_path_to_auto_name
+            if type is None or t == type)
+        paths.update(
+            p for (t, p) in self._name_to_typed_path.values()
+            if type is None or t == type)
 
         return paths
 

--- a/mrjob/setup.py
+++ b/mrjob/setup.py
@@ -425,19 +425,12 @@ class WorkingDirManager(object):
                     in self._name_to_typed_path.items()
                     if typed_path[0] == type)
 
-    def paths(self, type=None):
-        """Get a set of all paths tracked by this WorkingDirManager.
-
-        Optionally filter by type.
-        """
+    def paths(self):
+        """Get a set of all paths tracked by this WorkingDirManager."""
         paths = set()
 
-        paths.update(
-            p for (t, p) in self._typed_path_to_auto_name
-            if type is None or t == type)
-        paths.update(
-            p for (t, p) in self._name_to_typed_path.values()
-            if type is None or t == type)
+        paths.update(p for (t, p) in self._typed_path_to_auto_name)
+        paths.update(p for (t, p) in self._name_to_typed_path.values())
 
         return paths
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5802,6 +5802,32 @@ class UsesSparkTestCase(MockBotoTestCase):
             self.assertFalse(runner._has_spark_application())
 
 
+class SparkPyFilesTestCase(MockBotoTestCase):
+
+    def test_eggs(self):
+        egg1_path = self.makefile('dragon.egg')
+        egg2_path = self.makefile('horton.egg')
+
+        job = MRNullSpark([
+            '-r', 'emr',
+            '--py-file', egg1_path, '--py-file', egg2_path])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._add_job_files_for_upload()
+
+            # in the cloud, we need to upload py_files to cloud storage
+            self.assertIn(egg1_path, runner._upload_mgr.path_to_uri())
+            self.assertIn(egg2_path, runner._upload_mgr.path_to_uri())
+
+            self.assertEqual(
+                runner._spark_py_files(),
+                [runner._upload_mgr.uri(egg1_path),
+                 runner._upload_mgr.uri(egg2_path)]
+            )
+
+
+
 class DeprecatedAMIVersionKeywordOptionTestCase(MockBotoTestCase):
     # regression test for #1421
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5664,6 +5664,7 @@ class UsesSparkTestCase(MockBotoTestCase):
             self.assertFalse(runner._has_spark_steps())
             self.assertFalse(runner._has_spark_install_bootstrap_action())
             self.assertFalse(runner._has_spark_application())
+            self.assertFalse(runner._opts['bootstrap_spark'])
 
     def test_spark_step(self):
         job = MRNullSpark(['-r', 'emr'])
@@ -5779,6 +5780,15 @@ class UsesSparkTestCase(MockBotoTestCase):
         with job.make_runner() as runner:
             self.assertTrue(runner._uses_spark())
             self.assertTrue(runner._has_spark_application())
+
+    def test_bootstrap_spark(self):
+        # tests #1465
+        job = MRTwoStepJob(['-r', 'emr', '--bootstrap-spark'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertTrue(runner._uses_spark())
+            self.assertTrue(runner._opts['bootstrap_spark'])
 
     def test_ignores_new_supported_products_api_param(self):
         job = MRTwoStepJob(['-r', 'emr',

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1045,6 +1045,31 @@ class SparkStepArgsTestCase(SandboxedTestCase):
             ])
 
 
+class SparkPyFilesTestCase(MockHadoopTestCase):
+
+    def test_eggs(self):
+        egg1_path = self.makefile('dragon.egg')
+        egg2_path = self.makefile('horton.egg')
+
+        job = MRNullSpark([
+            '-r', 'hadoop',
+            '--py-file', egg1_path, '--py-file', egg2_path])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._add_job_files_for_upload()
+
+            self.assertEqual(
+                runner._spark_py_files(),
+                [egg1_path, egg2_path]
+            )
+
+            # the py_files get uploaded anyway since they appear in
+            # _upload_dir_mgr.
+            self.assertIn(egg1_path, runner._upload_mgr.path_to_uri())
+            self.assertIn(egg2_path, runner._upload_mgr.path_to_uri())
+
+
 class SetupLineEncodingTestCase(MockHadoopTestCase):
 
     def test_setup_wrapper_script_uses_local_line_endings(self):

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -21,8 +21,10 @@ import os.path
 import pty
 from io import BytesIO
 from subprocess import check_call
+from subprocess import PIPE
 
 import mrjob.step
+from mrjob.conf import combine_dicts
 from mrjob.fs.hadoop import HadoopFilesystem
 from mrjob.hadoop import HadoopJobRunner
 from mrjob.hadoop import fully_qualify_hdfs_path
@@ -1043,6 +1045,110 @@ class SparkStepArgsTestCase(SandboxedTestCase):
                 runner._step_output_uri(0),
                 ','.join(runner._step_input_uris(0)),
             ])
+
+
+class EnvForStepTestCase(MockHadoopTestCase):
+
+    def setUp(self):
+        super(EnvForStepTestCase, self).setUp()
+        os.environ.clear()  # for less noisy test failures
+
+    def test_streaming_step(self):
+        job = MRTwoStepJob(['-r', 'hadoop', '--cmdenv', 'FOO=bar'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._env_for_step(0),
+                dict(os.environ)
+            )
+
+    def test_jar_step(self):
+        job = MRJustAJar(['-r', 'hadoop', '--cmdenv', 'FOO=bar'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._env_for_step(0),
+                dict(os.environ)
+            )
+
+    def test_spark_step(self):
+        job = MRNullSpark(['-r', 'hadoop', '--cmdenv', 'FOO=bar'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._env_for_step(0),
+                combine_dicts(os.environ,
+                              dict(FOO='bar', PYSPARK_PYTHON=PYTHON_BIN))
+            )
+
+    def test_spark_script_step(self):
+        job = MRSparkScript(['-r', 'hadoop', '--cmdenv', 'FOO=bar'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._env_for_step(0),
+                combine_dicts(os.environ,
+                              dict(FOO='bar', PYSPARK_PYTHON=PYTHON_BIN))
+            )
+
+
+class RunJobInHadoopUsesEnvTestCase(MockHadoopTestCase):
+
+    def setUp(self):
+        super(RunJobInHadoopUsesEnvTestCase, self).setUp()
+
+        self.mock_num_steps = self.start(patch(
+            'mrjob.hadoop.HadoopJobRunner._num_steps',
+            return_value=1))
+
+        self.mock_args_for_step = self.start(patch(
+            'mrjob.hadoop.HadoopJobRunner._args_for_step',
+            return_value=['args', 'for', 'step']))
+
+        self.mock_env_for_step = self.start(patch(
+            'mrjob.hadoop.HadoopJobRunner._env_for_step',
+            return_value=dict(FOO='bar', BAZ='qux')))
+
+        self.mock_pty_fork = self.start(patch(
+            'pty.fork', return_value=(0, None)))
+
+        # end test once we invoke Popen or execvpe()
+        self.mock_Popen = self.start(patch(
+            'mrjob.hadoop.Popen', side_effect=StopIteration))
+
+        self.mock_execvpe = self.start(patch(
+            'os.execvpe', side_effect=StopIteration))
+
+    def test_with_pty(self):
+        job = MRNullSpark(['-r', 'hadoop'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertRaises(StopIteration, runner._run_job_in_hadoop)
+
+            self.mock_execvpe.assert_called_once_with(
+                'args', ['args', 'for', 'step'], dict(FOO='bar', BAZ='qux'))
+
+            self.assertFalse(self.mock_Popen.called)
+
+    def test_without_pty(self):
+        self.mock_pty_fork.side_effect = OSError
+
+        job = MRNullSpark(['-r', 'hadoop'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertRaises(StopIteration, runner._run_job_in_hadoop)
+
+            self.mock_Popen.assert_called_once_with(
+                ['args', 'for', 'step'],
+                stdout=PIPE, stderr=PIPE, env=dict(FOO='bar', BAZ='qux'))
+
+            self.assertFalse(self.mock_execvpe.called)
 
 
 class SparkPyFilesTestCase(MockHadoopTestCase):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -686,10 +686,12 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
     def test_file_args(self):
         foo1_path = self.makefile('foo1')
         foo2_path = self.makefile('foo2')
+        baz_path = self.makefile('baz.tar.gz')
 
         job = MRNullSpark(
             ['--file', foo1_path + '#foo1',
-             '--file', foo2_path + '#bar'])
+             '--file', foo2_path + '#bar',
+             '--archive', baz_path])
 
         with job.make_runner() as runner:
             runner._upload_mgr = self._mock_upload_mgr()
@@ -700,8 +702,10 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
                         cmdenv=dict(PYSPARK_PYTHON='mypy')
                     ) + [
                         '--files',
-                        runner._upload_mgr.uri(foo1_path) + '#foo1' + ',' +
-                        runner._upload_mgr.uri(foo2_path) + '#bar'
+                        (runner._upload_mgr.uri(foo1_path) + '#foo1' + ',' +
+                         runner._upload_mgr.uri(foo2_path) + '#bar'),
+                        '--archives',
+                        runner._upload_mgr.uri(baz_path) + '#baz.tar.gz'
                     ]
                 )
             )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -563,17 +563,9 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
         return args
 
-    def _mock_upload_mgr(self):
-        def mock_uri(path):
-            return '<uri of %s>' % path
-
-        m = Mock()
-        m.uri = Mock(side_effect=mock_uri)
-
-        return m
-
     def test_default(self):
         job = MRNullSpark()
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(
@@ -583,6 +575,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
     def test_cmdenv(self):
         job = MRNullSpark(['--cmdenv', 'FOO=bar', '--cmdenv', 'BAZ=qux'])
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(
@@ -592,6 +585,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
     def test_cmdenv_can_override_python_bin(self):
         job = MRNullSpark(['--cmdenv', 'PYSPARK_PYTHON=ourpy'])
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(
@@ -601,6 +595,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
     def test_jobconf(self):
         job = MRNullSpark(['--jobconf', 'spark.executor.memory=10g'])
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(
@@ -611,6 +606,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
     def test_jobconf_uses_jobconf_for_step(self):
         job = MRNullSpark()
+        job.sandbox()
 
         with job.make_runner() as runner:
             with patch.object(
@@ -630,6 +626,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
             ['--cmdenv', 'FOO=bar',
              '--jobconf', 'spark.executorEnv.FOO=baz',
              '--jobconf', 'spark.yarn.appMasterEnv.PYSPARK_PYTHON=ourpy'])
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(
@@ -646,6 +643,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
     def test_option_spark_args(self):
         job = MRNullSpark(['--spark-arg', '--name', '--spark-arg', 'Dave'])
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(
@@ -659,6 +657,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
     def test_job_spark_args(self):
         # --extra-spark-arg is a passthrough option for MRNullSpark
         job = MRNullSpark(['--extra-spark-arg', '-v'])
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(
@@ -673,6 +672,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
         job = MRNullSpark(
             ['--extra-spark-arg', '-v',
              '--spark-arg', '--name', '--spark-arg', 'Dave'])
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(
@@ -692,6 +692,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
             ['--file', foo1_path + '#foo1',
              '--file', foo2_path + '#bar',
              '--archive', baz_path])
+        job.sandbox()
 
         with job.make_runner() as runner:
             runner._upload_mgr = self._mock_upload_mgr()
@@ -710,8 +711,18 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
                 )
             )
 
+    def _mock_upload_mgr(self):
+        def mock_uri(path):
+            return '<uri of %s>' % path
+
+        m = Mock()
+        m.uri = Mock(side_effect=mock_uri)
+
+        return m
+
     def test_py_files(self):
         job = MRNullSpark()
+        job.sandbox()
 
         with job.make_runner() as runner:
             runner._spark_py_files = Mock(
@@ -734,6 +745,7 @@ class SparkPyFilesTestCase(SandboxedTestCase):
 
     def test_default(self):
         job = MRNullSpark()
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(runner._spark_py_files(), [])
@@ -744,6 +756,7 @@ class SparkPyFilesTestCase(SandboxedTestCase):
         egg2_path = self.makefile('horton.egg')
 
         job = MRNullSpark(['--py-file', egg1_path, '--py-file', egg2_path])
+        job.sandbox()
 
         with job.make_runner() as runner:
             self.assertEqual(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -710,6 +710,32 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
                 )
             )
 
+    def test_py_files(self):
+        egg1_path = self.makefile('dragon.egg')
+        egg2_path = self.makefile('horton.egg')
+
+
+        job = MRNullSpark(['--py-file', egg1_path, '--py-file', egg2_path])
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_py_files(),
+                [egg1_path, egg2_path]
+            )
+
+            self.assertEqual(
+                runner._spark_args_for_step(0), (
+                    self._expected_conf_args(
+                        cmdenv=dict(PYSPARK_PYTHON='mypy')
+                    ) + [
+                        # by default pass the py_files directly to Spark
+                        # (we only use _upload_mgr in the cloud)
+                        '--py-files',
+                        (egg1_path + ',' + egg2_path),
+                    ]
+                )
+            )
+
 
 class StrictProtocolsInConfTestCase(TestCase):
     # regression tests for #1302, where command-line option's default

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -766,8 +766,13 @@ class SparkPyFilesTestCase(SandboxedTestCase):
                 [egg1_path, egg2_path]
             )
 
+    def test_no_hash_paths(self):
+        egg_path = self.makefile('horton.egg')
 
+        job = MRNullSpark(['--py-file', egg_path + '#mayzie.egg'])
+        job.sandbox()
 
+        self.assertRaises(ValueError, job.make_runner)
 
 
 class StrictProtocolsInConfTestCase(TestCase):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -400,9 +400,6 @@ class WorkingDirManagerTestCase(TestCase):
                          {'bar.py': 'foo/bar.py'})
         self.assertEqual(wd.name_to_path('archive'),
                          {'baz.tar.gz': 's3://bucket/path/to/baz.tar.gz'})
-        self.assertEqual(wd.paths('file'), set(['foo/bar.py']))
-        self.assertEqual(wd.paths('archive'),
-                         set(['s3://bucket/path/to/baz.tar.gz']))
         self.assertEqual(
             wd.paths(),
             set(['foo/bar.py', 's3://bucket/path/to/baz.tar.gz']))

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -390,6 +390,7 @@ class WorkingDirManagerTestCase(TestCase):
         wd = WorkingDirManager()
         self.assertEqual(wd.name_to_path('archive'), {})
         self.assertEqual(wd.name_to_path('file'), {})
+        self.assertEqual(wd.paths(), set())
 
     def test_simple(self):
         wd = WorkingDirManager()
@@ -399,6 +400,12 @@ class WorkingDirManagerTestCase(TestCase):
                          {'bar.py': 'foo/bar.py'})
         self.assertEqual(wd.name_to_path('archive'),
                          {'baz.tar.gz': 's3://bucket/path/to/baz.tar.gz'})
+        self.assertEqual(wd.paths('file'), set(['foo/bar.py']))
+        self.assertEqual(wd.paths('archive'),
+                         set(['s3://bucket/path/to/baz.tar.gz']))
+        self.assertEqual(
+            wd.paths(),
+            set(['foo/bar.py', 's3://bucket/path/to/baz.tar.gz']))
 
     def test_explicit_name_collision(self):
         wd = WorkingDirManager()
@@ -419,6 +426,7 @@ class WorkingDirManagerTestCase(TestCase):
         self.assertEqual(wd.name_to_path('file'),
                          {'qux.py': 'foo/bar.py',
                           'bar.py': 'foo/bar.py'})
+        self.assertEqual(wd.paths(), set(['foo/bar.py']))
 
     def test_cant_give_same_path_different_types(self):
         wd = WorkingDirManager()


### PR DESCRIPTION
This add support for `--files` and `--archives` in Spark (fixes #1374)

This also adds `--py-file`, which works with both Spark steps and setup scripts (fixes #1375).

Cmdenv now gets passed directly to `spark-submit` by the Hadoop runner (fixes #1464).

Running `mrjob create-cluster --bootstrap-spark` will now pick an `m1.large`, not a `m1.medium` (fixes #1465).
