### PR TITLE
simplify terminate-idle-clusters

### DIFF
--- a/mrjob/tools/emr/terminate_idle_clusters.py
+++ b/mrjob/tools/emr/terminate_idle_clusters.py
@@ -152,7 +152,7 @@ def _maybe_terminate_clusters(dry_run=False,
     num_bootstrapping = 0
     num_done = 0
     num_idle = 0
-    num_not_streaming_or_spark = 0
+    num_non_streaming = 0
     num_pending = 0
     num_running = 0
 
@@ -181,8 +181,8 @@ def _maybe_terminate_clusters(dry_run=False,
 
         # we can't really tell if non-streaming jobs are idle or not, so
         # let them be (see Issue #60)
-        if _is_cluster_not_streaming_or_spark(steps):
-            num_not_streaming_or_spark += 1
+        if _is_cluster_non_streaming(steps):
+            num_non_streaming += 1
             continue
 
         if any(_is_step_running(step) for step in steps):
@@ -248,9 +248,9 @@ def _maybe_terminate_clusters(dry_run=False,
 
     log.info(
         'Cluster statuses: %d starting, %d bootstrapping, %d running,'
-        ' %d pending, %d idle, %d active non-streaming/Spark, %d done' % (
+        ' %d pending, %d idle, %d active non-streaming, %d done' % (
             num_starting, num_bootstrapping, num_running,
-            num_pending, num_idle, num_not_streaming_or_spark, num_done))
+            num_pending, num_idle, num_non_streaming, num_done))
 
 
 def _is_cluster_done(cluster):
@@ -259,7 +259,7 @@ def _is_cluster_done(cluster):
             hasattr(cluster.status.timeline, 'enddatetime'))
 
 
-def _is_cluster_not_streaming_or_spark(steps):
+def _is_cluster_non_streaming(steps):
     """Return ``True`` if the give cluster has steps, but none of them are
     Hadoop streaming steps (for example, if the cluster is running Hive).
     """
@@ -271,14 +271,11 @@ def _is_cluster_not_streaming_or_spark(steps):
             # This is hadoop streaming
             if arg.value == '-mapper':
                 return False
-            # This is Spark
-            if arg.value.split('/')[-1] == 'spark-submit':
-                return False
             # This is a debug jar associated with hadoop streaming
             if _DEBUG_JAR_ARG_RE.match(arg.value):
                 return False
     else:
-        # job has at least one step, and none are streaming or Spark steps
+        # job has at least one step, and none are streaming steps
         return True
 
 

--- a/tests/tools/emr/test_terminate_idle_clusters.py
+++ b/tests/tools/emr/test_terminate_idle_clusters.py
@@ -28,11 +28,10 @@ from mrjob.tools.emr.terminate_idle_clusters import _is_cluster_bootstrapping
 from mrjob.tools.emr.terminate_idle_clusters import _is_cluster_done
 from mrjob.tools.emr.terminate_idle_clusters import _is_cluster_running
 from mrjob.tools.emr.terminate_idle_clusters import _is_cluster_starting
-from mrjob.tools.emr.terminate_idle_clusters import _is_cluster_not_streaming_or_spark
+from mrjob.tools.emr.terminate_idle_clusters import _is_cluster_non_streaming
 from mrjob.tools.emr.terminate_idle_clusters import _cluster_has_pending_steps
 from mrjob.tools.emr.terminate_idle_clusters import _time_last_active
 
-from tests.mockboto import DEBUGGING_ARGS
 from tests.mockboto import MockBotoTestCase
 from tests.mockboto import MockEmrObject
 from tests.mockboto import to_iso8601
@@ -396,7 +395,7 @@ class ClusterTerminationTestCase(MockBotoTestCase):
             pool_hash=None,
             pool_name=None,
             running=False,
-            not_streaming_or_spark=False):
+            non_streaming=False):
 
         self.assertEqual(starting,
                          _is_cluster_starting(mock_cluster))
@@ -414,8 +413,8 @@ class ClusterTerminationTestCase(MockBotoTestCase):
                          _pool_hash_and_name(mock_cluster._bootstrapactions))
         self.assertEqual(running,
                          _is_cluster_running(mock_cluster._steps))
-        self.assertEqual(not_streaming_or_spark,
-                         _is_cluster_not_streaming_or_spark(mock_cluster._steps))
+        self.assertEqual(non_streaming,
+                         _is_cluster_non_streaming(mock_cluster._steps))
 
     def _lock_contents(self, mock_cluster, steps_ahead=0):
         conn = self.connect_s3()
@@ -493,7 +492,7 @@ class ClusterTerminationTestCase(MockBotoTestCase):
         self.assert_mock_cluster_is(
             self.mock_emr_clusters['j-HIVE'],
             idle_for=timedelta(hours=4),
-            not_streaming_or_spark=True,
+            non_streaming=True,
         )
 
     def test_hadoop_debugging_cluster(self):
@@ -761,67 +760,6 @@ class ClusterTerminationTestCase(MockBotoTestCase):
 
         # shouldn't *actually* terminate clusters
         self.assertEqual(self.ids_of_terminated_clusters(), [])
-
-
-class IsClusterNotStreamingOrSparkTestCase(TestCase):
-
-    def _make_steps(self, *args_list):
-        return [
-            MockEmrObject(
-                config=MockEmrObject(
-                    args=[
-                        MockEmrObject(value=arg) for arg in args
-                    ]
-                )
-            )
-            for args in args_list
-        ]
-
-    def test_empty(self):
-        self.assertTrue(_is_cluster_not_streaming_or_spark(
-            self._make_steps([])))
-
-    def test_streaming_step(self):
-        self.assertFalse(_is_cluster_not_streaming_or_spark(
-            self._make_steps(['-mapper', 'my_job.py --mapper',
-                              '-reducer', 'my_job.py --reducer'])))
-
-    def test_spark_step(self):
-        self.assertFalse(_is_cluster_not_streaming_or_spark(
-            self._make_steps([
-                'spark-submit',
-                '--master',
-                'yarn',
-                '--deploy-mode',
-                'cluster',
-            ])
-        ))
-
-    def test_spark_step_3_x_ami(self):
-        self.assertFalse(_is_cluster_not_streaming_or_spark(
-            self._make_steps([
-                '/home/hadoop/spark/bin/spark-submit',
-                '--master',
-                'yarn',
-                '--deploy-mode',
-                'cluster',
-            ])
-        ))
-
-    def test_debug_step(self):
-        self.assertFalse(_is_cluster_not_streaming_or_spark(
-            self._make_steps(DEBUGGING_ARGS)))
-
-    def test_hive(self):
-        self.assertTrue(_is_cluster_not_streaming_or_spark(
-            self._make_steps([])))  # hive step doesn't take args
-
-    def test_mixed(self):
-        self.assertFalse(_is_cluster_not_streaming_or_spark(
-            ['-mapper', 'my_job.py --mapper',
-             '-reducer', 'my_job.py --reducer'],
-            ['args', 'for', 'some', 'other', 'jar']
-        ))
 
 
 # make sure _DEBUG_JAR_ARG_RE works correctly with boto 2.40.0 (tests #1306)


### PR DESCRIPTION
This removes a special case from the `terminate-idle-clusters` that was designed to leave Hive clusters alone (see #60). Instead, if EMR says a cluster is idle, we believe it. Fixes #1363.

If this script *does* terminate interactive Hadoop processes that aren't really idle, the workaround is to run all your ordinary mrjobs with a particular pool name, and then specify that pool name to `terminate-idle-clusters`. Alternatively, you could just set `max_hours_idle` and let the clusters terminate themselves.