### PR TITLE
improve help, deprecate opt groups

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
 v0.5.8, 2017-01-?? -- ???
+ * jobs:
+   * deprecated option groups in MRJobs
+   * deprecated MRJob.get_all_option_groups()
  * moved mrjob.util.bunzip2_stream() to mrjob.cat
  * moved mrjob.util.gunzip_stream() to mrjob.cat
  * deprecated mrjob.util.args_for_opt_dest_subset()

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -29,6 +29,7 @@ from mrjob.conf import combine_dicts
 from mrjob.conf import combine_lists
 from mrjob.launch import MRJobLauncher
 from mrjob.launch import _READ_ARGS_FROM_SYS_ARGV
+from mrjob.options import _add_step_options
 from mrjob.protocol import JSONProtocol
 from mrjob.protocol import RawValueProtocol
 from mrjob.py2 import integer_types
@@ -850,33 +851,7 @@ class MRJob(MRJobLauncher):
             self.option_parser, 'Running specific parts of the job')
         self.option_parser.add_option_group(self.mux_opt_group)
 
-        self.mux_opt_group.add_option(
-            '--mapper', dest='run_mapper', action='store_true', default=False,
-            help='run a mapper')
-
-        self.mux_opt_group.add_option(
-            '--combiner', dest='run_combiner', action='store_true',
-            default=False, help='run a combiner')
-
-        self.mux_opt_group.add_option(
-            '--reducer', dest='run_reducer', action='store_true',
-            default=False, help='run a reducer')
-
-        # To run spark steps
-        self.mux_opt_group.add_option(
-            '--spark', dest='run_spark', action='store_true', default=False,
-            help='run Spark code')
-
-        # To choose step number
-        self.mux_opt_group.add_option(
-            '--step-num', dest='step_num', type='int', default=0,
-            help='which step to execute (default is 0)')
-
-        # To describe the steps
-        self.mux_opt_group.add_option(
-            '--steps', dest='show_steps', action='store_true', default=False,
-            help=('print the mappers, combiners, and reducers that this job'
-                  ' defines'))
+        _add_step_options(self.mux_opt_group)
 
     def all_option_groups(self):
         return super(MRJob, self).all_option_groups() + (self.mux_opt_group,)

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -30,6 +30,7 @@ from mrjob.conf import combine_lists
 from mrjob.launch import MRJobLauncher
 from mrjob.launch import _READ_ARGS_FROM_SYS_ARGV
 from mrjob.options import _add_step_options
+from mrjob.options import _print_help_for_steps
 from mrjob.protocol import JSONProtocol
 from mrjob.protocol import RawValueProtocol
 from mrjob.py2 import integer_types
@@ -874,13 +875,12 @@ class MRJob(MRJobLauncher):
         """
         self.args = args
 
-    def _help_main(self):
-        self.option_parser.option_groups = [
-            self.mux_opt_group,
-            self.proto_opt_group,
-        ]
-        self.option_parser.print_help()
-        sys.exit(0)
+    def _print_help(self, options):
+        """Implement --help --steps"""
+        if options.show_steps:
+            _print_help_for_steps()
+        else:
+            super(MRJob, self)._print_help(options)
 
     ### protocols ###
 

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -848,14 +848,14 @@ class MRJob(MRJobLauncher):
         super(MRJob, self).configure_options()
 
         # To run mappers or reducers
-        self.mux_opt_group = OptionGroup(
+        self._mux_opt_group = OptionGroup(
             self.option_parser, 'Running specific parts of the job')
-        self.option_parser.add_option_group(self.mux_opt_group)
+        self.option_parser.add_option_group(self._mux_opt_group)
 
-        _add_step_options(self.mux_opt_group)
+        _add_step_options(self._mux_opt_group)
 
     def all_option_groups(self):
-        return super(MRJob, self).all_option_groups() + (self.mux_opt_group,)
+        return super(MRJob, self).all_option_groups() + (self._mux_opt_group,)
 
     def is_task(self):
         """True if this is a mapper, combiner, reducer, or Spark script.

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -29,7 +29,6 @@ from mrjob.options import _add_basic_options
 from mrjob.options import _add_job_options
 from mrjob.options import _add_runner_options
 from mrjob.options import _allowed_keys
-from mrjob.options import _alphabetize_options
 from mrjob.options import _pick_runner_opts
 from mrjob.options import _print_help_for_runner
 from mrjob.options import _print_basic_help
@@ -87,6 +86,8 @@ class MRJobLauncher(object):
         self.option_parser = OptionParser(usage=self._usage(),
                                           option_class=self.OPTION_CLASS,
                                           add_help_option=False)
+
+        self.configure_options()
 
         # don't pass None to parse_args unless we're actually running
         # the MRJob script

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -264,97 +264,100 @@ class MRJobLauncher(object):
             help='include help for deprecated options')
 
         # protocol stuff
-        self.proto_opt_group = OptionGroup(
+        self._proto_opt_group = OptionGroup(
             self.option_parser, 'Protocols')
-        self.option_parser.add_option_group(self.proto_opt_group)
+        self.option_parser.add_option_group(self._proto_opt_group)
 
         _add_runner_options(
-            self.proto_opt_group, set(['strict_protocols']))
+            self._proto_opt_group, set(['strict_protocols']))
 
         # options for running the job (any runner)
-        self.runner_opt_group = OptionGroup(
+        self._runner_opt_group = OptionGroup(
             self.option_parser, 'Running the entire job')
-        self.option_parser.add_option_group(self.runner_opt_group)
+        self.option_parser.add_option_group(self._runner_opt_group)
 
-        _add_basic_options(self.runner_opt_group)
-        _add_job_options(self.runner_opt_group)
+        _add_basic_options(self._runner_opt_group)
+        _add_job_options(self._runner_opt_group)
         _add_runner_options(
-            self.runner_opt_group,
+            self._runner_opt_group,
             _pick_runner_opts('base') - set(['strict_protocols']))
 
         # options for inline/local runners
-        self.local_opt_group = OptionGroup(
+        self._local_opt_group = OptionGroup(
             self.option_parser,
             'Running locally (these apply when you set -r inline or -r local)')
-        self.option_parser.add_option_group(self.local_opt_group)
+        self.option_parser.add_option_group(self._local_opt_group)
 
         _add_runner_options(
-            self.local_opt_group,
+            self._local_opt_group,
             _pick_runner_opts('local') - _pick_runner_opts('base'))
 
         # options common to Hadoop and EMR
-        self.hadoop_emr_opt_group = OptionGroup(
+        self._hadoop_emr_opt_group = OptionGroup(
             self.option_parser,
             'Running on Hadoop or EMR (these apply when you set -r hadoop or'
             ' -r emr)')
-        self.option_parser.add_option_group(self.hadoop_emr_opt_group)
+        self.option_parser.add_option_group(self._hadoop_emr_opt_group)
 
         _add_runner_options(
-            self.hadoop_emr_opt_group,
+            self._hadoop_emr_opt_group,
             ((_pick_runner_opts('emr') & _pick_runner_opts('hadoop')) -
              _pick_runner_opts('base')))
 
         # options for running the job on Hadoop
-        self.hadoop_opt_group = OptionGroup(
+        self._hadoop_opt_group = OptionGroup(
             self.option_parser,
             'Running on Hadoop (these apply when you set -r hadoop)')
-        self.option_parser.add_option_group(self.hadoop_opt_group)
+        self.option_parser.add_option_group(self._hadoop_opt_group)
 
         _add_runner_options(
-            self.hadoop_opt_group,
+            self._hadoop_opt_group,
             (_pick_runner_opts('hadoop') -
              _pick_runner_opts('emr') - _pick_runner_opts('base')))
 
         # options for running the job on Dataproc or EMR
-        self.dataproc_emr_opt_group = OptionGroup(
+        self._dataproc_emr_opt_group = OptionGroup(
             self.option_parser,
             'Running on Dataproc or EMR (these apply when you set -r dataproc'
             ' or -r emr)')
-        self.option_parser.add_option_group(self.dataproc_emr_opt_group)
+        self.option_parser.add_option_group(self._dataproc_emr_opt_group)
 
         _add_runner_options(
-            self.dataproc_emr_opt_group,
+            self._dataproc_emr_opt_group,
             ((_pick_runner_opts('dataproc') & _pick_runner_opts('emr')) -
              _pick_runner_opts('base')))
 
         # options for running the job on Dataproc
-        self.dataproc_opt_group = OptionGroup(
+        self._dataproc_opt_group = OptionGroup(
             self.option_parser,
             'Running on Dataproc (these apply when you set -r dataproc)')
-        self.option_parser.add_option_group(self.dataproc_opt_group)
+        self.option_parser.add_option_group(self._dataproc_opt_group)
 
         _add_runner_options(
-            self.dataproc_opt_group,
+            self._dataproc_opt_group,
             (_pick_runner_opts('dataproc') -
              _pick_runner_opts('emr') - _pick_runner_opts('base')))
 
         # options for running the job on EMR
-        self.emr_opt_group = OptionGroup(
+        self._emr_opt_group = OptionGroup(
             self.option_parser,
             'Running on EMR (these apply when you set -r emr)')
-        self.option_parser.add_option_group(self.emr_opt_group)
+        self.option_parser.add_option_group(self._emr_opt_group)
 
         _add_runner_options(
-            self.emr_opt_group,
+            self._emr_opt_group,
             (_pick_runner_opts('emr') - _pick_runner_opts('hadoop') -
              _pick_runner_opts('dataproc') - _pick_runner_opts('base')))
 
     def all_option_groups(self):
-        return (self.option_parser, self.proto_opt_group,
-                self.runner_opt_group, self.hadoop_opt_group,
-                self.dataproc_emr_opt_group, self.hadoop_emr_opt_group,
-                self.dataproc_opt_group, self.emr_opt_group,
-                self.local_opt_group)
+        log.warning('all_option_groups() is deprecated and will be removed'
+                    ' in v0.6.0')
+
+        return (self.option_parser, self._proto_opt_group,
+                self._runner_opt_group, self._hadoop_opt_group,
+                self._dataproc_emr_opt_group, self._hadoop_emr_opt_group,
+                self._dataproc_opt_group, self._emr_opt_group,
+                self._local_opt_group)
 
     def is_task(self):
         """True if this is a mapper, combiner, or reducer.
@@ -729,6 +732,14 @@ class MRJobLauncher(object):
         self.stderr = stderr or BytesIO()
 
         return self
+
+    def __getattr__(self, name):
+        if name.startswith('_') and name.endswith('_opt_group'):
+            log.warning('The %s attribute is deprecated and will be removed'
+                        ' in v0.6.0' % name)
+            return getattr(self, name[1:])
+        else:
+            raise AttributeError(name)
 
 
 def _dests(opt_group):

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -88,14 +88,6 @@ class MRJobLauncher(object):
                                           option_class=self.OPTION_CLASS,
                                           add_help_option=False)
 
-        # temporary, for testing
-        self._option_parser = OptionParser()
-
-        self.configure_options()
-
-        for opt_group in self.all_option_groups():
-            _alphabetize_options(opt_group)
-
         # don't pass None to parse_args unless we're actually running
         # the MRJob script
         if args is _READ_ARGS_FROM_SYS_ARGV:
@@ -737,23 +729,6 @@ class MRJobLauncher(object):
         self.stderr = stderr or BytesIO()
 
         return self
-
-    ### deprecated option group methods ###
-
-    def _deprecated_option_group(self, opt_names, title):
-        if not getattr(self, '_warned_about_opt_groups', None):
-            log.warning('*_opt_group attributes are deprecated and going away'
-                        ' in v0.6.0')
-            self._warned_about_opt_groups = True
-
-        opt_group = OptionGroup(self._dummy_option_parser, title)
-
-        _add_runner_options(opt_group, opt_names)
-
-    ### temporary, for debugging ###
-
-    def _opt_group_names(self):
-        return set(name for name in dir(self) if name.endswith('_opt_group'))
 
 
 def _dests(opt_group):

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -154,6 +154,15 @@ def _port_range_callback(option, opt_str, value, parser):
 
     setattr(parser.values, option.dest, ports)
 
+### mux opts ###
+
+# these are used by MRJob to determine what part of a job to run
+
+# TODO: fill this in
+_MUX_OPTS = dict(
+)
+
+
 ### runner opts ###
 
 # map from runner option name to dict with the following keys (all optional):
@@ -308,8 +317,8 @@ _RUNNER_OPTS = dict(
                 action='append',
                 help=('Path to a Python module to install on EMR. These should'
                       ' be standard python module tarballs where you can cd'
-                      ' into a subdirectory and run ``sudo python setup.py'
-                      ' install``. You can use --bootstrap-python-package more'
+                      ' into a subdirectory and run "sudo python setup.py'
+                      ' install". You can use --bootstrap-python-package more'
                       ' than once.'),
             )),
         ],
@@ -1417,6 +1426,30 @@ def _print_help_for_groups(*args):
     option_parser = OptionParser(usage=SUPPRESS_USAGE, add_help_option=False)
     option_parser.option_groups = args
     option_parser.print_help()
+
+
+def _print_help_for_runner(runner_alias, include_deprecated=False):
+    help_parser = OptionParser(usage=SUPPRESS_USAGE, add_help_option=False)
+
+    opt_names = _pick_runner_opts(runner_alias)
+    _add_runner_options(help_parser, opt_names,
+                        include_deprecated=include_deprecated)
+
+    help_parser.print_help()
+
+
+def _print_non_runner_help(option_parser):
+    """Print all help for the parser (including passthrough options)"""
+    help_parser = OptionParser(usage=SUPPRESS_USAGE, add_help_option=False)
+
+    for option in option_parser._get_all_options():
+        if option.dest not in _RUNNER_OPTS:
+            help_parser.add_option(
+                *(option._short_opts + option._long_opts),
+                dest=option.dest,
+                help=option.help)
+
+    help_parser.print_help()
 
 
 def _alphabetize_options(opt_group):

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -157,9 +157,59 @@ def _port_range_callback(option, opt_str, value, parser):
 ### mux opts ###
 
 # these are used by MRJob to determine what part of a job to run
-
-# TODO: fill this in
-_MUX_OPTS = dict(
+#
+# this just maps dest to the args and kwargs to OptionParser.add_option()
+# (minus the dest keyword arg)
+_STEP_OPTS = dict(
+    run_combiner=(
+        ['--combiner'],
+        dict(
+            action='store_true',
+            default=False,
+            help='run a combiner',
+        ),
+    ),
+    run_mapper=(
+        ['--mapper'],
+        dict(
+            action='store_true',
+            default=False,
+            help='run a mapper'
+        ),
+    ),
+    run_reducer=(
+        ['--reducer'],
+        dict(
+            action='store_true',
+            default=False,
+            help='run a reducer',
+        ),
+    ),
+    run_spark=(
+        ['--spark'],
+        dict(
+            action='store_true',
+            default=False,
+            help='run Spark code',
+        ),
+    ),
+    show_steps=(
+        ['--steps'],
+        dict(
+            action='store_true',
+            default=False,
+            help=('print the mappers, combiners, and reducers that this job'
+                  ' defines'),
+        ),
+    ),
+    step_num=(
+        ['--step-num'],
+        dict(
+            type='int',
+            default=0,
+            help='which step to execute (default is 0)',
+        ),
+    ),
 )
 
 
@@ -1420,6 +1470,13 @@ def _add_job_options(opt_group):
               ' ignored by local runners.'))
 
 
+def _add_step_options(opt_group):
+    """Add options that determine what part of the job a MRJob runs."""
+    for dest, (args, kwargs) in _STEP_OPTS.items():
+        kwargs = dict(dest=dest, **kwargs)
+        opt_group.add_option(*args, **kwargs)
+
+
 ### other utilities for switches ###
 
 def _print_help_for_groups(*args):
@@ -1443,11 +1500,16 @@ def _print_non_runner_help(option_parser):
     help_parser = OptionParser(usage=SUPPRESS_USAGE, add_help_option=False)
 
     for option in option_parser._get_all_options():
-        if option.dest not in _RUNNER_OPTS:
-            help_parser.add_option(
-                *(option._short_opts + option._long_opts),
-                dest=option.dest,
-                help=option.help)
+        if option.dest in _RUNNER_OPTS:
+            continue
+
+        if option.dest in _STEP_OPTS:
+            continue
+
+        help_parser.add_option(
+            *(option._short_opts + option._long_opts),
+            dest=option.dest,
+            help=option.help)
 
     help_parser.print_help()
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1195,6 +1195,7 @@ _RUNNER_OPTS = dict(
         ],
     ),
     strict_protocols=dict(
+        deprecated=True,
         switches=[
             (['--strict-protocols'], dict(
                 action='store_true',

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1496,6 +1496,7 @@ def _print_help_for_runner(runner_alias, include_deprecated=False):
     _add_runner_options(help_parser, opt_names,
                         include_deprecated=include_deprecated)
 
+    _alphabetize_options(help_parser)
     help_parser.print_help()
 
 
@@ -1504,6 +1505,7 @@ def _print_help_for_steps():
 
     _add_step_options(help_parser)
 
+    _alphabetize_options(help_parser)
     help_parser.print_help()
 
 
@@ -1530,6 +1532,7 @@ def _print_basic_help(option_parser, usage, include_deprecated=False):
             dest=option.dest,
             help=option.help)
 
+    _alphabetize_options(help_parser)
     help_parser.print_help()
 
     print()

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -168,8 +168,7 @@ def parse_and_save_options(option_parser, args):
         elif value:
             arg_map[dest].extend(value)
 
-    sim_parser = OptionParser()
-    sim_parser.remove_option('-h')
+    sim_parser = OptionParser(add_help_option=False)
 
     # optparse is no longer being maintained, so it's safe to access
     # hidden methods and attributes


### PR DESCRIPTION
This replaces the extremely spammy `--help` printout with three possible modes:
 * basic help (`--help`), which shows config, input/output, and verbosity options, plus any custom options
 * runner help (`--help -r <runner>`) which shows runner-specific options for one runner
 * steps help (`--help --steps`) which show the options that select which part of a job to run (rarely needed)

To show deprecated switches, you have to add the `--deprecated` option.

Also added deprecation warnings for opt groups and the `get_all_opt_groups()` method. Also deprecated the `--strict-protocols` switch (which will go away in v0.6.0 because it'll be irrelevant.