### PR TITLE
boto3 tzutc() fix

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -397,7 +397,9 @@ def _attempt_to_acquire_lock(s3_fs, lock_uri, sync_wait_time, job_key,
         if mins_to_expiration is None:
             return False
         else:
-            age = datetime.utcnow() - key_data['LastModified']
+            # dateutil is a boto3 dependency
+            from dateutil.tz import tzutc
+            age = datetime.now(tzutc()) - key_data['LastModified']
             if age <= timedelta(minutes=mins_to_expiration):
                 return False
 

--- a/mrjob/tools/emr/s3_tmpwatch.py
+++ b/mrjob/tools/emr/s3_tmpwatch.py
@@ -49,6 +49,8 @@ from datetime import timedelta
 import logging
 from optparse import OptionParser
 
+from dateutil.tz import tzutc
+
 from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_options
@@ -89,7 +91,7 @@ def _s3_cleanup(glob_path, time_old, dry_run=False, **runner_kwargs):
              (glob_path, time_old))
 
     for path, key in runner.fs._ls(glob_path):
-        age = datetime.utcnow() - key.last_modified
+        age = datetime.now(tzutc()) - key.last_modified
         if age > time_old:
             # Delete it
             log.info('Deleting %s; is %s old' % (path, age))

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -29,6 +29,7 @@ import boto3
 import botocore.config
 from boto3.exceptions import S3UploadFailedError
 from botocore.exceptions import ClientError
+from dateutil.tz import tzutc
 
 try:
     import boto.emr.connection
@@ -346,7 +347,7 @@ def add_mock_s3_data(mock_s3_fs, data, time_modified=None, location=None):
     :param location string: the bucket's location cosntraint (a region name)
     """
     if time_modified is None:
-        time_modified = datetime.utcnow()
+        time_modified = datetime.now(tzutc())
     for bucket_name, key_name_to_bytes in data.items():
         bucket = mock_s3_fs.setdefault(bucket_name,
                                        {'keys': {}, 'location': ''})
@@ -572,7 +573,7 @@ class MockS3Object(object):
         if not isinstance(data, bytes):
             raise TypeError('Body or Body.read() must be bytes')
 
-        mock_keys[self.key] = (data, datetime.utcnow())
+        mock_keys[self.key] = (data, datetime.now(tzutc()))
 
     def upload_file(self, path, Config=None):
         if self.bucket_name not in self.meta.client.mock_s3_fs:
@@ -584,7 +585,7 @@ class MockS3Object(object):
 
         mock_keys = self._mock_bucket_keys('PutObject')
         with open(path, 'rb') as f:
-            mock_keys[self.key] = (f.read(), datetime.utcnow())
+            mock_keys[self.key] = (f.read(), datetime.now(tzutc()))
 
     def __getattr__(self, key):
         if key in ('e_tag', 'last_modified', 'size'):
@@ -1616,7 +1617,7 @@ class MockIAMClient(object):
         role = dict(
             Arn=('arn:aws:iam::012345678901:role/%s' % RoleName),
             AssumeRolePolicyDocument=json.loads(AssumeRolePolicyDocument),
-            CreateDate=datetime.utcnow(),
+            CreateDate=datetime.now(tzutc()),
             Path='/',
             RoleId='AROAMOCKMOCKMOCKMOCK',
             RoleName=RoleName,
@@ -1682,7 +1683,7 @@ class MockIAMClient(object):
         profile = dict(
             Arn=('arn:aws:iam::012345678901:instance-profile/%s' %
                  InstanceProfileName),
-            CreateDate=datetime.utcnow(),
+            CreateDate=datetime.now(tzutc()),
             InstanceProfileId='AIPAMOCKMOCKMOCKMOCK',
             InstanceProfileName=InstanceProfileName,
             Path='/',

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -23,6 +23,7 @@ import shutil
 import tempfile
 import time
 from datetime import datetime
+from datetime import timedelta
 from io import BytesIO
 
 import boto3
@@ -202,10 +203,10 @@ class MockBotoTestCase(SandboxedTestCase):
 
         self.start(patch.object(time, 'sleep'))
 
-    def add_mock_s3_data(self, data, time_modified=None, location=None):
+    def add_mock_s3_data(self, data, age=None, location=None):
         """Update self.mock_s3_fs with a map from bucket name
         to key name to data."""
-        add_mock_s3_data(self.mock_s3_fs, data, time_modified, location)
+        add_mock_s3_data(self.mock_s3_fs, data, age, location)
 
     def add_mock_emr_cluster(self, cluster):
         if cluster.id in self.mock_emr_clusters:
@@ -340,14 +341,15 @@ class MockBotoTestCase(SandboxedTestCase):
 
 ### S3 ###
 
-def add_mock_s3_data(mock_s3_fs, data, time_modified=None, location=None):
+def add_mock_s3_data(mock_s3_fs, data, age=None, location=None):
     """Update mock_s3_fs with a map from bucket name to key name to data.
 
-    :param last_modified: a UTC :py:class:`~datetime.datetime`
+    :param age: a timedelta
     :param location string: the bucket's location cosntraint (a region name)
     """
-    if time_modified is None:
-        time_modified = datetime.now(tzutc())
+    age = age or timedelta(0)
+    time_modified = datetime.now(tzutc()) - age
+
     for bucket_name, key_name_to_bytes in data.items():
         bucket = mock_s3_fs.setdefault(bucket_name,
                                        {'keys': {}, 'location': ''})

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2870,7 +2870,7 @@ class S3LockTestCase(MockBotoTestCase):
         # add an expired lock
         self.add_mock_s3_data({'locks': {
             'expired_lock': b'x',
-        }}, datetime.now(tzutc()) - timedelta(minutes=30))
+        }}, age=timedelta(minutes=30))
 
         did_lock = _attempt_to_acquire_lock(
             runner.fs, 's3://locks/expired_lock', 5.0, 'job_one',

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -27,6 +27,7 @@ from datetime import timedelta
 from io import BytesIO
 
 import boto3
+from dateutil.tz import tzutc
 
 import mrjob
 import mrjob.emr
@@ -2869,7 +2870,7 @@ class S3LockTestCase(MockBotoTestCase):
         # add an expired lock
         self.add_mock_s3_data({'locks': {
             'expired_lock': b'x',
-        }}, datetime.utcnow() - timedelta(minutes=30))
+        }}, datetime.now(tzutc()) - timedelta(minutes=30))
 
         did_lock = _attempt_to_acquire_lock(
             runner.fs, 's3://locks/expired_lock', 5.0, 'job_one',

--- a/tests/tools/emr/test_s3_tmpwatch.py
+++ b/tests/tools/emr/test_s3_tmpwatch.py
@@ -54,12 +54,12 @@ class S3TmpWatchTestCase(MockBotoTestCase):
         self.add_mock_s3_data(
             {'walrus': {'data/bar': b'bar\n',
                         'other/baz': b'baz\n'}},
-            time_modified=(datetime.now(tzutc()) - timedelta(days=45)))
+            age=timedelta(days=45))
 
         # qux is a little more than two days old
         self.add_mock_s3_data(
             {'walrus': {'data/qux': b'qux\n'}},
-            time_modified=(datetime.now(tzutc()) - timedelta(hours=50)))
+            age=timedelta(hours=50))
 
         self.assertEqual(
             sorted(runner.fs.ls('s3://walrus/')),

--- a/tests/tools/emr/test_s3_tmpwatch.py
+++ b/tests/tools/emr/test_s3_tmpwatch.py
@@ -18,6 +18,8 @@ from datetime import timedelta
 import tempfile
 import shutil
 
+from dateutil.tz import tzutc
+
 from mrjob.emr import EMRJobRunner
 from mrjob.tools.emr.s3_tmpwatch import _s3_cleanup
 from tests.mockboto import MockBotoTestCase
@@ -52,12 +54,12 @@ class S3TmpWatchTestCase(MockBotoTestCase):
         self.add_mock_s3_data(
             {'walrus': {'data/bar': b'bar\n',
                         'other/baz': b'baz\n'}},
-            time_modified=(datetime.utcnow() - timedelta(days=45)))
+            time_modified=(datetime.now(tzutc()) - timedelta(days=45)))
 
         # qux is a little more than two days old
         self.add_mock_s3_data(
             {'walrus': {'data/qux': b'qux\n'}},
-            time_modified=(datetime.utcnow() - timedelta(hours=50)))
+            time_modified=(datetime.now(tzutc()) - timedelta(hours=50)))
 
         self.assertEqual(
             sorted(runner.fs.ls('s3://walrus/')),

--- a/tests/tools/emr/test_terminate_idle_clusters.py
+++ b/tests/tools/emr/test_terminate_idle_clusters.py
@@ -185,7 +185,7 @@ class ClusterTerminationTestCase(MockBotoTestCase):
             'my_bucket': {
                 'locks/j-IDLE_AND_LOCKED/2': b'not_you',
             },
-        }, time_modified=self.now)
+        })
 
         # idle cluster with an expired lock
         self.add_mock_emr_cluster(MockEmrObject(
@@ -203,7 +203,7 @@ class ClusterTerminationTestCase(MockBotoTestCase):
             'my_bucket': {
                 'locks/j-IDLE_AND_EXPIRED/2': b'not_you',
             },
-        }, time_modified=(self.now - timedelta(minutes=5)))
+        }, age=timedelta(minutes=5))
 
         # idle cluster with an expired lock
         self.add_mock_emr_cluster(MockEmrObject(


### PR DESCRIPTION
Turns out if you want to interact with `boto3` `datetime`s, you need to specify a timezone. This updates `boto3` code (everything having to do with S3 and IAM) to specify `dateutil.tz.tzutc()` as the time zone.

`dateutil` is a dependency of `boto3`. Might want to add it explicitly.