### PR TITLE
spark_master option

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -130,6 +130,18 @@ Options available to hadoop and emr runners
 
     .. versionadded:: 0.4.1
 
+.. mrjob-opt::
+    :config: spark_args
+    :switch: --spark-arg
+    :type: :ref:`string list <data-type-string-list>`
+    :set: all
+    :default: ``[]``
+
+    Extra arguments to pass to :command:`spark-submit`.
+
+    .. versionadded:: 0.5.8.spark0
+
+
 Options available to hadoop runner only
 ---------------------------------------
 
@@ -217,15 +229,17 @@ Options available to hadoop runner only
        This option used to be named ``hdfs_scratch_dir``.
 
 .. mrjob-opt::
-    :config: spark_args
-    :switch: --spark-arg
-    :type: :ref:`string list <data-type-string-list>`
-    :set: all
-    :default: ``[]``
+    :config: spark_master
+    :switch: --spark-master
+    :type: :ref:`string <data-type-string>`
+    :set: hadoop
+    :default: ``'yarn'``
 
-    Extra arguments to pass to :command:`spark-submit`.
+    Name or URL to pass to the ``--master`` argument of
+    :command:`spark-submit` (e.g. ``spark://host:port``, ``yarn``).
 
-    .. versionadded:: 0.5.8.spark0
+    Note that archives (see :mrjob-opt:`upload_archives`) only work
+    when this is set to ``yarn``.
 
 .. mrjob-opt::
     :config: spark_submit_bin

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -103,9 +103,6 @@ _HADOOP_STDOUT_RE = re.compile(br'^packageJobJar: ')
 _HADOOP_STREAMING_JAR_RE = re.compile(
     r'^hadoop.*streaming.*(?<!-sources)\.jar$')
 
-# always use these args with spark-submit
-_HADOOP_SPARK_ARGS = ['--master', 'yarn']
-
 
 def fully_qualify_hdfs_path(path):
     """If path isn't an ``hdfs://`` URL, turn it into one."""
@@ -595,7 +592,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
         return args
 
     def _spark_submit_arg_prefix(self):
-        return _HADOOP_SPARK_ARGS
+        return ['--master', self._opts['spark_master']]
 
     def _env_for_step(self, step_num):
         step = self._get_step(step_num)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -420,6 +420,8 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
 
     def _run_job_in_hadoop(self):
         for step_num, step in enumerate(self._get_steps()):
+            self._warn_about_spark_archives(step)
+
             step_args = self._args_for_step(step_num)
             env = self._env_for_step(step_num)
 
@@ -500,6 +502,16 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
                 raise StepFailedException(
                     reason=reason, step_num=step_num,
                     num_steps=self._num_steps())
+
+    def _warn_about_spark_archives(self, step):
+        """If *step* is a Spark step, the *upload_archives* option is set,
+        and *spark_master* is not ``'yarn'``, warn that *upload_archives*
+        will be ignored by Spark."""
+        if (_is_spark_step_type(step['type']) and
+                self._opts['spark_master'] != 'yarn' and
+                self._opts['upload_archives']):
+            log.warning('Spark will probably ignore archives because'
+                        " spark_master is not set to 'yarn'")
 
     def _args_for_step(self, step_num):
         step = self._get_step(step_num)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -127,6 +127,7 @@ class HadoopRunnerOptionStore(RunnerOptionStore):
         super_opts = super(HadoopRunnerOptionStore, self).default_options()
         return combine_dicts(super_opts, {
             'hadoop_tmp_dir': 'tmp/mrjob',
+            'spark_master': 'yarn',
         })
 
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1035,6 +1035,15 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    spark_master=dict(
+        runners=['hadoop'],
+        switches=[
+            (['--spark-master'], dict(
+                help=('--master argument to spark-submit (e.g. '
+                      'spark://host:port, local. Default is yarn'),
+            )),
+        ],
+    ),
     spark_submit_bin=dict(
         combiner=combine_cmds,
         switches=[

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -33,7 +33,6 @@ from mrjob.emr import _3_X_SPARK_BOOTSTRAP_ACTION
 from mrjob.emr import _3_X_SPARK_SUBMIT
 from mrjob.emr import _4_X_COMMAND_RUNNER_JAR
 from mrjob.emr import _DEFAULT_IMAGE_VERSION
-from mrjob.emr import _EMR_SPARK_ARGS
 from mrjob.emr import _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH
 from mrjob.emr import _PRE_4_X_STREAMING_JAR
 from mrjob.emr import _attempt_to_acquire_lock
@@ -6127,3 +6126,14 @@ class ImageVersionGteTestCase(MockBotoTestCase):
         self.assertTrue(runner._image_version_gte('4.6.0'))
         self.assertTrue(runner._image_version_gte('4.8.2'))
         self.assertFalse(runner._image_version_gte('5'))
+
+
+class SparkSubmitArgPrefixTestCase(MockBotoTestCase):
+
+    def test_default(self):
+        # these are hard-coded and always the same
+        runner = EMRJobRunner()
+
+        self.assertEqual(
+            runner._spark_submit_arg_prefix(),
+            ['--master', 'yarn', '--deploy-mode', 'cluster'])

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1505,3 +1505,63 @@ class SparkSubmitArgPrefixTestCase(MockHadoopTestCase):
         self.assertEqual(
             runner._spark_submit_arg_prefix(),
             ['--master', 'local'])
+
+
+class WarnAboutSparkArchivesTestCase(MockHadoopTestCase):
+
+    def setUp(self):
+        super(WarnAboutSparkArchivesTestCase, self).setUp()
+
+        self.log = self.start(patch('mrjob.hadoop.log'))
+
+    def test_warning(self):
+        fake_archive = self.makefile('fake.tar.gz')
+
+        job = MRNullSpark(['-r', 'hadoop',
+                           '--spark-master', 'local',
+                           '--archive', fake_archive])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._warn_about_spark_archives(runner._get_step(0))
+
+        self.assertTrue(self.log.warning.called)
+
+    def test_requires_spark(self):
+        fake_archive = self.makefile('fake.tar.gz')
+
+        job = MRTwoStepJob(['-r', 'hadoop',
+                            '--spark-master', 'local',
+                            '--archive', fake_archive])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._warn_about_spark_archives(runner._get_step(0))
+
+        self.assertFalse(self.log.warning.called)
+
+    def test_requires_non_yarn_spark_master(self):
+        fake_archive = self.makefile('fake.tar.gz')
+
+        job = MRNullSpark(['-r', 'hadoop',
+                           '--spark-master', 'yarn',
+                           '--archive', fake_archive])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._warn_about_spark_archives(runner._get_step(0))
+
+        self.assertFalse(self.log.warning.called)
+
+    def test_requires_archives(self):
+        fake_file = self.makefile('fake.txt')
+
+        job = MRNullSpark(['-r', 'hadoop',
+                           '--spark-master', 'local',
+                           '--file', fake_file])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._warn_about_spark_archives(runner._get_step(0))
+
+        self.assertFalse(self.log.warning.called)

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1488,3 +1488,20 @@ class FindBinariesAndJARsTestCase(SandboxedTestCase):
             self.assertTrue(self.get_hadoop_version.called)
             self.assertTrue(self.get_hadoop_streaming_jar.called)
             self.assertTrue(self.get_spark_submit_bin.called)
+
+
+class SparkSubmitArgPrefixTestCase(MockHadoopTestCase):
+
+    def test_default(self):
+        runner = HadoopJobRunner()
+
+        self.assertEqual(
+            runner._spark_submit_arg_prefix(),
+            ['--master', 'yarn'])
+
+    def test_spark_master(self):
+        runner = HadoopJobRunner(spark_master='local')
+
+        self.assertEqual(
+            runner._spark_submit_arg_prefix(),
+            ['--master', 'local'])


### PR DESCRIPTION
Added a `spark_master` option to the Hadoop runner (fixes #1484)

Also warns if you're trying to use archives with a non-YARN spark master, since Spark will probably ignore these.
