### PR TITLE
Spark libjars

### DIFF
--- a/mrjob/examples/mr_spark_nick_nack_word_count.py
+++ b/mrjob/examples/mr_spark_nick_nack_word_count.py
@@ -1,0 +1,55 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+from operator import add
+
+from mrjob.job import MRJob
+
+# restrict to a-z so we don't get odd filenames
+WORD_RE = re.compile(r"[A-Za-z]+")
+
+
+class MRSparkNickNackWordCount(MRJob):
+    # use the nicknack JAR in this directory
+    #
+    # This JAR was downloaded from https://github.com/empiricalresults/nicknack
+    # and is also under the Apache 2.0 license.
+    LIBJARS = ['nicknack-1.0.0.jar']
+
+    def spark(self, input_path, output_path):
+        # Spark may not be available where script is launched
+        from pyspark import SparkContext
+
+        sc = SparkContext(appName='mrjob Spark wordcount script')
+
+        lines = sc.textFile(input_path)
+
+        counts = (
+            lines.flatMap(lambda line: WORD_RE.findall(line))
+            .map(lambda word: (word, 1))
+            .reduceByKey(add))
+
+        # MultipleValueOutputFormat expects Text, Text
+        counts = counts.map(lambda (word, count): (word, str(count)))
+
+        counts.saveAsHadoopFile(output_path,
+                                'nicknack.MultipleValueOutputFormat',
+                                'org.apache.hadoop.io.Text',
+                                'org.apache.hadoop.io.Text')
+
+        sc.stop()
+
+
+if __name__ == '__main__':
+    MRSparkNickNackWordCount.run()

--- a/mrjob/examples/mr_spark_nick_nack_word_count.py
+++ b/mrjob/examples/mr_spark_nick_nack_word_count.py
@@ -44,9 +44,7 @@ class MRSparkNickNackWordCount(MRJob):
         counts = counts.map(lambda (word, count): (word, str(count)))
 
         counts.saveAsHadoopFile(output_path,
-                                'nicknack.MultipleValueOutputFormat',
-                                'org.apache.hadoop.io.Text',
-                                'org.apache.hadoop.io.Text')
+                                'nicknack.MultipleValueOutputFormat')
 
         sc.stop()
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -565,7 +565,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
 
         args = []
 
-        args.extend(self._get_hadoop_bin())
+        args.extend(self.get_hadoop_bin())
 
         # -libjars, -D
         args.extend(self._hadoop_generic_args_for_step(step_num))

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -534,12 +534,8 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             args.extend(['-D', ('%s=0' % translate_jobconf(
                 'mapreduce.job.reduces', self.get_hadoop_version()))])
 
-        # -libjars (#198)
-        if self._opts['libjars']:
-            args.extend(['-libjars', ','.join(self._opts['libjars'])])
-
         # Add extra hadoop args first as hadoop args could be a hadoop
-        # specific argument (e.g. -libjars) which must come before job
+        # specific argument which must come before job
         # specific args.
         args.extend(self._hadoop_args_for_step(step_num))
 
@@ -567,6 +563,13 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
     def _args_for_jar_step(self, step_num):
         step = self._get_step(step_num)
 
+        args = []
+
+        args.extend(self._get_hadoop_bin())
+
+        # -libjars, -D
+        args.extend(self._hadoop_generic_args_for_step(step_num))
+
         # special case for consistency with EMR runner.
         #
         # This might look less like duplicated code if we ever
@@ -576,7 +579,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         else:
             jar = step['jar']
 
-        args = self.get_hadoop_bin() + ['jar', jar]
+        args.extend(['jar', jar])
 
         if step.get('main_class'):
             args.append(step['main_class'])

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1324,7 +1324,7 @@ class MRJobRunner(object):
         # add --jars, if any
         libjar_paths = self._libjar_paths()
         if libjar_paths:
-            args.extend(['--jars'], ','.join(libjar_paths))
+            args.extend(['--jars', ','.join(libjar_paths)])
 
         # --conf arguments include python bin, cmdenv, jobconf. Make sure
         # that we can always override these manually

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1149,6 +1149,25 @@ class MRJobRunner(object):
 
         return self._mrjob_tar_gz_path
 
+    def _hadoop_generic_args_for_step(self, step_num):
+        """Arguments like -D and -libjars that apply to every Hadoop
+        subcommand."""
+        args = []
+
+        # libjars (#198)
+        libjar_paths = self._libjar_paths()
+        if libjar_paths:
+            args.extend(['-libjars', ','.join(libjar_paths)])
+
+        # jobconf (-D)
+        jobconf = self._jobconf_for_step(step_num)
+
+        for key, value in sorted(jobconf.items()):
+            if value is not None:
+                args.extend(['-D', '%s=%s' % (key, value)])
+
+        return args
+
     def _jobconf_for_step(self, step_num):
         """Get the jobconf dictionary, optionally including step-specific
         jobconf info.
@@ -1178,13 +1197,8 @@ class MRJobRunner(object):
         """
         args = []
 
-        # translate the jobconf configuration names to match
-        # the hadoop version
-        jobconf = self._jobconf_for_step(step_num)
-
-        for key, value in sorted(jobconf.items()):
-            if value is not None:
-                args.extend(['-D', '%s=%s' % (key, value)])
+        # -libjars, -D
+        args.extend(self._hadoop_generic_args_for_step(step_num))
 
         # hadoop_extra_args (if defined; it's not for sim runners)
         # this has to come after -D because it may include streaming-specific
@@ -1307,6 +1321,11 @@ class MRJobRunner(object):
         if step.get('main_class'):
             args.extend(['--class', step['main_class']])
 
+        # add --jars, if any
+        libjar_paths = self._libjar_paths()
+        if libjar_paths:
+            args.extend(['--jars'], ','.join(libjar_paths))
+
         # --conf arguments include python bin, cmdenv, jobconf. Make sure
         # that we can always override these manually
         jobconf = {}
@@ -1348,6 +1367,13 @@ class MRJobRunner(object):
         we pass these as-is.
         """
         return self._opts['py_files']
+
+    def _libjar_paths(self):
+        """Paths or URIs of libjars, from Hadoop/Spark's point of view.
+
+        Override this for non-local libjars (e.g. on EMR).
+        """
+        return self._opts['libjars']
 
     def _upload_args(self):
         # just upload every file and archive in the working dir manager

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3361,16 +3361,11 @@ class BuildStreamingStepTestCase(MockBotoTestCase):
         self.assertEqual(ss['step_args'][2], '-files')
         self.assertTrue(ss['step_args'][3].endswith('#my_job.py'))
 
-    def test_libjars_and_hadoop_args_for_step(self):
-        self.start(patch(
-            'mrjob.emr.EMRJobRunner._libjar_step_args',
-            return_value=[
-                '-libjars',
-                '/home/hadoop/dir/honey.jar,/home/hadoop/door/a.jar']))
-
+    def test_hadoop_args_for_step(self):
         self.start(patch(
             'mrjob.emr.EMRJobRunner._hadoop_args_for_step',
-            return_value=['-D', 'foo=bar']))
+            return_value=['-libjars', '/home/hadoop/dora.jar',
+                          '-D', 'foo=bar']))
 
         ss = self._get_streaming_step(
             dict(type='streaming', mapper=dict(type='script')))
@@ -3383,17 +3378,17 @@ class BuildStreamingStepTestCase(MockBotoTestCase):
         self.assertTrue(ss['step_args'][1].endswith('#my_job.py'))
         self.assertEqual(
             ss['step_args'][2:],
-            ['-libjars', '/home/hadoop/dir/honey.jar,/home/hadoop/door/a.jar',
+            ['-libjars', '/home/hadoop/dora.jar',
              '-D', 'foo=bar'])
 
 
-class LibjarStepArgsTestCase(MockBotoTestCase):
+class LibjarPathsTestCase(MockBotoTestCase):
 
     def test_no_libjars(self):
         runner = EMRJobRunner()
         runner._add_master_node_setup_files_for_upload()
 
-        self.assertEqual(runner._libjar_step_args(), [])
+        self.assertEqual(runner._libjar_paths(), [])
 
     def test_libjars(self):
         runner = EMRJobRunner(libjars=[
@@ -3406,11 +3401,11 @@ class LibjarStepArgsTestCase(MockBotoTestCase):
         working_dir = runner._master_node_setup_working_dir()
 
         self.assertEqual(
-            runner._libjar_step_args(),
+            runner._libjar_paths(),
             [
-                '-libjars',
-                '%s/cookie.jar,%s/honey.jar,/left/dora.jar' % (
-                    working_dir, working_dir),
+                working_dir + '/cookie.jar',
+                working_dir + '/honey.jar',
+                '/left/dora.jar',
             ]
         )
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -724,6 +724,35 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                 )
             )
 
+    def test_libjars_option(self):
+        fake_libjar = self.makefile('fake_lib.jar')
+
+        job = MRNullSpark(
+            ['--libjar', fake_libjar])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_submit_args(0),
+                ['--jars', fake_libjar] +
+                self._expected_conf_args(
+                    cmdenv=dict(PYSPARK_PYTHON='mypy')))
+
+    def test_libjar_paths_override(self):
+        job = MRNullSpark()
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.start(patch.object(
+                runner, '_libjar_paths',
+                return_value=['s3://a/a.jar', 's3://b/b.jar']))
+
+            self.assertEqual(
+                runner._spark_submit_args(0),
+                ['--jars', 's3://a/a.jar,s3://b/b.jar'] +
+                self._expected_conf_args(
+                    cmdenv=dict(PYSPARK_PYTHON='mypy')))
+
     def test_option_spark_args(self):
         job = MRNullSpark(['--spark-arg', '--name', '--spark-arg', 'Dave'])
         job.sandbox()


### PR DESCRIPTION
This adds libjars support to Spark (fixes #1469) and also adds some missing libjars and jobconf support to JAR steps (fixes #1481).

Still need to hand-test this.