### PR TITLE
make pooling python-bin aware, other fixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ v0.5.7, 2016-10-?? -- ???
    * can use environment variables and ~ in hadoop_streaming_jar option
  * EMR runner:
    * added debug logging for pooling (#1449)
+   * cleaner error messages when bootstrapped mrjob won't compile
 
 v0.5.6, 2016-09-12 -- dataproc crash fix
  * Dataproc runner:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ v0.5.7, 2016-10-?? -- ???
  * EMR runner:
    * added debug logging for pooling (#1449)
    * cleaner error messages when bootstrapped mrjob won't compile
+   * master bootstrap script always created when pooling
 
 v0.5.6, 2016-09-12 -- dataproc crash fix
  * Dataproc runner:

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -868,7 +868,8 @@ class DataprocJobRunner(MRJobRunner):
             # un-compileable crud in the tarball (this would matter if
             # sh_bin were 'sh -e')
             mrjob_bootstrap.append(
-                ['sudo %s -m compileall -f $__mrjob_PYTHON_LIB/mrjob && true' %
+                ['sudo %s -m compileall -q'
+                 ' -f $__mrjob_PYTHON_LIB/mrjob && true' %
                  cmd_line(self._python_bin())])
 
         # we call the script b.py because there's a character limit on

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2444,7 +2444,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             # un-compileable crud in the tarball (this would matter if
             # sh_bin were 'sh -e')
             mrjob_bootstrap.append(
-                ['sudo %s -m compileall -f $__mrjob_PYTHON_LIB/mrjob && true' %
+                ['sudo %s -m compileall -q -f $__mrjob_PYTHON_LIB/mrjob && true' %
                  cmd_line(self._python_bin())])
 
         # TODO: shouldn't it be b.sh now?

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2416,9 +2416,12 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             return
 
         # Also don't bother if we're not bootstrapping
+        # (unless we're pooling, in which case we need the bootstrap
+        # script to attach the pool hash too; see #1503).
         if not (self._bootstrap or self._legacy_bootstrap or
                 self._opts['bootstrap_files'] or
-                self._bootstrap_mrjob()):
+                self._bootstrap_mrjob() or
+                self._opts['pool_clusters']):
             return
 
         # create mrjob.zip if we need it, and add commands to install it
@@ -2899,8 +2902,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 return
 
             # match pool name, and (bootstrap) hash
-            bootstrap_actions = _yield_all_bootstrap_actions(
-                emr_conn, cluster.id)
+            bootstrap_actions = list(_yield_all_bootstrap_actions(
+                emr_conn, cluster.id))
             pool_hash, pool_name = _pool_hash_and_name(bootstrap_actions)
 
             if req_hash != pool_hash:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3156,6 +3156,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
         if self._bootstrap_mrjob():
             things_to_hash.append(mrjob.__version__)
+            things_to_hash.append(self._python_bin())
 
         things_json = json.dumps(things_to_hash, sort_keys=True)
         if not isinstance(things_json, bytes):

--- a/mrjob/examples/mr_spark_nick_nack_word_count.py
+++ b/mrjob/examples/mr_spark_nick_nack_word_count.py
@@ -41,7 +41,8 @@ class MRSparkNickNackWordCount(MRJob):
             .reduceByKey(add))
 
         # MultipleValueOutputFormat expects Text, Text
-        counts = counts.map(lambda (word, count): (word, str(count)))
+        # w_c is (word, count)
+        counts = counts.map(lambda w_c: (w_c[0], str(w_c[1])))
 
         counts.saveAsHadoopFile(output_path,
                                 'nicknack.MultipleValueOutputFormat')

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -756,7 +756,7 @@ class MasterBootstrapScriptTestCase(MockGoogleAPITestCase):
                       " print(get_python_lib())')", lines)
         self.assertIn('sudo unzip $__mrjob_PWD/' + mrjob_zip_name +
                       ' -d $__mrjob_PYTHON_LIB', lines)
-        self.assertIn('sudo ' + PYTHON_BIN + ' -m compileall -f'
+        self.assertIn('sudo ' + PYTHON_BIN + ' -m compileall -q -f'
                       ' $__mrjob_PYTHON_LIB/mrjob && true', lines)
         # bootstrap_python
         if PY2:
@@ -786,7 +786,7 @@ class MasterBootstrapScriptTestCase(MockGoogleAPITestCase):
         with open(runner._master_bootstrap_script_path, 'r') as f:
             content = f.read()
 
-        self.assertIn('sudo anaconda -m compileall -f', content)
+        self.assertIn('sudo anaconda -m compileall -q -f', content)
 
 
 class DataprocNoMapperTestCase(MockGoogleAPITestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1518,7 +1518,7 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
                       " print(get_python_lib())')", lines)
         self.assertIn('  sudo unzip $__mrjob_PWD/' + mrjob_zip_name +
                       ' -d $__mrjob_PYTHON_LIB', lines)
-        self.assertIn('  sudo ' + expected_python_bin + ' -m compileall -f'
+        self.assertIn('  sudo ' + expected_python_bin + ' -m compileall -q -f'
                       ' $__mrjob_PYTHON_LIB/mrjob && true', lines)
         # bootstrap_python_packages
         if expect_pip_binary:
@@ -1627,7 +1627,7 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
         with open(runner._master_bootstrap_script_path, 'r') as f:
             content = f.read()
 
-        self.assertIn('sudo anaconda -m compileall -f', content)
+        self.assertIn('sudo anaconda -m compileall -q -f', content)
 
     def test_local_bootstrap_action(self):
         # make sure that local bootstrap action scripts get uploaded to S3

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2430,7 +2430,7 @@ class PoolMatchingTestCase(MockBotoTestCase):
             '--pool-name', 'not_pool1'])
 
     def test_dont_join_wrong_mrjob_version(self):
-        _, cluster_id = self.make_pooled_cluster('pool1')
+        _, cluster_id = self.make_pooled_cluster()
 
         old_version = mrjob.__version__
 
@@ -2438,8 +2438,7 @@ class PoolMatchingTestCase(MockBotoTestCase):
             mrjob.__version__ = 'OVER NINE THOUSAAAAAND'
 
             self.assertDoesNotJoin(cluster_id, [
-                '-r', 'emr', '-v', '--pool-clusters',
-                '--pool-name', 'not_pool1'])
+                '-r', 'emr', '--pool-clusters'])
         finally:
             mrjob.__version__ = old_version
 
@@ -2447,7 +2446,24 @@ class PoolMatchingTestCase(MockBotoTestCase):
         _, cluster_id = self.make_pooled_cluster()
 
         self.assertDoesNotJoin(cluster_id, [
-            '-r', 'emr', '--python-bin', 'snake'])
+            '-r', 'emr', '--pool-clusters',
+            '--python-bin', 'snake'])
+
+    def test_versions_dont_matter_if_no_bootstrap_mrjob(self):
+        _, cluster_id = self.make_pooled_cluster(
+            bootstrap_mrjob=False)
+
+        old_version = mrjob.__version__
+
+        try:
+            mrjob.__version__ = 'OVER NINE THOUSAAAAAND'
+
+            self.assertJoins(cluster_id, [
+                '-r', 'emr', '--pool-clusters',
+                '--no-bootstrap-mrjob',
+                '--python-bin', 'snake'])
+        finally:
+            mrjob.__version__ = old_version
 
     def test_join_similarly_bootstrapped_pool(self):
         local_input_path = os.path.join(self.tmp_dir, 'input')

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2443,6 +2443,12 @@ class PoolMatchingTestCase(MockBotoTestCase):
         finally:
             mrjob.__version__ = old_version
 
+    def test_dont_join_wrong_python_bin(self):
+        _, cluster_id = self.make_pooled_cluster()
+
+        self.assertDoesNotJoin(cluster_id, [
+            '-r', 'emr', '--python-bin', 'snake'])
+
     def test_join_similarly_bootstrapped_pool(self):
         local_input_path = os.path.join(self.tmp_dir, 'input')
         with open(local_input_path, 'w') as input_file:

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1568,14 +1568,17 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
         runner._add_bootstrap_files_for_upload()
         self.assertIsNone(runner._master_bootstrap_script_path)
 
-        # using pooling doesn't require us to create a bootstrap script
+
+    def test_pooling_requires_bootstrap_script(self):
+        # using pooling currently requires us to create a bootstrap script;
+        # see #1503
         runner = EMRJobRunner(conf_paths=[],
                               bootstrap_mrjob=False,
                               bootstrap_python=False,
                               pool_clusters=True)
 
         runner._add_bootstrap_files_for_upload()
-        self.assertIsNone(runner._master_bootstrap_script_path)
+        self.assertIsNotNone(runner._master_bootstrap_script_path)
 
     def test_bootstrap_actions_get_added(self):
         bootstrap_actions = [

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test the runner base class MRJobRunner"""
+import compileall
 import datetime
 import getpass
 import inspect
@@ -198,7 +199,7 @@ class TestJobName(TestCase):
         self.assertEqual(match.group(2), 'ads')
 
 
-class CreateMrjobZipTestCase(TestCase):
+class CreateMrjobZipTestCase(SandboxedTestCase):
 
     def test_create_mrjob_zip(self):
         with no_handlers_for_logger('mrjob.runner'):
@@ -214,6 +215,17 @@ class CreateMrjobZipTestCase(TestCase):
                 for filename in contents:
                     self.assertFalse(filename.endswith('.pyc'),
                                      msg="%s ends with '.pyc'" % filename)
+
+    def test_mrjob_zip_compiles(self):
+        runner = InlineMRJobRunner()
+        with no_handlers_for_logger('mrjob.runner'):
+            mrjob_zip = runner._create_mrjob_zip()
+
+        ZipFile(mrjob_zip).extractall(self.tmp_dir)
+
+        self.assertTrue(
+            compileall.compile_dir(os.path.join(self.tmp_dir, 'mrjob'),
+                                   quiet=1))
 
 
 class TestStreamingOutput(TestCase):


### PR DESCRIPTION
This includes `python_bin` in the pool hash whenever mrjob is bootstrapped. This fixes an issue where a job can join a pool started by a different Python version, and not be able to access the `mrjob` library (since it was installed for a different version of Python). Fixes #1503.

Also a couple of other small fixes:

* the "compileall" step of the master bootstrap script now uses the `-q` option, which suppresses everything except errors, making it easier to debug issues with development versions of the mrjob library (e.g. files that only compile in other versions of Python)
* made sure that the master bootstrap script is always created when using pooling, since the pool name and hash are passed as arguments to it.


