### PR TITLE
Misc warnings

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3343,10 +3343,20 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                     '  (try --image-version %s or later)' % (
                         image_version, suggested_version))
 
-        if not (PY2 or version_gte(image_version, _MIN_SPARK_PY3_AMI_VERSION)):
-            return ('  AMI version %s does not support Python 3 on Spark\n'
-                    '  (try --image-version %s or later)' % (
-                        image_version, _MIN_SPARK_PY3_AMI_VERSION))
+        if not version_gte(image_version, _MIN_SPARK_PY3_AMI_VERSION):
+            if PY2:
+                # even though this version of Spark "works" with Python 2,
+                # it doesn't work well
+                return ('  AMI version %s has an old version of Spark\n'
+                        ' and does not correctly determine when a Spark'
+                        ' job has failed\n'
+                        'Try --image-version %s or later)' % (
+                            image_version, _MIN_SPARK_PY3_AMI_VERSION))
+            else:
+                # this version of Spark doesn't support Python 3 at all!
+                return ('  AMI version %s does not support Python 3 on Spark\n'
+                        '  (try --image-version %s or later)' % (
+                            image_version, _MIN_SPARK_PY3_AMI_VERSION))
 
         # make sure there's enough memory to run Spark
         instance_groups = list(_yield_all_instance_groups(

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -407,6 +407,12 @@ class MRJobRunner(object):
         if self._ran_job:
             raise AssertionError("Job already ran!")
 
+        if not self._opts['strict_protocols']:
+            log.warning('\nNon-strict protocols are deprecated and will be'
+                        ' removed in v0.6.0. Please run your job with'
+                        ' --strict-protocols and fix any underlying'
+                        ' encoding issues\n')
+
         self._run()
         self._ran_job = True
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5964,9 +5964,6 @@ class TestClusterSparkSupportWarning(MockBotoTestCase):
             self.assertIsNone(message)
 
     def test_no_python_3(self):
-        if PY2:
-            return
-
         job = MRNullSpark(['-r', 'emr'])  # default AMI is 3.11.0
         job.sandbox()
 
@@ -5975,7 +5972,12 @@ class TestClusterSparkSupportWarning(MockBotoTestCase):
 
             message = runner._cluster_spark_support_warning()
             self.assertIsNotNone(message)
-            self.assertIn('Python 3', message)
+            # this version of Spark is bad for different reasons, depending
+            # on Python version
+            if PY2:
+                self.assertIn('old version of Spark', message)
+            else:
+                self.assertIn('Python 3', message)
             self.assertIn('4.0.0', message)
 
     def test_too_old(self):


### PR DESCRIPTION
Warn that "loose" protocols are going away (fixes #1452).

Issue a warning about running Spark on 3.x AMI versions even if we're not trying to run Python 3 (see #1485).