### PR TITLE
Spark JAR support

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -112,6 +112,7 @@ from mrjob.setup import UploadDirManager
 from mrjob.setup import parse_legacy_hash_path
 from mrjob.setup import parse_setup_cmd
 from mrjob.step import StepFailedException
+from mrjob.step import _is_spark_step_type
 from mrjob.util import cmd_line
 from mrjob.util import shlex_split
 from mrjob.util import random_identifier
@@ -1592,7 +1593,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             return self._build_streaming_step(step_num)
         elif step['type'] == 'jar':
             return self._build_jar_step(step_num)
-        elif step['type'] in ('spark', 'spark_script'):
+        elif _is_spark_step_type(step['type']):
             return self._build_spark_step(step_num)
         else:
             raise AssertionError('Bad step type: %r' % (step['type'],))

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -26,7 +26,6 @@ try:
 except ImportError:
     pty = None
 
-import mrjob.step
 from mrjob.compat import translate_jobconf
 from mrjob.compat import uses_yarn
 from mrjob.conf import combine_dicts
@@ -49,6 +48,7 @@ from mrjob.runner import MRJobRunner
 from mrjob.runner import RunnerOptionStore
 from mrjob.setup import UploadDirManager
 from mrjob.step import StepFailedException
+from mrjob.step import _is_spark_step_type
 from mrjob.util import cmd_line
 from mrjob.util import unique
 from mrjob.util import which
@@ -596,8 +596,8 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         env = dict(os.environ)
 
         # when running spark-submit, set its environment directly. See #1464
-        if step['type'].split('_')[0] == 'spark':
-            env.update(self._spark_cmdenv())
+        if _is_spark_step_type(step['type']):
+            env.update(self._spark_cmdenv(step_num))
 
         return env
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -507,7 +507,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             return self._args_for_streaming_step(step_num)
         elif step['type'] == 'jar':
             return self._args_for_jar_step(step_num)
-        elif step['type'] in ('spark', 'spark_script'):
+        elif _is_spark_step_type(step['type']):
             return self._args_for_spark_step(step_num)
         else:
             raise AssertionError('Bad step type: %r' % (step['type'],))

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -52,6 +52,7 @@ from mrjob.setup import WorkingDirManager
 from mrjob.setup import parse_legacy_hash_path
 from mrjob.setup import parse_setup_cmd
 from mrjob.step import STEP_TYPES
+from mrjob.step import _is_spark_step_type
 from mrjob.util import bash_wrap
 from mrjob.util import cmd_line
 from mrjob.util import tar_and_gzip

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -570,3 +570,8 @@ class SparkScriptStep(object):
             'script': self.script,
             'spark_args': self.spark_args,
         }
+
+
+def _is_spark_step_type(step_type):
+    """Does the given step type indicate that it uses Spark?"""
+    return step_type[0].split('_') == 'spark'

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -574,4 +574,4 @@ class SparkScriptStep(object):
 
 def _is_spark_step_type(step_type):
     """Does the given step type indicate that it uses Spark?"""
-    return step_type[0].split('_') == 'spark'
+    return step_type.split('_')[0] == 'spark'

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -19,7 +19,7 @@ from mrjob.py2 import string_types
 from mrjob.util import cmd_line
 
 
-STEP_TYPES = ('jar', 'spark', 'spark_script', 'streaming')
+STEP_TYPES = ('jar', 'spark', 'spark_jar', 'spark_script', 'streaming')
 
 # Function names mapping to mapper, reducer, and combiner operations
 _MAPPER_FUNCS = ('mapper', 'mapper_init', 'mapper_final', 'mapper_cmd',
@@ -38,11 +38,14 @@ _JOB_STEP_PARAMS = _JOB_STEP_FUNC_PARAMS + _HADOOP_OPTS
 # all allowable JarStep constructor keyword args
 _JAR_STEP_KWARGS = ['args', 'main_class']
 
-# all allowable SparkScriptStep constructor keyword args
-_SPARK_SCRIPT_STEP_KWARGS = ['args', 'script', 'spark_args']
-
 # all allowable SparkStep constructor keyword args
 _SPARK_STEP_KWARGS = ['spark', 'spark_args']
+
+# all allowable SparkJarStep constructor keyword args
+_SPARK_JAR_STEP_KWARGS = ['args', 'jar', 'main_class', 'spark_args']
+
+# all allowable SparkScriptStep constructor keyword args
+_SPARK_SCRIPT_STEP_KWARGS = ['args', 'script', 'spark_args']
 
 
 #: If passed as an argument to :py:class:`JarStep` or
@@ -433,6 +436,77 @@ class SparkStep(object):
         }
 
 
+class SparkJarStep(object):
+    """Represents a running a separate Jar through Spark
+
+    Accepts the following keyword arguments:
+
+    :param jar: The local path to the Python script to run. On EMR, this
+                   can also be an ``s3://`` URI, or ``file://`` to reference a
+                   jar on the local filesystem of your EMR instance(s).
+    :param main_class: Your application's main class (e.g.
+                       ``'org.apache.spark.examples.SparkPi'``)
+    :param args: (optional) A list of arguments to the script. Use
+                 :py:data:`mrjob.step.INPUT` and :py:data:`OUTPUT` to
+                 interpolate input and output paths.
+    :param spark_args: (optional) an array of arguments to pass to spark-submit
+                       (e.g. ``['--executor-memory', '2G']``).
+
+    *script* can also be passed as a positional argument
+    """
+    def __init__(self, jar, main_class, **kwargs):
+        bad_kwargs = sorted(set(kwargs) - set(_SPARK_JAR_STEP_KWARGS))
+        if bad_kwargs:
+            raise TypeError(
+                'SparkJarStep() got an unexpected keyword argument %r' %
+                bad_kwargs[0])
+
+        self.jar = jar
+        self.main_class = main_class
+
+        self.args = kwargs.get('args') or []
+        self.spark_args = kwargs.get('spark_args') or []
+
+    def __repr__(self):
+        repr_args = []
+        repr_args.append(repr(self.jar))
+        repr_args.append(repr(self.main_class))
+        if self.args:
+            repr_args.append('args=' + repr(self.args))
+        if self.spark_args:
+            repr_args.append('spark_args=' + repr(self.spark_args))
+
+        return 'SparkJarStep(%s)' % ', '.join(repr_args)
+
+    def __eq__(self, other):
+        return (isinstance(other, SparkJarStep) and
+                all(getattr(self, key) == getattr(other, key)
+                    for key in _SPARK_JAR_STEP_KWARGS))
+
+    def description(self, step_num):
+        """Returns a dictionary representation of this step:
+
+        .. code-block:: js
+
+            {
+                'type': 'spark_jar',
+                'jar': <path of the JAR>,
+                'main_class': <class of application>,
+                'args': <list of strings, args to the spark script>,
+                'spark_args': <list of strings, args to spark-submit>
+            }
+
+        See :ref:`steps-format` for examples.
+        """
+        return {
+            'type': 'spark_jar',
+            'args': self.args,
+            'jar': self.jar,
+            'main_class': self.main_class,
+            'spark_args': self.spark_args,
+        }
+
+
 class SparkScriptStep(object):
     """Represents a running a separate Python script through Spark
 
@@ -474,7 +548,7 @@ class SparkScriptStep(object):
     def __eq__(self, other):
         return (isinstance(other, SparkScriptStep) and
                 all(getattr(self, key) == getattr(other, key)
-                    for key in ('script', 'args', 'spark_args')))
+                    for key in _SPARK_SCRIPT_STEP_KWARGS))
 
     def description(self, step_num):
         """Returns a dictionary representation of this step:

--- a/tests/mr_spark_jar.py
+++ b/tests/mr_spark_jar.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Job that runs a single spark JAR, specified on the command line."""
+
+from mrjob.job import MRJob
+from mrjob.step import SparkJarStep
+
+
+class MRSparkJar(MRJob):
+
+    def configure_options(self):
+        super(MRSparkJar, self).configure_options()
+
+        self.add_passthrough_option(
+            '--jar', dest='jar')
+        self.add_passthrough_option(
+            '--class', dest='main_class')
+        self.add_passthrough_option(
+            '--jar-arg', dest='jar_args',
+            action='append', default=[])
+        self.add_passthrough_option(
+            '--jar-spark-arg', dest='jar_spark_args',
+            action='append', default=[])
+
+    def steps(self):
+        return [SparkJarStep(
+            jar=self.options.jar,
+            main_class=self.options.main_class,
+            args=self.options.jar_args,
+            spark_args=self.options.jar_spark_args,
+        )]
+
+
+if __name__ == '__main__':
+    MRSparkJar.run()

--- a/tests/mr_spark_jar.py
+++ b/tests/mr_spark_jar.py
@@ -26,7 +26,7 @@ class MRSparkJar(MRJob):
         self.add_passthrough_option(
             '--jar', dest='jar')
         self.add_passthrough_option(
-            '--class', dest='main_class')
+            '--jar-main-class', dest='jar_main_class')
         self.add_passthrough_option(
             '--jar-arg', dest='jar_args',
             action='append', default=[])
@@ -37,7 +37,7 @@ class MRSparkJar(MRJob):
     def steps(self):
         return [SparkJarStep(
             jar=self.options.jar,
-            main_class=self.options.main_class,
+            main_class=self.options.jar_main_class,
             args=self.options.jar_args,
             spark_args=self.options.jar_spark_args,
         )]

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -41,6 +41,7 @@ from tests.mockhadoop import get_mock_hdfs_root
 from tests.mr_jar_and_streaming import MRJarAndStreaming
 from tests.mr_just_a_jar import MRJustAJar
 from tests.mr_null_spark import MRNullSpark
+from tests.mr_spark_jar import MRSparkJar
 from tests.mr_spark_script import MRSparkScript
 from tests.mr_streaming_and_spark import MRStreamingAndSpark
 from tests.mr_two_step_hadoop_format_job import MRTwoStepJob
@@ -1080,6 +1081,16 @@ class EnvForStepTestCase(MockHadoopTestCase):
                 runner._env_for_step(0),
                 combine_dicts(os.environ,
                               dict(FOO='bar', PYSPARK_PYTHON=PYTHON_BIN))
+            )
+
+    def test_spark_jar_step(self):
+        job = MRSparkJar(['-r', 'hadoop', '--cmdenv', 'FOO=bar'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._env_for_step(0),
+                combine_dicts(os.environ, dict(FOO='bar'))
             )
 
     def test_spark_script_step(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -941,6 +941,20 @@ class SparkScriptPathTestCase(SandboxedTestCase):
                     inspect.getfile(MRNullSpark))
             )
 
+    def test_spark_jar(self):
+        # _spark_script_path() also works with jars
+        self.fake_jar = self.makefile('fake.jar')
+
+        job = MRSparkJar(['--jar', self.fake_jar])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_path(0),
+                self.mock_interpolate_spark_script_path(
+                    self.fake_jar)
+            )
+
     def test_spark_script(self):
         self.fake_script = self.makefile('fake_script.py')
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -43,6 +43,7 @@ from mrjob.util import tar_and_gzip
 
 from tests.mr_null_spark import MRNullSpark
 from tests.mr_os_walk_job import MROSWalkJob
+from tests.mr_spark_jar import MRSparkJar
 from tests.mr_spark_script import MRSparkScript
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
@@ -845,8 +846,31 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                 )
             )
 
+    def test_spark_jar_step(self):
+        job = MRSparkJar(['--jar-main-class', 'foo.Bar',
+                          '--cmdenv', 'BAZ=qux',
+                          '--jobconf', 'QUX=baz'])
+        job.sandbox()
 
-    def test_spark_script_step_okay(self):
+        with job.make_runner() as runner:
+            runner._spark_py_files = Mock(
+                return_value=['<first py_file>', '<second py_file>']
+            )
+
+
+            # should handle cmdenv and --class
+            # but not set PYSPARK_PYTHON or --py-file
+            self.assertEqual(
+                runner._spark_submit_args(0), (
+                    ['--class', 'foo.Bar'] +
+                    self._expected_conf_args(
+                        cmdenv=dict(BAZ='qux'),
+                        jobconf=dict(QUX='baz')
+                    )
+                )
+            )
+
+    def test_spark_script_step(self):
         job = MRSparkScript()
         job.sandbox()
 
@@ -856,7 +880,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                 self._expected_conf_args(
                     cmdenv=dict(PYSPARK_PYTHON='mypy')))
 
-    def test_streaming_step_not_okay(self):
+    def test_streaming_step_not_allowed(self):
         job = MRTwoStepJob()
         job.sandbox()
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1046,6 +1046,24 @@ class SparkScriptArgsTestCase(SandboxedTestCase):
             self.assertIn('foo', name_to_path)
             self.assertEqual(name_to_path['foo'], foo_path)
 
+    def test_spark_jar(self):
+        job = MRSparkJar(['--jar-arg', 'foo', '--jar-arg', 'bar'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_args(0),
+                ['foo', 'bar'])
+
+    def test_spark_jar_interpolation(self):
+        job = MRSparkJar(['--jar-arg', OUTPUT, '--jar-arg', INPUT])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_args(0),
+                ['<step 0 output>', '<step 0 input>'])
+
     def test_spark_script(self):
         job = MRSparkScript(['--script-arg', 'foo', '--script-arg', 'bar'])
         job.sandbox()

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -19,6 +19,7 @@ from mrjob.step import INPUT
 from mrjob.step import JarStep
 from mrjob.step import MRStep
 from mrjob.step import OUTPUT
+from mrjob.step import SparkJarStep
 from mrjob.step import SparkStep
 from mrjob.step import SparkScriptStep
 from mrjob.step import StepFailedException
@@ -416,6 +417,61 @@ class SparkStepTestCase(TestCase):
         self.assertEqual(step1.description(0), step2.description(0))
 
 
+class SparkJarStepTestCase(TestCase):
+
+    def test_empty(self):
+        self.assertRaises(TypeError, SparkJarStep)
+
+    def test_only_jar(self):
+        self.assertRaises(TypeError, SparkJarStep, 'dora.jar')
+
+    def test_defaults(self):
+        step = SparkJarStep(jar='dora.jar', main_class='backpack.Map')
+
+        self.assertEqual(step.jar, 'dora.jar')
+        self.assertEqual(step.main_class, 'backpack.Map')
+        self.assertEqual(step.args, [])
+        self.assertEqual(step.spark_args, [])
+        self.assertEqual(
+            step.description(0),
+            dict(
+                type='spark_jar',
+                jar='dora.jar',
+                main_class='backpack.Map',
+                args=[],
+                spark_args=[],
+             )
+        )
+
+    def test_all_args(self):
+        step = SparkJarStep(jar='dora.jar',
+                            main_class='backpack.Map',
+                            args=['ARGH', 'ARGH'],
+                            spark_args=['argh', 'argh'])
+
+        self.assertEqual(step.jar, 'dora.jar')
+        self.assertEqual(step.main_class, 'backpack.Map')
+        self.assertEqual(step.args, ['ARGH', 'ARGH'])
+        self.assertEqual(step.spark_args, ['argh', 'argh'])
+        self.assertEqual(
+            step.description(0),
+            dict(
+                type='spark_jar',
+                jar='dora.jar',
+                main_class='backpack.Map',
+                args=['ARGH', 'ARGH'],
+                spark_args=['argh', 'argh'],
+             )
+        )
+
+    def test_positional_args(self):
+        step1 = SparkJarStep('dora.jar', 'backpack.Map')
+        step2 = SparkJarStep(jar='dora.jar', main_class='backpack.Map')
+
+        self.assertEqual(step1, step2)
+        self.assertEqual(step1.description(0), step2.description(0))
+
+
 class SparkScriptStepTestCase(TestCase):
 
     def test_empty(self):
@@ -455,7 +511,7 @@ class SparkScriptStepTestCase(TestCase):
              )
         )
 
-    def test_positional_spark_arg(self):
+    def test_positional_args(self):
         step1 = SparkScriptStep('macbeth.py')
         step2 = SparkScriptStep(script='macbeth.py')
 


### PR DESCRIPTION
This lets you run JARs with `spark-submit`, which works almost like running Spark scripts, except that you have to specify a main class, and you can't use ``py_files``. Fixes #1377 

This doesn't add libjar support (see #1469).