### PR TITLE
port S3 code from boto to boto3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ v0.6.0, 2017-04-?? -- ???
    * changes to S3FileSystem:
      * removed make_s3_conn() (use make_s3_client() or make_s3_resource())
      * removed get_all_buckets() (use get_all_bucket_names())
+     * removed get_s3_key()
      * removed get_s3_keys()
      * create_bucket()'s second arg is now named region, not location
    * mrjob.fs.s3.wrap_aws_conn() removed

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 v0.6.0, 2017-03-?? -- ???
  * use boto3 instead of boto
-   * old boto make_*_conn() methods removed
+   * removed make_*_conn() from EMRJobRunner (use make_*_client())
+   * changes to S3FileSystem:
+     * removed make_s3_conn() (use make_s3_client() or make_s3_resource())
+     * removed get_all_buckets() (use get_all_bucket_names())
+     * create_bucket()'s second arg is now named region, not location
    * mrjob.fs.s3.wrap_aws_conn() removed
  * removed deprecated INPUT, OUTPUT attributes from JarStep
  * removed deprecated filesystem methods:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 v0.6.0, 2017-04-?? -- ???
  * use boto3 instead of boto
    * removed make_*_conn() from EMRJobRunner (use make_*_client())
+   * removed s3_key_to_uri() functions
    * changes to S3FileSystem:
      * removed make_s3_conn() (use make_s3_client() or make_s3_resource())
      * removed get_all_buckets() (use get_all_bucket_names())

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ v0.6.0, 2017-03-?? -- ???
    * changes to S3FileSystem:
      * removed make_s3_conn() (use make_s3_client() or make_s3_resource())
      * removed get_all_buckets() (use get_all_bucket_names())
+     * removed get_s3_keys()
      * create_bucket()'s second arg is now named region, not location
    * mrjob.fs.s3.wrap_aws_conn() removed
  * removed deprecated INPUT, OUTPUT attributes from JarStep

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
 v0.6.0, 2017-03-?? -- ???
+ * use boto3 instead of boto
+   * old boto make_*_conn() methods removed
+   * mrjob.fs.s3.wrap_aws_conn() removed
  * removed deprecated INPUT, OUTPUT attributes from JarStep
  * removed deprecated filesystem methods:
    * path_exists()

--- a/docs/runners-emr.rst
+++ b/docs/runners-emr.rst
@@ -20,11 +20,10 @@ S3 Utilities
 
 .. :py:module:: mrjob.fs.s3
 
-.. autofunction:: mrjob.fs.s3.s3_key_to_uri
-
 .. autoclass:: S3Filesystem
 
 .. automethod:: S3Filesystem.create_bucket
 .. automethod:: S3Filesystem.get_all_bucket_names
+.. automethod:: S3Filesystem.get_bucket
 .. automethod:: S3Filesystem.make_s3_client
 .. automethod:: S3Filesystem.make_s3_resource

--- a/docs/runners-emr.rst
+++ b/docs/runners-emr.rst
@@ -24,7 +24,7 @@ S3 Utilities
 
 .. autoclass:: S3Filesystem
 
-.. automethod:: S3Filesystem.make_s3_conn
-.. automethod:: S3Filesystem.get_s3_key
-.. automethod:: S3Filesystem.get_s3_keys
-.. automethod:: S3Filesystem.make_s3_key
+.. automethod:: S3Filesystem.create_bucket
+.. automethod:: S3Filesystem.get_all_bucket_names
+.. automethod:: S3Filesystem.make_s3_client
+.. automethod:: S3Filesystem.make_s3_resource

--- a/mrjob/aws.py
+++ b/mrjob/aws.py
@@ -179,7 +179,7 @@ _ALIAS_TO_REGION = {
 }
 
 # The region to assume if none is specified
-_DEFAULT_REGION = 'us-east-1'
+_DEFAULT_AWS_REGION = 'us-east-1'
 
 
 def _fix_region(region):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -395,17 +395,20 @@ def _lock_acquire_step_1(s3_fs, lock_uri, job_key, mins_to_expiration=None):
         key_data = None
 
     # if there's an unexpired lock, give up
-    if key_data and mins_to_expiration is not None:
-        age = datetime.utcnow() - key_data['LastModified']
-        if age <= timedelta(minutes=mins_to_expiration):
+    if key_data:
+        if mins_to_expiration is None:
             return None
+        else:
+            age = datetime.utcnow() - key_data['LastModified']
+            if age <= timedelta(minutes=mins_to_expiration):
+                return None
 
     s3_key.put(Body=job_key.encode('utf_8'))
     return s3_key
 
 
 def _lock_acquire_step_2(key, job_key):
-    key_value = key.get
+    key_value = key.get()['Body'].read()
     return (key_value == job_key.encode('utf_8'))
 
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -383,7 +383,7 @@ def _make_lock_uri(cloud_tmp_dir, cluster_id, step_num):
 # helpers for _attempt_to_acquire_lock()
 
 def _lock_acquire_step_1(s3_fs, lock_uri, job_key, mins_to_expiration=None):
-    s3_key = s3_fs.get_s3_key(lock_uri)
+    s3_key = s3_fs._get_s3_key(lock_uri)
 
     try:
         key_data = s3_key.get()
@@ -1045,7 +1045,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
     def _upload_contents(self, s3_uri, path):
         """Uploads the file at the given path to S3, possibly using
         multipart upload."""
-        s3_key = self.fs.get_s3_key(s3_uri)
+        s3_key = self.fs._get_s3_key(s3_uri)
 
         # you can also disable multipart upload by using s3_key.put()
         # directly, but I didn't want to have to maintain/test multiple

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -269,11 +269,6 @@ _CLUSTER_SELF_TERMINATED_RE = re.compile(
     '^.*The master node was terminated.*$', re.I)
 
 
-def s3_key_to_uri(s3_key):
-    """Convert a boto Key object into an ``s3://`` URI"""
-    return 's3://%s/%s' % (s3_key.bucket.name, s3_key.name)
-
-
 def _repeat(api_call, *args, **kwargs):
     """Make the same API call repeatedly until we've seen every page
     of the response (sets *marker* automatically).
@@ -2783,6 +2778,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         return self._cluster_id
 
     def get_cluster_id(self):
+        """Get the ID of the cluster our job is running on, or ``None``."""
         return self._cluster_id
 
     def _usable_clusters(self, emr_conn=None, exclude=None, num_steps=1):
@@ -3189,7 +3185,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         return self._get_app_versions().get('hadoop')
 
     def get_image_version(self):
-        """Get the AMI that our cluster is running.
+        """Get the version of the AMI that our cluster is running, or ``None``.
 
         .. versionchanged:: 0.5.4
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1030,6 +1030,10 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             ),
         )
 
+    def _get_upload_part_size(self):
+        # part size is in MB, as the minimum is 5 MB
+        return int((self._opts['cloud_upload_part_size'] or 0) * 1024 * 1024)
+
     def _ssh_tunnel_config(self):
         """Look up AMI version, and return a dict with the following keys:
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3320,35 +3320,6 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
         return None
 
-    ### deprecated boto (not boto3) connections ###
-
-    def make_iam_conn(self):
-        """Create a connection to IAM.
-
-        :return: a :py:class:`boto.iam.connection.IAMConnection`, wrapped in a
-                 :py:class:`mrjob.retry.RetryWrapper`
-        """
-        # give a non-cryptic error message if boto isn't installed
-        if boto is None:
-            raise ImportError('You must install boto to use make_iam_conn()')
-
-        log.warning('make_iam_conn() is deprecated and will be removed in'
-                    ' v0.7.0. Use make_iam_client(), which uses boto3,'
-                    ' instead.')
-
-        host = self._opts['iam_endpoint'] or 'iam.amazonaws.com'
-
-        log.debug('creating IAM connection to %s' % host)
-
-        raw_iam_conn = boto.connect_iam(
-            aws_access_key_id=self._opts['aws_access_key_id'],
-            aws_secret_access_key=self._opts['aws_secret_access_key'],
-            host=host,
-            security_token=self._opts['aws_security_token'])
-
-        return wrap_aws_conn(raw_iam_conn)
-
-
 
 def _encode_emr_api_params(x):
     """Recursively unpack parameters to the EMR API."""

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -207,12 +207,12 @@ class S3Filesystem(Filesystem):
             yield uri, key
 
     def md5sum(self, path):
-        k = self.get_s3_key(path)
+        k = self._get_s3_key(path)
         return k.e_tag.strip('"')
 
     def _cat_file(self, filename):
         # stream lines from the s3 key
-        s3_key = self.get_s3_key(filename)
+        s3_key = self._get_s3_key(filename)
         body = s3_key.get()['Body']
 
         return read_file(filename, fileobj=body, yields_lines=False)
@@ -241,7 +241,7 @@ class S3Filesystem(Filesystem):
     def touchz(self, dest):
         """Make an empty file in the given location. Raises an error if
         a non-empty file already exists in that location."""
-        key = self.get_s3_key(dest)
+        key = self._get_s3_key(dest)
 
         data = None
         try:
@@ -334,7 +334,7 @@ class S3Filesystem(Filesystem):
         resource = self.make_s3_resource(region_name)
         return resource.Bucket(bucket_name)
 
-    def get_s3_key(self, uri):
+    def _get_s3_key(self, uri):
         """Get the boto Key object matching the given S3 uri, or
         return None if that key doesn't exist.
 

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -202,8 +202,8 @@ class S3Filesystem(Filesystem):
             dir_glob = path_glob + '*'
 
         bucket = self.get_bucket(bucket_name)
-        for key in bucket.list(base_name):
-            uri = "%s://%s/%s" % (scheme, bucket_name, key.name)
+        for key in bucket.objects.filter(Prefix=base_name):
+            uri = "%s://%s/%s" % (scheme, bucket_name, key.key)
 
             # enforce globbing
             if not (fnmatch.fnmatchcase(uri, path_glob) or

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -297,7 +297,7 @@ class S3Filesystem(Filesystem):
         if boto3 is None:
             raise ImportError('You must install boto3 to connect to S3')
 
-        kwargs = self._client_kwargs(region_name)
+        kwargs = self._client_kwargs(region_name or self._s3_region)
 
         log.debug('creating S3 client (%s)' % (
             kwargs['endpoint_url'] or kwargs['region_name'] or 'default'))
@@ -307,18 +307,12 @@ class S3Filesystem(Filesystem):
     def _client_kwargs(self, region_name):
         """Keyword args for creating resources or clients."""
 
-        # self._s3_endpoint overrides region
-        endpoint_url = None
-        if self._s3_endpoint_url:
-            endpoint_url = self._s3_endpoint_url
-            region_name = self._s3_region
-
         return dict(
             aws_access_key_id=self._aws_access_key_id,
             aws_secret_access_key=self._aws_secret_access_key,
             aws_session_token=self._aws_session_token,
-            endpoint_url=endpoint_url,
-            region_name=region_name,
+            endpoint_url=self._s3_endpoint_url,
+            region_name=(region_name or self._s3_region),
         )
 
     def get_bucket(self, bucket_name):

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""S3 Filesystem.
+
+Also the place for common code used to establish and wrap AWS connections."""
 import fnmatch
 import logging
 import socket
@@ -58,6 +61,14 @@ _EMR_MAX_TRIES = 20  # this takes about a day before we run out of tries
 def s3_key_to_uri(s3_key):
     """Convert a boto Key object into an ``s3://`` URI"""
     return 's3://%s/%s' % (s3_key.bucket.name, s3_key.name)
+
+
+def _endpoint_url(host_or_uri):
+    """If *host_or_url* isn't a URI, prepend ``'https://'``."""
+    if is_uri(host_or_uri):
+        return host_or_uri
+    else:
+        return 'https://' + host_or_uri
 
 
 # only exists for deprecated boto library support, going away in v0.7.0

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -93,6 +93,7 @@ def _is_retriable_client_error(ex):
     """Is the exception from a boto client retriable?"""
     if isinstance(ex, botocore.exceptions.ClientError):
         code = _client_error_code(ex)
+        # "Throttl" catches "Throttled" and "Throttling"
         if any(c in code for c in ('Throttl', 'RequestExpired', 'Timeout')):
             return True
         # spurious 505s thought to be part of an AWS load balancer issue

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -47,6 +47,7 @@ from mrjob.parse import parse_s3_uri
 from mrjob.parse import urlparse
 from mrjob.retry import RetryWrapper
 from mrjob.runner import GLOB_RE
+from mrjob.runner import _BUFFER_SIZE
 from mrjob.util import read_file
 
 
@@ -241,9 +242,11 @@ class S3Filesystem(Filesystem):
         k = self.get_s3_key(path)
         return k.e_tag.strip('"')
 
+    # TODO: start here
     def _cat_file(self, filename):
         # stream lines from the s3 key
         s3_key = self.get_s3_key(filename)
+
         # yields_lines=False: warn read_file that s3_key yields chunks of bytes
         return read_file(
             s3_key_to_uri(s3_key), fileobj=s3_key, yields_lines=False)
@@ -380,6 +383,7 @@ class S3Filesystem(Filesystem):
         bucket_name, key_name = parse_s3_uri(uri)
         return self.get_bucket(bucket_name).Object(key_name)
 
+    # TODO: need to port or remove this
     def make_s3_key(self, uri):
         """Create the given S3 key, and return the corresponding
         boto Key object.

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -373,17 +373,6 @@ class S3Filesystem(Filesystem):
 
         return self.get_bucket(bucket_name).new_key(key_name)
 
-    def get_s3_keys(self, uri):
-        """Get a stream of boto Key objects for each key inside
-        the given dir on S3.
-
-        uri is an S3 URI: ``s3://foo/bar``
-        """
-        bucket_name, key_prefix = parse_s3_uri(uri)
-        bucket = self.get_bucket(bucket_name)
-        for key in bucket.list(key_prefix):
-            yield key
-
     def get_all_bucket_names(self):
         """Get a stream of the names of all buckets owned by this user
         on S3."""

--- a/mrjob/retry.py
+++ b/mrjob/retry.py
@@ -1,5 +1,6 @@
 # Copyright 2009-2013 Yelp, David Marin
 # Copyright 2015 Yelp
+# Copyright 2017 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -160,5 +161,6 @@ class RetryWrapper(object):
                         raise
 
         # pretend to be the original function
-        call_and_maybe_retry.__name__ == f.__name__
+        if hasattr(f, '__name__'):
+            call_and_maybe_retry.__name__ == f.__name__
         return call_and_maybe_retry

--- a/mrjob/tools/emr/terminate_idle_clusters.py
+++ b/mrjob/tools/emr/terminate_idle_clusters.py
@@ -323,7 +323,7 @@ def _terminate_and_notify(runner, cluster_id, cluster_name, num_steps,
         did_terminate = True
     else:
         status = _attempt_to_acquire_lock(
-            runner.fs.make_s3_conn(),
+            runner.fs,
             runner._lock_uri(cluster_id, num_steps),
             runner._opts['cloud_fs_sync_secs'],
             '%s (%s)' % (msg,

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -343,6 +343,21 @@ def to_lines(chunks):
     Only breaks lines on ``\\n`` (not ``\\r``), and does not add
     a trailing newline.
 
+    For efficiency, passes through anything with a ``readline()`` attribute.
+    """
+    # hopefully this is good enough for anything mrjob will encounter
+    if hasattr(chunks, 'readline'):
+        return chunks
+    else:
+        return _to_lines(chunks)
+
+
+def _to_lines(chunks):
+    """Take in data as a sequence of bytes, and yield it, one line at a time.
+
+    Only breaks lines on ``\\n`` (not ``\\r``), and does not add
+    a trailing newline.
+
     Optimizes for:
 
     * chunks bigger than lines (e.g. reading test files)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ try:
             'boto>=2.35.0',
             'boto3>=1.4.4',
             'botocore>=1.5.0',
-            'filechunkio',
             #'google-api-python-client>=1.5.0'  # see below
             'PyYAML>=3.08',
         ],

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -154,8 +154,13 @@ class S3FSRegionTestCase(MockBotoTestCase):
     def test_default_endpoint(self):
         fs = S3Filesystem()
 
-        s3_conn = fs.make_s3_conn()
-        self.assertEqual(s3_conn.host, 's3.amazonaws.com')
+        client = fs.make_s3_client()
+        self.assertEqual(client.meta.endpoint_url,
+                         'https://s3.amazonaws.com')
+
+        resource = fs.make_s3_resource()
+        self.assertEqual(resource.meta.client.meta.endpoint_url,
+                         'https://s3.amazonaws.com')
 
     def test_force_s3_endpoint(self):
         fs = S3Filesystem(s3_endpoint='s3-us-west-1.amazonaws.com')

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -162,11 +162,43 @@ class S3FSRegionTestCase(MockBotoTestCase):
         self.assertEqual(resource.meta.client.meta.endpoint_url,
                          'https://s3.amazonaws.com')
 
-    def test_force_s3_endpoint(self):
-        fs = S3Filesystem(s3_endpoint='s3-us-west-1.amazonaws.com')
+    def test_force_s3_endpoint_host(self):
+        fs = S3Filesystem(s3_endpoint='myproxy')
 
-        s3_conn = fs.make_s3_conn()
-        self.assertEqual(s3_conn.host, 's3-us-west-1.amazonaws.com')
+        client = fs.make_s3_client()
+        self.assertEqual(client.meta.endpoint_url,
+                         'https://myproxy')
+
+        resource = fs.make_s3_resource()
+        self.assertEqual(resource.meta.client.meta.endpoint_url,
+                         'https://myproxy')
+
+    def test_force_s3_endpoint_url(self):
+        fs = S3Filesystem(s3_endpoint='https://myproxy:8080')
+
+        client = fs.make_s3_client()
+        self.assertEqual(client.meta.endpoint_url,
+                         'https://myproxy:8080')
+
+        resource = fs.make_s3_resource()
+        self.assertEqual(resource.meta.client.meta.endpoint_url,
+                         'https://myproxy:8080')
+
+    def test_force_s3_endpoint_region(self):
+        # this is the actual mrjob default region
+        fs = S3Filesystem(s3_region='us-west-2')
+
+        client = fs.make_s3_client()
+        self.assertEqual(client.meta.endpoint_url,
+                         'https://s3-us-west-2.amazonaws.com')
+        self.assertEqual(client.meta.region_name,
+                         'us-west-2')
+
+        resource = fs.make_s3_resource()
+        self.assertEqual(resource.meta.client.meta.endpoint_url,
+                         'https://s3-us-west-2.amazonaws.com')
+        self.assertEqual(resource.meta.client.meta.region_name,
+                         'us-west-2')
 
     def test_endpoint_for_bucket_in_us_west_2(self):
         self.add_mock_s3_data({'walrus': {}}, location='us-west-2')

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -150,6 +150,12 @@ class S3FSTestCase(MockBotoTestCase):
         self.assertEqual(self.fs.exists('s3://walrus/data/foo'), False)
         self.assertEqual(self.fs.exists('s3://walrus/data/bar/baz'), False)
 
+    def test_md5sum(self):
+        self.add_mock_s3_data({
+            'walrus': {'data/foo': b'abcd'}})
+
+        self.assertEqual(self.fs.md5sum('s3://walrus/data/foo'),
+                         'e2fc714c4727ee9395f324cd2e7f331f')
 
 class S3FSRegionTestCase(MockBotoTestCase):
 

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -157,6 +157,7 @@ class S3FSTestCase(MockBotoTestCase):
         self.assertEqual(self.fs.md5sum('s3://walrus/data/foo'),
                          'e2fc714c4727ee9395f324cd2e7f331f')
 
+
 class S3FSRegionTestCase(MockBotoTestCase):
 
     def test_default_endpoint(self):

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -149,13 +149,40 @@ class S3FSTestCase(MockBotoTestCase):
         self.fs.rm('s3://walrus/data')
         self.assertEqual(self.fs.exists('s3://walrus/data/foo'), False)
         self.assertEqual(self.fs.exists('s3://walrus/data/bar/baz'), False)
-
     def test_md5sum(self):
         self.add_mock_s3_data({
             'walrus': {'data/foo': b'abcd'}})
 
         self.assertEqual(self.fs.md5sum('s3://walrus/data/foo'),
                          'e2fc714c4727ee9395f324cd2e7f331f')
+
+    def test_touchz(self):
+        self.add_mock_s3_data({'walrus': {}})
+
+        self.assertEqual(list(self.fs.ls('s3://walrus/')), [])
+
+        self.fs.touchz('s3://walrus/empty')
+
+        self.assertEqual(list(self.fs.ls('s3://walrus/')),
+                         ['s3://walrus/empty'])
+
+    def test_okay_to_touchz_empty_file(self):
+        self.add_mock_s3_data({'walrus': {'empty': b''}})
+
+        self.assertEqual(list(self.fs.ls('s3://walrus/')),
+                         ['s3://walrus/empty'])
+
+        self.fs.touchz('s3://walrus/empty')
+
+        self.assertEqual(list(self.fs.ls('s3://walrus/')),
+                         ['s3://walrus/empty'])
+
+    def test_cant_touchz_file_with_contents(self):
+        self.add_mock_s3_data({'walrus': {'full': b'contents'}})
+
+        self.assertRaises(OSError,
+                          self.fs.touchz, 's3://walrus/full')
+
 
     # TODO: test touchz, mkdir, get_bucket, create_bucket
 

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -157,6 +157,8 @@ class S3FSTestCase(MockBotoTestCase):
         self.assertEqual(self.fs.md5sum('s3://walrus/data/foo'),
                          'e2fc714c4727ee9395f324cd2e7f331f')
 
+    # TODO: test touchz, mkdir, get_bucket, create_bucket
+
     # S3-specific utilities
 
     def test_get_all_bucket_names(self):
@@ -164,8 +166,6 @@ class S3FSTestCase(MockBotoTestCase):
 
         self.assertEqual(list(self.fs.get_all_bucket_names()),
                          ['kitteh', 'walrus'])
-
-
 
 
 class S3FSRegionTestCase(MockBotoTestCase):

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -157,6 +157,16 @@ class S3FSTestCase(MockBotoTestCase):
         self.assertEqual(self.fs.md5sum('s3://walrus/data/foo'),
                          'e2fc714c4727ee9395f324cd2e7f331f')
 
+    # S3-specific utilities
+
+    def test_get_all_bucket_names(self):
+        self.add_mock_s3_data({'walrus': {}, 'kitteh': {}})
+
+        self.assertEqual(list(self.fs.get_all_bucket_names()),
+                         ['kitteh', 'walrus'])
+
+
+
 
 class S3FSRegionTestCase(MockBotoTestCase):
 

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -149,6 +149,7 @@ class S3FSTestCase(MockBotoTestCase):
         self.fs.rm('s3://walrus/data')
         self.assertEqual(self.fs.exists('s3://walrus/data/foo'), False)
         self.assertEqual(self.fs.exists('s3://walrus/data/bar/baz'), False)
+
     def test_md5sum(self):
         self.add_mock_s3_data({
             'walrus': {'data/foo': b'abcd'}})
@@ -369,7 +370,3 @@ class S3FSRegionTestCase(MockBotoTestCase):
                          'https://s3-us-west-2.amazonaws.com')
         self.assertEqual(bucket.meta.client.meta.region_name,
                          'us-west-2')
-
-
-
-# TODO: check buckets that cross regions

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -435,9 +435,20 @@ class MockS3Resource(object):
             )
         )
 
+        self.buckets = MockObject(
+            all=self._buckets_all,
+        )
+
+
     def Bucket(self, name):
         # boto3's Bucket() doesn't care if the bucket exists
         return MockS3Bucket(self.meta.client, name)
+
+    def _buckets_all(self):
+        # technically, this only lists buckets we own, but our mock fs
+        # doesn't simulate buckets owned by others
+        for bucket_name in sorted(self.meta.client.mock_s3_fs):
+            yield self.Bucket(bucket_name)
 
 
 #class MockS3Connection(object):
@@ -650,6 +661,8 @@ class MockS3Object(object):
     def _get_key_data_and_mtime(self):
         """Return (key_data, time_modified)."""
         self._check_key_exists()
+
+        # TODO: check if we're accessing bucket from wrong endpoint
 
         mock_s3_fs = self.meta.client.mock_s3_fs
         return mock_s3_fs[self.bucket_name]['keys'][self.key]

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -608,7 +608,7 @@ class MockS3Object(object):
         if hasattr(self, key):
             return getattr(self, key)
         else:
-            raise AttributeException(
+            raise AttributeError(
                 "'s3.Object' object has no attribute '%s'" % key)
 
     def _check_bucket_exists(self, operation_name):

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -176,6 +176,7 @@ class MockBotoTestCase(SandboxedTestCase):
             None, self.MAX_EMR_CONNECTIONS)
 
         self.start(patch.object(boto3, 'client', self.client))
+        self.start(patch.object(boto3, 'resource', self.resource))
 
         self.start(patch.object(boto, 'connect_s3', self.connect_s3))
         self.start(patch.object(
@@ -319,6 +320,10 @@ class MockBotoTestCase(SandboxedTestCase):
             return MockIAMClient(**kwargs)
         else:
             raise ValueError
+
+    # mock boto3.resource()
+    def resource(self, service_name, **kwargs):
+        raise NotImplementedError
 
 
 ### S3 ###

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -645,7 +645,15 @@ class MockS3Object(object):
 
         mock_keys = self._mock_bucket_keys('PutObject')
 
-        mock_keys[self.key] = (Body, datetime.utcnow())
+        if isinstance(Body, bytes):
+            contents = Body
+        elif hasattr(Body, 'read'):
+            contents = Body.read()
+
+        if not isinstance(contents, bytes):
+            raise TypeError('Body or Body.read() must be bytes')
+
+        mock_keys[self.key] = (contents, datetime.utcnow())
 
     def upload_file(self, path, Config=None):
         if self.bucket_name not in self.meta.client.mock_s3_fs:

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1805,8 +1805,15 @@ class MockIAMClient(object):
         self.mock_iam_role_attached_policies = combine_values(
             {}, mock_iam_role_attached_policies)
 
-        # so we can easily check this
-        self.endpoint_url = endpoint_url
+        # use botocore to translate region_name to endpoint_url
+        real_client = real_boto3_client(
+            'iam',
+            endpoint_url=endpoint_url,
+            config=botocore.config.Config(region_name='aws-global'))
+
+        self.meta = MockObject(
+            endpoint_url=real_client.meta.endpoint_url,
+            region_name=real_client.meta.region_name)
 
     def get_paginator(self, operation_name):
         return MockPaginator(

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -439,7 +439,6 @@ class MockS3Resource(object):
             all=self._buckets_all,
         )
 
-
     def Bucket(self, name):
         # boto3's Bucket() doesn't care if the bucket exists
         return MockS3Bucket(self.meta.client, name)

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -617,6 +617,15 @@ class MockS3Object(object):
             LastModified=mtime,
         )
 
+    @property
+    def size(self):
+        try:
+            key_data, mtime = self._get_key_data_and_mtime()
+            return len(key_data)
+        except ClientError:
+            # implemented through __getattr__()
+            raise AttributeError("'s3.Object' object has no attribute 'size'")
+
 #    def read_mock_data(self):
 #        """Read the bytes for this key out of the fake boto state."""
 #        if self.name in self.bucket.mock_state():

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -539,14 +539,15 @@ class MockS3Bucket(object):
         self.name = name
         self.meta = MockObject(client=client)
 
-        self.objects = MockObject(filter=self._objects_filter)
+        self.objects = MockObject(
+            all=self._objects_all,
+            filter=self._objects_filter)
 
     def Object(self, key):
         return MockS3Object(self.meta.client, self.name, key)
 
-    def _check_bucket_exists(self, operation_name):
-        if self.name not in self.meta.client.mock_s3_fs:
-            raise _no_such_bucket_error(self.name, operation_name)
+    def _objects_all(self):
+        return self._objects_filter()
 
     def _objects_filter(self, Prefix=None):
         self._check_bucket_exists('ListObjects')
@@ -562,6 +563,11 @@ class MockS3Bucket(object):
             # emulate ObjectSummary by pre-filling size, e_tag, etc.
             key.get()
             yield key
+
+    def _check_bucket_exists(self, operation_name):
+        if self.name not in self.meta.client.mock_s3_fs:
+            raise _no_such_bucket_error(self.name, operation_name)
+
 
 #    def mock_state(self):
 #        """Returns a dictionary from key to data representing the

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -420,6 +420,16 @@ class MockS3Client(object):
         if bucket_name not in self.mock_s3_fs:
             raise _no_such_bucket_error(bucket_name, operation_name)
 
+    def create_bucket(self, Bucket, CreateBucketConfiguration=None):
+        # boto3 doesn't seem to mind if you try to create a bucket that exists
+        if Bucket not in self.mock_s3_fs:
+            location = (CreateBucketConfiguration or {}).get(
+                'LocationConstraint', '')
+            self.mock_s3_fs[Bucket] = dict(keys={}, location=location)
+
+        # "Location" here actually refers to the bucket name
+        return dict(Location=('/' + Bucket))
+
     def get_bucket_location(self, Bucket):
         self._check_bucket_exists(Bucket, 'GetBucketLocation')
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3996,10 +3996,6 @@ class SecurityTokenTestCase(MockBotoTestCase):
         self.mock_client = self.start(patch('boto3.client'))
         self.mock_resource = self.start(patch('boto3.resource'))
 
-        # runner needs to do stuff with S3 on initialization
-        self.mock_s3 = self.start(patch('boto.connect_s3',
-                                        wraps=boto.connect_s3))
-
     def assert_conns_use_security_token(self, runner, security_token):
         runner.make_emr_conn()
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4345,13 +4345,14 @@ class IAMEndpointTestCase(MockBotoTestCase):
         runner = EMRJobRunner()
 
         iam_client = runner.make_iam_client()
-        self.assertEqual(iam_client.endpoint_url, 'https://iam.amazonaws.com')
+        self.assertEqual(iam_client.meta.endpoint_url,
+                         'https://iam.amazonaws.com')
 
     def test_explicit_iam_endpoint(self):
         runner = EMRJobRunner(iam_endpoint='https://iam.us-gov.amazonaws.com')
 
         iam_client = runner.make_iam_client()
-        self.assertEqual(iam_client.endpoint_url,
+        self.assertEqual(iam_client.meta.endpoint_url,
                          'https://iam.us-gov.amazonaws.com')
 
     def test_iam_endpoint_option(self):
@@ -4361,7 +4362,7 @@ class IAMEndpointTestCase(MockBotoTestCase):
 
         with mr_job.make_runner() as runner:
             iam_client = runner.make_iam_client()
-            self.assertEqual(iam_client.endpoint_url,
+            self.assertEqual(iam_client.meta.endpoint_url,
                              'https://iam.us-gov.amazonaws.com')
 
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5352,8 +5352,6 @@ class WaitForStepsToCompleteTestCase(MockBotoTestCase):
         self.start(patch.object(
             runner, '_check_for_missing_default_iam_roles'))
         self.start(patch.object(
-            runner, '_check_for_key_pair_from_wrong_region'))
-        self.start(patch.object(
             runner, '_check_for_failed_bootstrap_action',
             side_effect=self.StopTest))
 
@@ -5361,7 +5359,6 @@ class WaitForStepsToCompleteTestCase(MockBotoTestCase):
                           runner._wait_for_steps_to_complete)
 
         self.assertTrue(runner._check_for_missing_default_iam_roles.called)
-        self.assertTrue(runner._check_for_key_pair_from_wrong_region.called)
         self.assertTrue(runner._check_for_failed_bootstrap_action.called)
 
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -46,7 +46,6 @@ from mrjob.emr import _list_all_steps
 from mrjob.emr import _yield_all_bootstrap_actions
 from mrjob.emr import _yield_all_clusters
 from mrjob.emr import _yield_all_instance_groups
-from mrjob.emr import filechunkio
 from mrjob.job import MRJob
 from mrjob.parse import parse_s3_uri
 from mrjob.pool import _pool_hash_and_name
@@ -3936,7 +3935,6 @@ class MultiPartUploadTestCase(MockBotoTestCase):
 
         self.assert_upload_succeeds(runner, data, expect_multipart=False)
 
-    @skipIf(filechunkio is None, 'need filechunkio')
     def test_large_file(self):
         # Real S3 has a minimum chunk size of 5MB, but I'd rather not
         # store that in memory (in our mock S3 filesystem)
@@ -3970,7 +3968,6 @@ class MultiPartUploadTestCase(MockBotoTestCase):
                 self.assert_upload_succeeds(runner, data,
                                             expect_multipart=False)
 
-    @skipIf(filechunkio is None, 'need filechunkio')
     def test_exception_while_uploading_large_file(self):
 
         runner = EMRJobRunner(cloud_upload_part_size=self.PART_SIZE_IN_MB)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3926,7 +3926,7 @@ class MultiPartUploadTestCase(MockBotoTestCase):
         with patch.object(runner, '_upload_parts', wraps=runner._upload_parts):
             self.upload_data(runner, data)
 
-            s3_key = runner.fs.get_s3_key(self.TEST_S3_URI)
+            s3_key = runner.fs._get_s3_key(self.TEST_S3_URI)
             self.assertEqual(s3_key.get_contents_as_string(), data)
             self.assertEqual(runner._upload_parts.called, expect_multipart)
 
@@ -3981,7 +3981,7 @@ class MultiPartUploadTestCase(MockBotoTestCase):
         with patch.object(runner, '_upload_parts', side_effect=IOError):
             self.assertRaises(IOError, self.upload_data, runner, data)
 
-            s3_key = runner.fs.get_s3_key(self.TEST_S3_URI)
+            s3_key = runner.fs._get_s3_key(self.TEST_S3_URI)
             self.assertTrue(s3_key.mock_multipart_upload_was_cancelled())
 
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -84,6 +84,7 @@ from tests.py2 import patch
 from tests.py2 import skipIf
 from tests.quiet import logger_disabled
 from tests.quiet import no_handlers_for_logger
+from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_conf_patcher
 from tests.test_hadoop import HadoopExtraArgsTestCase
 from tests.test_local import _bash_wrap
@@ -1349,22 +1350,11 @@ class TestSSHLs(MockBotoTestCase):
                           self.runner.fs.ls('ssh://testmaster/does_not_exist'))
 
 
-class TestNoBoto(TestCase):
+class NoBoto3TestCase(SandboxedTestCase):
 
     def setUp(self):
-        self.blank_out_boto()
-
-    def tearDown(self):
-        self.restore_boto()
-
-    def blank_out_boto(self):
-        self._real_boto = mrjob.emr.boto
-        mrjob.emr.boto = None
-        mrjob.fs.s3.boto = None
-
-    def restore_boto(self):
-        mrjob.emr.boto = self._real_boto
-        mrjob.fs.s3.boto = self._real_boto
+        self.start(patch('mrjob.emr.boto3', None))
+        self.start(patch('mrjob.fs.s3.boto3', None))
 
     def test_init(self):
         # merely creating an EMRJobRunner should raise an exception

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1806,9 +1806,9 @@ class RemoteCreateDirArchiveTestCase(MockBotoTestCase):
 
         fs = S3Filesystem()
 
-        fs.create_bucket('walrus')
-        fs.make_s3_key('s3://walrus/archive/foo')
-        fs.make_s3_key('s3://walrus/archive/bar/baz')
+        self.add_mock_s3_data(
+            {'walrus': {'archive/foo': b'foo',
+                        'archive/bar/baz': b'baz'}})
 
     def test_archive_remote_data(self):
         runner = EMRJobRunner()


### PR DESCRIPTION
mrjob now uses `boto3` for all of its S3 needs. This fixes the S3 part of #1304 (only EMR left).