### PR TITLE
use ListInstances, not dfsadmin

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 v0.5.8, 2017-01-?? -- ???
  * deprecated mrjob.util.tar_and_gz
+ * deprecated SSHFilesystem.ssh_slave_hosts()
 
 v0.5.7, 2016-12-19 -- Spark
  * EMR and Hadoop runners:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2326,7 +2326,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 host_desc = ssh_host
                 if ssh_to_workers:
                     try:
-                        hosts.extend(self._ssh_worker_ips())
+                        hosts.extend(self._ssh_worker_hosts())
                         host_desc += ' and task/core nodes'
                     except IOError:
                         log.warning('Could not get slave addresses for %s' %
@@ -2349,10 +2349,14 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             log.info('Looking for %s in %s...' % (log_desc, cloud_log_dir))
             yield [cloud_log_dir]
 
-    def _ssh_worker_ips(self):
-        """Get the private IP addresses of all core and task nodes,
+    def _ssh_worker_hosts(self):
+        """Get the hostnames of all core and task nodes,
         that are currently running, so we can SSH to them through the master
-         nodes and read their logs."""
+        nodes and read their logs.
+
+        (This currently returns IP addresses rather than full hostnames
+        because they're shorter.)
+        """
         return [
             instance.privateipaddress for instance in
             _yield_all_instances(

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -289,6 +289,14 @@ def _yield_all_bootstrap_actions(emr_conn, cluster_id, *args, **kwargs):
             yield action
 
 
+def _yield_all_instances(emr_conn, cluster_id, *args, **kwargs):
+    """Get information about all instances for the given cluster."""
+    for resp in _repeat(emr_conn.list_instances,
+                        cluster_id, *args, **kwargs):
+        for instance in getattr(resp, 'instances', []):
+            yield instance
+
+
 def _yield_all_instance_groups(emr_conn, cluster_id, *args, **kwargs):
     """Get all instance groups for the given cluster.
 
@@ -2255,7 +2263,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             'task logs',
             dir_name=dir_name,
             s3_dir_name=s3_dir_name,
-            ssh_to_slaves=True)  # TODO: does this make sense on YARN?
+            ssh_to_workers=True)  # TODO: does this make sense on YARN?
 
     def _get_step_log_interpretation(self, log_interpretation, step_type):
         """Fetch and interpret the step log."""
@@ -2301,11 +2309,11 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             s3_dir_name=posixpath.join('steps', step_id))
 
     def _stream_log_dirs(self, log_desc, dir_name, s3_dir_name,
-                         ssh_to_slaves=False):
+                         ssh_to_workers=False):
         """Stream log dirs for any kind of log.
 
         Our general strategy is first, if SSH is enabled, to SSH into the
-        master node (and possibly slaves, if *ssh_to_slaves* is set).
+        master node (and possibly slaves, if *ssh_to_workers* is set).
 
         If this doesn't work, we have to look on S3. If the cluster is
         TERMINATING, we first wait for it to terminate (since that
@@ -2316,9 +2324,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             if ssh_host:
                 hosts = [ssh_host]
                 host_desc = ssh_host
-                if ssh_to_slaves:
+                if ssh_to_workers:
                     try:
-                        hosts.extend(self.fs.ssh_slave_hosts(ssh_host))
+                        hosts.extend(self._ssh_worker_ips())
                         host_desc += ' and task/core nodes'
                     except IOError:
                         log.warning('Could not get slave addresses for %s' %
@@ -2340,6 +2348,19 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             cloud_log_dir = posixpath.join(self._s3_log_dir(), s3_dir_name)
             log.info('Looking for %s in %s...' % (log_desc, cloud_log_dir))
             yield [cloud_log_dir]
+
+    def _ssh_worker_ips(self):
+        """Get the private IP addresses of all core and task nodes,
+        that are currently running, so we can SSH to them through the master
+         nodes and read their logs."""
+        return [
+            instance.privateipaddress for instance in
+            _yield_all_instances(
+                self.make_emr_conn(),
+                self._cluster_id,
+                instance_group_types=['CORE', 'TASK'])
+            if instance.status.state == 'RUNNING'
+        ]
 
     def _wait_for_logs_on_s3(self):
         """If the cluster is already terminating, wait for it to terminate,

--- a/mrjob/fs/ssh.py
+++ b/mrjob/fs/ssh.py
@@ -58,7 +58,6 @@ class SSHFilesystem(Filesystem):
 
         # should we use sudo (for EMR)? Enable with use_sudo_over_ssh()
         self._sudo = False
-
     def can_handle_path(self, path):
         return _SSH_URI_RE.match(path) is not None
 
@@ -153,6 +152,9 @@ class SSHFilesystem(Filesystem):
 
     def ssh_slave_hosts(self, host, force=False):
         """Get a list of the slave hosts reachable through *hosts*"""
+        log.warning('ssh_slave_hosts() is deprecated and will be removed'
+                    ' in v0.6.0')
+
         if force or host not in self._host_to_slave_hosts:
             self._host_to_slave_hosts[host] = _ssh_slave_addresses(
                 self._ssh_bin, host, self._ec2_key_pair_file)

--- a/mrjob/tools/emr/mrboss.py
+++ b/mrjob/tools/emr/mrboss.py
@@ -119,7 +119,7 @@ def _run_on_all_nodes(runner, output_dir, cmd_args, print_stderr=True):
     ec2_key_pair_file = runner._opts['ec2_key_pair_file']
 
     keyfile = None
-    slave_addrs = runner.fs.ssh_slave_hosts(master_addr)
+    slave_addrs = runner._ssh_worker_ips()
 
     if slave_addrs:
         addresses += ['%s!%s' % (master_addr, slave_addr)

--- a/mrjob/tools/emr/mrboss.py
+++ b/mrjob/tools/emr/mrboss.py
@@ -119,7 +119,7 @@ def _run_on_all_nodes(runner, output_dir, cmd_args, print_stderr=True):
     ec2_key_pair_file = runner._opts['ec2_key_pair_file']
 
     keyfile = None
-    slave_addrs = runner._ssh_worker_ips()
+    slave_addrs = runner._ssh_worker_hosts()
 
     if slave_addrs:
         addresses += ['%s!%s' % (master_addr, slave_addr)

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1213,7 +1213,7 @@ class MockEmrConnection(object):
 
                 instance.status = MockEmrObject(state=state)
 
-                if state != 'STARTING':
+                if state not in ('PROVISIONING', 'AWAITING_FULLFILLMENT'):
                     # this is just an easy way to assign a unique IP
                     instance.privateipaddress = '172.172.%d.%d' % (
                         i + 1, j + 1)

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -247,6 +247,7 @@ class MockBotoTestCase(SandboxedTestCase):
         runner._fs = None
         #runner.fs
 
+    # TODO: this should be replaced once we get rid of ssh_slave_hosts()
     def add_slave(self):
         """Add a mocked slave to the cluster. Caller is responsible for setting
         runner._opts['num_ec2_instances'] to the correct number.

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -6159,3 +6159,29 @@ class SparkSubmitArgPrefixTestCase(MockBotoTestCase):
         self.assertEqual(
             runner._spark_submit_arg_prefix(),
             ['--master', 'yarn', '--deploy-mode', 'cluster'])
+
+
+class SSHWorkerHostsTestCase(MockBotoTestCase):
+
+    def _ssh_worker_hosts(self, *args):
+        mr_job = MRTwoStepJob(['-r', 'emr'] + list(args))
+        mr_job.sandbox()
+
+        with mr_job.make_runner() as runner:
+            runner.run()
+
+            return runner._ssh_worker_hosts()
+
+    def test_ignore_master(self):
+        self.assertEqual(len(self._ssh_worker_hosts()), 0)
+
+    def test_include_core_nodes(self):
+        self.assertEqual(
+            len(self._ssh_worker_hosts('--num-core-instances', '2')),
+            2)
+
+    def test_include_task_nodes(self):
+        self.assertEqual(
+            len(self._ssh_worker_hosts('--num-core-instances', '2',
+                                       '--num-task-instances', '3')),
+            5)

--- a/tests/tools/emr/test_mrboss.py
+++ b/tests/tools/emr/test_mrboss.py
@@ -22,6 +22,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.tools.emr.mrboss import _run_on_all_nodes
 from tests.mockssh import mock_ssh_file
 from tests.mockboto import MockBotoTestCase
+from tests.py2 import patch
 from tests.test_emr import BUCKET_URI
 from tests.test_emr import LOG_DIR
 
@@ -30,6 +31,11 @@ class MRBossTestCase(MockBotoTestCase):
 
     def setUp(self):
         super(MRBossTestCase, self).setUp()
+
+        self.ssh_worker_hosts = self.start(patch(
+            'mrjob.emr.EMRJobRunner._ssh_worker_hosts',
+            return_value=[]))
+
         self.make_runner()
 
     def tearDown(self):
@@ -67,6 +73,8 @@ class MRBossTestCase(MockBotoTestCase):
 
     def test_two_nodes(self):
         self.add_slave()
+        self.ssh_worker_hosts.return_value = ['testslave0']
+
         self.runner._opts['num_ec2_instances'] = 2
 
         mock_ssh_file('testmaster', 'some_file', b'file contents 1')


### PR DESCRIPTION
When we fetch task logs via SSH, we have to tunnel through the master node to the worker (core and task) nodes. Previously, we relied on running `dfsadmin`, which excludes task nodes because they don't run HDFS.

This change includes task nodes as well (fixes #1400) by using the `ListInstances` EMR API call (fixes #1345).

