### PR TITLE
bootstrap mrjob with .zip, not .tar.gz

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -41,7 +41,7 @@ options related to file uploading.
     :set: all
     :default: (automatic)
 
-    Should we automatically tar up the mrjob library and install it when we run
+    Should we automatically zip up the mrjob library and install it when we run
     job? By default, we do unless :mrjob-opt:`interpreter` is set.
 
     Set this to ``False`` if you've already installed ``mrjob`` on your

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -462,7 +462,7 @@ class DataprocJobRunner(MRJobRunner):
         Create the master bootstrap script if necessary.
 
         """
-        # lazily create mrjob.tar.gz
+        # lazily create mrjob.zip
         if self._bootstrap_mrjob():
             self._create_mrjob_zip()
             self._bootstrap_dir_mgr.add('file', self._mrjob_zip_path)
@@ -846,7 +846,7 @@ class DataprocJobRunner(MRJobRunner):
         if not (self._bootstrap or self._bootstrap_mrjob()):
             return
 
-        # create mrjob.tar.gz if we need it, and add commands to install it
+        # create mrjob.zip if we need it, and add commands to install it
         mrjob_bootstrap = []
         if self._bootstrap_mrjob():
             assert self._mrjob_zip_path
@@ -860,9 +860,9 @@ class DataprocJobRunner(MRJobRunner):
                 "'from distutils.sysconfig import get_python_lib;"
                 " print(get_python_lib())')" %
                 cmd_line(self._python_bin())])
-            # un-tar mrjob.tar.gz
+            # unzip mrjob.zip
             mrjob_bootstrap.append(
-                ['sudo tar xfz ', path_dict, ' -C $__mrjob_PYTHON_LIB'])
+                ['sudo unzip ', path_dict, ' -d $__mrjob_PYTHON_LIB'])
             # re-compile pyc files now, since mappers/reducers can't
             # write to this directory. Don't fail if there is extra
             # un-compileable crud in the tarball (this would matter if

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -464,8 +464,8 @@ class DataprocJobRunner(MRJobRunner):
         """
         # lazily create mrjob.tar.gz
         if self._bootstrap_mrjob():
-            self._create_mrjob_tar_gz()
-            self._bootstrap_dir_mgr.add('file', self._mrjob_tar_gz_path)
+            self._create_mrjob_zip()
+            self._bootstrap_dir_mgr.add('file', self._mrjob_zip_path)
 
         # all other files needed by the script are already in
         # _bootstrap_dir_mgr
@@ -849,9 +849,9 @@ class DataprocJobRunner(MRJobRunner):
         # create mrjob.tar.gz if we need it, and add commands to install it
         mrjob_bootstrap = []
         if self._bootstrap_mrjob():
-            assert self._mrjob_tar_gz_path
+            assert self._mrjob_zip_path
             path_dict = {
-                'type': 'file', 'name': None, 'path': self._mrjob_tar_gz_path}
+                'type': 'file', 'name': None, 'path': self._mrjob_zip_path}
             self._bootstrap_dir_mgr.add(**path_dict)
 
             # find out where python keeps its libraries

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -942,7 +942,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
         persistent -- set by make_persistent_cluster()
         """
-        # lazily create mrjob.tar.gz
+        # lazily create mrjob.zip
         if self._bootstrap_mrjob():
             self._create_mrjob_zip()
             self._bootstrap_dir_mgr.add('file', self._mrjob_zip_path)
@@ -2403,7 +2403,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 self._bootstrap_mrjob()):
             return
 
-        # create mrjob.tar.gz if we need it, and add commands to install it
+        # create mrjob.zip if we need it, and add commands to install it
         mrjob_bootstrap = []
         if self._bootstrap_mrjob():
             # _add_bootstrap_files_for_upload() should have done this
@@ -2418,9 +2418,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 "'from distutils.sysconfig import get_python_lib;"
                 " print(get_python_lib())')" %
                 cmd_line(self._python_bin())])
-            # un-tar mrjob.tar.gz
+            # copy mrjob.zip over
             mrjob_bootstrap.append(
-                ['sudo tar xfz ', path_dict, ' -C $__mrjob_PYTHON_LIB'])
+                ['sudo unzip ', path_dict, ' -d $__mrjob_PYTHON_LIB'])
             # re-compile pyc files now, since mappers/reducers can't
             # write to this directory. Don't fail if there is extra
             # un-compileable crud in the tarball (this would matter if
@@ -2429,7 +2429,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 ['sudo %s -m compileall -f $__mrjob_PYTHON_LIB/mrjob && true' %
                  cmd_line(self._python_bin())])
 
-        # TODO: isn't it b.sh now?
+        # TODO: shouldn't it be b.sh now?
         # we call the script b.py because there's a character limit on
         # bootstrap script names (or there was at one time, anyway)
         path = os.path.join(self._get_local_tmp_dir(), 'b.py')
@@ -3117,9 +3117,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         (pooling requires the exact same version of :py:mod:`mrjob` anyway).
         """
         things_to_hash = [
-            # exclude mrjob.tar.gz because it's only created if the
+            # exclude mrjob.zip because it's only created if the
             # job starts its own cluster (also, its hash changes every time
-            # since the tarball contains different timestamps).
+            # since the zip file contains different timestamps).
             # The filenames/md5sums are sorted because we need to
             # ensure the order they're added doesn't affect the hash
             # here. Previously this used a dict, but Python doesn't

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -944,8 +944,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         """
         # lazily create mrjob.tar.gz
         if self._bootstrap_mrjob():
-            self._create_mrjob_tar_gz()
-            self._bootstrap_dir_mgr.add('file', self._mrjob_tar_gz_path)
+            self._create_mrjob_zip()
+            self._bootstrap_dir_mgr.add('file', self._mrjob_zip_path)
 
         # all other files needed by the script are already in
         # _bootstrap_dir_mgr
@@ -2407,9 +2407,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         mrjob_bootstrap = []
         if self._bootstrap_mrjob():
             # _add_bootstrap_files_for_upload() should have done this
-            assert self._mrjob_tar_gz_path
+            assert self._mrjob_zip_path
             path_dict = {
-                'type': 'file', 'name': None, 'path': self._mrjob_tar_gz_path}
+                'type': 'file', 'name': None, 'path': self._mrjob_zip_path}
             self._bootstrap_dir_mgr.add(**path_dict)
 
             # find out where python keeps its libraries
@@ -3128,7 +3128,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             sorted(
                 (name, self.fs.md5sum(path)) for name, path
                 in self._bootstrap_dir_mgr.name_to_path('file').items()
-                if not path == self._mrjob_tar_gz_path),
+                if not path == self._mrjob_zip_path),
             self._opts['additional_emr_info'],
             self._bootstrap,
             self._bootstrap_actions(),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -267,14 +267,14 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--bootstrap-mrjob'], dict(
                 action='store_true',
-                help=("Automatically tar up the mrjob library and install it"
+                help=("Automatically zip up the mrjob library and install it"
                       " when we run the mrjob. This is the default. Use"
                       " --no-bootstrap-mrjob if you've already installed"
                       " mrjob on your Hadoop cluster."),
             )),
             (['--no-bootstrap-mrjob'], dict(
                 action='store_false',
-                help=("Don't automatically tar up the mrjob library and"
+                help=("Don't automatically zip up the mrjob library and"
                       " install it when we run this job. Use this if you've"
                       " already installed mrjob on your Hadoop cluster."),
             )),

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -55,7 +55,7 @@ from mrjob.step import STEP_TYPES
 from mrjob.step import _is_spark_step_type
 from mrjob.util import bash_wrap
 from mrjob.util import cmd_line
-from mrjob.util import tar_and_gzip
+from mrjob.util import zip_dir
 
 
 log = logging.getLogger(__name__)
@@ -327,8 +327,8 @@ class MRJobRunner(object):
             self._stdin = stdin or sys.stdin.buffer
         self._stdin_path = None  # temp file containing dump from stdin
 
-        # where a tarball of the mrjob library is stored locally
-        self._mrjob_tar_gz_path = None
+        # where a zip file of the mrjob library is stored locally
+        self._mrjob_zip_path = None
 
         # store output_dir
         self._output_dir = output_dir
@@ -887,8 +887,8 @@ class MRJobRunner(object):
 
         if self._bootstrap_mrjob() and self.BOOTSTRAP_MRJOB_IN_SETUP:
             # patch setup to add mrjob.tar.gz to PYTYHONPATH
-            mrjob_tar_gz = self._create_mrjob_tar_gz()
-            path_dict = {'type': 'archive', 'name': None, 'path': mrjob_tar_gz}
+            mrjob_zip = self._create_mrjob_zip()
+            path_dict = {'type': 'archive', 'name': None, 'path': mrjob_zip}
             self._working_dir_mgr.add(**path_dict)
             setup = [['export PYTHONPATH=', path_dict, ':$PYTHONPATH']] + setup
 
@@ -974,7 +974,7 @@ class MRJobRunner(object):
 
         return setup
 
-    def _setup_wrapper_script_content(self, setup, mrjob_tar_gz_name=None):
+    def _setup_wrapper_script_content(self, setup, mrjob_zip_name=None):
         """Return a (Bourne) shell script that runs the setup commands and then
         executes whatever is passed to it (this will be our mapper/reducer),
         as a list of strings (one for each line, including newlines).
@@ -1111,17 +1111,17 @@ class MRJobRunner(object):
 
         return [interpolate(arg) for arg in args]
 
-    def _create_mrjob_tar_gz(self):
-        """Make a tarball of the mrjob library, without .pyc or .pyo files,
-        This will also set ``self._mrjob_tar_gz_path`` and return it.
+    def _create_mrjob_zip(self):
+        """Make a zip of the mrjob library, without .pyc or .pyo files,
+        This will also set ``self._mrjob_zip_path`` and return it.
 
         Typically called from
         :py:meth:`_create_setup_wrapper_script`.
 
         It's safe to call this method multiple times (we'll only create
-        the tarball once.)
+        the zip file once.)
         """
-        if not self._mrjob_tar_gz_path:
+        if not self._mrjob_zip_path:
             # find mrjob library
             import mrjob
 
@@ -1132,8 +1132,7 @@ class MRJobRunner(object):
 
             mrjob_dir = os.path.dirname(mrjob.__file__) or '.'
 
-            tar_gz_path = os.path.join(self._get_local_tmp_dir(),
-                                       'mrjob.tar.gz')
+            zip_path = os.path.join(self._get_local_tmp_dir(), 'mrjob.zip')
 
             def filter_path(path):
                 filename = os.path.basename(path)
@@ -1147,13 +1146,12 @@ class MRJobRunner(object):
                            filename.startswith('._'))
 
             log.debug('archiving %s -> %s as %s' % (
-                mrjob_dir, tar_gz_path, os.path.join('mrjob', '')))
-            tar_and_gzip(
-                mrjob_dir, tar_gz_path, filter=filter_path, prefix='mrjob')
+                mrjob_dir, zip_path, os.path.join('mrjob', '')))
+            zip_dir(mrjob_dir, zip_path, filter=filter_path, prefix='mrjob')
 
-            self._mrjob_tar_gz_path = tar_gz_path
+            self._mrjob_zip_path = zip_path
 
-        return self._mrjob_tar_gz_path
+        return self._mrjob_zip_path
 
     def _hadoop_generic_args_for_step(self, step_num):
         """Arguments like -D and -libjars that apply to every Hadoop

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -886,9 +886,11 @@ class MRJobRunner(object):
         setup = self._setup
 
         if self._bootstrap_mrjob() and self.BOOTSTRAP_MRJOB_IN_SETUP:
-            # patch setup to add mrjob.tar.gz to PYTYHONPATH
+            # patch setup to add mrjob.zip to PYTHONPATH
             mrjob_zip = self._create_mrjob_zip()
-            path_dict = {'type': 'archive', 'name': None, 'path': mrjob_zip}
+            # this is a file, not an archive, since Python can import directly
+            # from .zip files
+            path_dict = {'type': 'file', 'name': None, 'path': mrjob_zip}
             self._working_dir_mgr.add(**path_dict)
             setup = [['export PYTHONPATH=', path_dict, ':$PYTHONPATH']] + setup
 
@@ -919,7 +921,7 @@ class MRJobRunner(object):
         :py:func:`mrjob.setup.parse_setup_cmd()`.
 
         If *bootstrap_mrjob* and ``self.BOOTSTRAP_MRJOB_IN_SETUP`` are both
-        true, create mrjob.tar.gz (if it doesn't exist already) and
+        true, create mrjob.zip (if it doesn't exist already) and
         prepend a setup command that adds it to PYTHONPATH.
 
         Patch in *py_files*.

--- a/mrjob/tools/emr/create_cluster.py
+++ b/mrjob/tools/emr/create_cluster.py
@@ -50,11 +50,11 @@ Options::
                         File to upload to the master node before running
                         bootstrap_cmds (for example, debian packages). You can
                         use --bootstrap-file more than once.
-  --bootstrap-mrjob     Automatically tar up the mrjob library and install it
+  --bootstrap-mrjob     Automatically zip up the mrjob library and install it
                         when we run the mrjob. This is the default. Use --no-
                         bootstrap-mrjob if you've already installed mrjob on
                         your Hadoop cluster.
-  --no-bootstrap-mrjob  Don't automatically tar up the mrjob library and
+  --no-bootstrap-mrjob  Don't automatically zip up the mrjob library and
                         install it when we run this job. Use this if you've
                         already installed mrjob on your Hadoop cluster.
   --bootstrap-python    Attempt to install a compatible version of Python at

--- a/tests/logs/test_task.py
+++ b/tests/logs/test_task.py
@@ -1079,10 +1079,10 @@ class ParseTaskStderrTestCase(TestCase):
             "+ python3 -c 'import fcntl; fcntl.flock(9, fcntl.LOCK_EX)\n",
             '+ export PYTHONPATH=/mnt/var/lib/hadoop/tmp/nm-local-dir'
             '/usercache/hadoop/appcache/application_1453488173054_0002'
-            '/container_1453488173054_0002_01_000005/mrjob.tar.gz:\n',
+            '/container_1453488173054_0002_01_000005/mrjob.zip:\n',
             '+ PYTHONPATH=/mnt/var/lib/hadoop/tmp/nm-local-dir/usercache'
             '/hadoop/appcache/application_1453488173054_0002'
-            '/container_1453488173054_0002_01_000005/mrjob.tar.gz:\n',
+            '/container_1453488173054_0002_01_000005/mrjob.zip:\n',
             '+ rm /\n',
             'rm: cannot remove ‘/’: Is a directory\n',
         ]

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Mercilessly taunt an Amazonian river dolphin.
+
 This is by no means a complete mock of boto, just what we need for tests.
 """
 import hashlib
@@ -145,13 +146,13 @@ class MockBotoTestCase(SandboxedTestCase):
     def setUpClass(cls):
         # we don't care what's in this file, just want mrjob to stop creating
         # and deleting a complicated archive.
-        cls.fake_mrjob_tgz_path = tempfile.mkstemp(
-            prefix='fake_mrjob_', suffix='.tar.gz')[1]
+        cls.fake_mrjob_zip_path = tempfile.mkstemp(
+            prefix='fake_mrjob_', suffix='.zip')[1]
 
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists(cls.fake_mrjob_tgz_path):
-            os.remove(cls.fake_mrjob_tgz_path)
+        if os.path.exists(cls.fake_mrjob_zip_path):
+            os.remove(cls.fake_mrjob_zip_path)
 
     def setUp(self):
         # patch boto
@@ -176,8 +177,8 @@ class MockBotoTestCase(SandboxedTestCase):
 
         # patch slow things
         def fake_create_mrjob_zip(mocked_self, *args, **kwargs):
-            mocked_self._mrjob_zip_path = self.fake_mrjob_tgz_path
-            return self.fake_mrjob_tgz_path
+            mocked_self._mrjob_zip_path = self.fake_mrjob_zip_path
+            return self.fake_mrjob_zip_path
 
         self.start(patch.object(
             EMRJobRunner, '_create_mrjob_zip',

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -175,13 +175,13 @@ class MockBotoTestCase(SandboxedTestCase):
         super(MockBotoTestCase, self).setUp()
 
         # patch slow things
-        def fake_create_mrjob_tar_gz(mocked_self, *args, **kwargs):
-            mocked_self._mrjob_tar_gz_path = self.fake_mrjob_tgz_path
+        def fake_create_mrjob_zip(mocked_self, *args, **kwargs):
+            mocked_self._mrjob_zip_path = self.fake_mrjob_tgz_path
             return self.fake_mrjob_tgz_path
 
         self.start(patch.object(
-            EMRJobRunner, '_create_mrjob_tar_gz',
-            fake_create_mrjob_tar_gz))
+            EMRJobRunner, '_create_mrjob_zip',
+            fake_create_mrjob_zip))
 
         self.start(patch.object(time, 'sleep'))
 

--- a/tests/mockgoogleapiclient.py
+++ b/tests/mockgoogleapiclient.py
@@ -198,13 +198,13 @@ class MockGoogleAPITestCase(SandboxedTestCase):
         super(MockGoogleAPITestCase, self).setUp()
 
         # patch slow things
-        def fake_create_mrjob_tar_gz(mocked_self, *args, **kwargs):
-            mocked_self._mrjob_tar_gz_path = self.fake_mrjob_tgz_path
+        def fake_create_mrjob_zip(mocked_self, *args, **kwargs):
+            mocked_self._mrjob_zip_path = self.fake_mrjob_tgz_path
             return self.fake_mrjob_tgz_path
 
         self.start(patch.object(
-            DataprocJobRunner, '_create_mrjob_tar_gz',
-            fake_create_mrjob_tar_gz))
+            DataprocJobRunner, '_create_mrjob_zip',
+            fake_create_mrjob_zip))
 
         self.start(patch.object(time, 'sleep'))
 

--- a/tests/mockgoogleapiclient.py
+++ b/tests/mockgoogleapiclient.py
@@ -166,13 +166,13 @@ class MockGoogleAPITestCase(SandboxedTestCase):
     def setUpClass(cls):
         # we don't care what's in this file, just want mrjob to stop creating
         # and deleting a complicated archive.
-        cls.fake_mrjob_tgz_path = tempfile.mkstemp(
-            prefix='fake_mrjob_', suffix='.tar.gz')[1]
+        cls.fake_mrjob_zip_path = tempfile.mkstemp(
+            prefix='fake_mrjob_', suffix='.zip')[1]
 
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists(cls.fake_mrjob_tgz_path):
-            os.remove(cls.fake_mrjob_tgz_path)
+        if os.path.exists(cls.fake_mrjob_zip_path):
+            os.remove(cls.fake_mrjob_zip_path)
 
     def setUp(self):
         self._dataproc_client = MockDataprocClient(self)
@@ -199,8 +199,8 @@ class MockGoogleAPITestCase(SandboxedTestCase):
 
         # patch slow things
         def fake_create_mrjob_zip(mocked_self, *args, **kwargs):
-            mocked_self._mrjob_zip_path = self.fake_mrjob_tgz_path
-            return self.fake_mrjob_tgz_path
+            mocked_self._mrjob_zip_path = self.fake_mrjob_zip_path
+            return self.fake_mrjob_zip_path
 
         self.start(patch.object(
             DataprocJobRunner, '_create_mrjob_zip',

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -161,10 +161,10 @@ class DataprocJobRunnerEndToEndTestCase(MockGoogleAPITestCase):
 
             # make sure mrjob.tar.gz is created and uploaded as
             # a bootstrap file
-            self.assertTrue(os.path.exists(runner._mrjob_tar_gz_path))
-            self.assertIn(runner._mrjob_tar_gz_path,
+            self.assertTrue(os.path.exists(runner._mrjob_zip_path))
+            self.assertIn(runner._mrjob_zip_path,
                           runner._upload_mgr.path_to_uri())
-            self.assertIn(runner._mrjob_tar_gz_path,
+            self.assertIn(runner._mrjob_zip_path,
                           runner._bootstrap_dir_mgr.paths())
 
             cluster_id = runner.get_cluster_id()
@@ -734,7 +734,7 @@ class TestMasterBootstrapScript(MockGoogleAPITestCase):
         # check files get downloaded
         assertScriptDownloads(foo_py_path, 'bar.py')
         assertScriptDownloads('gs://walrus/scripts/ohnoes.sh')
-        assertScriptDownloads(runner._mrjob_tar_gz_path)
+        assertScriptDownloads(runner._mrjob_zip_path)
 
         # check scripts get run
 
@@ -750,12 +750,12 @@ class TestMasterBootstrapScript(MockGoogleAPITestCase):
         self.assertIn('/tmp/s.sh', lines)
 
         # bootstrap_mrjob
-        mrjob_tar_gz_name = runner._bootstrap_dir_mgr.name(
-            'file', runner._mrjob_tar_gz_path)
+        mrjob_zip_name = runner._bootstrap_dir_mgr.name(
+            'file', runner._mrjob_zip_path)
         self.assertIn("__mrjob_PYTHON_LIB=$(" + PYTHON_BIN + " -c 'from"
                       " distutils.sysconfig import get_python_lib;"
                       " print(get_python_lib())')", lines)
-        self.assertIn('sudo tar xfz $__mrjob_PWD/' + mrjob_tar_gz_name +
+        self.assertIn('sudo tar xfz $__mrjob_PWD/' + mrjob_zip_name +
                       ' -C $__mrjob_PYTHON_LIB', lines)
         self.assertIn('sudo ' + PYTHON_BIN + ' -m compileall -f'
                       ' $__mrjob_PYTHON_LIB/mrjob && true', lines)

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -667,7 +667,7 @@ class GCEInstanceGroupTestCase(MockGoogleAPITestCase):
             task=(20, HIGHCPU_GCE_INSTANCE))
 
 
-class TestMasterBootstrapScript(MockGoogleAPITestCase):
+class MasterBootstrapScriptTestCase(MockGoogleAPITestCase):
 
     def test_usr_bin_env(self):
         runner = DataprocJobRunner(conf_paths=[],
@@ -755,8 +755,8 @@ class TestMasterBootstrapScript(MockGoogleAPITestCase):
         self.assertIn("__mrjob_PYTHON_LIB=$(" + PYTHON_BIN + " -c 'from"
                       " distutils.sysconfig import get_python_lib;"
                       " print(get_python_lib())')", lines)
-        self.assertIn('sudo tar xfz $__mrjob_PWD/' + mrjob_zip_name +
-                      ' -C $__mrjob_PYTHON_LIB', lines)
+        self.assertIn('sudo unzip $__mrjob_PWD/' + mrjob_zip_name +
+                      ' -d $__mrjob_PYTHON_LIB', lines)
         self.assertIn('sudo ' + PYTHON_BIN + ' -m compileall -f'
                       ' $__mrjob_PYTHON_LIB/mrjob && true', lines)
         # bootstrap_python

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -159,8 +159,7 @@ class DataprocJobRunnerEndToEndTestCase(MockGoogleAPITestCase):
             # job overrides jobconf in step 1
             self.assertIn('x=z', step_1_args)
 
-            # make sure mrjob.tar.gz is created and uploaded as
-            # a bootstrap file
+            # make sure mrjob.zip is created and uploaded as a bootstrap file
             self.assertTrue(os.path.exists(runner._mrjob_zip_path))
             self.assertIn(runner._mrjob_zip_path,
                           runner._upload_mgr.path_to_uri())

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1517,8 +1517,8 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
         self.assertIn("  __mrjob_PYTHON_LIB=$(" + expected_python_bin +
                       " -c 'from distutils.sysconfig import get_python_lib;"
                       " print(get_python_lib())')", lines)
-        self.assertIn('  sudo tar xfz $__mrjob_PWD/' + mrjob_zip_name +
-                      ' -C $__mrjob_PYTHON_LIB', lines)
+        self.assertIn('  sudo unzip $__mrjob_PWD/' + mrjob_zip_name +
+                      ' -d $__mrjob_PYTHON_LIB', lines)
         self.assertIn('  sudo ' + expected_python_bin + ' -m compileall -f'
                       ' $__mrjob_PYTHON_LIB/mrjob && true', lines)
         # bootstrap_python_packages

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -234,10 +234,10 @@ class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
 
             # make sure mrjob.tar.gz is created and uploaded as
             # a bootstrap file
-            self.assertTrue(os.path.exists(runner._mrjob_tar_gz_path))
-            self.assertIn(runner._mrjob_tar_gz_path,
+            self.assertTrue(os.path.exists(runner._mrjob_zip_path))
+            self.assertIn(runner._mrjob_zip_path,
                           runner._upload_mgr.path_to_uri())
-            self.assertIn(runner._mrjob_tar_gz_path,
+            self.assertIn(runner._mrjob_zip_path,
                           runner._bootstrap_dir_mgr.paths())
 
         self.assertEqual(sorted(results),
@@ -1495,7 +1495,7 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
         assertScriptDownloads(foo_py_path, 'bar.py')
         assertScriptDownloads('s3://walrus/scripts/ohnoes.sh')
         assertScriptDownloads('/tmp/quz', 'quz')
-        assertScriptDownloads(runner._mrjob_tar_gz_path)
+        assertScriptDownloads(runner._mrjob_zip_path)
         assertScriptDownloads('speedups.sh')
         assertScriptDownloads('/tmp/s.sh')
         if PY2:
@@ -1512,12 +1512,12 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
         self.assertIn('  true', lines)
         self.assertIn('  ls', lines)
         # bootstrap_mrjob
-        mrjob_tar_gz_name = runner._bootstrap_dir_mgr.name(
-            'file', runner._mrjob_tar_gz_path)
+        mrjob_zip_name = runner._bootstrap_dir_mgr.name(
+            'file', runner._mrjob_zip_path)
         self.assertIn("  __mrjob_PYTHON_LIB=$(" + expected_python_bin +
                       " -c 'from distutils.sysconfig import get_python_lib;"
                       " print(get_python_lib())')", lines)
-        self.assertIn('  sudo tar xfz $__mrjob_PWD/' + mrjob_tar_gz_name +
+        self.assertIn('  sudo tar xfz $__mrjob_PWD/' + mrjob_zip_name +
                       ' -C $__mrjob_PYTHON_LIB', lines)
         self.assertIn('  sudo ' + expected_python_bin + ' -m compileall -f'
                       ' $__mrjob_PYTHON_LIB/mrjob && true', lines)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -232,8 +232,7 @@ class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
             # job overrides jobconf in step 1
             self.assertIn('x=z', step_1_args)
 
-            # make sure mrjob.tar.gz is created and uploaded as
-            # a bootstrap file
+            # make sure mrjob.zip is created and uploaded as a bootstrap file
             self.assertTrue(os.path.exists(runner._mrjob_zip_path))
             self.assertIn(runner._mrjob_zip_path,
                           runner._upload_mgr.path_to_uri())

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -681,7 +681,7 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
             self.assertIn(runner._setup_wrapper_script_path,
                           runner._upload_mgr.path_to_uri())
             mrjob_zip_name = runner._working_dir_mgr.name(
-                'archive', runner._mrjob_zip_path)
+                'file', runner._mrjob_zip_path)
             with open(runner._setup_wrapper_script_path) as wrapper:
                 self.assertTrue(any(
                     ('export PYTHONPATH' in line and mrjob_zip_name in line)

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -670,13 +670,13 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
             self.assertEqual(runner._opts['hadoop_extra_args'],
                              ['-verbose'])
 
-            # make sure mrjob.tar.gz is was uploaded
+            # make sure mrjob.zip was uploaded
             self.assertTrue(os.path.exists(runner._mrjob_zip_path))
             self.assertIn(runner._mrjob_zip_path,
                           runner._upload_mgr.path_to_uri())
 
-            # make sure setup script exists, and mrjob.tar.gz is added
-            # to PYTHONPATH in it
+            # make sure setup script exists, and that it adds mrjob.zip
+            # to PYTHONPATH
             self.assertTrue(os.path.exists(runner._setup_wrapper_script_path))
             self.assertIn(runner._setup_wrapper_script_path,
                           runner._upload_mgr.path_to_uri())

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -671,8 +671,8 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
                              ['-verbose'])
 
             # make sure mrjob.tar.gz is was uploaded
-            self.assertTrue(os.path.exists(runner._mrjob_tar_gz_path))
-            self.assertIn(runner._mrjob_tar_gz_path,
+            self.assertTrue(os.path.exists(runner._mrjob_zip_path))
+            self.assertIn(runner._mrjob_zip_path,
                           runner._upload_mgr.path_to_uri())
 
             # make sure setup script exists, and mrjob.tar.gz is added
@@ -680,11 +680,11 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
             self.assertTrue(os.path.exists(runner._setup_wrapper_script_path))
             self.assertIn(runner._setup_wrapper_script_path,
                           runner._upload_mgr.path_to_uri())
-            mrjob_tar_gz_name = runner._working_dir_mgr.name(
-                'archive', runner._mrjob_tar_gz_path)
+            mrjob_zip_name = runner._working_dir_mgr.name(
+                'archive', runner._mrjob_zip_path)
             with open(runner._setup_wrapper_script_path) as wrapper:
                 self.assertTrue(any(
-                    ('export PYTHONPATH' in line and mrjob_tar_gz_name in line)
+                    ('export PYTHONPATH' in line and mrjob_zip_name in line)
                     for line in wrapper))
 
         self.assertEqual(runner.counters(),

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -21,7 +21,6 @@ import shutil
 import signal
 import stat
 import sys
-import tarfile
 import tempfile
 from io import BytesIO
 from subprocess import CalledProcessError
@@ -199,14 +198,14 @@ class TestJobName(TestCase):
         self.assertEqual(match.group(2), 'ads')
 
 
-class CreateMrjobTarGzTestCase(TestCase):
+class CreateMrjobZipTestCase(TestCase):
 
     def test_create_mrjob_zip(self):
         with no_handlers_for_logger('mrjob.runner'):
             with InlineMRJobRunner(conf_paths=[]) as runner:
                 mrjob_zip_path = runner._create_mrjob_zip()
-                mrjob_zip = tarfile.open(mrjob_zip_path)
-                contents = mrjob_zip.getnames()
+                mrjob_zip = ZipFile(mrjob_zip_path)
+                contents = mrjob_zip.namelist()
 
                 for path in contents:
                     self.assertEqual(path[:6], 'mrjob/')

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -201,12 +201,12 @@ class TestJobName(TestCase):
 
 class CreateMrjobTarGzTestCase(TestCase):
 
-    def test_create_mrjob_tar_gz(self):
+    def test_create_mrjob_zip(self):
         with no_handlers_for_logger('mrjob.runner'):
             with InlineMRJobRunner(conf_paths=[]) as runner:
-                mrjob_tar_gz_path = runner._create_mrjob_tar_gz()
-                mrjob_tar_gz = tarfile.open(mrjob_tar_gz_path)
-                contents = mrjob_tar_gz.getnames()
+                mrjob_zip_path = runner._create_mrjob_zip()
+                mrjob_zip = tarfile.open(mrjob_zip_path)
+                contents = mrjob_zip.getnames()
 
                 for path in contents:
                     self.assertEqual(path[:6], 'mrjob/')


### PR DESCRIPTION
This uses a `.zip` file rather than a tarball to bootstrap mrjob, for better compatibility with Spark. Fixes #1492.