### PR TITLE
bootstrap mrjob in Spark

### DIFF
--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1372,7 +1372,16 @@ class MRJobRunner(object):
         By default (cluster mode), Spark only accepts local files, so
         we pass these as-is.
         """
-        return self._opts['py_files']
+        py_files = []
+
+        py_files.extend(self._opts['py_files'])
+
+        # Spark doesn't have setup scripts; instead, we need to add
+        # mrjob to
+        if  self._bootstrap_mrjob() and self.BOOTSTRAP_MRJOB_IN_SETUP:
+            py_files.append(self._create_mrjob_zip())
+
+        return py_files
 
     def _libjar_paths(self):
         """Paths or URIs of libjars, from Hadoop/Spark's point of view.

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1193,7 +1193,7 @@ class SparkPyFilesTestCase(MockHadoopTestCase):
 
             self.assertEqual(
                 runner._spark_py_files(),
-                [egg1_path, egg2_path]
+                [egg1_path, egg2_path, runner._create_mrjob_zip()]
             )
 
             # the py_files get uploaded anyway since they appear in

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -613,6 +613,10 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         self.start(patch('mrjob.runner.MRJobRunner._python_bin',
                          return_value=['mypy']))
 
+        # bootstrapping mrjob is tested below in SparkPyFilesTestCase
+        self.start(patch('mrjob.runner.MRJobRunner._bootstrap_mrjob',
+                         return_value=False))
+
     def _expected_conf_args(self, cmdenv=None, jobconf=None):
         conf = {}
 
@@ -869,7 +873,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                         cmdenv=dict(PYSPARK_PYTHON='mypy')
                     ) + [
                         '--py-files',
-                        '<first py_file>,<second py_file>,'
+                        '<first py_file>,<second py_file>'
                     ]
                 )
             )


### PR DESCRIPTION
In the Hadoop runner, we now add the mrjob zip to `py_files`. This is keyed off `BOOTSTRAP_MRJOB_IN_SETUP`, so in theory this would happen in the local runners as well if they supported Spark.

Fixes #1496.