### PR TITLE
Add Python 3.6 to .travis.yml and classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev"
+  - "3.6"
+  - "3.6-dev"
   - "nightly"
   - "pypy3"
 matrix:

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: System :: Distributed Computing',
     ],
     description='Python MapReduce framework',


### PR DESCRIPTION
This acknowledges that mrjob works with Python 3.6 (newly released) and adds a continuous integration test builder for 3.6. Fixes #1507.