### PR TITLE
Spark passthrough args

### DIFF
--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1215,13 +1215,11 @@ class MRJobRunner(object):
         """
         step = self._get_step(step_num)
 
-        spark_args = self._spark_submit_args(step_num)
         script_path, script_args = self._spark_script_path_and_args(step_num)
 
         return (
             self.get_spark_submit_bin() +
-            self._spark_submit_arg_prefix() +
-            spark_args +
+            self._spark_submit_args(step_num) +
             [self._interpolate_spark_script_path(script_path)] +
             self._interpolate_input_and_output(script_args, step_num)
         )
@@ -1273,6 +1271,9 @@ class MRJobRunner(object):
         step = self._get_step(step_num)
 
         args = []
+
+        # add runner-specific args
+        args.extend(self._spark_submit_arg_prefix())
 
         # --conf arguments include python bin, cmdenv, jobconf. Make sure
         # that we can always override these manually

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1229,7 +1229,7 @@ class MRJobRunner(object):
         elif step['type'] == 'spark_script':
             path = step['script']
         else:
-            raise ValueError('Unknown spark step type: %r' % step['type'])
+            raise TypeError('Bad step type: %r' % step['type'])
 
         return self._interpolate_spark_script_path(path)
 
@@ -1249,7 +1249,7 @@ class MRJobRunner(object):
         elif step['type'] == 'spark_script':
             args = step['args']
         else:
-            raise ValueError('Unknown spark step type: %r' % step['type'])
+            raise TypeError('Bad step type: %r' % step['type'])
 
         return self._interpolate_input_and_output(args, step_num)
 
@@ -1280,6 +1280,9 @@ class MRJobRunner(object):
         """Build a list of extra args to the spark-submit binary for
         the given spark or spark_script step."""
         step = self._get_step(step_num)
+
+        if step['type'].split('_')[0] != 'spark':
+            raise TypeError('non-Spark step: %r' % step)
 
         args = []
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1215,7 +1215,7 @@ class MRJobRunner(object):
         """
         step = self._get_step(step_num)
 
-        spark_args = self._spark_args_for_step(step_num)
+        spark_args = self._spark_submit_args(step_num)
         script_path, script_args = self._spark_script_path_and_args(step_num)
 
         return (
@@ -1267,7 +1267,7 @@ class MRJobRunner(object):
         cmdenv.update(self._opts['cmdenv'])
         return cmdenv
 
-    def _spark_args_for_step(self, step_num):
+    def _spark_submit_args(self, step_num):
         """Build a list of extra args to the spark-submit binary for
         the given spark or spark_script step."""
         step = self._get_step(step_num)

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1240,12 +1240,15 @@ class MRJobRunner(object):
 
         if step['type'] == 'spark':
             # TODO: add in passthrough options
-            args = [
-                '--step-num=%d' % step_num,
-                '--spark',
-                mrjob.step.INPUT,
-                mrjob.step.OUTPUT,
-            ]
+            args = (
+                [
+                    '--step-num=%d' % step_num,
+                    '--spark',
+                ] + self._mr_job_extra_args() + [
+                    mrjob.step.INPUT,
+                    mrjob.step.OUTPUT,
+                ]
+            )
         elif step['type'] == 'spark_script':
             args = step['args']
         else:

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -295,6 +295,7 @@ class MRJobRunner(object):
                 arg_file = parse_legacy_hash_path('file', path)
                 self._working_dir_mgr.add(**arg_file)
                 self._file_upload_args.append((arg, arg_file))
+                self._spark_files.append((arg_file['name'], arg_file['path']))
 
         # set up uploading
         for path in self._opts['upload_files']:

--- a/tests/mr_null_spark.py
+++ b/tests/mr_null_spark.py
@@ -26,6 +26,9 @@ class MRNullSpark(MRJob):
             '--extra-spark-arg', dest='extra_spark_args',
             action='append', default=[])
 
+        self.add_file_option(
+            '--extra-file', dest='extra_file')
+
     def spark(self):
         pass
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3629,7 +3629,7 @@ class SparkStepTestCase(MockBotoTestCase):
         # _spark_submit_args() is tested elsewhere
         self.start(patch(
             'mrjob.runner.MRJobRunner._spark_submit_args',
-            return_value=['<spark args for step>']))
+            return_value=['<spark submit args>']))
 
     # TODO: test warning for for AMIs prior to 3.8.0, which don't offer Spark
 
@@ -3689,9 +3689,8 @@ class SparkStepTestCase(MockBotoTestCase):
             # the first arg is spark-submit and varies by AMI
             self.assertEqual(
                 step_args[1:],
-                _EMR_SPARK_ARGS +
                 [
-                    '<spark args for step>',
+                    '<spark submit args>',
                     script_uri,
                     '--step-num=0',
                     '--spark',
@@ -3711,7 +3710,7 @@ class SparkScriptStepTestCase(MockBotoTestCase):
         # _spark_submit_args() is tested elsewhere
         self.start(patch(
             'mrjob.runner.MRJobRunner._spark_submit_args',
-            return_value=['<spark args for step>']))
+            return_value=['<spark submit args>']))
 
     def test_script_gets_uploaded(self):
         job = MRSparkScript(['-r', 'emr', '--script', self.fake_script])
@@ -3732,7 +3731,7 @@ class SparkScriptStepTestCase(MockBotoTestCase):
             # the first arg is spark-submit and varies by AMI
             self.assertEqual(
                 step_args[1:],
-                _EMR_SPARK_ARGS + ['<spark args for step>', script_uri])
+                ['<spark submit args>', script_uri])
 
     # TODO: test warning for for AMIs prior to 3.8.0, which don't offer Spark
 
@@ -3798,9 +3797,8 @@ class SparkScriptStepTestCase(MockBotoTestCase):
             # the first arg is spark-submit and varies by AMI
             self.assertEqual(
                 step_args[1:],
-                _EMR_SPARK_ARGS +
                 [
-                    '<spark args for step>',
+                    '<spark submit args>',
                     script_uri,
                     input1_uri + ',' + input2_uri,
                     '-o',

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3626,9 +3626,9 @@ class SparkStepTestCase(MockBotoTestCase):
     def setUp(self):
         super(SparkStepTestCase, self).setUp()
 
-        # _spark_args_for_step() is tested elsewhere
+        # _spark_submit_args() is tested elsewhere
         self.start(patch(
-            'mrjob.runner.MRJobRunner._spark_args_for_step',
+            'mrjob.runner.MRJobRunner._spark_submit_args',
             return_value=['<spark args for step>']))
 
     # TODO: test warning for for AMIs prior to 3.8.0, which don't offer Spark
@@ -3708,9 +3708,9 @@ class SparkScriptStepTestCase(MockBotoTestCase):
         self.fake_script = os.path.join(self.tmp_dir, 'fake.py')
         open(self.fake_script, 'w').close()
 
-        # _spark_args_for_step() is tested elsewhere
+        # _spark_submit_args() is tested elsewhere
         self.start(patch(
-            'mrjob.runner.MRJobRunner._spark_args_for_step',
+            'mrjob.runner.MRJobRunner._spark_submit_args',
             return_value=['<spark args for step>']))
 
     def test_script_gets_uploaded(self):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -30,7 +30,7 @@ import mrjob.emr
 from mrjob.emr import EMRJobRunner
 from mrjob.emr import _3_X_SPARK_BOOTSTRAP_ACTION
 from mrjob.emr import _3_X_SPARK_SUBMIT
-from mrjob.emr import _4_X_INTERMEDIARY_JAR
+from mrjob.emr import _4_X_COMMAND_RUNNER_JAR
 from mrjob.emr import _DEFAULT_IMAGE_VERSION
 from mrjob.emr import _EMR_SPARK_ARGS
 from mrjob.emr import _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH
@@ -3424,7 +3424,7 @@ class StreamingJarAndStepArgPrefixTestCase(MockBotoTestCase):
     def test_4_x_ami(self):
         runner = self.launch_runner('--image-version', '4.0.0')
         self.assertEqual(runner._get_streaming_jar_and_step_arg_prefix(),
-                         (_4_X_INTERMEDIARY_JAR, ['hadoop-streaming']))
+                         (_4_X_COMMAND_RUNNER_JAR, ['hadoop-streaming']))
 
     def test_local_hadoop_streaming_jar(self):
         jar_path = os.path.join(self.tmp_dir, 'righteousness.jar')
@@ -3662,7 +3662,7 @@ class SparkStepTestCase(MockBotoTestCase):
 
             self.assertEqual(len(steps), 1)
             self.assertEqual(
-                steps[0].config.jar, _4_X_INTERMEDIARY_JAR)
+                steps[0].config.jar, _4_X_COMMAND_RUNNER_JAR)
             self.assertEqual(
                 steps[0].config.args[0].value, 'spark-submit')
 
@@ -3767,7 +3767,7 @@ class SparkScriptStepTestCase(MockBotoTestCase):
 
             self.assertEqual(len(steps), 1)
             self.assertEqual(
-                steps[0].config.jar, _4_X_INTERMEDIARY_JAR)
+                steps[0].config.jar, _4_X_COMMAND_RUNNER_JAR)
             self.assertEqual(
                 steps[0].config.args[0].value, 'spark-submit')
 

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1001,7 +1001,7 @@ class SparkStepArgsTestCase(SandboxedTestCase):
         # _spark_submit_args() is tested elsewhere
         self.start(patch(
             'mrjob.runner.MRJobRunner._spark_submit_args',
-            return_value=['<spark args for step>']))
+            return_value=['<spark submit args>']))
 
     def test_spark_step(self):
         job = MRNullSpark([
@@ -1014,8 +1014,7 @@ class SparkStepArgsTestCase(SandboxedTestCase):
 
             self.assertEqual(runner._args_for_step(0), [
                 'spark-submit',
-                '--master', 'yarn',
-                '<spark args for step>',
+                '<spark submit args>',
                 runner._script_path,
                 '--step-num=0',
                 '--spark',
@@ -1038,8 +1037,7 @@ class SparkStepArgsTestCase(SandboxedTestCase):
 
             self.assertEqual(runner._args_for_step(0), [
                 'spark-submit',
-                '--master', 'yarn',
-                '<spark args for step>',
+                '<spark submit args>',
                 '/path/to/spark_script.py',
                 'foo',
                 runner._step_output_uri(0),

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -998,9 +998,9 @@ class SparkStepArgsTestCase(SandboxedTestCase):
     def setUp(self):
         super(SparkStepArgsTestCase, self).setUp()
 
-        # _spark_args_for_step() is tested elsewhere
+        # _spark_submit_args() is tested elsewhere
         self.start(patch(
-            'mrjob.runner.MRJobRunner._spark_args_for_step',
+            'mrjob.runner.MRJobRunner._spark_submit_args',
             return_value=['<spark args for step>']))
 
     def test_spark_step(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -539,6 +539,10 @@ class HadoopArgsForStepTestCase(EmptyMrjobConfTestCase):
                              ['-partitioner', partitioner])
 
 
+
+
+
+
 class SparkSubmitArgsTestCase(SandboxedTestCase):
 
     def setUp(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -538,6 +538,49 @@ class HadoopArgsForStepTestCase(EmptyMrjobConfTestCase):
             self.assertEqual(runner._hadoop_args_for_step(0),
                              ['-partitioner', partitioner])
 
+class ArgsForSparkStepTestCase(SandboxedTestCase):
+    # just test the structure of _args_for_spark_step()
+
+    def setUp(self):
+        self.mock_get_spark_submit_bin = self.start(patch(
+            'mrjob.runner.MRJobRunner.get_spark_submit_bin',
+            return_value=['<spark-submit bin>']))
+
+        self.mock_spark_submit_args = self.start(patch(
+            'mrjob.runner.MRJobRunner._spark_submit_args',
+            return_value=['<spark submit args>']))
+
+        self.mock_spark_script_path = self.start(patch(
+            'mrjob.runner.MRJobRunner._spark_script_path',
+            return_value='<spark script path>'))
+
+        self.mock_spark_script_args = self.start(patch(
+            'mrjob.runner.MRJobRunner._spark_script_args',
+            return_value=['<spark script args>']))
+
+    def _test_step(self, step_num):
+        job = MRNullSpark()
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._args_for_spark_step(step_num),
+                ['<spark-submit bin>',
+                 '<spark submit args>',
+                 '<spark script path>',
+                 '<spark script args>'])
+
+            self.mock_get_spark_submit_bin.assert_called_once_with()
+            self.mock_spark_submit_args.assert_called_once_with(step_num)
+            self.mock_spark_script_path.assert_called_once_with(step_num)
+            self.mock_spark_script_args.assert_called_once_with(step_num)
+
+    def test_step_0(self):
+        self._test_step(0)
+
+    def test_step_1(self):
+        self._test_step(1)
+
 
 class SparkSubmitArgsTestCase(SandboxedTestCase):
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -539,10 +539,6 @@ class HadoopArgsForStepTestCase(EmptyMrjobConfTestCase):
                              ['-partitioner', partitioner])
 
 
-
-
-
-
 class SparkSubmitArgsTestCase(SandboxedTestCase):
 
     def setUp(self):
@@ -550,9 +546,6 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
 
         self.start(patch('mrjob.runner.MRJobRunner._python_bin',
                          return_value=['mypy']))
-
-        self.start(patch('mrjob.runner.MRJobRunner._spark_submit_arg_prefix',
-                         return_value=['<arg prefix>']))
 
     def _expected_conf_args(self, cmdenv=None, jobconf=None):
         conf = {}
@@ -565,7 +558,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         if jobconf:
             conf.update(jobconf)
 
-        args = ['<arg prefix>']
+        args = []
 
         for key, value in sorted(conf.items()):
             args.extend(['--conf', '%s=%s' % (key, value)])
@@ -579,6 +572,20 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         with job.make_runner() as runner:
             self.assertEqual(
                 runner._spark_submit_args(0),
+                self._expected_conf_args(
+                    cmdenv=dict(PYSPARK_PYTHON='mypy')))
+
+    def test_spark_submit_arg_prefix(self):
+        self.start(patch('mrjob.runner.MRJobRunner._spark_submit_arg_prefix',
+                         return_value=['<arg prefix>']))
+
+        job = MRNullSpark()
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_submit_args(0),
+                ['<arg prefix>'] +
                 self._expected_conf_args(
                     cmdenv=dict(PYSPARK_PYTHON='mypy')))
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -547,6 +547,9 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         self.start(patch('mrjob.runner.MRJobRunner._python_bin',
                          return_value=['mypy']))
 
+        self.start(patch('mrjob.runner.MRJobRunner._spark_submit_arg_prefix',
+                         return_value=['<arg prefix>']))
+
     def _expected_conf_args(self, cmdenv=None, jobconf=None):
         conf = {}
 
@@ -558,7 +561,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         if jobconf:
             conf.update(jobconf)
 
-        args = []
+        args = ['<arg prefix>']
 
         for key, value in sorted(conf.items()):
             args.extend(['--conf', '%s=%s' % (key, value)])

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -539,10 +539,10 @@ class HadoopArgsForStepTestCase(EmptyMrjobConfTestCase):
                              ['-partitioner', partitioner])
 
 
-class SparkArgsForStepTestCase(SandboxedTestCase):
+class SparkSubmitArgsTestCase(SandboxedTestCase):
 
     def setUp(self):
-        super(SparkArgsForStepTestCase, self).setUp()
+        super(SparkSubmitArgsTestCase, self).setUp()
 
         self.start(patch('mrjob.runner.MRJobRunner._python_bin',
                          return_value=['mypy']))
@@ -571,7 +571,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
         with job.make_runner() as runner:
             self.assertEqual(
-                runner._spark_args_for_step(0),
+                runner._spark_submit_args(0),
                 self._expected_conf_args(
                     cmdenv=dict(PYSPARK_PYTHON='mypy')))
 
@@ -581,7 +581,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
         with job.make_runner() as runner:
             self.assertEqual(
-                runner._spark_args_for_step(0),
+                runner._spark_submit_args(0),
                 self._expected_conf_args(
                     cmdenv=dict(PYSPARK_PYTHON='mypy', FOO='bar', BAZ='qux')))
 
@@ -591,7 +591,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
         with job.make_runner() as runner:
             self.assertEqual(
-                runner._spark_args_for_step(0),
+                runner._spark_submit_args(0),
                 self._expected_conf_args(
                     cmdenv=dict(PYSPARK_PYTHON='ourpy')))
 
@@ -601,7 +601,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
         with job.make_runner() as runner:
             self.assertEqual(
-                runner._spark_args_for_step(0),
+                runner._spark_submit_args(0),
                 self._expected_conf_args(
                     cmdenv=dict(PYSPARK_PYTHON='mypy'),
                     jobconf={'spark.executor.memory': '10g'}))
@@ -616,7 +616,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
                     return_value=dict(foo='bar')) as mock_jobconf_for_step:
 
                 self.assertEqual(
-                    runner._spark_args_for_step(0),
+                    runner._spark_submit_args(0),
                     self._expected_conf_args(
                         cmdenv=dict(PYSPARK_PYTHON='mypy'),
                         jobconf=dict(foo='bar')))
@@ -632,7 +632,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
         with job.make_runner() as runner:
             self.assertEqual(
-                runner._spark_args_for_step(0),
+                runner._spark_submit_args(0),
                 self._expected_conf_args(
                     jobconf={
                         'spark.executorEnv.FOO': 'baz',
@@ -649,7 +649,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
         with job.make_runner() as runner:
             self.assertEqual(
-                runner._spark_args_for_step(0), (
+                runner._spark_submit_args(0), (
                     self._expected_conf_args(
                         cmdenv=dict(PYSPARK_PYTHON='mypy')) +
                     ['--name', 'Dave']
@@ -663,7 +663,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
         with job.make_runner() as runner:
             self.assertEqual(
-                runner._spark_args_for_step(0), (
+                runner._spark_submit_args(0), (
                     self._expected_conf_args(
                         cmdenv=dict(PYSPARK_PYTHON='mypy')) +
                     ['-v']
@@ -678,7 +678,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
 
         with job.make_runner() as runner:
             self.assertEqual(
-                runner._spark_args_for_step(0), (
+                runner._spark_submit_args(0), (
                     self._expected_conf_args(
                         cmdenv=dict(PYSPARK_PYTHON='mypy')) +
                     ['--name', 'Dave', '-v']
@@ -700,7 +700,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
             runner._upload_mgr = self._mock_upload_mgr()
 
             self.assertEqual(
-                runner._spark_args_for_step(0), (
+                runner._spark_submit_args(0), (
                     self._expected_conf_args(
                         cmdenv=dict(PYSPARK_PYTHON='mypy')
                     ) + [
@@ -732,7 +732,7 @@ class SparkArgsForStepTestCase(SandboxedTestCase):
             )
 
             self.assertEqual(
-                runner._spark_args_for_step(0), (
+                runner._spark_submit_args(0), (
                     self._expected_conf_args(
                         cmdenv=dict(PYSPARK_PYTHON='mypy')
                     ) + [

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -816,8 +816,6 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                 )
             )
 
-
-
     def _mock_upload_mgr(self):
         def mock_uri(path):
             return '<uri of %s>' % path

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -951,7 +951,19 @@ class SparkScriptArgsTestCase(SandboxedTestCase):
                  '<step 0 input>',
                  '<step 0 output>'])
 
-    # test passthrough args here
+    def test_spark_passthrough_arg(self):
+        job = MRNullSpark(['--extra-spark-arg', '--verbose'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_args(0),
+                ['--step-num=0',
+                 '--spark',
+                 '--extra-spark-arg',
+                 '--verbose',
+                 '<step 0 input>',
+                 '<step 0 output>'])
 
     def test_spark_script(self):
         job = MRSparkScript(['--script-arg', 'foo', '--script-arg', 'bar'])

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -582,6 +582,25 @@ class ArgsForSparkStepTestCase(SandboxedTestCase):
         self._test_step(1)
 
 
+class GetSparkSubmitBinTestCase(SandboxedTestCase):
+
+    def test_default(self):
+        job = MRNullSpark()
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(runner.get_spark_submit_bin(),
+                             ['spark-submit'])
+
+    def test_spark_submit_bin_option(self):
+        job = MRNullSpark(['--spark-submit-bin', 'spork-submit -kfc'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(runner.get_spark_submit_bin(),
+                             ['spork-submit', '-kfc'])
+
+
 class SparkSubmitArgsTestCase(SandboxedTestCase):
 
     def setUp(self):


### PR DESCRIPTION
Added support to spark jobs for passthrough args, including file options (fixes #1380).

Also merged common code between Hadoop and EMR runners, vastly improved its structure, and added much more complete tests.