### PR TITLE
drop container_to_attempt_id

### DIFF
--- a/mrjob/logs/errors.py
+++ b/mrjob/logs/errors.py
@@ -15,7 +15,7 @@
 """Merging errors, picking the best one, and displaying it."""
 import json
 
-from .ids import _make_time_sort_key
+from .ids import _time_sort_key
 
 
 def _pick_error(log_interpretation):
@@ -29,31 +29,23 @@ def _pick_error(log_interpretation):
             for error in errors or ():
                 yield error
 
-    # looks like this is only available from history logs
-    container_to_attempt_id = log_interpretation.get(
-        'history', {}).get('container_to_attempt_id')
-
-    errors = _merge_and_sort_errors(yield_errors(), container_to_attempt_id)
+    errors = _merge_and_sort_errors(yield_errors())
     if errors:
         return errors[0]
     else:
         return None
 
 
-def _merge_and_sort_errors(errors, container_to_attempt_id=None):
+def _merge_and_sort_errors(errors):
     """Merge errors from one or more lists of errors and then return
     them, sorted by recency.
 
-    Optionally pass in *container_to_attempt_id
-
     We allow None in place of an error list.
     """
-    sort_key = _make_time_sort_key(container_to_attempt_id)
-
     key_to_error = {}
 
     for error in errors:
-        key = sort_key(error)
+        key = _time_sort_key(error)
         key_to_error.setdefault(key, {})
         key_to_error[key].update(error)
 

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -145,8 +145,6 @@ def _parse_yarn_history_log(lines):
 
     This returns a dictionary which may contain the following keys:
 
-    container_to_attempt_id: map from container_id to attempt_id (useful
-        for matching with task errors where we don't know attempt ID)
     counters: map from group to counter to amount. If job failed, we sum
         counters for succesful tasks
     errors: a list of dictionaries with the keys:
@@ -180,13 +178,6 @@ def _parse_yarn_history_log(lines):
             continue
         events = [e for e in record['event'].values()
                   if isinstance(e, dict)]
-
-        # update container_id -> attempt_id mapping
-        for event in events:
-            if 'attemptId' in event and 'containerId' in event:
-                result.setdefault('container_to_attempt_id', {})
-                result['container_to_attempt_id'][
-                    event['containerId']] = event['attemptId']
 
         if record_type.endswith('_ATTEMPT_FAILED'):
             for event in events:

--- a/tests/logs/test_errors.py
+++ b/tests/logs/test_errors.py
@@ -157,45 +157,6 @@ class PickErrorTestCase(TestCase):
             )
         )
 
-    def test_container_to_attempt_id(self):
-        container_id = 'container_1449525218032_0005_01_000010'
-        attempt_id = 'attempt_1449525218032_0005_m_000000_3'
-        task_id = _attempt_id_to_task_id(attempt_id)
-
-        container_to_attempt_id = {container_id: attempt_id}
-
-        log_interpretation = dict(
-            history=dict(
-                container_to_attempt_id=container_to_attempt_id,
-                errors=[
-                    dict(
-                        attempt_id=attempt_id,
-                        hadoop_error=dict(message='SwordsMischiefException'),
-                        task_id=task_id,
-                    ),
-                ],
-            ),
-            task=dict(
-                errors=[
-                    dict(
-                        container_id=container_id,
-                        hadoop_error=dict(message='SwordsMischiefException'),
-                        task_error=dict(message='en garde!'),
-                    ),
-                ],
-            ),
-        )
-
-        self.assertEqual(
-            _pick_error(log_interpretation),
-            dict(
-                attempt_id=attempt_id,
-                container_id=container_id,
-                hadoop_error=dict(message='SwordsMischiefException'),
-                task_error=dict(message='en garde!'),
-                task_id=task_id,
-            ))
-
 
 class MergeAndSortErrorsTestCase(TestCase):
 

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -323,38 +323,6 @@ class ParseYARNHistoryLogTestCase(TestCase):
                     ),
                 ]))
 
-    def test_container_to_attempt_mapping(self):
-        lines = [
-            '{"type":"MAP_ATTEMPT_STARTED","event":{'
-            '"org.apache.hadoop.mapreduce.jobhistory.TaskAttemptStarted":{'
-            '"taskid":"task_1449525218032_0005_m_000000","taskType":"MAP",'
-            '"attemptId":"attempt_1449525218032_0005_m_000000_3","startTime":'
-            '1449532586958,"trackerName":"0a7802e19139","httpPort":8042,'
-            '"shufflePort":13562,"containerId":'
-            '"container_1449525218032_0005_01_000010","locality":{"string":'
-            '"NODE_LOCAL"},"avataar":{"string":"VIRGIN"}}}}\n',
-            '{"type":"MAP_ATTEMPT_STARTED","event":{'
-            '"org.apache.hadoop.mapreduce.jobhistory.TaskAttemptStarted":{'
-            '"taskid":"task_1449525218032_0005_m_000001","taskType":"MAP",'
-            '"attemptId":"attempt_1449525218032_0005_m_000001_3","startTime":'
-            '1449532587976,"trackerName":"0a7802e19139","httpPort":8042,'
-            '"shufflePort":13562,"containerId":'
-            '"container_1449525218032_0005_01_000011","locality":{"string":'
-            '"NODE_LOCAL"},"avataar":{"string":"VIRGIN"}}}}\n',
-        ]
-
-        self.assertEqual(
-            _parse_yarn_history_log(lines),
-            dict(
-                container_to_attempt_id={
-                    'container_1449525218032_0005_01_000010':
-                    'attempt_1449525218032_0005_m_000000_3',
-                    'container_1449525218032_0005_01_000011':
-                    'attempt_1449525218032_0005_m_000001_3',
-                }
-            )
-        )
-
 
 class ParsePreYARNHistoryLogTestCase(TestCase):
     JOB_COUNTER_LINES = [


### PR DESCRIPTION
We don't need it to sort by recency, and you can infer attempt number directly from container ID anyway. Fixes #1487.