### PR TITLE
boto3 StreamingBody fix

### DIFF
--- a/mrjob/cat.py
+++ b/mrjob/cat.py
@@ -102,6 +102,7 @@ def decompress(fileobj, path, bufsize=1024):
         return _yield_chunks(fileobj, bufsize=bufsize)
 
 
+# TODO: name this to_chunks()
 def _yield_chunks(readable, bufsize=1024):
     while True:
         chunk = readable.read(bufsize)

--- a/mrjob/cat.py
+++ b/mrjob/cat.py
@@ -82,7 +82,7 @@ def gunzip_stream(fileobj, bufsize=1024):
             yield data
 
 
-def decompress(fileobj, path):
+def decompress(fileobj, path, bufsize=1024):
     """Take a *fileobj* correponding to the given path and returns an iterator
     that yield chunks of bytes, or, if *path* doesn't correspond to a
     compressed file type, *fileobj* itself.
@@ -95,8 +95,20 @@ def decompress(fileobj, path):
                             ' (likely not installed).')
         else:
             return bunzip2_stream(fileobj)
-    else:
+    elif hasattr(fileobj, '__iter__'):
         return fileobj
+    else:
+        # not a real fileobj (e.g. boto3 StreamingBody)
+        return _yield_chunks(fileobj, bufsize=bufsize)
+
+
+def _yield_chunks(readable, bufsize=1024):
+    while True:
+        chunk = readable.read(bufsize)
+        if chunk:
+            yield chunk
+        else:
+            return
 
 
 def _main():

--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -555,7 +555,7 @@ class MockS3Object(object):
         self.size = len(key_data)
 
         return dict(
-            Body=BytesIO(key_data),
+            Body=MockStreamingBody(key_data),
             ContentLength=self.size,
             ETag=self.e_tag,
             LastModified=self.last_modified,
@@ -619,6 +619,28 @@ class MockS3Object(object):
             raise _no_such_key_error(self.key, 'GetObject')
 
         return mock_keys[self.key]
+
+
+class MockStreamingBody(object):
+    """Mock of boto3's not-really-a-fileobj for reading from S3"""
+
+    def __init__(self, data):
+        if not isinstance(data, bytes):
+            raise TypeError
+
+        self._data = data
+        self._offset = 0
+
+    def read(self, amt=None):
+        start = self._offset
+
+        if amt is None:
+            end = len(self._data)
+        else:
+            end = start + amt
+
+        self._offset = end
+        return self._data[start:end]
 
 
 ### EMR ###


### PR DESCRIPTION
Turns out `boto3`'s `StreamingBody` isn't *really* a fileobj. This fixes the way we deal with `StreamingBody` so that we can `cat()` data from S3 again.
