### PR TITLE
add --step-output-dir option

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -233,6 +233,23 @@ Temp files and cleanup
     Don't stream output to STDOUT after job completion.  This is often used in
     conjunction with ``--output-dir`` to store output only in HDFS or S3.
 
+.. mrjob-opt::
+   :config: step_output_dir
+   :switch: --step-output-dir
+   :type: :ref:`string <data-type-string>`
+   :set: no_mrjob_conf
+   :default: (automatic)
+
+   For a multi-step job, where to put output from job steps other than
+   the last one. Each step's output will go into a numbered subdirectory
+   of this one (``0000/``, ``0001/``, etc.)
+
+   This option can be useful for debugging. By default, intermediate output
+   goes into HDFS, which is fastest but not easily accessible on EMR or
+   Dataproc.
+
+   This option currently does nothing on local and inline runners.
+
 Job execution context
 =====================
 

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -786,11 +786,9 @@ class DataprocJobRunner(MRJobRunner):
 
             raise StepFailedException(step_num=step_num, num_steps=num_steps)
 
-    def _intermediate_output_uri(self, step_num):
-        # TODO: davidmarin @ mtai: noticed this is 1-indexed and uses
-        # %05d instead of %04d. Any particular reason?
-        return 'hdfs:///tmp/mrjob/%s/step-output/%05d/' % (
-            self._job_key, step_num + 1)
+    def _default_step_output_dir(self):
+        # put intermediate data in HDFS
+        return 'hdfs:///tmp/mrjob/%s/step-output' % self._job_key
 
     def counters(self):
         # TODO - mtai @ davidmarin - Counters are currently always empty as we

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2156,11 +2156,9 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 '/emr-quickstart.html#configuring-ssh-credentials\n' %
                 (_DEFAULT_REGION, _DEFAULT_REGION))
 
-    def _intermediate_output_uri(self, step_num):
-        """Where to store output for non-final steps."""
+    def _default_step_output_dir(self):
         # put intermediate data in HDFS
-        return ('hdfs:///tmp/mrjob/%s/step-output/%04d/' %
-                (self._job_key, step_num))
+        return 'hdfs:///tmp/mrjob/%s/step-output' % self._job_key
 
     ### LOG PARSING (implementation of LogInterpretationMixin) ###
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -617,9 +617,8 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
 
         return env
 
-    def _intermediate_output_uri(self, step_num):
-        return posixpath.join(self._hadoop_tmp_dir,
-                              'step-output/%04d' % step_num)
+    def _default_step_output_dir(self):
+        return posixpath.join(self._hadoop_tmp_dir, 'step-output')
 
     def _cleanup_hadoop_tmp(self):
         if self._hadoop_tmp_dir:

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -167,6 +167,11 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             self._output_dir or
             posixpath.join(self._hadoop_tmp_dir, 'output'))
 
+        # Fully qualify step_output_dir, if set
+        if self._step_output_dir:
+            self._step_output_dir = fully_qualify_hdfs_path(
+                self._step_output_dir)
+
         # Track job and (YARN) application ID to enable log parsing
         self._application_id = None
         self._job_id = None

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -630,6 +630,7 @@ class MRJobLauncher(object):
             output_dir=self.options.output_dir,
             partitioner=self.partitioner(),
             stdin=self.stdin,
+            step_output_dir=self.options.step_output_dir,
         )
 
     def _kwargs_from_switches(self, keys):

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1404,6 +1404,12 @@ def _add_job_options(opt_group):
         help=('Where to run the job; one of dataproc, emr, hadoop, inline,'
               ' or local'))
 
+    opt_group.add_option(
+        '--step-output-dir', dest='step_output_dir', default=None,
+        help=('A directory to store output from job steps other than'
+              ' the last one. Useful for debugging. Currently'
+              ' ignored by local runners.'))
+
 
 ### other utilities for switches ###
 

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -89,6 +89,7 @@ class SimMRJobRunner(MRJobRunner):
         '_hadoop_input_format',
         '_hadoop_output_format',
         '_partitioner',
+        '_step_output_dir',
     ]
 
     # options that we ignore becaue they require real Hadoop.

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -411,6 +411,7 @@ class JobRunnerKwargsTestCase(TestCase):
         'partitioner',
         'sort_values',
         'stdin',
+        'step_output_dir',
     ])
 
     CONF_ONLY_OPTIONS = set([


### PR DESCRIPTION
This allows you to specify where to put the intermediate output of multi-step jobs (e.g. on S3, for future safekeeping). We don't want to do this by default (HDFS is faster), but this can be useful for debugging.

Fixes #263.