### PR TITLE
bump default AMI version to 4.8.2

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -231,7 +231,7 @@ Cluster creation and configuration
     :switch: --image-version
     :type: :ref:`string <data-type-string>`
     :set: emr
-    :default: ``'3.11.0'``
+    :default: ``'4.8.2'``
 
     EMR AMI (Amazon Machine Image) version to use. This controls which Hadoop
     version(s) are available and which version of Python is installed, among

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -735,15 +735,14 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         if local or not PY2:
             return super(EMRJobRunner, self)._default_python_bin(local=local)
 
-        if self._opts['release_label'] or version_gte(
-                self._opts['image_version'], '3'):
+        if self._image_version_gte('3'):
             # on 3.x and 4.x AMIs, both versions of Python work, so just
             # match whatever version we're using locally
             if sys.version_info >= (2, 7):
                 return ['python2.7']
             else:
                 return ['python2.6']
-        elif version_gte(self._opts['image_version'], '2.4.3'):
+        elif self._image_version_gte('2.4.3'):
             # on 2.4.3+, use python2.7 because the default python
             # doesn't have a working pip
             return ['python2.7']
@@ -751,6 +750,21 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             # prior to 2.4.3, Python 2.6 is the only version installed.
             # Use "python2.6" and not "python" for consistency
             return ['python2.6']
+
+    def _image_version_gte(self, version):
+        """Check if the requested image version is greater than
+        or equal to *version*. If the *release_label* opt is set,
+        look at that instead.
+
+        If you're checking the actual image version of a cluster, just
+        use :py:func:`~mrjob.compat.version_gte` and
+        :py:meth:`get_image_version`.
+        """
+        if self._opts['release_label']:
+            return version_gte(
+                self._opts['release_label'].lstrip('emr-'), version)
+        else:
+            return version_gte(self._opts['image_version'], version)
 
     def _fix_s3_tmp_and_log_uri_opts(self):
         """Fill in cloud_tmp_dir and cloud_log_dir (in self._opts) if they
@@ -1299,8 +1313,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     def _cheapest_manager_instance_type(self):
         """What's the cheapest instance type we can get away with
         for the master node (when it's not also running jobs)?"""
-        if (self._opts['release_label'] or
-            version_gte(self._opts['image_version'], '3')):
+        if self._image_version_gte('3'):
             return _CHEAPEST_INSTANCE_TYPE
         else:
             return _CHEAPEST_2_X_INSTANCE_TYPE
@@ -2447,11 +2460,10 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         # and warn if it's an AMI before 3.7.0
         if self._opts['bootstrap_python'] or (
                 self._opts['bootstrap_python'] is None and
-                not version_gte(self._opts['image_version'], '4.6.0')):
+                not self._image_version_gte('4.6.0')):
 
             # we have to have at least on AMI 3.7.0. But give it a shot
-            if not (self._opts['release_label'] or
-                    version_gte(self._opts['image_version'], '3.7.0')):
+            if not self._image_version_gte('3.7.0'):
                 log.warning(
                     'bootstrapping Python 3 will probably not work on'
                     ' AMIs prior to 3.7.0. For an alternative, see:'
@@ -3204,22 +3216,6 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         .. versionadded:: 0.4.5
         """
         return self._get_cluster_info('image_version')
-
-    def _image_version_gte(self, version):
-        """Check if the requested image version is greater than
-        or equal to *version*. If the *release_label* opt is set,
-        look at that instead."""
-        if self._opts['release_label']:
-            if self._opts['release_label'].startswith('emr-'):
-                try:
-                    return version_gte(self._opts['release_label'][4:],
-                                       version)
-                except TypeError:
-                    pass  # account for non-numeric versions
-
-            return version_gte('4', version)
-        else:
-            return version_gte(self._opts['image_version'], version)
 
     def _address_of_master(self):
         """Get the address of the master node so we can SSH to it"""

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3205,6 +3205,22 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         """
         return self._get_cluster_info('image_version')
 
+    def _image_version_gte(self, version):
+        """Check if the requested image version is greater than
+        or equal to *version*. If the *release_label* opt is set,
+        look at that instead."""
+        if self._opts['release_label']:
+            if self._opts['release_label'].startswith('emr-'):
+                try:
+                    return version_gte(self._opts['release_label'][4:],
+                                       version)
+                except TypeError:
+                    pass  # account for non-numeric versions
+
+            return version_gte('4', version)
+        else:
+            return version_gte(self._opts['image_version'], version)
+
     def _address_of_master(self):
         """Get the address of the master node so we can SSH to it"""
         return self._get_cluster_info('master_public_dns')

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -177,7 +177,7 @@ _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH = os.path.join(
 _DEFAULT_REGION = 'us-west-2'
 
 # default AMI to use on EMR. This will be updated with each version
-_DEFAULT_IMAGE_VERSION = '3.11.0'
+_DEFAULT_IMAGE_VERSION = '4.8.2'
 
 # EMR translates the dead/deprecated "latest" AMI version to 2.4.2
 # (2.4.2 isn't actually the latest version by a long shot)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1299,7 +1299,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     def _cheapest_manager_instance_type(self):
         """What's the cheapest instance type we can get away with
         for the master node (when it's not also running jobs)?"""
-        if version_gte(self._opts['image_version'], '3'):
+        if (self._opts['release_label'] or
+            version_gte(self._opts['image_version'], '3')):
             return _CHEAPEST_INSTANCE_TYPE
         else:
             return _CHEAPEST_2_X_INSTANCE_TYPE

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -802,7 +802,8 @@ class MockEmrConnection(object):
                 else:
                     version = DUMMY_APPLICATION_VERSION
 
-                applications.append(MockEmrObject(name=name, version=version))
+                applications.append(
+                    MockEmrObject(name=app_name, version=version))
         else:
             if application_objs:
                 raise boto.exception.EmrResponseError(

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -90,6 +90,10 @@ AMI_HADOOP_VERSION_UPDATES = {
     '3.1.0': '2.4.0',
     '4.0.0': '2.6.0',
     '4.3.0': '2.7.1',
+    '4.5.0': '2.7.2',
+    '4.8.2': '2.7.3',
+    '5.0.0': '2.7.2',
+    '5.0.3': '2.7.3',
 }
 
 # need to fill in a version for non-Hadoop applications

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -796,8 +796,8 @@ class MockEmrConnection(object):
                 application_names = set(['Hadoop'])
 
             applications = []
-            for name in sorted(application_names):
-                if name == 'Hadoop':
+            for app_name in sorted(application_names):
+                if app_name == 'Hadoop':
                     version = running_hadoop_version
                 else:
                     version = DUMMY_APPLICATION_VERSION

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4118,7 +4118,7 @@ class BootstrapPythonTestCase(MockBotoTestCase):
             self.assertEqual(runner._bootstrap, [])
 
     def test_default(self):
-        self._assert_installs_python3_on_py3()
+        self._assert_never_installs_python3()  # pre-installed on 4.8.2 AMI
 
     def test_bootstrap_python_switch(self):
         self._assert_installs_python3_on_py3('--bootstrap-python')
@@ -4159,7 +4159,9 @@ class BootstrapPythonTestCase(MockBotoTestCase):
             '--no-bootstrap-python', '--image-version', '3.7.0')
 
     def test_bootstrap_python_comes_before_bootstrap(self):
-        mr_job = MRTwoStepJob(['-r', 'emr', '--bootstrap', 'true'])
+        mr_job = MRTwoStepJob(['-r', 'emr',
+                               '--bootstrap', 'true',
+                               '--bootstrap-python'])
 
         with mr_job.make_runner() as runner:
             self.assertEqual(

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -6125,19 +6125,3 @@ class ImageVersionGteTestCase(MockBotoTestCase):
         self.assertTrue(runner._image_version_gte('4.6.0'))
         self.assertTrue(runner._image_version_gte('4.8.2'))
         self.assertFalse(runner._image_version_gte('5'))
-
-    def test_non_numeric_release_label(self):
-        # equivalent to version 4, shouldn't error
-        runner = EMRJobRunner(release_label='emr-is-great')
-
-        self.assertTrue(runner._image_version_gte('3.11.0'))
-        self.assertTrue(runner._image_version_gte('4'))
-        self.assertFalse(runner._image_version_gte('4.6.0'))
-
-    def test_non_emr_release_label(self):
-        # equivalent to version 4
-        runner = EMRJobRunner(release_label='hi')
-
-        self.assertTrue(runner._image_version_gte('3.11.0'))
-        self.assertTrue(runner._image_version_gte('4'))
-        self.assertFalse(runner._image_version_gte('4.6.0'))

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -971,6 +971,11 @@ class EC2InstanceGroupTestCase(MockBotoTestCase):
             core=(2, 'm1.small', None),
             master=(1, 'm1.small', None))
 
+    def test_release_label_hides_image_version(self):
+        self._test_instance_groups(
+            dict(release_label='emr-4.0.0', image_version='2.4.11'),
+            master=(1, 'm1.medium', None))
+
     def test_spark_defaults_single_node(self):
         # Spark needs at least m1.large
         self._test_instance_groups(

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5984,7 +5984,7 @@ class TestClusterSparkSupportWarning(MockBotoTestCase):
         if PY2:
             return
 
-        job = MRNullSpark(['-r', 'emr'])  # default AMI is 3.11.0
+        job = MRNullSpark(['-r', 'emr', '--image-version', '3.11.0'])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -6097,3 +6097,47 @@ class TestClusterSparkSupportWarning(MockBotoTestCase):
 
             message = runner._cluster_spark_support_warning()
             self.assertIsNone(message)
+
+
+class ImageVersionGteTestCase(MockBotoTestCase):
+
+    def test_image_version(self):
+        runner = EMRJobRunner(image_version='3.7.0')
+
+        self.assertTrue(runner._image_version_gte('3'))
+        self.assertTrue(runner._image_version_gte('3.7.0'))
+        self.assertFalse(runner._image_version_gte('3.8.0'))
+
+    def test_release_label(self):
+        runner = EMRJobRunner(release_label='emr-4.8.2')
+
+        self.assertTrue(runner._image_version_gte('4'))
+        self.assertTrue(runner._image_version_gte('4.6.0'))
+        self.assertTrue(runner._image_version_gte('4.8.2'))
+        self.assertFalse(runner._image_version_gte('4.9.0'))
+        self.assertFalse(runner._image_version_gte('5'))
+
+    def test_release_label_hides_image_version(self):
+        runner = EMRJobRunner(image_version='3.7.0',
+                              release_label='emr-4.8.2')
+
+        self.assertTrue(runner._image_version_gte('4'))
+        self.assertTrue(runner._image_version_gte('4.6.0'))
+        self.assertTrue(runner._image_version_gte('4.8.2'))
+        self.assertFalse(runner._image_version_gte('5'))
+
+    def test_non_numeric_release_label(self):
+        # equivalent to version 4, shouldn't error
+        runner = EMRJobRunner(release_label='emr-is-great')
+
+        self.assertTrue(runner._image_version_gte('3.11.0'))
+        self.assertTrue(runner._image_version_gte('4'))
+        self.assertFalse(runner._image_version_gte('4.6.0'))
+
+    def test_non_emr_release_label(self):
+        # equivalent to version 4
+        runner = EMRJobRunner(release_label='hi')
+
+        self.assertTrue(runner._image_version_gte('3.11.0'))
+        self.assertTrue(runner._image_version_gte('4'))
+        self.assertFalse(runner._image_version_gte('4.6.0'))

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4604,9 +4604,8 @@ class StreamLogDirsTestCase(MockBotoTestCase):
             image_version='2.4.11', ssh=False)
 
     def test_cant_stream_history_log_dirs_from_3_x_amis(self):
-        runner = EMRJobRunner()
-        results = runner._stream_history_log_dirs(
-            image_version='3.11.0')
+        runner = EMRJobRunner(image_version='3.11.0')
+        results = runner._stream_history_log_dirs()
         self.assertRaises(StopIteration, next, results)
 
     def test_stream_history_log_dirs_from_4_x_amis(self):
@@ -4661,8 +4660,8 @@ class StreamLogDirsTestCase(MockBotoTestCase):
         self, ssh, bad_ssh_slave_hosts=False, application_id=None,
         image_version=_DEFAULT_IMAGE_VERSION,
         expected_local_path='/mnt/var/log/hadoop/userlogs',
-        expected_dir_name='hadoop/userlogs',
-        expected_s3_dir_name='task-attempts'
+        expected_dir_name='hadoop-yarn/containers',
+        expected_s3_dir_name='containers',
     ):
         ec2_key_pair_file = '/path/to/EMR.pem' if ssh else None
         runner = EMRJobRunner(ec2_key_pair_file=ec2_key_pair_file)
@@ -4729,15 +4728,15 @@ class StreamLogDirsTestCase(MockBotoTestCase):
     def test_stream_task_log_dirs_with_application_id(self):
         self._test_stream_task_log_dirs(
             ssh=True, application_id='application_1',
-            expected_dir_name='hadoop/userlogs/application_1',
-            expected_s3_dir_name='task-attempts/application_1')
-
-    def test_stream_task_log_dirs_from_4_x_amis(self):
-        self._test_stream_task_log_dirs(
-            ssh=True, application_id='application_1',
-            image_version='4.3.0',
             expected_dir_name='hadoop-yarn/containers/application_1',
             expected_s3_dir_name='containers/application_1')
+
+    def test_stream_task_log_dirs_from_3_x_amis(self):
+        self._test_stream_task_log_dirs(
+            ssh=True,
+            image_version='3.11.0',
+            expected_dir_name='hadoop/userlogs',
+            expected_s3_dir_name='task-attempts')
 
 
 class LsStepSyslogsTestCase(MockBotoTestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4155,6 +4155,16 @@ class BootstrapPythonTestCase(MockBotoTestCase):
         self._assert_never_installs_python3(
             '--image-version', '4.6.0')
 
+    def test_release_label_emr_4_6_0(self):
+        self._assert_never_installs_python3(
+            '--release-label', 'emr-4.6.0')
+
+    def test_release_label_overrides_image_version(self):
+        self._assert_never_installs_python3(
+            '--release-label', 'emr-4.6.0',
+            '--image-version', '3.11.0',
+        )
+
     def test_force_booststrap_python(self):
         self._assert_installs_python3_on_py3(
             '--bootstrap-python', '--image-version', '4.6.0')

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -207,6 +207,7 @@ class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
             self.assertTrue(any(runner.fs.ls(runner.get_output_dir())))
 
             cluster = runner._describe_cluster()
+
             name_match = _JOB_KEY_RE.match(cluster.name)
             self.assertEqual(name_match.group(1), 'mr_hadoop_format_job')
             self.assertEqual(name_match.group(2), getpass.getuser())

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3455,7 +3455,7 @@ class StreamingJarAndStepArgPrefixTestCase(MockBotoTestCase):
     def test_default(self):
         runner = self.launch_runner()
         self.assertEqual(runner._get_streaming_jar_and_step_arg_prefix(),
-                         (_PRE_4_X_STREAMING_JAR, []))
+                         (_4_X_COMMAND_RUNNER_JAR, ['hadoop-streaming']))
 
     def test_pre_4_x_ami(self):
         runner = self.launch_runner('--image-version', '3.8.0')
@@ -4605,12 +4605,12 @@ class StreamLogDirsTestCase(MockBotoTestCase):
 
     def test_cant_stream_history_log_dirs_from_3_x_amis(self):
         runner = EMRJobRunner()
-        results = runner._stream_history_log_dirs()
+        results = runner._stream_history_log_dirs(
+            image_version='3.11.0')
         self.assertRaises(StopIteration, next, results)
 
     def test_stream_history_log_dirs_from_4_x_amis(self):
-        # history log fetching is disabled until we fix
-        # #1244 and #1253
+        # history log fetching is disabled until we fix #1253
         runner = EMRJobRunner(image_version='4.3.0')
         results = runner._stream_history_log_dirs()
         self.assertRaises(StopIteration, next, results)


### PR DESCRIPTION
Bump the default AMI version to 4.8.2, because 3.11.0 has iffy Spark support (no Python 3, doesn't properly detect errors).

Fixes #1486 