### PR TITLE
Spark docs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,17 +1,13 @@
-v0.5.?, 2016-??-?? -- Spark
- * JarStep.{INPUT,OUTPUT} are deprecated (use mrjob.step.{INPUT,OUTPUT})
- * runners:
-   * EMR:
-     * default to cheapest instance type that will work (#1369)
-
-v0.5.7, 2016-10-?? -- ???
+v0.5.7, 2016-12-?? -- Spark
  * deprecated mrjob.parse.parse_*_list() functions
  * deprecated mrjob.parse.scrape_options_into_new_groups()
+ * JarStep.{INPUT,OUTPUT} are deprecated (use mrjob.step.{INPUT,OUTPUT})
  * EMR and Hadoop runners:
    * can use environment variables and ~ in hadoop_streaming_jar option
  * EMR runner:
    * added debug logging for pooling (#1449)
    * cleaner error messages when bootstrapped mrjob won't compile
+   * defaults to cheapest instance type that will work (#1369)
    * master bootstrap script always created when pooling
 
 v0.5.6, 2016-09-12 -- dataproc crash fix

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ mrjob: the Python MapReduce library
 mrjob is a Python 2.6+/3.3+ package that helps you write and run Hadoop
 Streaming jobs.
 
-`Stable version (v0.5.6) documentation <http://packages.python.org/mrjob/>`_
+`Stable version (v0.5.7) documentation <http://packages.python.org/mrjob/>`_
 
 `Development version documentation <http://mrjob.readthedocs.org/en/latest/>`_
 
@@ -22,6 +22,7 @@ Some important features:
 
 * Run jobs on EMR, Google Cloud Dataproc, your own Hadoop cluster, or locally (for testing).
 * Write multi-step jobs (one map-reduce step feeds into the next)
+* Easily launch Spark jobs on EMR or your own Hadoop cluster
 * Duplicate your production environment inside Hadoop
 
   * Upload your source tree and put it in your job's ``$PYTHONPATH``
@@ -29,7 +30,7 @@ Some important features:
   * Set environment variables (e.g. ``$TZ``)
   * Easily install python packages from tarballs (EMR only)
   * Setup handled transparently by ``mrjob.conf`` config file
-* Automatically interpret error logs (EMR only)
+* Automatically interpret error logs
 * SSH tunnel to hadoop job tracker (EMR only)
 * Minimal setup
 

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -9,6 +9,7 @@ Guides
     guides/concepts.rst
     guides/writing-mrjobs.rst
     guides/runners.rst
+    guides/spark.rst
     guides/configs-basics.rst
     guides/configs-all-runners.rst
     guides/configs-hadoopy-runners.rst
@@ -18,7 +19,6 @@ Guides
     guides/testing.rst
     guides/dataproc.rst
     guides/emr.rst
-    guides/spark.rst
     guides/py2-vs-py3.rst
     guides/contributing.rst
     guides/runner-job-interactions.rst

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -59,7 +59,7 @@ options related to file uploading.
    This is based on a Spark feature, but it works just as well with streaming
    jobs.
 
-   .. versionadded:: 0.5.8.spark0
+   .. versionadded:: 0.5.7
 
 .. mrjob-opt::
     :config: python_archives
@@ -71,7 +71,7 @@ options related to file uploading.
     Same as upload_archives, except they get added to the job's
     :envvar:`PYTHONPATH`.
 
-    .. deprecated:: 0.5.8.spark0
+    .. deprecated:: 0.5.7
 
        Try :mrjob-opt:`py_files` with a `.zip` or `.egg` file instead. If you
        must use an archive, see :ref:`cookbook-src-tree-pythonpath`.
@@ -97,7 +97,7 @@ options related to file uploading.
 
         --file file_1.txt --file file_2.sqlite
 
-    .. versionchanged:: 0.5.8.spark0
+    .. versionchanged:: 0.5.7
 
        This works with Spark as well.
 
@@ -115,7 +115,7 @@ options related to file uploading.
     ``foo.tar.gz/``, and ``foo.tar.gz#stuff`` is unpacked to the directory
     ``stuff/``).
 
-    .. versionchanged:: 0.5.8.spark0
+    .. versionchanged:: 0.5.7
 
        This works with Spark as well.
 
@@ -231,7 +231,7 @@ Job execution context
 
         --cmdenv PYTHONPATH=$HOME/stuff,TZ=America/Los_Angeles
 
-    .. versionchanged:: 0.5.8.spark
+    .. versionchanged:: 0.5.7
 
        This works with Spark too. In client mode (hadoop runner), these
        environment variables are passed directly to :command:`spark-submit`.

--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -139,7 +139,7 @@ Options available to hadoop and emr runners
 
     Extra arguments to pass to :command:`spark-submit`.
 
-    .. versionadded:: 0.5.8.spark0
+    .. versionadded:: 0.5.7
 
 
 Options available to hadoop runner only
@@ -261,4 +261,4 @@ Options available to hadoop runner only
 
     If all else fails, we just use ``spark-submit`` and hope for the best.
 
-    .. versionadded:: 0.5.8.spark0
+    .. versionadded:: 0.5.7

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -514,9 +514,16 @@ and install another Python binary.
 
    By default, we automatically install Spark only if our job has Spark steps.
 
-   .. TODO: update versionadded for spark release
-   .. versionadded:: 0.5.8
+   .. versionadded:: 0.5.7
 
+   In case you're curious, here's how mrjob determines you're using Spark:
+
+   * any :py:class:`~mrjob.step.SparkStep` or
+     :py:class:`~mrjob.step.SparkScriptStep` in your job's steps (including
+     implicitly through the :py:class:`~mrjob.job.MRJob.spark` method)
+   * "Spark" included in :mrjob-opt:`emr_applications` option
+   * any bootstrap action (see :mrjob-opt:`bootstrap_actions`) ending in
+     ``/spark-install`` (this is how you install Spark on 3.x AMIs)
 
 .. mrjob-opt::
     :config: bootstrap_python_packages
@@ -589,7 +596,7 @@ Number and type of instances
     By default, mrjob picks the cheapest instance type that will work at all.
     This is usually ``m1.medium``, with two exceptions:
 
-    * ``m1.large`` if you're running Spark (see :ref:`spark-auto-detection`)
+    * ``m1.large`` if you're running Spark (see :mrjob-opt:`bootstrap_spark`)
     * ``m1.small`` if you're running on the (deprecated) 2.x AMIs
 
     Once you've tested a job and want to run it at scale, it's usually a good

--- a/docs/guides/runners.rst
+++ b/docs/guides/runners.rst
@@ -73,7 +73,6 @@ Running on your own Hadoop cluster
 ----------------------------------
 
 * Set up a hadoop cluster (see http://hadoop.apache.org/common/docs/current/)
-* Make sure :envvar:`$HADOOP_PREFIX` is set
 * Run your job with ``-r hadoop``::
 
     python your_mr_job_sub_class.py -r hadoop < input > output

--- a/docs/guides/setup-cookbook.rst
+++ b/docs/guides/setup-cookbook.rst
@@ -17,13 +17,37 @@ EMR, take a look at the :doc:`emr-bootstrap-cookbook`.
 Putting your source tree in :envvar:`PYTHONPATH`
 ------------------------------------------------
 
-First you need to make a tarball of your source tree. Make sure that the root
-of your source tree is at the root of the tarball's file listing (e.g. the
-module ``foo.bar`` appears as ``foo/bar.py`` and not
-``your-src-dir/foo/bar.py``).
+The simplest way to do this is to package your source tree as a ``.zip`` file
+(which Python can import from without unarchving it):
 
-For reference, here is a command line that will put an entire source directory
-into a tarball:
+.. code-block:: sh
+
+  cd my-source-tree
+  zip -r ../my-source-tree.zip .
+
+Then reference that ``.zip`` with the :mrjob-opt:`py_files` option. Either run
+your job with:
+
+.. code-block:: sh
+
+   --py-file my-source-tree.zip
+
+Or update your :file:`mrjob.conf` like this:
+
+.. code-block:: yaml
+
+    runners:
+      hadoop:
+        py_files:
+        - my-source-tree.zip
+
+Uploading your source tree as an archive
+----------------------------------------
+
+If your source tree isn't zip-safe (for example, if it contains non-Python
+support files), you can upload it as an archive instead.
+
+First you need to make a tarball of your source tree:
 
 .. code-block:: sh
 

--- a/docs/guides/spark.rst
+++ b/docs/guides/spark.rst
@@ -1,22 +1,219 @@
 Spark
 =====
 
-
-.. _spark-auto-detection:
-
-Auto-detecting Spark jobs
+Why use mrjob with Spark?
 -------------------------
 
-When you use Spark on EMR, mrjob can generally detect when you're trying to
-use Spark and set up your cluster accordingly. This includes installing Spark
-(if needed) and picking an instance type large enough to run it (see
-:mrjob-opt:`instance_type`).
+mrjob augments `Spark <http://spark.apache.org/>`__\'s native Python support with
+the following features familiar to users of mrjob:
 
-In case you're curious, here's how mrjob determines you're using Spark:
+* automatically parse logs to explain errors and other Spark job failures
+* automatic matching of Python version (see :mrjob-opt:`python_bin`)
+* easily pass through environment variables (see :mrjob-opt:`cmdenv`)
+* support for :mrjob-opt:`libjars`
+* passthrough and file options (see :ref:`writing-cl-opts`)
+* automatically upload input and other support files to HDFS or S3 (see :mrjob-opt:`upload_files`, :mrjob-opt:`upload_archives`, and :mrjob-opt:`py_files`)
+* automatically set up Spark on EMR (see :mrjob-opt:`bootstrap_spark`)
+* automatically making the mrjob library available to your job
+  (see :mrjob-opt:`bootstrap_mrjob`)
 
-* any :py:class:`~mrjob.step.SparkStep` or
-  :py:class:`~mrjob.step.SparkScriptStep` in your job's steps (including
-  implicitly through the :py:class:`~mrjob.job.MRJob.spark` method)
-* "Spark" included in :mrjob-opt:`emr_applications` option
-* any bootstrap action (see :mrjob-opt:`bootstrap_actions`) ending in
-  ``/spark-install`` (this is how you install Spark on 3.x AMIs)
+Writing your first Spark job
+----------------------------
+
+The simplest way to integrate mrjob with Spark is to add a
+:py:meth:`~mrjob.job.MRJob.spark` method to your :py:class:`~mrjob.job.MRJob`
+class, and put your Spark code inside it.
+
+Here's how you'd implement a word frequency count job in Spark::
+
+  import re
+  from operator import add
+
+  from mrjob.job import MRJob
+
+  WORD_RE = re.compile(r"[\w']+")
+
+
+  class MRSparkWordcount(MRJob):
+
+      def spark(self, input_path, output_path):
+          # Spark may not be available where script is launched
+          from pyspark import SparkContext
+
+          sc = SparkContext(appName='mrjob Spark wordcount script')
+
+          lines = sc.textFile(input_path)
+
+          counts = (
+              lines.flatMap(lambda line: WORD_RE.findall(line))
+              .map(lambda word: (word, 1))
+              .reduceByKey(add))
+
+          counts.saveAsTextFile(output_path)
+
+          sc.stop()
+
+
+  if __name__ == '__main__':
+      MRSparkWordcount.run()
+
+Since Spark already supports Python, mrjob takes care of setting up your
+cluster, passes in input and output paths, and otherwise gets out of the way.
+If you pass in multiple input paths, *input_path* will be these paths joined
+by a comma (:py:meth:`SparkContext.textFile` will accept this).
+
+Note that :py:mod:`pyspark` is imported *inside* the
+:py:meth:`~mrjob.job.MRJob.spark` method. This allows your job to run whether
+:py:mod:`pyspark` is installed locally or not.
+
+The :py:meth:`~mrjob.job.MRJob.spark` method can be used to execute arbitrary
+code, so there's nothing stopping you from using *SparkSession* instead of
+*SparkContext* in Spark 2, or writing a streaming-mode job rather than a
+batch one.
+
+Running on your own Hadoop cluster
+----------------------------------
+
+Run your script with ``-r hadoop``::
+
+  python your_mr_spark_job -r hadoop input_file1 input_file2 > output
+
+There isn't currently a "local" or "inline" mode that works independently
+from Spark, but you can use the :mrjob-opt:`spark_master` option to run in
+Spark's local mode::
+
+  python your_mr_spark_job -r hadoop --spark-master local input > output
+
+The Hadoop runner always submits jobs to Spark in ``client`` mode, though
+you could change this using the :mrjob-opt:`spark_args` option.
+
+Also, note that if you set the Spark master to anything but ``yarn``
+(the default), Spark will ignore archive files (see
+:mrjob-opt:`upload_archives`).
+
+Running on EMR
+--------------
+
+Run your script with ``-r emr``::
+
+  python your_mr_spark_job -r emr input_file1 input_file2 > output
+
+The default EMR image should work fine for most Spark 1 jobs.
+
+If you want to run on Spark 2, please set :mrjob-opt:`image_version` to
+5.0.0 or higher::
+
+  python your_mr_spark2_job -r emr --image-version 5.0.0 input > output
+
+EMR introduced Spark support in AMI version 3.8.0, but it's not recommended
+to use the 3.x AMIs if you can avoid it because they only support Python 2,
+and have trouble detecting when Spark jobs succeed (instead silently producing
+no output).
+
+The EMR runner always submits jobs to Spark in ``cluster`` mode, which it needs
+to access files on S3.
+
+Passing in libraries
+--------------------
+
+Use ``--py-file`` to pass in ``.zip`` or ``.egg`` files full of Python code::
+
+  python your_mr_spark_job -r hadoop --py-file lib1.zip --py-file lib2.egg
+
+Or set :mrjob-opt:`py_files` in ``mrjob.conf``.
+
+Command-line options
+--------------------
+
+Command-line options (passthrough options, etc.) work exactly like they
+do with regular streaming jobs. See :ref:`writing-cl-opts`.
+
+No setup scripts
+----------------
+
+Unlike with streaming jobs, you can't wrap Spark jobs in
+:doc:`setup scripts <setup-cookbook>`;
+once Spark starts operating on serialized data, it's operating in pure
+Python/Java on serialized data and there's not a way to slip in a shell script.
+
+If you're running in EMR, you can use
+:doc:`bootstrap scripts <emr-bootstrap-cookbook>` to set up your
+environment when the cluster is created.
+
+Multi-step jobs
+---------------
+
+There generally isn't a need to define multiple Spark steps (Spark lets
+you map/reduce as many times as you want). However, it may sometimes be useful
+to pre- or post-process Spark data using a
+:py:class:`streaming <mrjob.step.MRStep>` or
+:py:class:`jar <mrjob.step.JarStep>` step.
+
+This is accomplished by overriding your job's :py:meth:`~mrjob.job.MRJob.steps`
+method and using the :py:class:`~mrjob.step.SparkStep` class::
+
+  def steps():
+    return [
+      MRStep(mapper=self.preprocessing_mapper),
+      MRSparkStep(spark=self.spark),
+    ]
+
+External Spark scripts
+----------------------
+
+mrjob can also be used to launch external (non-mrjob) Spark scripts using
+the :py:class:`~mrjob.step.SparkScriptStep` class, which specifies the
+path (or URI) of the script and its arguments.
+
+As with :py:class:`~mrjob.job.JarStep`\s, you can interpolate input
+and output paths using :py:data:`~mrjob.step.INPUT` and
+:py:data:`~mrjob.step.OUTPUT` constants. For example, you could set your job's
+:py:meth:`~mrjob.job.MRJob.steps` method up like this::
+
+  def steps():
+    return [
+      SparkScriptStep(
+        script=os.path.join(os.path.dirname(__file__), 'my_spark_script.py'),
+        args=[INPUT, '-o', OUTPUT, '--other-switch'],
+      ),
+    ]
+
+Custom input and output formats
+-------------------------------
+
+mrjob allows you to use input and output formats from custom JARs with Spark,
+just like you can :ref:`with streaming jobs <input-and-output-formats>`.
+
+First `download your JAR <https://github.com/empiricalresults/nicknack/releases/download/v1.0.0/nicknack-1.0.0.jar>`__
+to the same directory as your job, and add it to your job class with the
+:py:attr:`~mrjob.job.MRJob.LIBJARS` attribute::
+
+  LIBJARS = ['nicknack-1.0.0.jar']
+
+Then use Spark's own capabilities to reference your input or output format,
+keeping in mind the data types they expect.
+
+For example, nicknack's ``MultipleValueOutputFormat`` expects ``<Text,Text>``,
+so if we wanted to integrate it with our wordcount example, we'd have to
+convert the count to a string::
+
+  def spark(self, input_path, output_path):
+    from pyspark import SparkContext
+
+    sc = SparkContext(appName='mrjob Spark wordcount script')
+
+    lines = sc.textFile(input_path)
+
+    counts = (
+        lines.flatMap(lambda line: WORD_RE.findall(line))
+        .map(lambda word: (word, 1))
+        .reduceByKey(add))
+
+    # MultipleValueOutputFormat expects Text, Text
+    # w_c is (word, count)
+    counts = counts.map(lambda w_c: (w_c[0], str(w_c[1])))
+
+    counts.saveAsHadoopFile(output_path,
+                            'nicknack.MultipleValueOutputFormat')
+
+    sc.stop()

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -620,6 +620,8 @@ be propagated to other runs of your script. Instead, you can use mrjob's option
 API: :py:meth:`~mrjob.job.MRJob.add_passthrough_option` and
 :py:meth:`~mrjob.job.MRJob.add_file_option`.
 
+.. _passthrough-opts:
+
 Passthrough options
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ several platforms.** You can:
 * Run on a Hadoop cluster
 * Run in the cloud using `Amazon Elastic MapReduce (EMR)`_
 * Run in the cloud using `Google Cloud Dataproc (Dataproc)`_
+* Easily run :doc:`Spark <guides/spark>` jobs on EMR or your own Hadoop cluster
 
 .. _Google Cloud Dataproc (Dataproc): https://cloud.google.com/dataproc/overview
 .. _Amazon Elastic MapReduce (EMR): http://aws.amazon.com/documentation/elasticmapreduce/


### PR DESCRIPTION
This updates the documentation for Spark. Also updated the setup cookbook to prefer `py_files` over a setup script.

Also merges the speculative 0.5.8.spark release into 0.5.7 in `CHANGES.txt` and documentation.

