### PR TITLE
use sh_bin, not bash_wrap()

### DIFF
--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -59,7 +59,6 @@ from mrjob.setup import parse_legacy_hash_path
 from mrjob.setup import parse_setup_cmd
 from mrjob.step import STEP_TYPES
 from mrjob.step import _is_spark_step_type
-from mrjob.util import bash_wrap
 from mrjob.util import cmd_line
 from mrjob.util import zip_dir
 
@@ -850,7 +849,7 @@ class MRJobRunner(object):
                 return self._sh_wrap(
                     '%s | %s' % (step[mrc]['pre_filter'], cmd_str))
             else:
-                return cmd
+                return cmd_str
         else:
             raise ValueError("Invalid %s step %d: %r" % (
                 mrc, step_num, step[mrc]))

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -839,17 +839,18 @@ class MRJobRunner(object):
 
         if step[mrc]['type'] == 'command':
             # never wrap custom hadoop streaming commands in bash
-            return step[mrc]['command'], False
+            return step[mrc]['command']
 
         elif step[mrc]['type'] == 'script':
-            cmd = cmd_line(self._script_args_for_step(step_num, mrc))
+            cmd_str = cmd_line(self._script_args_for_step(step_num, mrc))
 
             # filter input and pipe for great speed, if user asks
-            # but we have to wrap the command in bash
+            # but we have to wrap the command in sh -c
             if 'pre_filter' in step[mrc]:
-                return '%s | %s' % (step[mrc]['pre_filter'], cmd), True
+                return self._sh_wrap(
+                    '%s | %s' % (step[mrc]['pre_filter'], cmd_str))
             else:
-                return cmd, False
+                return cmd
         else:
             raise ValueError("Invalid %s step %d: %r" % (
                 mrc, step_num, step[mrc]))
@@ -861,31 +862,23 @@ class MRJobRunner(object):
             return self._substep_cmd_line(step_num, mrc)
         else:
             if mrc == 'mapper':
-                return 'cat', False
+                return 'cat'
             else:
-                return None, False
+                return None
 
     def _hadoop_streaming_commands(self, step_num):
-        # Hadoop streaming stuff
-        mapper, bash_wrap_mapper = self._render_substep(
-            step_num, 'mapper')
+        return (
+            self._render_substep(step_num, 'mapper'),
+            self._render_substep(step_num, 'combiner'),
+            self._render_substep(step_num, 'reducer'),
+        )
 
-        combiner, bash_wrap_combiner = self._render_substep(
-            step_num, 'combiner')
-
-        reducer, bash_wrap_reducer = self._render_substep(
-            step_num, 'reducer')
-
-        if bash_wrap_mapper:
-            mapper = bash_wrap(mapper)
-
-        if bash_wrap_combiner:
-            combiner = bash_wrap(combiner)
-
-        if bash_wrap_reducer:
-            reducer = bash_wrap(reducer)
-
-        return mapper, combiner, reducer
+    def _sh_wrap(self, cmd_str):
+        """Wrap command in sh -c '...' to allow for pipes, etc.
+        Use *sh_bin* option."""
+        return "%s -c '%s'" % (
+            cmd_line(self._opts['sh_bin']),
+            cmd_str.replace("'", "'\\''"))
 
     def _mr_job_extra_args(self, local=False):
         """Return arguments to add to every invocation of MRJob.

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -144,7 +144,10 @@ def bash_wrap(cmd_str):
     This low-tech replacement works because we control the surrounding string
     and single quotes are the only character in a single-quote string that
     needs escaping.
+
+    .. deprecated:: 0.5.8
     """
+    log.warning('bash_wrap() is deprecated and will be removed in v0.6.0')
     return "bash -c '%s'" % cmd_str.replace("'", "'\\''")
 
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3343,15 +3343,15 @@ class BuildStreamingStepTestCase(MockBotoTestCase):
                      pre_filter='grep something')))
 
         self.assertEqual(ss['mapper'],
-                         "bash -c 'grep anything | " +
+                         "/bin/sh -ex -c 'grep anything | " +
                          PYTHON_BIN +
                          " my_job.py --step-num=0 --mapper'")
         self.assertEqual(ss['combiner'],
-                         "bash -c 'grep nothing | " +
+                         "/bin/sh -ex -c 'grep nothing | " +
                          PYTHON_BIN +
                          " my_job.py --step-num=0 --combiner'")
         self.assertEqual(ss['reducer'],
-                         "bash -c 'grep something | " +
+                         "/bin/sh -ex -c 'grep something | " +
                          PYTHON_BIN +
                          " my_job.py --step-num=0 --reducer'")
 
@@ -3364,7 +3364,7 @@ class BuildStreamingStepTestCase(MockBotoTestCase):
 
         self.assertEqual(
             ss['mapper'],
-            "bash -c 'bash -c '\\''grep"
+            "/bin/sh -ex -c 'bash -c '\\''grep"
             " '\\''\\'\\'''\\''anything'\\''\\'\\'''\\'''\\'' | " +
             PYTHON_BIN +
             " my_job.py --step-num=0 --mapper'")

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -889,13 +889,13 @@ class StreamingArgsTestCase(EmptyMrjobConfTestCase):
             self.runner._args_for_streaming_step(0),
             (self.BASIC_HADOOP_ARGS + self.BASIC_JOB_ARGS + [
              '-mapper',
-             "bash -c 'grep anything | " + PYTHON_BIN +
+             "sh -ex -c 'grep anything | " + PYTHON_BIN +
              " my_job.py --step-num=0 --mapper'",
              '-combiner',
-             "bash -c 'grep nothing | " + PYTHON_BIN +
+             "sh -ex -c 'grep nothing | " + PYTHON_BIN +
              " my_job.py --step-num=0 --combiner'",
              '-reducer',
-             "bash -c 'grep something | " + PYTHON_BIN +
+             "sh -ex -c 'grep something | " + PYTHON_BIN +
              " my_job.py --step-num=0 --reducer'"]))
 
     def test_pre_filter_escaping(self):
@@ -916,7 +916,7 @@ class StreamingArgsTestCase(EmptyMrjobConfTestCase):
              ['-D', 'mapreduce.job.reduces=0'] +
              self.BASIC_JOB_ARGS + [
                  '-mapper',
-                 "bash -c 'bash -c '\\''grep"
+                 "sh -ex -c 'bash -c '\\''grep"
                  " '\\''\\'\\'''\\''anything'\\''\\'\\'''\\'''\\'' | " +
                  PYTHON_BIN +
                  " my_job.py --step-num=0 --mapper'"]))


### PR DESCRIPTION
This uses whatever the `sh_bin` option is set to for wrapping streaming tasks that require piping one command into another. That way, if you don't have `bash` installed, no worries.