### PR TITLE
is_uri() only accepts file-like URIs

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -445,9 +445,9 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         and issue a warning."""
         if self['hadoop_streaming_jar_on_emr']:
             jar = 'file://' + self['hadoop_streaming_jar_on_emr']
-            log.warn('hadoop_streaming_jar_on_emr is deprecated'
-                     ' and will be removed in v0.6.0.'
-                     ' Set hadoop_streaming_jar to %s instead' % jar)
+            log.warning('hadoop_streaming_jar_on_emr is deprecated'
+                        ' and will be removed in v0.6.0.'
+                        ' Set hadoop_streaming_jar to %s instead' % jar)
             if not self['hadoop_streaming_jar']:
                 self['hadoop_streaming_jar'] = jar
 

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -50,6 +50,8 @@ _WINPATH_RE = re.compile(r"^[aA-zZ]:\\")
 
 def is_windows_path(uri):
     """Return True if *uri* is a windows path."""
+    log.warning('is_windows_path() is deprecated and will be removed in v0.6.0')
+
     if _WINPATH_RE.match(uri):
         return True
     else:
@@ -57,11 +59,10 @@ def is_windows_path(uri):
 
 
 def is_uri(uri):
-    """Return True if *uri* is any sort of URI."""
-    if is_windows_path(uri):
-        return False
-
-    return bool(urlparse(uri).scheme)
+    """Return True if *uri* is a URI and contains ``://``
+    (we only care about URIs that can describe files)
+    """
+    return '://' in uri and bool(urlparse(uri).scheme)
 
 
 def is_s3_uri(uri):

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -575,8 +575,8 @@ class MRJobRunner(object):
 
         .. deprecated:: 0.5.0
         """
-        log.warn('get_job_name() has been renamed to get_job_key().'
-                 ' get_job_name() will be removed in v0.6.0')
+        log.warning('get_job_name() has been renamed to get_job_key().'
+                    ' get_job_name() will be removed in v0.6.0')
         return self.get_job_key()
 
     def get_output_dir(self):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3458,9 +3458,9 @@ class DeprecatedHadoopStreamingJarOnEMROptionTestCase(MockBotoTestCase):
         self.log = self.start(patch('mrjob.emr.log'))
 
     def assert_deprecation_warning(self):
-        self.assertTrue(self.log.warn.called)
+        self.assertTrue(self.log.warning.called)
         self.assertIn('hadoop_streaming_jar_on_emr is deprecated',
-                      self.log.warn.call_args[0][0])
+                      self.log.warning.call_args[0][0])
 
     def test_absolute_path(self):
         runner = EMRJobRunner(hadoop_streaming_jar_on_emr='/fridge/pickle.jar')

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -227,6 +227,8 @@ class URITestCase(TestCase):
         self.assertEqual(is_uri('2016-10-11T06:29:17'), False)
         # sorry, we only care about file URIs
         self.assertEqual(is_uri('mailto:someone@example.com'), False)
+        # urlparse has to accept it
+        self.assertEqual(is_uri('://'), False)
 
     def test_is_s3_uri(self):
         self.assertEqual(is_s3_uri('s3://a/uri'), True)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -219,15 +219,25 @@ class PortRangeListTestCase(TestCase):
 
 
 class URITestCase(TestCase):
-    def test_uri_parsing(self):
+    def test_is_uri(self):
         self.assertEqual(is_uri('notauri!'), False)
         self.assertEqual(is_uri('they://did/the/monster/mash'), True)
         self.assertEqual(is_uri('C:\some\windows\path'), False)
-        self.assertEqual(is_windows_path('C:\some\windows\path'), True)
-        self.assertEqual(is_windows_path('s3://a/uri'), False)
+        # test #1455
+        self.assertEqual(is_uri('2016-10-11T06:29:17'), False)
+        # sorry, we only care about file URIs
+        self.assertEqual(is_uri('mailto:someone@example.com'), False)
+
+    def test_is_s3_uri(self):
         self.assertEqual(is_s3_uri('s3://a/uri'), True)
         self.assertEqual(is_s3_uri('s3n://a/uri'), True)
         self.assertEqual(is_s3_uri('hdfs://a/uri'), False)
+
+    def test_is_windows_path(self):
+        self.assertEqual(is_windows_path('C:\some\windows\path'), True)
+        self.assertEqual(is_windows_path('s3://a/uri'), False)
+
+    def test_parse_s3_uri(self):
         self.assertEqual(parse_s3_uri('s3://bucket/loc'), ('bucket', 'loc'))
 
     def test_urlparse(self):


### PR DESCRIPTION
This fixes a problem where mrjob thought a timestamp was a URI (see #1455).

Also deprecated `is_windows_path()` (since `is_uri()` no longer needs it).