### PR TITLE
Handle missing SSH binary

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1168,9 +1168,10 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             ssh_proc = None
             try:
                 ssh_proc = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-            except OSError as popen_exception:
+            except OSError as ex:
                 # e.g. OSError(2, 'File not found')
-                break  # warning handled below
+                popen_exception = ex   # warning handled below
+                break
 
             if ssh_proc:
                 time.sleep(_WAIT_FOR_SSH_TO_FAIL)

--- a/mrjob/logs/wrap.py
+++ b/mrjob/logs/wrap.py
@@ -30,7 +30,7 @@ def _cat_log(fs, path):
             return
         for line in fs.cat(path):
             yield to_string(line)
-    except IOError as e:
+    except (IOError, OSError) as e:
         log.warning("couldn't cat() %s: %r" % (path, e))
 
 
@@ -60,7 +60,7 @@ def _ls_logs(fs, log_dir_stream, matcher, **kwargs):
             if fs.exists(log_dir):
                 for path in fs.ls(log_dir):
                     yield path
-        except IOError as e:
+        except (IOError, OSError) as e:
             log.warning("couldn't ls() %s: %r" % (log_dir, e))
 
     for log_dirs in log_dir_stream:

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5784,6 +5784,7 @@ class SetUpSSHTunnelTestCase(MockBotoTestCase):
         self.assertEqual(params['local_port'], 10003)
 
     def test_missing_ssh_binary(self):
+        # tests #1474
         self.mock_Popen.side_effect = OSError(2, 'No such file or directory')
 
         self.get_ssh_args(assert_tunnel_failed=True)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5672,7 +5672,7 @@ class SetUpSSHTunnelTestCase(MockBotoTestCase):
 
         self.start(patch('os.kill'))  # don't clean up fake SSH proc
 
-    def get_ssh_args(self, *args):
+    def get_ssh_args(self, *args, **kwargs):
         job_args = [
             '-r', 'emr',
             '--ssh-tunnel',
@@ -5694,6 +5694,9 @@ class SetUpSSHTunnelTestCase(MockBotoTestCase):
             runner._set_up_ssh_tunnel()
 
             ssh_args = self.mock_Popen.call_args[0][0]
+
+            if kwargs.get('assert_tunnel_failed'):
+                self.assertFalse(runner._ssh_proc)
 
             return ssh_args
 
@@ -5779,6 +5782,16 @@ class SetUpSSHTunnelTestCase(MockBotoTestCase):
 
         self.assertEqual(self.mock_Popen.call_count, 3)
         self.assertEqual(params['local_port'], 10003)
+
+    def test_missing_ssh_binary(self):
+        self.mock_Popen.side_effect = OSError(2, 'No such file or directory')
+
+        self.get_ssh_args(assert_tunnel_failed=True)
+
+    def test_other_popen_error(self):
+        self.mock_Popen.side_effect = NotImplementedError()
+
+        self.assertRaises(NotImplementedError, self.get_ssh_args)
 
 
 class UsesSparkTestCase(MockBotoTestCase):


### PR DESCRIPTION
This change gracefully handles the errors we get when there is no `ssh` binary, or when `ssh_bin` is misconfigured. Fixes #1474.
