### PR TITLE
aws_session_token option rename

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -36,7 +36,7 @@ about setting these options.
     :envvar:`AWS_SECRET_ACCESS_KEY` instead.
 
 .. mrjob-opt::
-    :config: aws_security_token
+    :config: aws_session_token
     :type: :ref:`string <data-type-string>`
     :set: emr
     :default: ``None``
@@ -47,6 +47,10 @@ about setting these options.
     There isn't a command-line switch for this option because credentials are
     supposed to be secret! Use the environment variable
     :envvar:`AWS_SECURITY_TOKEN` instead.
+
+    .. versionchanged:: 0.5.10
+
+       this used to be called *aws_security_token*.
 
 .. mrjob-opt::
     :config: ec2_key_pair

--- a/mrjob.conf.example
+++ b/mrjob.conf.example
@@ -17,7 +17,7 @@ runners:
     aws_access_key_id: AKIAAAAAAAAAAAAAAAAAAAAAAAAAAAA
     aws_secret_access_key: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
     # instead of keys, you can use a temporary security token
-    #aws_security_token: AREALLYLONGHASH
+    #aws_session_token: AREALLYLONGHASH
     # $BT is the path to our source tree. This lets us add modules to
     # install on EMR by simply dumping them in this dir.
     bootstrap_python_packages:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -573,7 +573,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         if not opt_value:
             return opt_value
 
-        if opt_key in ('aws_secret_access_key', 'aws_security_token'):
+        if opt_key in ('aws_secret_access_key', 'aws_session_token'):
             # don't expose any part of secret credentials
             return '...'
         elif opt_key == 'aws_access_key_id':
@@ -890,7 +890,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             s3_fs = S3Filesystem(
                 aws_access_key_id=self._opts['aws_access_key_id'],
                 aws_secret_access_key=self._opts['aws_secret_access_key'],
-                aws_security_token=self._opts['aws_security_token'],
+                aws_security_token=self._opts['aws_session_token'],
                 s3_endpoint=self._opts['s3_endpoint'])
 
             if self._opts['ec2_key_pair_file']:
@@ -3319,7 +3319,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                 region=boto.regioninfo.RegionInfo(
                     name=self._opts['region'], endpoint=endpoint,
                     connection_cls=boto.emr.connection.EmrConnection),
-                security_token=self._opts['aws_security_token'])
+                security_token=self._opts['aws_session_token'])
 
             return conn
 
@@ -3461,7 +3461,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             aws_access_key_id=self._opts['aws_access_key_id'],
             aws_secret_access_key=self._opts['aws_secret_access_key'],
             host=host,
-            security_token=self._opts['aws_security_token'])
+            security_token=self._opts['aws_session_token'])
 
         return wrap_aws_conn(raw_iam_conn)
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -268,8 +268,9 @@ _RUNNER_OPTS = dict(
         cloud_role='connect',
         runners=['emr'],
     ),
-    aws_security_token=dict(
+    aws_session_token=dict(
         cloud_role='connect',
+        deprecated_aliases=['aws_security_token'],
         runners=['emr'],
     ),
     bootstrap=dict(

--- a/mrjob/protocol.py
+++ b/mrjob/protocol.py
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Yelp and Contributors
-# Copyright 2015-2016 Yelp
+# Copyright 2015-2017 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mrjob/setup.py
+++ b/mrjob/setup.py
@@ -1,6 +1,7 @@
 # Copyright 2012 Yelp and Contributors
 # Copyright 2013 David Marin and Lyft
 # Copyright 2014-2016 Yelp and Contributors
+# Copyright 2017 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4120,22 +4120,22 @@ class SessionTokenTestCase(MockBotoTestCase):
 
         self.assertTrue(self.mock_emr.called)
         emr_kwargs = self.mock_emr.call_args[1]
-        self.assertIn('session_token', emr_kwargs)
-        self.assertEqual(emr_kwargs['session_token'], session_token)
+        self.assertIn('security_token', emr_kwargs)
+        self.assertEqual(emr_kwargs['security_token'], session_token)
 
         runner.make_iam_conn()
 
         self.assertTrue(self.mock_iam.called)
         iam_kwargs = self.mock_iam.call_args[1]
-        self.assertIn('session_token', iam_kwargs)
-        self.assertEqual(iam_kwargs['session_token'], session_token)
+        self.assertIn('security_token', iam_kwargs)
+        self.assertEqual(iam_kwargs['security_token'], session_token)
 
         runner.fs.make_s3_conn()
 
         self.assertTrue(self.mock_s3.called)
         s3_kwargs = self.mock_s3.call_args[1]
-        self.assertIn('session_token', s3_kwargs)
-        self.assertEqual(s3_kwargs['session_token'], session_token)
+        self.assertIn('security_token', s3_kwargs)
+        self.assertEqual(s3_kwargs['security_token'], session_token)
 
     def test_connections_without_session_token(self):
         runner = EMRJobRunner()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4103,10 +4103,10 @@ class MultiPartUploadTestCase(MockBotoTestCase):
             self.assertTrue(s3_key.mock_multipart_upload_was_cancelled())
 
 
-class SecurityTokenTestCase(MockBotoTestCase):
+class SessionTokenTestCase(MockBotoTestCase):
 
     def setUp(self):
-        super(SecurityTokenTestCase, self).setUp()
+        super(SessionTokenTestCase, self).setUp()
 
         self.mock_emr = self.start(patch('boto.emr.connection.EmrConnection'))
         self.mock_iam = self.start(patch('boto.connect_iam'))
@@ -4115,37 +4115,37 @@ class SecurityTokenTestCase(MockBotoTestCase):
         self.mock_s3 = self.start(patch('boto.connect_s3',
                                         wraps=boto.connect_s3))
 
-    def assert_conns_use_security_token(self, runner, security_token):
+    def assert_conns_use_session_token(self, runner, session_token):
         runner.make_emr_conn()
 
         self.assertTrue(self.mock_emr.called)
         emr_kwargs = self.mock_emr.call_args[1]
-        self.assertIn('security_token', emr_kwargs)
-        self.assertEqual(emr_kwargs['security_token'], security_token)
+        self.assertIn('session_token', emr_kwargs)
+        self.assertEqual(emr_kwargs['session_token'], session_token)
 
         runner.make_iam_conn()
 
         self.assertTrue(self.mock_iam.called)
         iam_kwargs = self.mock_iam.call_args[1]
-        self.assertIn('security_token', iam_kwargs)
-        self.assertEqual(iam_kwargs['security_token'], security_token)
+        self.assertIn('session_token', iam_kwargs)
+        self.assertEqual(iam_kwargs['session_token'], session_token)
 
         runner.fs.make_s3_conn()
 
         self.assertTrue(self.mock_s3.called)
         s3_kwargs = self.mock_s3.call_args[1]
-        self.assertIn('security_token', s3_kwargs)
-        self.assertEqual(s3_kwargs['security_token'], security_token)
+        self.assertIn('session_token', s3_kwargs)
+        self.assertEqual(s3_kwargs['session_token'], session_token)
 
-    def test_connections_without_security_token(self):
+    def test_connections_without_session_token(self):
         runner = EMRJobRunner()
 
-        self.assert_conns_use_security_token(runner, None)
+        self.assert_conns_use_session_token(runner, None)
 
-    def test_connections_with_security_token(self):
-        runner = EMRJobRunner(aws_security_token='meow')
+    def test_connections_with_session_token(self):
+        runner = EMRJobRunner(aws_session_token='meow')
 
-        self.assert_conns_use_security_token(runner, 'meow')
+        self.assert_conns_use_session_token(runner, 'meow')
 
 
 class BootstrapPythonTestCase(MockBotoTestCase):

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -417,7 +417,7 @@ class JobRunnerKwargsTestCase(TestCase):
     CONF_ONLY_OPTIONS = set([
         'aws_access_key_id',
         'aws_secret_access_key',
-        'aws_security_token',
+        'aws_session_token',
         'local_tmp_dir',
     ])
 

--- a/tests/test_option_store.py
+++ b/tests/test_option_store.py
@@ -581,12 +581,12 @@ class OptionStoreDebugPrintoutTestCase(ConfigFilesTestCase):
         self.assertNotIn('PASSWORD', printout)
         self.assertIn("'...'", printout)
 
-    def test_aws_security_token(self):
+    def test_aws_session_token(self):
         printout = self.get_debug_printout(
             EMRRunnerOptionStore, 'emr', dict(
-                aws_security_token='TOKEN'))
+                aws_session_token='TOKEN'))
 
-        self.assertIn("'aws_security_token'", printout)
+        self.assertIn("'aws_session_token'", printout)
         self.assertNotIn('TOKEN', printout)
         self.assertIn("'...'", printout)
 
@@ -597,4 +597,4 @@ class OptionStoreDebugPrintoutTestCase(ConfigFilesTestCase):
         self.assertNotIn("'...'", printout)
         self.assertIn("'aws_access_key_id'", printout)
         self.assertIn("'aws_secret_access_key'", printout)
-        self.assertIn("'aws_security_token'", printout)
+        self.assertIn("'aws_session_token'", printout)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,5 +1,6 @@
 # Copyright 2009-2013 Yelp and Contributors
 # Copyright 2015 Yelp
+# Copyright 2017 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Rename this to `aws_security_token` so we can get rid of the old, deprecated name in mrjob 0.6.