### PR TITLE
faster task log interpretation

### DIFF
--- a/mrjob/logs/mixin.py
+++ b/mrjob/logs/mixin.py
@@ -33,15 +33,15 @@ from mrjob.logs.errors import _pick_error
 from mrjob.logs.history import _interpret_history_log
 from mrjob.logs.history import _ls_history_logs
 from mrjob.logs.task import _interpret_task_logs
-from mrjob.logs.task import _ls_task_syslogs
+from mrjob.logs.task import _ls_task_logs
 
 log = getLogger(__name__)
 
 
 # a callback for _interpret_task_logs(). Breaking it out to make
 # testing easier
-def _log_parsing_task_stderr(stderr_path):
-    log.info('  Parsing task stderr: %s' % stderr_path)
+def _log_parsing_task_log(log_path):
+    log.info('  Parsing task log: %s' % log_path)
 
 
 class LogInterpretationMixin(object):
@@ -184,21 +184,21 @@ class LogInterpretationMixin(object):
 
         log_interpretation['task'] = _interpret_task_logs(
             self.fs,
-            self._ls_task_syslogs(
+            self._ls_task_logs(
                 application_id=application_id,
                 job_id=job_id,
                 output_dir=output_dir),
             partial=partial,
-            stderr_callback=_log_parsing_task_stderr)
+            log_callback=_log_parsing_task_log)
 
-    def _ls_task_syslogs(
+    def _ls_task_logs(
             self, application_id=None, job_id=None, output_dir=None):
-        """Yield task log matches, logging a message for each one."""
-        for match in _ls_task_syslogs(
+        """Yield task log matches."""
+        # logging messages are handled by a callback in _interpret_task_logs()
+        for match in _ls_task_logs(
                 self.fs,
                 self._stream_task_log_dirs(
                     application_id=application_id, output_dir=output_dir),
                 application_id=application_id,
                 job_id=job_id):
-            log.info('  Parsing task syslog: %s' % match['path'])
             yield match

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -35,14 +35,6 @@ _JAVA_TRACEBACK_RE = re.compile(
 _OPENING_FOR_READING_RE = re.compile(
     r"^Opening '(?P<path>.*?)' for reading$")
 
-# what syslog paths look like pre-YARN
-_PRE_YARN_TASK_SYSLOG_PATH_RE = re.compile(
-    r'^(?P<prefix>.*?/)'
-    r'(?P<attempt_id>attempt_(?P<timestamp>\d+)_(?P<step_num>\d+)_'
-    r'(?P<task_type>[mr])_(?P<task_num>\d+)_'
-    r'(?P<attempt_num>\d+))/'
-    r'syslog(?P<suffix>\.\w+)?$')
-
 # what log paths look like pre-YARN
 _PRE_YARN_TASK_LOG_PATH_RE = re.compile(
     r'^(?P<prefix>.*?/)'
@@ -69,13 +61,6 @@ _YARN_INPUT_SPLIT_RE = re.compile(
     r'^Processing split:\s+(?P<path>.*)'
     r':(?P<start_line>\d+)\+(?P<num_lines>\d+)$')
 
-# what syslog paths look like on YARN
-_YARN_TASK_SYSLOG_PATH_RE = re.compile(
-    r'^(?P<prefix>.*?/)'
-    r'(?P<application_id>application_\d+_\d{4})/'
-    r'(?P<container_id>container(_\d+)+)/'
-    r'syslog(?P<suffix>\.\w+)?$')
-
 # what log paths look like on YARN
 _YARN_TASK_LOG_PATH_RE = re.compile(
     r'^(?P<prefix>.*?/)'
@@ -83,42 +68,6 @@ _YARN_TASK_LOG_PATH_RE = re.compile(
     r'(?P<container_id>container(_\d+)+)/'
     r'(?P<log_type>stderr|syslog)(?P<suffix>\.\w{1,3})?$')
 # TODO: add stdout log type for Spark
-
-
-
-def _ls_task_syslogs(fs, log_dir_stream, application_id=None, job_id=None):
-    """Yield matching syslogs, optionally filtering by application_id
-    or job_id."""
-    return _ls_logs(fs, log_dir_stream, _match_task_syslog_path,
-                    application_id=application_id,
-                    job_id=job_id)
-
-
-# TODO: will need to filter by step_num on EMR
-def _match_task_syslog_path(path, application_id=None, job_id=None):
-    """Is this the path/URI of a task syslog?
-
-    If so, return a dictionary containing application_id and container_id
-    (on YARN) or attempt_id (on pre-YARN Hadoop). Otherwise, return None
-
-    Optionally, filter by application_id (YARN) or job_id (pre-YARN).
-    """
-    m = _PRE_YARN_TASK_SYSLOG_PATH_RE.match(path)
-    if m:
-        if job_id and job_id != _to_job_id(m.group('attempt_id')):
-            return None  # matches, but wrong job_id
-        return dict(
-            attempt_id=m.group('attempt_id'))
-
-    m = _YARN_TASK_SYSLOG_PATH_RE.match(path)
-    if m:
-        if application_id and application_id != m.group('application_id'):
-            return None  # matches, but wrong application_id
-        return dict(
-            application_id=m.group('application_id'),
-            container_id=m.group('container_id'))
-
-    return None
 
 
 def _ls_task_logs(fs, log_dir_stream, application_id=None, job_id=None):
@@ -188,13 +137,13 @@ def _match_task_log_path(path, application_id=None, job_id=None):
     return None
 
 
-def _interpret_task_logs(fs, matches, partial=True, stderr_callback=None):
+def _interpret_task_logs(fs, matches, partial=True, log_callback=None):
     """Look for errors in task syslog/stderr.
 
     If *partial* is true (the default), stop when we find the first error
     that includes a *task_error*.
 
-    If *stderr_callback* is set, every time we're about to parse a stderr
+    If *log_callback* is set, every time we're about to parse a
         file, call it with a single argument, the path of that file
 
     Returns a dictionary possibly containing the key 'errors', which
@@ -219,15 +168,43 @@ def _interpret_task_logs(fs, matches, partial=True, stderr_callback=None):
     this dictionary will contain the key *partial*, set to True.
     """
     result = {}
-    task_error = None
+    syslogs_parsed = set()
 
     for match in matches:
-        syslog_path = match['path']
+        error = {}
 
-        # get hadoop_error and possibly split from syslog
-        error = _parse_task_syslog(_cat_log(fs, syslog_path))
-        if not error.get('hadoop_error'):
+        # are is this match for a stderr file, or a syslog?
+        if match.get('syslog'):
+            stderr_path = match['path']
+            syslog_path = match['syslog']['path']
+        else:
+            stderr_path = None
+            syslog_path = match['path']
+
+        if stderr_path:
+            if log_callback:
+                log_callback(stderr_path)
+            task_error = _parse_task_stderr(_cat_log(fs, stderr_path))
+
+            if task_error:
+                task_error['path'] = stderr_path
+                error['task_error'] = task_error
+            else:
+                continue  # can parse syslog independently later
+
+        # already parsed this syslog in conjunction with an earlier task error
+        if syslog_path in syslogs_parsed:
             continue
+
+        if log_callback:
+            log_callback(syslog_path)
+        syslog_error = _parse_task_syslog(_cat_log(fs, syslog_path))
+
+        if not syslog_error.get('hadoop_error'):
+            # if no entry in Hadoop syslog, probably just noise
+            continue
+
+        error.update(syslog_error)
         error['hadoop_error']['path'] = syslog_path
 
         # path in IDs we learned from path
@@ -235,38 +212,14 @@ def _interpret_task_logs(fs, matches, partial=True, stderr_callback=None):
             if id_key in match:
                 error[id_key] = match[id_key]
 
-        _add_implied_task_id(error)
-
-        # look for task_error in stderr, if it exists
-        stderr_path = _syslog_to_stderr_path(syslog_path)
-        if fs.exists(stderr_path):
-            if stderr_callback:
-                stderr_callback(stderr_path)
-
-            task_error = _parse_task_stderr(_cat_log(fs, stderr_path))
-
-            if task_error:
-                task_error['path'] = stderr_path
-                error['task_error'] = task_error
-
         result.setdefault('errors', [])
         result['errors'].append(error)
 
-        if partial and task_error:
+        if partial:
             result['partial'] = True
             break
 
     return result
-
-
-def _syslog_to_stderr_path(path):
-    """Get the path/uri of the stderr log corresponding to the given syslog.
-
-    If the syslog is gzipped (/path/to/syslog.gz), we'll expect
-    stderr to be gzipped too (/path/to/stderr.gz).
-    """
-    stem, filename = posixpath.split(path)
-    return posixpath.join(stem, 'stderr' + file_ext(filename))
 
 
 def _parse_task_syslog(lines):

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -199,6 +199,7 @@ def _interpret_task_logs(fs, matches, partial=True, log_callback=None):
         if log_callback:
             log_callback(syslog_path)
         syslog_error = _parse_task_syslog(_cat_log(fs, syslog_path))
+        syslogs_parsed.add(syslog_path)
 
         if not syslog_error.get('hadoop_error'):
             # if no entry in Hadoop syslog, probably just noise
@@ -208,9 +209,10 @@ def _interpret_task_logs(fs, matches, partial=True, log_callback=None):
         error['hadoop_error']['path'] = syslog_path
 
         # path in IDs we learned from path
-        for id_key in 'attempt_id', 'container_id', 'type_id':
+        for id_key in 'attempt_id', 'container_id':
             if id_key in match:
                 error[id_key] = match[id_key]
+        _add_implied_task_id(error)
 
         result.setdefault('errors', [])
         result['errors'].append(error)

--- a/tests/logs/test_task.py
+++ b/tests/logs/test_task.py
@@ -115,6 +115,8 @@ class MatchTaskLogPathTestCase(TestCase):
 
 class InterpretTaskLogsTestCase(PatcherTestCase):
 
+    maxDiff = None
+
     def setUp(self):
         super(InterpretTaskLogsTestCase, self).setUp()
 
@@ -333,14 +335,26 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
         }
 
         self.assertEqual(self.interpret_task_logs(), {})
+        self.assertEqual(self.mock_paths_catted, [stderr_path, syslog_path])
 
-        # never even looked at stderr, because no error in syslog
-        self.assertEqual(self.mock_paths_catted, [syslog_path])
+    def test_stderr_without_corresponding_syslog(self):
+        stderr_path = '/userlogs/attempt_201512232143_0008_m_000001_3/stderr'
 
-    maxDiff = None
+        self.mock_paths = [stderr_path]
 
-    # indirectly tests _ls_task_syslogs() and its ability to sort by recency
+        self.path_to_mock_result = {
+            stderr_path: dict(message='because, exploding code')
+        }
+
+        # don't even look at stderr if it doesn't have a matching syslog
+        self.assertEqual(self.interpret_task_logs(), {})
+        self.assertEqual(self.mock_paths_catted, [])
+
+
+    # indirectly tests _ls_task_syslogs() and its ability to sort by
+    # log type and recency
     def test_multiple_logs(self):
+        stderr1_path = '/userlogs/attempt_201512232143_0008_m_000001_3/stderr'
         syslog1_path = '/userlogs/attempt_201512232143_0008_m_000001_3/syslog'
         stderr2_path = '/userlogs/attempt_201512232143_0008_m_000002_3/stderr'
         syslog2_path = '/userlogs/attempt_201512232143_0008_m_000002_3/syslog'
@@ -348,32 +362,27 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
         syslog3_path = '/userlogs/attempt_201512232143_0008_m_000003_3/syslog'
         syslog4_path = '/userlogs/attempt_201512232143_0008_m_000004_3/syslog'
 
-        self.mock_paths = [syslog1_path,
-                           stderr2_path,
-                           syslog2_path,
-                           stderr3_path,
-                           syslog3_path,
-                           syslog4_path]
+        self.mock_paths = [
+            stderr1_path,
+            syslog1_path,
+            stderr2_path,
+            syslog2_path,
+            stderr3_path,
+            syslog3_path,
+            syslog4_path,
+        ]
 
         self.path_to_mock_result = {
             syslog1_path: dict(hadoop_error=dict(message='BOOM1')),
             syslog2_path: dict(hadoop_error=dict(message='BOOM2')),
             stderr2_path: dict(message='BoomException'),
             syslog3_path: dict(hadoop_error=dict(message='BOOM3')),
-            # no errors for stderr3_path or syslog4_path
+            # no errors for stderr1_path, stderr3_path, or syslog4_path
         }
 
         # we should read from syslog2_path first (later task number)
         self.assertEqual(self.interpret_task_logs(), dict(
             errors=[
-                dict(
-                    attempt_id='attempt_201512232143_0008_m_000003_3',
-                    hadoop_error=dict(
-                        message='BOOM3',
-                        path=syslog3_path,
-                    ),
-                    task_id='task_201512232143_0008_m_000003',
-                ),
                 dict(
                     attempt_id='attempt_201512232143_0008_m_000002_3',
                     hadoop_error=dict(
@@ -390,11 +399,11 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
             partial=True,
         ))
 
-        # shouldn't even bother with syslog1_path
+        # skip over syslog4_path (no stderr), never get to syslog1_path
         self.assertEqual(self.mock_paths_catted, [
-            syslog4_path,
-            syslog3_path, stderr3_path,
-            syslog2_path, stderr2_path,
+            stderr3_path,
+            stderr2_path,
+            syslog2_path,
         ])
 
         # try again, with partial=False
@@ -403,14 +412,6 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
         # paths still get sorted by _ls_logs()
         self.assertEqual(self.interpret_task_logs(partial=False), dict(
             errors=[
-                dict(
-                    attempt_id='attempt_201512232143_0008_m_000003_3',
-                    hadoop_error=dict(
-                        message='BOOM3',
-                        path=syslog3_path,
-                    ),
-                    task_id='task_201512232143_0008_m_000003',
-                ),
                 dict(
                     attempt_id='attempt_201512232143_0008_m_000002_3',
                     hadoop_error=dict(
@@ -424,6 +425,14 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
                     task_id='task_201512232143_0008_m_000002',
                 ),
                 dict(
+                    attempt_id='attempt_201512232143_0008_m_000003_3',
+                    hadoop_error=dict(
+                        message='BOOM3',
+                        path=syslog3_path,
+                    ),
+                    task_id='task_201512232143_0008_m_000003',
+                ),
+                dict(
                     attempt_id='attempt_201512232143_0008_m_000001_3',
                     hadoop_error=dict(
                         message='BOOM1',
@@ -434,8 +443,16 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
             ],
         ))
 
-        self.assertEqual(self.mock_paths_catted,
-                         list(reversed(self.mock_paths)))
+        self.assertEqual(self.mock_paths_catted, [
+            stderr3_path,
+            stderr2_path,
+            syslog2_path,
+            stderr1_path,
+            syslog4_path,
+            syslog3_path,
+            syslog1_path,
+        ])
+
 
     def test_pre_yarn_sorting(self):
         # NOTE: we currently don't have to handle errors from multiple

--- a/tests/logs/test_task.py
+++ b/tests/logs/test_task.py
@@ -18,6 +18,7 @@ from mrjob.logs.task import _match_task_log_path
 from mrjob.logs.task import _parse_task_stderr
 from mrjob.logs.task import _parse_task_syslog
 
+from tests.py2 import call
 from tests.py2 import Mock
 from tests.py2 import TestCase
 from tests.py2 import patch
@@ -210,6 +211,7 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
                     task_id='task_201512232143_0008_m_000001',
                 ),
             ],
+            partial=True,
         ))
 
     def test_syslog_with_error_and_split(self):
@@ -234,6 +236,7 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
                     task_id='task_201512232143_0008_m_000001',
                 ),
             ],
+            partial=True,
         ))
 
     def test_syslog_with_corresponding_stderr(self):
@@ -269,7 +272,9 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
             )
         )
 
-        mock_log_callback.assert_called_once_with(stderr_path)
+        self.assertEqual(
+            mock_log_callback.call_args_list,
+            [call(stderr_path), call(syslog_path)])
 
     def test_syslog_with_empty_corresponding_stderr(self):
         syslog_path = '/userlogs/attempt_201512232143_0008_m_000001_3/syslog'
@@ -295,10 +300,13 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
                         task_id='task_201512232143_0008_m_000001',
                     ),
                 ],
+                partial=True,
             )
         )
 
-        mock_log_callback.assert_called_once_with(stderr_path)
+        self.assertEqual(
+            mock_log_callback.call_args_list,
+            [call(stderr_path), call(syslog_path)])
 
     def test_yarn_syslog_with_error(self):
         # this works the same way as the other tests, except we get
@@ -322,6 +330,7 @@ class InterpretTaskLogsTestCase(PatcherTestCase):
                     ),
                 ),
             ],
+            partial=True,
         ))
 
     def test_error_in_stderr_only(self):


### PR DESCRIPTION
This change allows us to stop parsing task logs when we find the first task error with a corresponding hadoop error, *or*, if there are no task stderr logs (or we've looked at them all), the first hadoop error. Fixes #1450 

