### PR TITLE
Add support for rapidjson

### DIFF
--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -377,8 +377,10 @@ See :py:mod:`mrjob.protocol` for the full list of protocols built-in to mrjob.
     an alias for one of two different protocols depending on your Python
     version.
 
-.. [#json] |JSONProtocol| is an alias for one of two different implementations;
-    we try to use the (much faster) :py:mod:`ujson` library if it is available.
+.. [#json] |JSONProtocol| is an alias for one of four different
+    implementations; we try to use the (much faster) :py:mod:`ujson` library
+    if it is available, and if not, :py:mod:`rapidjson` or :py:mod:`simplejson`
+    before falling back to the built-in :py:mod:`json` implementation.
 
 Data flow walkthrough by example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/protocols.rst
+++ b/docs/protocols.rst
@@ -34,17 +34,18 @@ JSON
 ----
 .. py:class:: JSONProtocol
 
-    Encode ``(key, value)`` as two JSONs separated by a tab.
+   Encode ``(key, value)`` as two JSONs separated by a tab.
 
-    **This is the default protocol used by jobs to write output and communicate
-    between steps.**
+   **This is the default protocol used by jobs to write output and communicate
+   between steps.**
 
-    This is an alias for :py:class:`UltraJSONProtocol` if :py:mod:`ujson`
-    is installed, :py:class:`SimpleJSONProtocol` if :py:mod:`simplejson`
-    is installed and :py:mod:`ujson` is not and
-    :py:class:`StandardJSONProtocol` if neither is installed.
+   This is an alias for the first one of :py:class:`UltraJSONProtocol`,
+   :py:class:`RapidJSONProtocol`, :py:class:`SimpleJSONProtocol`,
+   or :py:class:`StandardJSONProtocol` for which the underlying library is
+   available.
 
 .. autoclass:: UltraJSONProtocol
+.. autoclass:: RapidJSONProtocol
 .. autoclass:: SimpleJSONProtocol
 .. autoclass:: StandardJSONProtocol
 
@@ -53,12 +54,13 @@ JSON
    Encode ``value`` as a JSON and discard ``key`` (``key`` is read in as
    ``None``).
 
-    This is an alias for :py:class:`UltraJSONValueProtocol` if :py:mod:`ujson`
-    is installed, :py:class:`SimpleJSONValueProtocol` if :py:mod:`simplejson`
-    is installed and :py:mod:`ujson` is not and
-    :py:class:`StandardJSONValueProtocol` if neither is installed.
+   This is an alias for the first one of :py:class:`UltraJSONValueProtocol`,
+   :py:class:`RapidJSONValueProtocol`, :py:class:`SimpleJSONValueProtocol`,
+   or :py:class:`StandardJSONValueProtocol` for which the underlying library is
+   available.
 
 .. autoclass:: UltraJSONValueProtocol
+.. autoclass:: RapidJSONValueProtocol
 .. autoclass:: SimpleJSONValueProtocol
 .. autoclass:: StandardJSONValueProtocol
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ try:
         ],
         'provides': ['mrjob'],
         'test_suite': 'tests.suite.load_tests',
+        'tests_require': ['simplejson'],
         'zip_safe': False,  # so that we can bootstrap mrjob
     }
 
@@ -46,9 +47,12 @@ try:
         setuptools_kwargs['install_requires'].append(
             'google-api-python-client>=1.5.0')
 
+    if sys.version_info >= (3, 0):
+        setuptools_kwargs['extras_require']['rapidjson'] = ['rapidjson']
+
     # mock is included in Python 3.3 as unittest.mock
     if sys.version_info < (3, 3):
-        setuptools_kwargs['tests_require'] = ['mock']
+        setuptools_kwargs['tests_require'].append('mock')
 
         # unittest2 is a backport of unittest from Python 2.7
         if sys.version_info < (2, 7):


### PR DESCRIPTION
mrjob will now use `rapidjson` by default if it's installed and `ujson` isn't available. Fixes #1579.

