### PR TITLE
use relative path for cat.py in local mode

### DIFF
--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -261,6 +261,11 @@ class InlineMRJobRunnerJobConfTestCase(SandboxedTestCase):
         self.assertEqual(sorted(results),
                          [(input_path, 3), (input_gz_path, 1)])
 
+    def _extra_expected_local_files(self, runner):
+        """A list of additional local files expected, as tuples
+        of (path, name). Hook for dealing with cat.py in local mode."""
+        return []
+
     def test_jobconf_simulated_by_runner(self):
         input_path = os.path.join(self.tmp_dir, 'input')
         with open(input_path, 'wb') as input_file:
@@ -303,16 +308,24 @@ class InlineMRJobRunnerJobConfTestCase(SandboxedTestCase):
                                       'job_local_dir', '0', 'mapper', '0'))
 
         self.assertEqual(results['mapreduce.job.cache.archives'], '')
-        expected_cache_files = (
+        expected_cache_files = [
             script_path + '#mr_test_jobconf.py',
-            upload_path + '#upload')
+            upload_path + '#upload'
+        ] + [
+            '%s#%s' % (path, name)
+            for path, name in self._extra_expected_local_files(runner)
+        ]
         self.assertEqual(
             sorted(results['mapreduce.job.cache.files'].split(',')),
             sorted(expected_cache_files))
         self.assertEqual(results['mapreduce.job.cache.local.archives'], '')
-        expected_local_files = (
+        expected_local_files = [
             os.path.join(working_dir, 'mr_test_jobconf.py'),
-            os.path.join(working_dir, 'upload'))
+            os.path.join(working_dir, 'upload')
+        ] + [
+            os.path.join(working_dir, name)
+            for path, name in self._extra_expected_local_files(runner)
+        ]
         self.assertEqual(
             sorted(results['mapreduce.job.cache.local.files'].split(',')),
             sorted(expected_local_files))

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -514,6 +514,10 @@ class LocalMRJobRunnerJobConfTestCase(InlineMRJobRunnerJobConfTestCase):
 
     RUNNER = 'local'
 
+    def _extra_expected_local_files(self, runner):
+        cat_py = runner._cat_py()
+        return [(cat_py, runner._working_dir_mgr.name('file', cat_py))]
+
 
 class LocalMRJobRunnerNoMapperTestCase(InlineMRJobRunnerNoMapperTestCase):
 


### PR DESCRIPTION
Local mode now uploads mrjob/cat.py (which handles uncompressing input files, to pipe them into the task) into the job's working directory and invokes them by relative path. This allows you to use a specially designed Docker script as your `python_bin`, since now all the files you need to get into Docker will be in the job's working dir.

