### PR TITLE
A ton of local mode/pre-filter fixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 v0.5.8, 2017-01-?? -- ???
+ * moved mrjob.util.bunzip2_stream() to mrjob.cat
+ * moved mrjob.util.gunzip_stream() to mrjob.cat
  * deprecated mrjob.util.bash_wrap()
  * deprecated mrjob.util.tar_and_gz()
  * deprecated SSHFilesystem.ssh_slave_hosts()

--- a/docs/utils-cat.rst
+++ b/docs/utils-cat.rst
@@ -1,0 +1,5 @@
+mrjob.cat - auto-decompress files based on extension
+====================================================
+
+.. automodule:: mrjob.cat
+    :members:

--- a/mrjob/cat.py
+++ b/mrjob/cat.py
@@ -11,27 +11,111 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""A simple utility that prints the contents of files, uncompressing
+"""Emulating the way Hadoop handles input files, decompressing compressed
 files based on their file extension.
 
-This does not handle globs."""
-from sys import argv
-from sys import stdout
+This module also functions as a :command:`cat` substitute that can handle
+compressed files. It it used by :py:mod:`local <mrjob.local>` mode and can
+function without the rest of the mrjob library.
+"""
+import sys
+import zlib
 
-from mrjob.util import read_input
+try:
+    import bz2
+    bz2  # redefine bz2 for pepflakes
+except ImportError:
+    bz2 = None
 
 
-def main():
-    # we want to write bytes
-    if hasattr(stdout, 'buffer'):
-        stdout_buffer = stdout.buffer
+def bunzip2_stream(fileobj, bufsize=1024):
+    """Decompress gzipped data on the fly.
+
+    :param fileobj: object supporting ``read()``
+    :param bufsize: number of bytes to read from *fileobj* at a time.
+
+    .. warning::
+
+        This yields decompressed chunks; it does *not* split on lines. To get
+        lines, wrap this in :py:func:`to_lines`.
+    """
+    if bz2 is None:
+        raise Exception(
+            'bz2 module was not successfully imported (likely not installed).')
+
+    d = bz2.BZ2Decompressor()
+
+    while True:
+        chunk = fileobj.read(bufsize)
+        if not chunk:
+            return
+
+        part = d.decompress(chunk)
+        if part:
+            yield part
+
+
+def gunzip_stream(fileobj, bufsize=1024):
+    """Decompress gzipped data on the fly.
+
+    :param fileobj: object supporting ``read()``
+    :param bufsize: number of bytes to read from *fileobj* at a time. The
+                    default is the same as in :py:mod:`gzip`.
+
+    .. warning::
+
+        This yields decompressed chunks; it does *not* split on lines. To get
+        lines, wrap this in :py:func:`to_lines`.
+    """
+    # see Issue #601 for why we need this.
+
+    # we need this flag to read gzip rather than raw zlib, but it's not
+    # actually defined in zlib, so we define it here.
+    READ_GZIP_DATA = 16
+    d = zlib.decompressobj(READ_GZIP_DATA | zlib.MAX_WBITS)
+    while True:
+        chunk = fileobj.read(bufsize)
+        if not chunk:
+            return
+        data = d.decompress(chunk)
+        if data:
+            yield data
+
+
+
+def decompress(fileobj, path):
+    """Take a *fileobj* correponding to the given path and returns an iterator
+    that yield chunks of bytes, or, if *path* doesn't correspond to a
+    compressed file type, *fileobj* itself.
+    """
+    if path.endswith('.gz'):
+        return gunzip_stream(fileobj)
+    elif path.endswith('.bz2'):
+        if bz2 is None:
+            raise Exception('bz2 module was not successfully imported'
+                            ' (likely not installed).')
+        else:
+            return bunzip2_stream(fileobj)
     else:
-        stdout_buffer = stdout
+        return fileobj
 
-    for path in argv[1:] or ['-']:
-        for chunk in read_input(path):
+
+def _main():
+    args = sys.argv[1:]
+    if len(args) != 1:
+        raise ValueError('please pass a single path')
+    path = args[0]
+
+    # we want to write bytes
+    if hasattr(sys.stdout, 'buffer'):
+        stdout_buffer = sys.stdout.buffer
+    else:
+        stdout_buffer = sys.stdout
+
+    with open(path, 'rb') as f:
+        for chunk in decompress(f, path):
             stdout_buffer.write(chunk)
 
 
 if __name__ == '__main__':
-    main()
+    _main()

--- a/mrjob/cat.py
+++ b/mrjob/cat.py
@@ -1,0 +1,37 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A simple utility that prints the contents of files, uncompressing
+files based on their file extension.
+
+This does not handle globs."""
+from sys import argv
+from sys import stdout
+
+from mrjob.util import read_input
+
+
+def main():
+    # we want to write bytes
+    if hasattr(stdout, 'buffer'):
+        stdout_buffer = stdout.buffer
+    else:
+        stdout_buffer = stdout
+
+    for path in argv[1:] or ['-']:
+        for chunk in read_input(path):
+            stdout_buffer.write(chunk)
+
+
+if __name__ == '__main__':
+    main()

--- a/mrjob/examples/mr_grep_word_freq_count.py
+++ b/mrjob/examples/mr_grep_word_freq_count.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+# Copyright 2009-2010 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The classic MapReduce job, minus lines containing "e".
+"""
+from mrjob.job import MRJob
+import re
+
+WORD_RE = re.compile(r"[\w']+")
+
+
+class MRGrepWordFreqCount(MRJob):
+
+    def mapper_pre_filter(self):
+        return 'grep -v -i e'
+
+    def mapper(self, _, line):
+        for word in WORD_RE.findall(line):
+            yield (word.lower(), 1)
+
+    def combiner(self, word, counts):
+        yield (word, sum(counts))
+
+    def reducer(self, word, counts):
+        yield (word, sum(counts))
+
+
+if __name__ == '__main__':
+    MRGrepWordFreqCount.run()

--- a/mrjob/examples/mr_u_word_freq_count.py
+++ b/mrjob/examples/mr_u_word_freq_count.py
@@ -12,18 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""The classic MapReduce job, minus lines containing "e".
+"""The classic MapReduce job, but only for words containing "v"
 """
 from mrjob.job import MRJob
 import re
 
-WORD_RE = re.compile(r"[\w']+")
+WORD_RE = re.compile(r"[\w']*u[\w']*", re.I)
 
 
-class MRGrepWordFreqCount(MRJob):
+class MRVWordFreqCount(MRJob):
 
     def mapper_pre_filter(self):
-        return 'grep -v -i e'
+        return 'grep -i u'
 
     def mapper(self, _, line):
         for word in WORD_RE.findall(line):
@@ -37,4 +37,4 @@ class MRGrepWordFreqCount(MRJob):
 
 
 if __name__ == '__main__':
-    MRGrepWordFreqCount.run()
+    MRVWordFreqCount.run()

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -347,7 +347,7 @@ class MRJob(MRJobLauncher):
         # class as functions that return strings, so call the functions.
         updates = {}
         for k, v in kwargs.items():
-            if k.endswith('_cmd'):
+            if k.endswith('_cmd') or k.endswith('_pre_filter'):
                 updates[k] = v()
 
         kwargs.update(updates)

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -131,6 +131,10 @@ class LocalMRJobRunner(SimMRJobRunner):
                 step, step_num, input_path)
 
         # add . to PYTHONPATH (in case mrjob isn't actually installed)
+        # we need this to access mrjob.cat
+
+        # if we wanted, we could move read_file() and read_input()
+        # to mrjob.cat and make it a standalone script
         env = combine_local_envs(env, {'PYTHONPATH': abspath('.')})
 
         proc_dicts = self._invoke_processes(

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -21,6 +21,7 @@ from subprocess import CalledProcessError
 from subprocess import Popen
 from subprocess import PIPE
 
+import mrjob.cat
 from mrjob.conf import combine_local_envs
 from mrjob.logs.counters import _format_counters
 from mrjob.parse import _find_python_traceback
@@ -147,8 +148,13 @@ class LocalMRJobRunner(SimMRJobRunner):
 
         self._all_proc_dicts = []
 
-    def _cat_args(self, *input_paths):
-        return self._python_bin() + ['-m', 'mrjob.cat'] + list(input_paths)
+    def _cat_args(self, input_path):
+        """Return a command line that can call mrjob's internal "cat" script
+        from any working directory, without mrjob in PYTHONPATH"""
+        return self._python_bin() + [
+            abspath(mrjob.cat.__file__),
+            input_path
+        ]
 
     def _mapper_arg_chain(self, step_dict, step_num, input_path):
         procs_args = []

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1037,6 +1037,17 @@ class StepsTestCase(TestCase):
         def jobconf(self):
             return {'mapred.baz': 'bar'}
 
+    class PreFilterJob(MRJob):
+
+        def mapper_pre_filter(self):
+            return 'grep m'
+
+        def combiner_pre_filter(self):
+            return 'grep c'
+
+        def reducer_pre_filter(self):
+            return 'grep r'
+
     # for spark testing used mock methods instead
 
     def test_steps(self):
@@ -1072,6 +1083,19 @@ class StepsTestCase(TestCase):
         self.assertEqual(
             j.steps()[0],
             MRStep(mapper=j.mapper))
+
+    def test_pre_filters(self):
+        j = self.PreFilterJob(['--no-conf'])
+        self.assertEqual(
+            j._steps_desc(),
+            [
+                dict(
+                    type='streaming',
+                    mapper=dict(type='script', pre_filter='grep m'),
+                    combiner=dict(type='script', pre_filter='grep c'),
+                    reducer=dict(type='script', pre_filter='grep r'),
+                )
+            ])
 
     def test_spark_method(self):
         j = MRJob(['--no-conf'])


### PR DESCRIPTION
Made several important fixes to local mode and pre-filters:

#1061: Local mode can now handle compressed input files passed through pre-filters. Every file that local mode pipes into another command first goes through `mrjob/cat.py`, which auto-decompresses compressed files based on their file extension. `mrjob/cat.py` depends on the standard library only, so we don't need to hack `PYTHONPATH` to ensure access to `mrjob`

#1126: This was a symptom of general brokenness with pre-filters, and should be fixed.

#1521: You can now override `*_pre_filter()` methods to get pre-filters in a single-step job. This used be totally broken.

#1524: Local mode used to report a failure if the pre-filter command reported failure. This can be a problem; for example BSD grep reports exit status 1 on no matching input, and there's no way to change this. Fixed this by doing the same thing we do in "real" Hadoop; using `sh -c` to pipe the pre-filter command into the job command. This made it possible to get rid of a lot of pretend-piping code.

Also, local mode no longer expects mrjobs to be able to take to take path arguments, so we're halfway to fixing #567.
