### PR TITLE
fix unzip stall when bootstrapping mrjob

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -878,9 +878,7 @@ class DataprocJobRunner(MRJobRunner):
                  ' -f $__mrjob_PYTHON_LIB/mrjob && true' %
                  cmd_line(self._python_bin())])
 
-        # we call the script b.py because there's a character limit on
-        # bootstrap script names (or there was at one time, anyway)
-        path = os.path.join(self._get_local_tmp_dir(), 'b.py')
+        path = os.path.join(self._get_local_tmp_dir(), 'b.sh')
         log.info('writing master bootstrap script to %s' % path)
 
         contents = self._master_bootstrap_script_content(

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -826,6 +826,8 @@ class DataprocJobRunner(MRJobRunner):
 
     ### Bootstrapping ###
 
+    # TODO: merge code shared with emr.py
+
     def _create_master_bootstrap_script_if_needed(self):
         """Helper for :py:meth:`_add_bootstrap_files_for_upload`.
 
@@ -859,9 +861,14 @@ class DataprocJobRunner(MRJobRunner):
                 "'from distutils.sysconfig import get_python_lib;"
                 " print(get_python_lib())')" %
                 cmd_line(self._python_bin())])
+
+            # remove anything that might be in the way (see #1567)
+            mrjob_bootstrap.append(['sudo rm -rf $__mrjob_PYTHON_LIB/mrjob'])
+
             # unzip mrjob.zip
             mrjob_bootstrap.append(
                 ['sudo unzip ', path_dict, ' -d $__mrjob_PYTHON_LIB'])
+
             # re-compile pyc files now, since mappers/reducers can't
             # write to this directory. Don't fail if there is extra
             # un-compileable crud in the tarball (this would matter if

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2575,7 +2575,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         # TODO: shouldn't it be b.sh now?
         # we call the script b.py because there's a character limit on
         # bootstrap script names (or there was at one time, anyway)
-        path = os.path.join(self._get_local_tmp_dir(), 'b.py')
+        path = os.path.join(self._get_local_tmp_dir(), 'b.sh')
         log.debug('writing master bootstrap script to %s' % path)
 
         contents = self._master_bootstrap_script_content(

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2556,9 +2556,14 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 "'from distutils.sysconfig import get_python_lib;"
                 " print(get_python_lib())')" %
                 cmd_line(self._python_bin())])
+
+            # remove anything that might be in the way (see #1567)
+            mrjob_bootstrap.append(['sudo rm -rf $__mrjob_PYTHON_LIB/mrjob'])
+
             # copy mrjob.zip over
             mrjob_bootstrap.append(
                 ['sudo unzip ', path_dict, ' -d $__mrjob_PYTHON_LIB'])
+
             # re-compile pyc files now, since mappers/reducers can't
             # write to this directory. Don't fail if there is extra
             # un-compileable crud in the tarball (this would matter if

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1661,7 +1661,7 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
 
         # check for master bootstrap script
         self.assertTrue(actions[1].scriptpath.startswith('s3://mrjob-'))
-        self.assertTrue(actions[1].scriptpath.endswith('b.py'))
+        self.assertTrue(actions[1].scriptpath.endswith('b.sh'))
         self.assertEqual(actions[1].args, [])
         self.assertEqual(actions[1].name, 'master')
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1613,7 +1613,7 @@ class MasterBootstrapScriptTestCase(MockBotoTestCase):
 
         # check for master bootstrap script
         self.assertTrue(actions[2].scriptpath.startswith('s3://mrjob-'))
-        self.assertTrue(actions[2].scriptpath.endswith('b.py'))
+        self.assertTrue(actions[2].scriptpath.endswith('b.sh'))
         self.assertEqual(actions[2].args, [])
         self.assertEqual(actions[2].name, 'master')
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -25,6 +25,7 @@ from io import BytesIO
 
 import mrjob
 from mrjob.local import LocalMRJobRunner
+from mrjob.step import StepFailedException
 from mrjob.util import bash_wrap
 from mrjob.util import cmd_line
 from mrjob.util import read_file
@@ -496,11 +497,12 @@ class LocalBootstrapMrjobTestCase(TestCase):
                 try:
                     with no_handlers_for_logger():
                         runner.run()
-                except Exception as e:
-                    # if mrjob is not installed, script won't be able to run
-                    self.assertIn('ImportError', str(e))
+                except StepFailedException:
+                    # this is what happens when mrjob isn't installed elsewhere
                     return
 
+                # however, if mrjob is installed, we need to verify that
+                # we're using the installed version and not a bootstrapped copy
                 output = list(runner.stream_output())
 
                 self.assertEqual(len(output), 1)


### PR DESCRIPTION
This fixes an edge case that can happen when mrjob is already installed and then we try to unzip our bootstrapped mrjob in the same directory, causing `unzip` to go into interactive mode and wait forever. Fixes #1567.

Also fixed the file extension of the master bootstrap script (fixes #1504).

This affects both Dataproc and EMR (which probably should share common code).

