### PR TITLE
auto-archive directories

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v0.5.8, 2017-01-?? -- ???
+ * deprecated mrjob.util.tar_and_gz
+
 v0.5.7, 2016-12-19 -- Spark
  * EMR and Hadoop runners:
    * full support for Spark (#1320)

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -81,6 +81,44 @@ options related to file uploading.
        must use an archive, see :ref:`cookbook-src-tree-pythonpath`.
 
 .. mrjob-opt::
+    :config: upload_archives
+    :switch: --archive
+    :type: :ref:`path list <data-type-path-list>`
+    :set: all
+    :default: ``[]``
+
+    A list of archives (e.g. tarballs) to unpack in the local directory of the
+    mr_job script when it runs. You can set the name in the job's working
+    directory we unpack into by appending ``#nameinworkingdir`` to the path;
+    otherwise we just use the
+    name of the archive file (e.g. ``foo.tar.gz`` is unpacked to the directory
+    ``foo.tar.gz/``, and ``foo.tar.gz#stuff`` is unpacked to the directory
+    ``stuff/``).
+
+    .. versionchanged:: 0.5.7
+
+       This works with Spark as well.
+
+.. mrjob-opt::
+    :config: upload_dirs
+    :switch: --dir
+    :type: :ref:`path list <data-type-path-list>`
+    :set: all
+    :default: ``[]``
+
+    A list of directories to copy to the local directory of the
+    mr_job script when it runs (mrjob does this by tarballing the directory
+    and submitting the tarball to Hadoop as an archive).
+
+    You can set the name in the job's working directory of the directory
+    we copy by appending
+    ``#nameinworkingdir`` to the path; otherwise we just use its name.
+
+    This works with Spark as well.
+
+    .. versionadded:: 0.5.8
+
+.. mrjob-opt::
     :config: upload_files
     :switch: --file
     :type: :ref:`path list <data-type-path-list>`
@@ -88,8 +126,9 @@ options related to file uploading.
     :default: ``[]``
 
     Files to copy to the local directory of the mr_job script when it runs. You
-    can set the local name of the dir we unpack into by appending
-    ``#localname`` to the path; otherwise we just use the name of the file.
+    can set the name of the file in the job's working directory by appending
+    ``#nameinworkingdir`` to the path; otherwise we just use the name of the
+    file.
 
     In the config file::
 
@@ -100,24 +139,6 @@ options related to file uploading.
     On the command line::
 
         --file file_1.txt --file file_2.sqlite
-
-    .. versionchanged:: 0.5.7
-
-       This works with Spark as well.
-
-.. mrjob-opt::
-    :config: upload_archives
-    :switch: --archive
-    :type: :ref:`path list <data-type-path-list>`
-    :set: all
-    :default: ``[]``
-
-    A list of archives (e.g. tarballs) to unpack in the local directory of the
-    mr_job script when it runs. You can set the local name of the dir we unpack
-    into by appending ``#localname`` to the path; otherwise we just use the
-    name of the archive file (e.g. ``foo.tar.gz`` is unpacked to the directory
-    ``foo.tar.gz/``, and ``foo.tar.gz#stuff`` is unpacked to the directory
-    ``stuff/``).
 
     .. versionchanged:: 0.5.7
 
@@ -319,8 +340,18 @@ Job execution context
 
     *path* may also be a URI, and ``~`` and environment variables within *path*
     will be resolved based on the local environment. *name* is optional.
+
     You can indicate that an archive should be unarchived into a directory by
-    putting a ``/`` after *name*. For details of parsing, see
+    putting a ``/`` after *name* (e.g. ``foo.tar.gz#foo/``).
+
+    You can indicate that a directory should be copied into the job's
+    working directory by putting a ``/`` after *path* (e.g. ``src-tree/#``).
+    You may optionally put a ``/`` after *name* as well
+    (e.g. ``cd src-tree/#/subdir``).
+
+    .. versionadded:: 0.5.8 support for directories (above)
+
+    For more details of parsing, see
     :py:func:`~mrjob.setup.parse_setup_cmd`.
 
 .. mrjob-opt::

--- a/docs/guides/setup-cookbook.rst
+++ b/docs/guides/setup-cookbook.rst
@@ -12,42 +12,48 @@ All our :file:`mrjob.conf` examples below are for the ``hadoop`` runner,
 but these work equally well with the ``emr`` runner. Also, if you are using
 EMR, take a look at the :doc:`emr-bootstrap-cookbook`.
 
+.. note::
+
+   Setup scripts don't work with :doc:`spark`; try :mrjob-opt:`py_files`
+   instead.
+
 .. _cookbook-src-tree-pythonpath:
 
-Putting your source tree in :envvar:`PYTHONPATH`
-------------------------------------------------
+Uploading your source tree
+--------------------------
 
-The simplest way to do this is to package your source tree as a ``.zip`` file
-(which Python can import from without unarchving it):
+.. note:: This relies on a feature that was added in 0.5.8. See below
+          for how to do it in earlier versions.
 
-.. code-block:: sh
+mrjob can automatically tarball your source directory and include it
+in your job's working directory. We can use setup scripts to upload the
+directory and then add it to :envvar:`PYTHONPATH`.
 
-  cd my-source-tree
-  zip -r ../my-source-tree.zip .
-
-Then reference that ``.zip`` with the :mrjob-opt:`py_files` option. Either run
-your job with:
+Run your job with:
 
 .. code-block:: sh
 
-   --py-file my-source-tree.zip
+    --setup 'export PYTHONPATH=$PYTHONPATH:your-src-code/#'
 
-Or update your :file:`mrjob.conf` like this:
+The ``/`` before the ``#`` tells mrjob that :file:`your-src-code` is a
+directory. You may optionally include a ``/`` after the ``#`` as well
+(e.g. ``export PYTHONPATH=$PYTHONPATH:your-source-code/#/your-lib``).
+
+If every job you run is going to want to use :file:`your-src-code`, you can do
+this in your :file:`mrjob.conf`:
 
 .. code-block:: yaml
 
     runners:
       hadoop:
-        py_files:
-        - my-source-tree.zip
+        setup:
+        - export PYTHONPATH=$PYTHONPATH:your-src-code/#
 
 Uploading your source tree as an archive
 ----------------------------------------
 
-If your source tree isn't zip-safe (for example, if it contains non-Python
-support files), you can upload it as an archive instead.
-
-First you need to make a tarball of your source tree:
+If you're using an earlier version of Python, you'll have to build the
+tarball yourself:
 
 .. code-block:: sh
 
@@ -57,10 +63,12 @@ Then, run your job with:
 
 .. code-block:: sh
 
-    --setup 'export PYTHONPATH=$PYTHONPATH:your-src-dir.tar.gz#/'
+    --setup 'export PYTHONPATH=$PYTHONPATH:your-src-code.tar.gz#/'
 
-If every job you run is going to want to use ``your-src-code.tar.gz``, you can do
-this in your :file:`mrjob.conf`:
+The ``/`` after the ``#`` (without one before it) is what tells mrjob that
+``your-src-code.tar.gz`` is an archive that Hadoop should unpack.
+
+To do the same thing in :file:`mrjob.conf`:
 
 .. code-block:: yaml
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1205,7 +1205,7 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--dir'], dict(
                 action='append',
-                help('Tarball the given directory and unpack the resulting'
+                help=('Tarball the given directory and unpack the resulting'
                      ' archive in the working directory of this script.'
                      ' You can use --dir multiple times'),
             )),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1200,6 +1200,17 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    upload_dirs=dict(
+        combiner=combine_path_lists,
+        switches=[
+            (['--dir'], dict(
+                action='append',
+                help('Tarball the given directory and unpack the resulting'
+                     ' archive in the working directory of this script.'
+                     ' You can use --dir multiple times'),
+            )),
+        ],
+    ),
     upload_files=dict(
         combiner=combine_path_lists,
         switches=[

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -344,13 +344,13 @@ class MRJobRunner(object):
         for cmd in self._setup:
             for token in cmd:
                 if isinstance(token, dict):
+                    # convert dir archives tokens to archives
                     if token['type'] == 'dir':
                         # feed the archive's path to self._working_dir_mgr
-                        archive_path = self._dir_archive_path(token['path'])
-                        self._working_dir_mgr.add(
-                            'archive', archive_path, name=token['name'])
-                    else:
-                        self._working_dir_mgr.add(**token)
+                        token['path'] = self._dir_archive_path(token['path'])
+                        token['type'] = 'archive'
+
+                    self._working_dir_mgr.add(**token)
 
         # Where to read input from (log files, etc.)
         self._input_paths = input_paths or ['-']  # by default read from stdin

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -315,20 +315,21 @@ class MRJobRunner(object):
                 self._spark_files.append((arg_file['name'], arg_file['path']))
 
         # set up uploading
-        for path in self._opts['upload_files']:
-            uf = parse_legacy_hash_path('file', path, must_name='upload_files')
+        for hash_path in self._opts['upload_files']:
+            uf = parse_legacy_hash_path('file', hash_path,
+                                        must_name='upload_files')
             self._working_dir_mgr.add(**uf)
             self._spark_files.append((uf['name'], uf['path']))
 
-        for path in self._opts['upload_archives']:
-            ua = parse_legacy_hash_path('archive', path,
+        for hash_path in self._opts['upload_archives']:
+            ua = parse_legacy_hash_path('archive', hash_path,
                                         must_name='upload_archives')
             self._working_dir_mgr.add(**ua)
             self._spark_archives.append((ua['name'], ua['path']))
 
-        for path in self._opts['upload_dirs']:
+        for hash_path in self._opts['upload_dirs']:
             # pick name based on directory path
-            ud = parse_legacy_hash_path('dir', path,
+            ud = parse_legacy_hash_path('dir', hash_path,
                                         must_name='upload_archives')
             # but feed working_dir_mgr the archive's path
             archive_path = self._dir_archive_path(ud['path'])

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -267,6 +267,8 @@ class MRJobRunner(object):
         self._fs = None
 
         self._working_dir_mgr = WorkingDirManager()
+        # cache of directories that have been converted to tarballs
+        self._dir_to_archive = {}
 
         # track (name, path) of files and archives to upload to spark.
         # these are a subset of those in self._working_dir_mgr
@@ -1041,6 +1043,29 @@ class MRJobRunner(object):
         writeln('"$@"')
 
         return out
+
+    def _archive_dir(self, dir_path, name):
+        """Get the archive corresponding to *path*, which is a directory that's
+        been added to self._working_dir_mgr."""
+        # TODO: verify that we're not tarballing a directory that contains the
+        # temp directory
+
+        if dir_path in self._dir_to_archive:
+            return self._dir_to_archive[dir_path]
+
+        tar_gz_name = (
+            self._working_dir_mgr.name('dir', dir_path, name) + '.tar.gz')
+
+        # TODO: start here
+
+        for path in self._fs.ls(dir_path):
+            # if not local, copy to tmp file
+
+            # add to tarball
+
+            # if dir_path appears, raise an exception (not a directory)
+            pass
+
 
     def _bootstrap_mrjob(self):
         """Should we bootstrap mrjob?"""

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -269,6 +269,10 @@ class MRJobRunner(object):
         self._opts = self.OPTION_STORE_CLASS(self.alias, opts, conf_paths)
         self._fs = None
 
+        # a local tmp directory that will be cleaned up when we're done
+        # access/make this using self._get_local_tmp_dir()
+        self._local_tmp_dir = None
+
         self._working_dir_mgr = WorkingDirManager()
 
         # mapping from dir to path for corresponding archive. we pick
@@ -327,7 +331,7 @@ class MRJobRunner(object):
             ud = parse_legacy_hash_path('dir', path,
                                         must_name='upload_archives')
             # but feed working_dir_mgr the archive's path
-            archive_path = self._dir_archive_path(path)
+            archive_path = self._dir_archive_path(ud['path'])
             self._working_dir_mgr.add(
                 'archive', archive_path, name=ud['name'])
             self._spark_archives.append((ud['name'], archive_path))
@@ -367,10 +371,6 @@ class MRJobRunner(object):
         # store hadoop input and output formats
         self._hadoop_input_format = hadoop_input_format
         self._hadoop_output_format = hadoop_output_format
-
-        # a local tmp directory that will be cleaned up when we're done
-        # access/make this using self._get_local_tmp_dir()
-        self._local_tmp_dir = None
 
         # A cache for self._get_steps(); also useful as a test hook
         self._steps = None

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1107,7 +1107,7 @@ class MRJobRunner(object):
         if not os.path.isdir(os.path.dirname(tar_gz_path)):
             os.makedirs(os.path.dirname(tar_gz_path))
 
-        log.info('Archiving %s into %s' % (dir_path, tar_gz_path))
+        log.info('Archiving %s -> %s' % (dir_path, tar_gz_path))
 
         tar_gz = tarfile.open(tar_gz_path, mode='w:gz')
 

--- a/mrjob/setup.py
+++ b/mrjob/setup.py
@@ -90,9 +90,11 @@ def parse_setup_cmd(cmd):
 
     If *path* is followed by a trailing slash, that indicates *path* is a
     directory and should be tarballed and later unarchived into a directory
-    on the remote system. The trailing slash will *also* be kept as part of the
-    original command. You may also include a slash after *name* as needed
-    (this will only result in a single slash in the final command).
+    on the remote system. The trailing slash will also be kept as part of
+    the original command. You may optionally include a slash after *name* as
+    well (this will only result in a single slash in the final command).
+
+    .. versionadded:: 0.5.8 support for directories (above)
 
     Parsed hash paths are dicitionaries with the keys ``path``, ``name``, and
     ``type`` (either ``'file'``, ``'archive'``, or ``'dir'``).

--- a/mrjob/setup.py
+++ b/mrjob/setup.py
@@ -35,6 +35,7 @@ manager classes.
 """
 import itertools
 import logging
+import os
 import os.path
 import posixpath
 import re
@@ -47,7 +48,7 @@ from mrjob.util import expand_path
 log = logging.getLogger(__name__)
 
 
-_SUPPORTED_TYPES = ('archive', 'file')
+_SUPPORTED_TYPES = ('archive', 'dir', 'file')
 
 
 _SETUP_CMD_RE = re.compile(
@@ -244,7 +245,7 @@ def name_uniquely(path, names_taken=(), proposed_name=None, unhide=False):
     'foo-1.tar.gz'
     """
     if not proposed_name:
-        proposed_name = os.path.basename(path)
+        proposed_name = os.path.basename(path.rstrip('/' + os.sep))
 
     if unhide:
         proposed_name = proposed_name.lstrip('.').lstrip('_')

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -621,6 +621,8 @@ def tar_and_gzip(dir, out_path, filter=None, prefix=''):
     :param prefix: subdirectory inside the tarball to put everything into (e.g.
                    ``'mrjob'``)
     """
+    log.warn('tar_and_gzip() is deprecated and will be removed in v0.6.0')
+
     if not os.path.isdir(dir):
         raise IOError('Not a directory: %r' % (dir,))
 

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -621,7 +621,8 @@ def tar_and_gzip(dir, out_path, filter=None, prefix=''):
     :param prefix: subdirectory inside the tarball to put everything into (e.g.
                    ``'mrjob'``)
     """
-    log.warn('tar_and_gzip() is deprecated and will be removed in v0.6.0')
+    # might move this to tests/; we use it a few places there
+    log.warning('tar_and_gzip() is deprecated and will be removed in v0.6.0')
 
     if not os.path.isdir(dir):
         raise IOError('Not a directory: %r' % (dir,))

--- a/tests/mr_os_walk_job.py
+++ b/tests/mr_os_walk_job.py
@@ -21,9 +21,6 @@ from mrjob.job import MRJob
 class MROSWalkJob(MRJob):
     """Recursively return the name and size of each file in the current dir."""
 
-    def mapper(self, key, value):
-        return  # ignore input
-
     def mapper_final(self):
         # hook for test_local.LocalRunnerSetupTestCase.test_python_archive()
         try:

--- a/tests/mr_os_walk_job.py
+++ b/tests/mr_os_walk_job.py
@@ -32,7 +32,7 @@ class MROSWalkJob(MRJob):
         except ImportError:
             pass
 
-        for dirpath, _, filenames in os.walk('.'):
+        for dirpath, _, filenames in os.walk('.', followlinks=True):
             for filename in filenames:
                 path = os.path.join(dirpath, filename)
                 size = os.path.getsize(path)

--- a/tests/mr_os_walk_job.py
+++ b/tests/mr_os_walk_job.py
@@ -1,4 +1,5 @@
 # Copyright 2013 David Marin
+# Copyright 2016 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +21,9 @@ from mrjob.job import MRJob
 class MROSWalkJob(MRJob):
     """Recursively return the name and size of each file in the current dir."""
 
+    def mapper(self, key, value):
+        return  # ignore input
+
     def mapper_final(self):
         # hook for test_local.LocalRunnerSetupTestCase.test_python_archive()
         try:
@@ -33,6 +37,12 @@ class MROSWalkJob(MRJob):
                 path = os.path.join(dirpath, filename)
                 size = os.path.getsize(path)
                 yield path, size
+
+    def reducer(self, key, values):
+        # remove duplicates
+        for value in values:
+            yield (key, value)
+            break
 
 
 if __name__ == '__main__':

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -124,7 +124,7 @@ class SandboxedTestCase(EmptyMrjobConfTestCase):
         return abs_path
 
     def makefile(self, path, contents=b'', executable=False):
-        self.makedirs(os.path.split(path)[0])
+        self.makedirs(os.path.dirname(path))
         abs_path = os.path.join(self.tmp_dir, path)
 
         mode = 'wb' if isinstance(contents, bytes) else 'w'

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1366,6 +1366,24 @@ class SetupTestCase(SandboxedTestCase):
         self.assertEqual(path_to_size.get('./foo.tar.gz/foo.py'),
                          self.foo_py_size * 2)
 
+    def test_python_dir_archive(self):
+        job = MROSWalkJob([
+            '-r', 'local',
+            '--setup', 'export PYTHONPATH=%s/#:$PYTHONPATH' % self.foo_dir
+        ])
+        job.sandbox()
+
+        with job.make_runner() as r:
+            r.run()
+
+            path_to_size = dict(job.parse_output_line(line)
+                                for line in r.stream_output())
+
+        # foo.py should be there, and getsize() should be patched to return
+        # double the number of bytes
+        self.assertEqual(path_to_size.get('./foo.tar.gz/foo.py'),
+                         self.foo_py_size * 2)
+
     def test_python_zip_file(self):
         job = MROSWalkJob([
             '-r', 'local',

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -246,7 +246,7 @@ class ParseLegacyHashPathTestCase(TestCase):
     def test_bad_path_type(self):
         self.assertRaises(
             ValueError,
-            parse_legacy_hash_path, 'dir', 'foo#bar')
+            parse_legacy_hash_path, 'symlink', 'foo#bar')
 
     def test_bad_name(self):
         self.assertRaises(
@@ -269,7 +269,7 @@ class NameUniquelyTestCase(TestCase):
 
     def test_use_basename_by_default(self):
         self.assertEqual(name_uniquely('foo/bar.py'), 'bar.py')
-        self.assertEqual(name_uniquely('foo/bar/'), '1')
+        self.assertEqual(name_uniquely('/'), '1')
 
     def test_dont_use_names_taken(self):
         self.assertEqual(name_uniquely('foo.py'), 'foo.py')
@@ -343,6 +343,14 @@ class NameUniquelyTestCase(TestCase):
             name_uniquely(
                 'foo.py', proposed_name='.hidden.foo.py', unhide=True),
             'hidden.foo.py')
+
+    def test_strip_trailing_slash(self):
+        self.assertEqual(
+            name_uniquely('s3://bucket/archive-dir/'), 'archive-dir')
+
+    def test_strip_trailing_os_sep(self):
+        self.assertEqual(
+            name_uniquely(os.path.join('foo', 'bar', '')), 'bar')
 
 
 class UploadDirManagerTestCase(TestCase):
@@ -494,9 +502,9 @@ class WorkingDirManagerTestCase(TestCase):
 
     def test_bad_path_type(self):
         wd = WorkingDirManager()
-        self.assertRaises(ValueError, wd.add, 'dir', 'foo.py')
-        self.assertRaises(ValueError, wd.name_to_path, 'dir')
-        self.assertRaises(ValueError, wd.name, 'dir', 'foo.py')
+        self.assertRaises(ValueError, wd.add, 'symlink', 'foo.py')
+        self.assertRaises(ValueError, wd.name_to_path, 'symlink')
+        self.assertRaises(ValueError, wd.name, 'symlink', 'foo.py')
 
     def test_cant_name_unknown_paths(self):
         wd = WorkingDirManager()


### PR DESCRIPTION
You can now pass directories to mrjob with the `--dir` switch, the `upload_dirs` option, or by using the syntax ``dir/#`` in setup scripts. Fixes #23.
