### PR TITLE
Spark log interpretation

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2234,6 +2234,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             return
 
         if _is_spark_step_type(step_type):
+            # Spark also has a "controller" log4j log, but it doesn't
+            # contain errors or anything else we need
             return _interpret_emr_step_syslog(
                 self.fs,  self._ls_step_stderr_logs(step_id=step_id))
         else:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1986,7 +1986,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             # and Spark, which has no counters.)
             if step.status.state != 'CANCELLED':
                 if step_num >= 0 and not _is_spark_step_type(step_type):
-                    counters = self._pick_counters(log_interpretation)
+                    counters = self._pick_counters(
+                        log_interpretation, step_type)
                     if counters:
                         log.info(_format_counters(counters))
                     else:
@@ -1996,7 +1997,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 return
 
             if step.status.state == 'FAILED':
-                error = self._pick_error(log_interpretation)
+                error = self._pick_error(log_interpretation, step_type)
                 if error:
                     log.error('Probable cause of failure:\n\n%s\n\n' %
                               _format_error(error))

--- a/mrjob/examples/mr_sparkaboom.py
+++ b/mrjob/examples/mr_sparkaboom.py
@@ -1,0 +1,42 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mrjob.job import MRJob
+
+
+class MRSparKaboom(MRJob):
+
+    def spark(self, input_path, output_path):
+        # Spark may not be available where script is launched
+        from pyspark import SparkContext
+
+        sc = SparkContext(appName='mrjob Spark wordcount script')
+
+        lines = sc.textFile(input_path)
+
+        def kaboom(line):
+            raise Exception('KABOOM')
+
+        # make sure the exception happens inside Spark, not just at the
+        # top-level client
+
+        # strangely, Spark 1.2 thinks this is all good. Probably not something
+        # we can fix.
+        kaboomed_lines = lines.flatMap(kaboom)
+        kaboomed_lines.saveAsTextFile(output_path)
+
+        sc.stop()
+
+
+if __name__ == '__main__':
+    MRSparKaboom.run()

--- a/mrjob/examples/mr_sparkaboom.py
+++ b/mrjob/examples/mr_sparkaboom.py
@@ -20,6 +20,8 @@ class MRSparKaboom(MRJob):
         # Spark may not be available where script is launched
         from pyspark import SparkContext
 
+        raise Exception('BOOM')
+
         sc = SparkContext(appName='mrjob Spark wordcount script')
 
         lines = sc.textFile(input_path)

--- a/mrjob/examples/mr_sparkaboom.py
+++ b/mrjob/examples/mr_sparkaboom.py
@@ -20,8 +20,6 @@ class MRSparKaboom(MRJob):
         # Spark may not be available where script is launched
         from pyspark import SparkContext
 
-        raise Exception('BOOM')
-
         sc = SparkContext(appName='mrjob Spark wordcount script')
 
         lines = sc.textFile(input_path)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -482,15 +482,17 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
 
             log_interpretation['step'] = step_interpretation
 
-            if not _is_spark_step_type(step['type']):
-                counters = self._pick_counters(log_interpretation)
+            step_type = step['type']
+
+            if not _is_spark_step_type(step_type):
+                counters = self._pick_counters(log_interpretation, step_type)
                 if counters:
                     log.info(_format_counters(counters))
                 else:
                     log.warning('No counters found')
 
             if returncode:
-                error = self._pick_error(log_interpretation)
+                error = self._pick_error(log_interpretation, step_type)
                 if error:
                     log.error('Probable cause of failure:\n\n%s\n' %
                               _format_error(error))

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -421,7 +421,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         return stdin_path
 
     def _run_job_in_hadoop(self):
-        for step_num in range(self._num_steps()):
+        for step_num, step in enumerate(self._get_steps()):
             step_args = self._args_for_step(step_num)
             env = self._env_for_step(step_num)
 
@@ -482,11 +482,12 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
 
             log_interpretation['step'] = step_interpretation
 
-            counters = self._pick_counters(log_interpretation)
-            if counters:
-                log.info(_format_counters(counters))
-            else:
-                log.warning('No counters found')
+            if not _is_spark_step_type(step['type']):
+                counters = self._pick_counters(log_interpretation)
+                if counters:
+                    log.info(_format_counters(counters))
+                else:
+                    log.warning('No counters found')
 
             if returncode:
                 error = self._pick_error(log_interpretation)

--- a/mrjob/logs/mixin.py
+++ b/mrjob/logs/mixin.py
@@ -82,7 +82,7 @@ class LogInterpretationMixin(object):
         # dir and depend on regexes to find the right subdir.
         return ()
 
-    def _get_step_log_interpretation(self, log_interpretation):
+    def _get_step_log_interpretation(self, log_interpretation, step_type):
         """Return interpretation of the step log. Either implement
         this, or fill ``'step'`` yourself (e.g. from Hadoop binary's
         output."""
@@ -100,7 +100,7 @@ class LogInterpretationMixin(object):
 
         if not counters:
             log.info('Attempting to fetch counters from logs...')
-            self._interpret_step_logs(log_interpretation)
+            self._interpret_step_logs(log_interpretation, step_type)
             counters = _pick_counters(log_interpretation)
 
         if not counters:
@@ -114,7 +114,7 @@ class LogInterpretationMixin(object):
         if not all(log_type in log_interpretation for
                    log_type in ('job', 'step', 'task')):
             log.info('Scanning logs for probable cause of failure...')
-            self._interpret_step_logs(log_interpretation)
+            self._interpret_step_logs(log_interpretation, step_type)
             self._interpret_history_log(log_interpretation)
             self._interpret_task_logs(log_interpretation, step_type)
 
@@ -150,13 +150,13 @@ class LogInterpretationMixin(object):
             log.info('  Parsing history log: %s' % match['path'])
             yield match
 
-    def _interpret_step_logs(self, log_interpretation):
+    def _interpret_step_logs(self, log_interpretation, step_type):
         """Add *step* to the log interpretation, if it's not already there."""
         if 'step' in log_interpretation:
             return
 
         step_interpretation = self._get_step_log_interpretation(
-            log_interpretation)
+            log_interpretation, step_type)
         if step_interpretation:
             log_interpretation['step'] = step_interpretation
 

--- a/mrjob/logs/mixin.py
+++ b/mrjob/logs/mixin.py
@@ -96,7 +96,7 @@ class LogInterpretationMixin(object):
         """Pick counters from our log interpretation, interpreting
         history logs if need be."""
         if _is_spark_step_type(step_type):
-            return None
+            return {}
 
         counters = _pick_counters(log_interpretation)
 

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -26,7 +26,7 @@ from .wrap import _ls_logs
 # Match a java exception, possibly preceded by 'PipeMapRed failed!', etc.
 # use this with search()
 _JAVA_TRACEBACK_RE = re.compile(
-    r'$\s+at .*\((.*\.java:\d+|Native Method)\)$',
+    r'$\s+at .*\((.*\.(java|scala):\d+|Native Method)\)$',
     re.MULTILINE)
 
 # Match an error stating that Spark's subprocess has failed (and thus we

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -384,7 +384,7 @@ def _parse_task_syslog(lines):
 
         if (record['logger'] == _SPARK_APP_MASTER_LOGGER and
                 record['level'] == 'ERROR'):
-            m = _SPARK_APP_MASTER_LOGGER.match(message)
+            m = _SPARK_APP_EXITED_RE.match(message)
             if m:
                 result['hadoop_error'] = dict(
                     message=message,

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -32,7 +32,7 @@ _JAVA_TRACEBACK_RE = re.compile(
 # Match an error stating that Spark's subprocess has failed (and thus we
 # should read stdout
 _SPARK_APP_EXITED_RE = re.compile(
-    r'^\s+User application exited with status \d+\s+$')
+    r'^\s*User application exited with status \d+\s*$')
 
 # the name of the logger that logs the above
 _SPARK_APP_MASTER_LOGGER = 'ApplicationMaster'
@@ -309,7 +309,7 @@ def _interpret_spark_task_logs(fs, matches, partial=True, log_callback=None):
         else:
             continue
 
-        stdout_path = match.get('stdout')
+        stdout_path = match.get('stdout', {}).get('path')
         check_stdout = error.pop('check_stdout', None)
 
         if stdout_path and check_stdout:

--- a/tests/logs/test_mixin.py
+++ b/tests/logs/test_mixin.py
@@ -115,7 +115,7 @@ class InterpretStepLogTestCase(LogInterpretationMixinTestCase):
     def test_step_interpretation_already_filled(self):
         log_interpretation = dict(step={})
 
-        self.runner._interpret_step_logs(log_interpretation)
+        self.runner._interpret_step_logs(log_interpretation, 'streaming')
 
         self.assertEqual(
             log_interpretation, dict(step={}))
@@ -128,26 +128,41 @@ class InterpretStepLogTestCase(LogInterpretationMixinTestCase):
 
         log_interpretation = {}
 
-        self.runner._interpret_step_logs(log_interpretation)
+        self.runner._interpret_step_logs(log_interpretation, 'streaming')
 
         self.assertEqual(
             log_interpretation,
             dict(step=dict(job_id='job_1')))
 
         self.runner._get_step_log_interpretation.assert_called_once_with(
-            log_interpretation)
+            log_interpretation, 'streaming')
+
+    def test_spark_step_interpretation(self):
+        self.runner._get_step_log_interpretation.return_value = dict(
+            job_id='job_1')
+
+        log_interpretation = {}
+
+        self.runner._interpret_step_logs(log_interpretation, 'spark')
+
+        self.assertEqual(
+            log_interpretation,
+            dict(step=dict(job_id='job_1')))
+
+        self.runner._get_step_log_interpretation.assert_called_once_with(
+            log_interpretation, 'spark')
 
     def test_no_step_interpretation(self):
         self.runner._get_step_log_interpretation.return_value = None
 
         log_interpretation = {}
 
-        self.runner._interpret_step_logs(log_interpretation)
+        self.runner._interpret_step_logs(log_interpretation, 'streaming')
 
         self.assertEqual(log_interpretation, {})
 
         self.runner._get_step_log_interpretation.assert_called_once_with(
-            log_interpretation)
+            log_interpretation, 'streaming')
 
 
 class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):

--- a/tests/logs/test_mixin.py
+++ b/tests/logs/test_mixin.py
@@ -173,24 +173,34 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
         self.runner._ls_task_logs = Mock()
         self._interpret_task_logs = (
             self.start(patch('mrjob.logs.mixin._interpret_task_logs')))
+        self._interpret_spark_task_logs = (
+            self.start(patch('mrjob.logs.mixin._interpret_spark_task_logs')))
         self.runner.get_hadoop_version = Mock(return_value='2.7.1')
 
     def _test_task_interpretation_already_filled(
-            self, log_interpretation, **kwargs):
+            self, log_interpretation, step_type='streaming', **kwargs):
         orig_log_interpretation = deepcopy(log_interpretation)
 
-        self.runner._interpret_task_logs(log_interpretation, **kwargs)
+        self.runner._interpret_task_logs(
+            log_interpretation, step_type, **kwargs)
 
         self.assertEqual(log_interpretation, orig_log_interpretation)
 
         self.assertFalse(self.log.warning.called)
         self.assertFalse(self._interpret_task_logs.called)
         self.assertFalse(self.runner._ls_task_logs.called)
+        self.assertFalse(self.runner._ls_spark_task_logs.called)
 
     def test_task_interpretation_already_filled(self):
         log_interpretation = dict(task={})
 
         self._test_task_interpretation_already_filled(log_interpretation)
+
+    def test_spark_task_interpretation_already_filled(self):
+        log_interpretation = dict(task={})
+
+        self._test_task_interpretation_already_filled(log_interpretation,
+                                                      'spark')
 
     def test_task_interpretation_already_partially_filled(self):
         log_interpretation = dict(task=dict(partial=True))
@@ -209,7 +219,8 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
             step=dict(application_id='app_id'),
             task=dict(partial=True))
 
-        self.runner._interpret_task_logs(log_interpretation, partial=False)
+        self.runner._interpret_task_logs(
+            log_interpretation, 'streaming', partial=False)
 
         self.assertTrue(self.runner._ls_task_logs.called)
         self.assertTrue(self._interpret_task_logs.called)
@@ -220,7 +231,7 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
 
         log_interpretation = dict(step=dict(application_id='app_1'))
 
-        self.runner._interpret_task_logs(log_interpretation)
+        self.runner._interpret_task_logs(log_interpretation, 'streaming')
 
         self.assertEqual(
             log_interpretation,
@@ -229,10 +240,38 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
 
         self.assertFalse(self.log.warning.called)
         self.runner._ls_task_logs.assert_called_once_with(
+            'streaming',
             application_id='app_1',
             job_id=None,
             output_dir=None)
         self._interpret_task_logs.assert_called_once_with(
+            self.runner.fs,
+            self.runner._ls_task_logs.return_value,
+            partial=True,
+            log_callback=_log_parsing_task_log)
+
+    def test_spark(self):
+        # don't need to test spark with job_id, since it doesn't run
+        # in Hadoop 1
+        self._interpret_spark_task_logs.return_value = dict(
+            counters={'foo': {'bar': 1}})
+
+        log_interpretation = dict(step=dict(application_id='app_1'))
+
+        self.runner._interpret_task_logs(log_interpretation, 'spark')
+
+        self.assertEqual(
+            log_interpretation,
+            dict(step=dict(application_id='app_1'),
+                 task=dict(counters={'foo': {'bar': 1}})))
+
+        self.assertFalse(self.log.warning.called)
+        self.runner._ls_task_logs.assert_called_once_with(
+            'spark',
+            application_id='app_1',
+            job_id=None,
+            output_dir=None)
+        self._interpret_spark_task_logs.assert_called_once_with(
             self.runner.fs,
             self.runner._ls_task_logs.return_value,
             partial=True,
@@ -246,7 +285,7 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
 
         log_interpretation = dict(step=dict(job_id='job_1'))
 
-        self.runner._interpret_task_logs(log_interpretation)
+        self.runner._interpret_task_logs(log_interpretation, 'streaming')
 
         self.assertEqual(
             log_interpretation,
@@ -255,6 +294,7 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
 
         self.assertFalse(self.log.warning.called)
         self.runner._ls_task_logs.assert_called_once_with(
+            'streaming',
             application_id=None,
             job_id='job_1',
             output_dir=None)
@@ -271,7 +311,7 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
         log_interpretation = dict(
             step=dict(application_id='app_1', output_dir='hdfs:///path/'))
 
-        self.runner._interpret_task_logs(log_interpretation)
+        self.runner._interpret_task_logs(log_interpretation, 'streaming')
 
         self.assertEqual(
             log_interpretation,
@@ -280,6 +320,7 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
 
         self.assertFalse(self.log.warning.called)
         self.runner._ls_task_logs.assert_called_once_with(
+            'streaming',
             application_id='app_1',
             job_id=None,
             output_dir='hdfs:///path/')
@@ -292,7 +333,7 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
     def test_missing_application_id(self):
         log_interpretation = dict(step=dict(job_id='job_1'))
 
-        self.runner._interpret_task_logs(log_interpretation)
+        self.runner._interpret_task_logs(log_interpretation, 'streaming')
 
         self.assertEqual(
             log_interpretation, dict(step=dict(job_id='job_1')))
@@ -306,7 +347,7 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
 
         log_interpretation = dict(step=dict(app_id='app_1'))
 
-        self.runner._interpret_task_logs(log_interpretation)
+        self.runner._interpret_task_logs(log_interpretation, 'streaming')
 
         self.assertEqual(
             log_interpretation,

--- a/tests/logs/test_mixin.py
+++ b/tests/logs/test_mixin.py
@@ -15,6 +15,7 @@ from copy import deepcopy
 
 from mrjob.logs.mixin import LogInterpretationMixin
 from mrjob.logs.mixin import _log_parsing_task_log
+from mrjob.step import _is_spark_step_type
 
 from tests.py2 import Mock
 from tests.py2 import patch
@@ -312,12 +313,12 @@ class PickCountersTestCase(LogInterpretationMixinTestCase):
         # no need to mock mrjob.logs.counters._pick_counters();
         # what it does is really straightforward
 
-    def test_counter_already_present(self):
+    def test_counters_already_present(self):
         log_interpretation = dict(
             step=dict(counters={'foo': {'bar': 1}}))
 
         self.assertEqual(
-            self.runner._pick_counters(log_interpretation),
+            self.runner._pick_counters(log_interpretation, 'streaming'),
             {'foo': {'bar': 1}})
 
         # don't log anything if runner._pick_counters() doesn't have
@@ -326,8 +327,8 @@ class PickCountersTestCase(LogInterpretationMixinTestCase):
         self.assertFalse(self.runner._interpret_step_logs.called)
         self.assertFalse(self.runner._interpret_history_log.called)
 
-    def test_counter_from_step_logs(self):
-        def mock_interpret_step_logs(log_interpretation):
+    def test_counters_from_step_logs(self):
+        def mock_interpret_step_logs(log_interpretation, step_type):
             log_interpretation['step'] = dict(
                 counters={'foo': {'bar': 1}})
 
@@ -337,14 +338,14 @@ class PickCountersTestCase(LogInterpretationMixinTestCase):
         log_interpretation = {}
 
         self.assertEqual(
-            self.runner._pick_counters(log_interpretation),
+            self.runner._pick_counters(log_interpretation, 'streaming'),
             {'foo': {'bar': 1}})
 
         self.assertTrue(self.log.info.called)  # 'Attempting to fetch...'
         self.assertTrue(self.runner._interpret_step_logs.called)
         self.assertFalse(self.runner._interpret_history_log.called)
 
-    def test_counter_from_history_logs(self):
+    def test_counters_from_history_logs(self):
         def mock_interpret_history_log(log_interpretation):
             log_interpretation['history'] = dict(
                 counters={'foo': {'bar': 1}})
@@ -355,12 +356,25 @@ class PickCountersTestCase(LogInterpretationMixinTestCase):
         log_interpretation = {}
 
         self.assertEqual(
-            self.runner._pick_counters(log_interpretation),
+            self.runner._pick_counters(log_interpretation, 'streaming'),
             {'foo': {'bar': 1}})
 
         self.assertTrue(self.log.info.called)  # 'Attempting to fetch...'
         self.assertTrue(self.runner._interpret_step_logs.called)
         self.assertTrue(self.runner._interpret_history_log.called)
+
+    def test_do_nothing_for_spark_logs(self):
+        log_interpretation = {}
+
+        self.assertEqual(
+            self.runner._pick_counters(log_interpretation, 'spark'),
+            {})
+
+        self.assertFalse(self.log.info.called)  # 'Attempting to fetch...'
+        self.assertFalse(self.runner._interpret_step_logs.called)
+        self.assertFalse(self.runner._interpret_history_log.called)
+
+
 
 
 class LsHistoryLogsTestCase(LogInterpretationMixinTestCase):
@@ -410,9 +424,12 @@ class LsTaskLogsTestCase(LogInterpretationMixinTestCase):
 
         self._ls_task_logs = self.start(patch(
             'mrjob.logs.mixin._ls_task_logs'))
+        self._ls_spark_task_logs = self.start(patch(
+            'mrjob.logs.mixin._ls_spark_task_logs'))
+
         self.runner._stream_task_log_dirs = Mock()
 
-    def test_basic(self):
+    def _test_step_type(self, step_type):
         # the _ls_task_logs() method is a very thin wrapper. Just
         # verify that the keyword args get passed through and
         # that logging happens in the right order
@@ -423,6 +440,7 @@ class LsTaskLogsTestCase(LogInterpretationMixinTestCase):
         ]
 
         results = self.runner._ls_task_logs(
+            'streaming',
             application_id='app_1',
             job_id='job_1', output_dir='hdfs:///output/')
 
@@ -433,11 +451,21 @@ class LsTaskLogsTestCase(LogInterpretationMixinTestCase):
         self.runner._stream_task_log_dirs.assert_called_once_with(
             application_id='app_1',
             output_dir='hdfs:///output/')
-        self._ls_task_logs.assert_called_once_with(
-            self.runner.fs,
-            self.runner._stream_task_log_dirs.return_value,
-            application_id='app_1',
-            job_id='job_1')
+
+        if _is_spark_step_type(step_type):
+            self._ls_spark_task_logs.assert_called_once_with(
+                self.runner.fs,
+                self.runner._stream_task_log_dirs.return_value,
+                application_id='app_1',
+                job_id='job_1')
+            self.assertFalse(self._ls_task_logs.called)
+        else:
+            self._ls_task_logs.assert_called_once_with(
+                self.runner.fs,
+                self.runner._stream_task_log_dirs.return_value,
+                application_id='app_1',
+                job_id='job_1')
+            self.assertFalse(self._ls_spark_task_logs.called)
 
         self.assertEqual(
             list(results),
@@ -448,11 +476,19 @@ class LsTaskLogsTestCase(LogInterpretationMixinTestCase):
         # with a callback
         self.assertFalse(self.log.info.called)
 
+    def test_streaming_step(self):
+        self.assertFalse(_is_spark_step_type('streaming'))
+        self._test_step_type('streaming')
 
-class PickErrorsTestCase(LogInterpretationMixinTestCase):
+    def test_spark_step(self):
+        self.assertTrue(_is_spark_step_type('spark'))
+        self._test_step_type('spark')
+
+
+class PickErrorTestCase(LogInterpretationMixinTestCase):
 
     def setUp(self):
-        super(PickErrorsTestCase, self).setUp()
+        super(PickErrorTestCase, self).setUp()
 
         self.runner._interpret_history_log = Mock()
         self.runner._interpret_step_logs = Mock()
@@ -466,7 +502,7 @@ class PickErrorsTestCase(LogInterpretationMixinTestCase):
             job={}, step={}, task={})
 
         self.assertEqual(
-            self.runner._pick_error(log_interpretation),
+            self.runner._pick_error(log_interpretation, 'streaming'),
             self._pick_error.return_value)
 
         # don't log a message or interpret logs
@@ -477,7 +513,7 @@ class PickErrorsTestCase(LogInterpretationMixinTestCase):
 
     def _test_interpret_all_logs(self, log_interpretation):
         self.assertEqual(
-            self.runner._pick_error(log_interpretation),
+            self.runner._pick_error(log_interpretation, 'streaming'),
             self._pick_error.return_value)
 
         # log a message ('Scanning logs...') and call _interpret() methods

--- a/tests/logs/test_task.py
+++ b/tests/logs/test_task.py
@@ -619,6 +619,45 @@ class ParseTaskSyslogTestCase(TestCase):
                     start_line=0,
                 )))
 
+    maxDiff = None
+
+    def test_spark_executor_exception(self):
+        lines = [
+            '16/11/16 22:05:00 ERROR Executor: Exception in task 0.2 in stage'
+            ' 0.0 (TID 4)'
+            ' org.apache.spark.api.python.PythonException: Traceback (most'
+            ' recent call last):\n',
+            '  File "/mnt/yarn/usercache/hadoop/appcache/application'
+            '_1479325434015_0003/container_1479325434015_0003_02_000002/'
+            'pyspark.zip/pyspark/worker.py", line 111, in main process()\n'
+            'Exception: KABOOM\n',
+            '\n',
+            '        at org.apache.spark.api.python.PythonRunner$$anon$1.read'
+            '(PythonRDD.scala:166)\n',
+        ]
+
+        self.assertEqual(
+            _parse_task_syslog(lines),
+            dict(
+                hadoop_error=dict(
+                    message=(
+                        'Exception in task 0.2 in stage'
+                        ' 0.0 (TID 4)'
+                        ' org.apache.spark.api.python.PythonException:'
+                        ' Traceback (most recent call last):'
+                        '  File "/mnt/yarn/usercache/hadoop/appcache/'
+                        'application_1479325434015_0003/container'
+                        '_1479325434015_0003_02_000002/pyspark.zip/pyspark/'
+                        'worker.py", line 111, in main process()\n'
+                        'Exception: KABOOM\n'
+                        '\n'
+                        '        at org.apache.spark.api.python.PythonRunner'
+                        '$$anon$1.read(PythonRDD.scala:166)\n'),
+                    num_lines=4,
+                    start_line=0,
+                )
+            ))
+
 
 class ParseTaskStderrTestCase(TestCase):
 

--- a/tests/logs/test_task.py
+++ b/tests/logs/test_task.py
@@ -644,7 +644,7 @@ class ParseTaskSyslogTestCase(TestCase):
                         'Exception in task 0.2 in stage'
                         ' 0.0 (TID 4)'
                         ' org.apache.spark.api.python.PythonException:'
-                        ' Traceback (most recent call last):'
+                        ' Traceback (most recent call last):\n'
                         '  File "/mnt/yarn/usercache/hadoop/appcache/'
                         'application_1479325434015_0003/container'
                         '_1479325434015_0003_02_000002/pyspark.zip/pyspark/'
@@ -652,7 +652,7 @@ class ParseTaskSyslogTestCase(TestCase):
                         'Exception: KABOOM\n'
                         '\n'
                         '        at org.apache.spark.api.python.PythonRunner'
-                        '$$anon$1.read(PythonRDD.scala:166)\n'),
+                        '$$anon$1.read(PythonRDD.scala:166)'),
                     num_lines=4,
                     start_line=0,
                 )

--- a/tests/logs/test_task.py
+++ b/tests/logs/test_task.py
@@ -619,8 +619,6 @@ class ParseTaskSyslogTestCase(TestCase):
                     start_line=0,
                 )))
 
-    maxDiff = None
-
     def test_spark_executor_exception(self):
         lines = [
             '16/11/16 22:05:00 ERROR Executor: Exception in task 0.2 in stage'
@@ -657,6 +655,30 @@ class ParseTaskSyslogTestCase(TestCase):
                     start_line=0,
                 )
             ))
+
+    def test_spark_application_failed(self):
+        lines = [
+            '16/11/16 22:26:22 ERROR ApplicationMaster: User application'
+            ' exited with status 1\n',
+            '16/11/16 22:26:22 INFO ApplicationMaster: Final app status:'
+            ' FAILED, exitCode: 1, (reason: User application exited with'
+            ' status 1)\n',
+            '16/11/16 22:26:31 ERROR ApplicationMaster: SparkContext did not'
+            ' initialize after waiting for 100000 ms. Please check earlier'
+            ' log output for errors. Failing the application.\n',
+        ]
+
+        self.assertEqual(
+            _parse_task_syslog(lines),
+            dict(
+                check_stdout=True,
+                hadoop_error=dict(
+                    message='User application exited with status 1',
+                    num_lines=1,
+                    start_line=0,
+                ),
+            )
+        )
 
 
 class ParseTaskStderrTestCase(TestCase):

--- a/tests/logs/test_task.py
+++ b/tests/logs/test_task.py
@@ -34,6 +34,9 @@ class MatchTaskLogPathTestCase(TestCase):
 
     YARN_STDERR_PATH = ('/log/dir/userlogs/application_1450486922681_0004/'
                         'container_1450486922681_0005_01_000003/stderr')
+    # stdout is only used by Spark
+    YARN_STDOUT_PATH = ('/log/dir/userlogs/application_1450486922681_0004/'
+                        'container_1450486922681_0005_01_000003/stdout')
     YARN_SYSLOG_PATH = ('/log/dir/userlogs/application_1450486922681_0004/'
                         'container_1450486922681_0005_01_000003/syslog')
 
@@ -97,6 +100,13 @@ class MatchTaskLogPathTestCase(TestCase):
             dict(application_id='application_1450486922681_0004',
                  container_id='container_1450486922681_0005_01_000003',
                  log_type='stderr'))
+
+    def test_match_yarn_stdout(self):
+        self.assertEqual(
+            _match_task_log_path(self.YARN_STDOUT_PATH),
+            dict(application_id='application_1450486922681_0004',
+                 container_id='container_1450486922681_0005_01_000003',
+                 log_type='stdout'))
 
     def test_yarn_application_id_filter(self):
         self.assertEqual(

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4855,7 +4855,8 @@ class GetStepLogInterpretationTestCase(MockBotoTestCase):
         self.log.reset_mock()
 
         self.assertEqual(
-            runner._get_step_log_interpretation(log_interpretation),
+            runner._get_step_log_interpretation(
+                log_interpretation, 'streaming'),
             self._interpret_emr_step_syslog.return_value)
 
         self.assertFalse(self.log.warning.called)
@@ -4873,7 +4874,9 @@ class GetStepLogInterpretationTestCase(MockBotoTestCase):
         self.log.reset_mock()
 
         self.assertEqual(
-            runner._get_step_log_interpretation(log_interpretation), None)
+            runner._get_step_log_interpretation(
+                log_interpretation, 'streaming'),
+            None)
 
         self.assertTrue(self.log.warning.called)
         self.assertFalse(self._ls_step_syslogs.called)
@@ -4891,7 +4894,8 @@ class GetStepLogInterpretationTestCase(MockBotoTestCase):
         self._interpret_emr_step_syslog.return_value = {}
 
         self.assertEqual(
-            runner._get_step_log_interpretation(log_interpretation),
+            runner._get_step_log_interpretation(
+                log_interpretation, 'streaming'),
             self._interpret_emr_step_stderr.return_value)
 
         self.assertFalse(self.log.warning.called)
@@ -4901,6 +4905,26 @@ class GetStepLogInterpretationTestCase(MockBotoTestCase):
         self._ls_step_stderr_logs.assert_called_once_with(step_id='s-STEPID')
         self._interpret_emr_step_stderr.assert_called_once_with(
             runner.fs, self._ls_step_stderr_logs.return_value)
+
+    def test_spark(self):
+        runner = EMRJobRunner()
+
+        log_interpretation = dict(step_id='s-STEPID')
+
+        self.log.reset_mock()
+
+        self.assertEqual(
+            runner._get_step_log_interpretation(
+                log_interpretation, 'spark'),
+            self._interpret_emr_step_syslog.return_value)
+
+        self.assertFalse(self.log.warning.called)
+        self.assertFalse(self._ls_step_syslogs.called)
+        self._ls_step_stderr_logs.assert_called_once_with(step_id='s-STEPID')
+        self._interpret_emr_step_syslog.assert_called_once_with(
+            runner.fs, self._ls_step_stderr_logs.return_value)
+        self.assertFalse(self._interpret_emr_step_stderr.called)
+
 
 
 # this basically just checks that hadoop_extra_args is an option

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1236,7 +1236,7 @@ class PickErrorTestCase(MockHadoopTestCase):
         self.runner = HadoopJobRunner()
 
     def test_empty(self):
-        self.assertEqual(self.runner._pick_error({}), None)
+        self.assertEqual(self.runner._pick_error({}, 'streaming'), None)
 
     def test_yarn_python_exception(self):
         APPLICATION_ID = 'application_1450486922681_0004'
@@ -1275,8 +1275,10 @@ class PickErrorTestCase(MockHadoopTestCase):
             stderr.write('    MRBoom.run()\n')
             stderr.write('Exception: BOOM\n')
 
-        error = self.runner._pick_error(dict(
-            step=dict(application_id=APPLICATION_ID, job_id=JOB_ID)))
+        error = self.runner._pick_error(
+            dict(step=dict(application_id=APPLICATION_ID, job_id=JOB_ID)),
+            'streaming',
+        )
 
         self.assertIsNotNone(error)
 

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1127,9 +1127,9 @@ class RunJobInHadoopUsesEnvTestCase(MockHadoopTestCase):
     def setUp(self):
         super(RunJobInHadoopUsesEnvTestCase, self).setUp()
 
-        self.mock_num_steps = self.start(patch(
-            'mrjob.hadoop.HadoopJobRunner._num_steps',
-            return_value=1))
+        self.mock_get_steps = self.start(patch(
+            'mrjob.hadoop.HadoopJobRunner._get_steps',
+            return_value=[dict(type='spark')]))
 
         self.mock_args_for_step = self.start(patch(
             'mrjob.hadoop.HadoopJobRunner._args_for_step',


### PR DESCRIPTION
This updates our log-interpreting code to correctly handle logs from Spark (fixes #1378)

Highlights:
 * correct filenames (the primary Spark task log is named `stderr`, not `syslog`)
 * don't try to fetch counters from Spark
 * different sorting and logic for which Spark logs to parse (we only look at `stdout` if the `stderr` file indicates that the application exited)
 * many methods, including those in `LogInterpretationMixin`, now take `step_type` as a required argument
