### PR TITLE
add jobconf for all step types

### DIFF
--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -329,6 +329,7 @@ class _Step(object):
         'jar': string_types,
         'jobconf': dict,
         'main_class': string_types,
+        'script': string_types,
         'spark_args': (list, tuple),
     }
 
@@ -358,13 +359,13 @@ class _Step(object):
             elif k in self._STEP_ATTR_TYPES and not isinstance(
                     v, self._STEP_ATTR_TYPES[k]):
                 raise TypeError('%s is not an instance of %r: %r' % (
-                    k, attr_type, v))
+                    k, self._STEP_ATTR_TYPES[k], v))
 
             setattr(self, k, v)
 
     def __repr__(self):
         kwargs = dict(
-            (k, gettattr(self, k))
+            (k, getattr(self, k))
             for k in self._STEP_ATTR_TYPES if hasattr(self, k))
 
         return '%s(%s)' % (

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1084,7 +1084,7 @@ class StepsTestCase(TestCase):
 
         self.assertEqual(
             j._steps_desc(),
-            [dict(type='spark', spark_args=[])]
+            [dict(type='spark', jobconf={}, spark_args=[])]
         )
 
     def test_spark_and_spark_args_methods(self):
@@ -1099,7 +1099,7 @@ class StepsTestCase(TestCase):
 
         self.assertEqual(
             j._steps_desc(),
-            [dict(type='spark', spark_args=['argh', 'ARRRRGH!'])]
+            [dict(type='spark', jobconf={}, spark_args=['argh', 'ARRRRGH!'])]
         )
 
     def test_spark_and_streaming_dont_mix(self):

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -398,17 +398,22 @@ class SparkStepTestCase(TestCase):
         self.assertEqual(step.spark_args, [])
         self.assertEqual(
             step.description(0),
-            dict(type='spark', spark_args=[]),
+            dict(type='spark', jobconf={}, spark_args=[]),
         )
 
     def test_all_args(self):
-        step = SparkStep(spark=spark_func, spark_args=['argh', 'argh'])
+        step = SparkStep(
+            jobconf=dict(foo='bar'),
+            spark=spark_func,
+            spark_args=['argh', 'argh'])
 
         self.assertEqual(step.spark, spark_func)
         self.assertEqual(step.spark_args, ['argh', 'argh'])
         self.assertEqual(
             step.description(0),
-            dict(type='spark', spark_args=['argh', 'argh']),
+            dict(type='spark',
+                 jobconf=dict(foo='bar'),
+                 spark_args=['argh', 'argh']),
         )
 
     def test_positional_spark_arg(self):
@@ -441,6 +446,7 @@ class SparkJarStepTestCase(TestCase):
                 jar='dora.jar',
                 main_class='backpack.Map',
                 args=[],
+                jobconf={},
                 spark_args=[],
             )
         )
@@ -449,6 +455,7 @@ class SparkJarStepTestCase(TestCase):
         step = SparkJarStep(jar='dora.jar',
                             main_class='backpack.Map',
                             args=['ARGH', 'ARGH'],
+                            jobconf=dict(foo='bar'),
                             spark_args=['argh', 'argh'])
 
         self.assertEqual(step.jar, 'dora.jar')
@@ -462,6 +469,7 @@ class SparkJarStepTestCase(TestCase):
                 jar='dora.jar',
                 main_class='backpack.Map',
                 args=['ARGH', 'ARGH'],
+                jobconf=dict(foo='bar'),
                 spark_args=['argh', 'argh'],
             )
         )
@@ -491,6 +499,7 @@ class SparkScriptStepTestCase(TestCase):
                 type='spark_script',
                 script='macbeth.py',
                 args=[],
+                jobconf={},
                 spark_args=[],
             )
         )
@@ -498,6 +507,7 @@ class SparkScriptStepTestCase(TestCase):
     def test_all_args(self):
         step = SparkScriptStep(script='macbeth.py',
                                args=['ARGH', 'ARGH'],
+                               jobconf=dict(foo='bar'),
                                spark_args=['argh', 'argh'])
 
         self.assertEqual(step.script, 'macbeth.py')
@@ -509,6 +519,7 @@ class SparkScriptStepTestCase(TestCase):
                 type='spark_script',
                 script='macbeth.py',
                 args=['ARGH', 'ARGH'],
+                jobconf=dict(foo='bar'),
                 spark_args=['argh', 'argh'],
             )
         )

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -109,6 +109,15 @@ class JarStepTestCase(TestCase):
         })
         self.assertEqual(JarStep(**kwargs).description(0), expected)
 
+    def test_bad_arg_types(self):
+        self.assertRaises(TypeError, JarStep, args='argh argh argh')
+        self.assertRaises(TypeError, JarStep, jar=['mason'])
+        self.assertRaises(TypeError, JarStep, jobconf='nah')
+        self.assertRaises(TypeError, JarStep, main_class=1)
+
+    def test_bad_arg(self):
+        self.assertRaises(TypeError, JarStep, 'dora.jar', pickle='dill')
+
     def test_deprecated_INPUT_and_OUTPUT_attrs(self):
         self.assertEqual(JarStep.INPUT, INPUT)
         self.assertEqual(JarStep.OUTPUT, OUTPUT)
@@ -423,6 +432,13 @@ class SparkStepTestCase(TestCase):
         self.assertEqual(step1, step2)
         self.assertEqual(step1.description(0), step2.description(0))
 
+    def test_bad_arg_types(self):
+        self.assertRaises(TypeError, SparkStep, jobconf=['confs'])
+        self.assertRaises(TypeError, SparkStep, spark_args='argh argh argh')
+
+    def test_bad_arg(self):
+        self.assertRaises(TypeError, SparkJarStep, jar='dora.jar')
+
 
 class SparkJarStepTestCase(TestCase):
 
@@ -481,6 +497,16 @@ class SparkJarStepTestCase(TestCase):
         self.assertEqual(step1, step2)
         self.assertEqual(step1.description(0), step2.description(0))
 
+    def test_bad_arg_types(self):
+        self.assertRaises(TypeError, SparkJarStep, args='argh argh argh')
+        self.assertRaises(TypeError, SparkJarStep, jar=['mason'])
+        self.assertRaises(TypeError, SparkJarStep, jobconf='nah')
+        self.assertRaises(TypeError, SparkJarStep, main_class=1)
+        self.assertRaises(TypeError, SparkJarStep, spark_args='*ARGH* *ARGH*')
+
+    def test_bad_arg(self):
+        self.assertRaises(TypeError, SparkJarStep, 'dora.jar', spark='*')
+
 
 class SparkScriptStepTestCase(TestCase):
 
@@ -530,3 +556,13 @@ class SparkScriptStepTestCase(TestCase):
 
         self.assertEqual(step1, step2)
         self.assertEqual(step1.description(0), step2.description(0))
+
+    def test_bad_arg_types(self):
+        self.assertRaises(TypeError, SparkScriptStep, args='argh argh argh')
+        self.assertRaises(TypeError, SparkScriptStep, jobconf='nah')
+        self.assertRaises(TypeError, SparkScriptStep, main_class=1)
+        self.assertRaises(TypeError, SparkScriptStep, script=['macbeth'])
+        self.assertRaises(TypeError, SparkScriptStep, spark_args='*ARGH* *ARGH*')
+
+    def test_bad_arg(self):
+        self.assertRaises(TypeError, SparkScriptStep, 'hap.py', spark='*')

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -433,8 +433,12 @@ class SparkStepTestCase(TestCase):
         self.assertEqual(step1.description(0), step2.description(0))
 
     def test_bad_arg_types(self):
-        self.assertRaises(TypeError, SparkStep, jobconf=['confs'])
-        self.assertRaises(TypeError, SparkStep, spark_args='argh argh argh')
+        self.assertRaises(TypeError,
+                          SparkStep, spark_func, jobconf=['confs'])
+        self.assertRaises(TypeError,
+                          SparkStep, spark='never call me')
+        self.assertRaises(TypeError,
+                          SparkStep, spark_func, spark_args='argh argh argh')
 
     def test_bad_arg(self):
         self.assertRaises(TypeError, SparkJarStep, jar='dora.jar')

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -90,6 +90,7 @@ class JarStepTestCase(TestCase):
             'jar': 'binks.jar.jar',
             'main_class': 'MyMainMan',
             'args': ['argh', 'argh'],
+            'jobconf': dict(foo='bar')
         }
         expected = kwargs.copy()
         expected['type'] = 'jar'
@@ -104,6 +105,7 @@ class JarStepTestCase(TestCase):
             'type': 'jar',
             'main_class': None,
             'args': [],
+            'jobconf': {},
         })
         self.assertEqual(JarStep(**kwargs).description(0), expected)
 


### PR DESCRIPTION
This adds `jobconf` to all step types and adds type-checking of most keyword arguments. Fixes #1447.

This also replaces a lot of boilerplate code with a common base class (`_Step`), fixing #1368. Left `MRStep` alone because it is so old and different (see #1518).