### PR TITLE
replace to_string() with to_unicode()

### DIFF
--- a/docs/guides/py2-vs-py3.rst
+++ b/docs/guides/py2-vs-py3.rst
@@ -20,7 +20,7 @@ The following things are bytes in any version of Python (which means you need to
 
 The :py:attr:`~mrjob.job.MRJob.stdin`, :py:attr:`~mrjob.job.MRJob.stdout`, and :py:attr:`~mrjob.job.MRJob.stderr` attributes of :py:class:`~mrjob.job.MRJob`\ s are always bytestreams (so, for example, ``self.stderr`` defaults to ``sys.stderr.buffer`` in Python 3).
 
-Everything else (including file paths, URIs, arguments to commands, and logging messages) are strings; that is, ``str`` on Python 3, and either ``str`` or ``unicode`` on Python 2. Like with :py:class:`~mrjob.protocol.RawValueProtocol`, most of the time it'll just work even if you don't think about it.
+Everything else (including file paths, URIs, arguments to commands, and logging messages) are strings; that is, ``str``\s on Python 3, and either ``unicode``\s or ASCII ``str``\s on Python 2. Like with :py:class:`~mrjob.protocol.RawValueProtocol`, most of the time it'll just work even if you don't think about it.
 
 python_bin
 ----------

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -23,7 +23,7 @@ from subprocess import CalledProcessError
 
 from mrjob.compat import uses_yarn
 from mrjob.fs.base import Filesystem
-from mrjob.py2 import to_string
+from mrjob.py2 import to_unicode
 from mrjob.parse import is_uri
 from mrjob.parse import urlparse
 from mrjob.util import cmd_line
@@ -119,7 +119,7 @@ class HadoopFilesystem(Filesystem):
                 first_line = stdout.split(b'\n')[0]
                 m = _HADOOP_VERSION_RE.match(first_line)
                 if m:
-                    self._hadoop_version = to_string(m.group('version'))
+                    self._hadoop_version = to_unicode(m.group('version'))
                     log.info("Using Hadoop version %s" % self._hadoop_version)
                 else:
                     raise Exception('Unable to determine Hadoop version.')
@@ -152,7 +152,7 @@ class HadoopFilesystem(Filesystem):
         log_func = log.debug if proc.returncode == 0 else log.error
         if not return_stdout:
             for line in BytesIO(stdout):
-                log_func('STDOUT: ' + to_string(line.rstrip(b'\r\n')))
+                log_func('STDOUT: ' + to_unicode(line.rstrip(b'\r\n')))
 
         # check if STDERR is okay
         stderr_is_ok = False
@@ -164,7 +164,7 @@ class HadoopFilesystem(Filesystem):
 
         if not stderr_is_ok:
             for line in BytesIO(stderr):
-                log_func('STDERR: ' + to_string(line.rstrip(b'\r\n')))
+                log_func('STDERR: ' + to_unicode(line.rstrip(b'\r\n')))
 
         ok_returncodes = ok_returncodes or [0]
 
@@ -242,7 +242,7 @@ class HadoopFilesystem(Filesystem):
             if not path_index:
                 raise IOError("Could not locate path in string %r" % line)
 
-            path = to_string(line.split(b' ', path_index)[-1])
+            path = to_unicode(line.split(b' ', path_index)[-1])
             # handle fully qualified URIs from newer versions of Hadoop ls
             # (see Pull Request #577)
             if is_uri(path):
@@ -260,7 +260,7 @@ class HadoopFilesystem(Filesystem):
         def cleanup():
             # this does someties happen; see #1396
             for line in cat_proc.stderr:
-                log.error('STDERR: ' + to_string(line.rstrip(b'\r\n')))
+                log.error('STDERR: ' + to_unicode(line.rstrip(b'\r\n')))
 
             cat_proc.stdout.close()
             cat_proc.stderr.close()

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -42,7 +42,7 @@ from mrjob.options import _allowed_keys
 from mrjob.options import _combiners
 from mrjob.options import _deprecated_aliases
 from mrjob.parse import is_uri
-from mrjob.py2 import to_string
+from mrjob.py2 import to_unicode
 from mrjob.runner import MRJobRunner
 from mrjob.runner import RunnerOptionStore
 from mrjob.setup import UploadDirManager
@@ -447,7 +447,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
 
                 # there shouldn't be much output to STDOUT
                 for line in step_proc.stdout:
-                    _log_line_from_hadoop(to_string(line).strip('\r\n'))
+                    _log_line_from_hadoop(to_unicode(line).strip('\r\n'))
 
                 step_proc.stdout.close()
                 step_proc.stderr.close()

--- a/mrjob/logs/step.py
+++ b/mrjob/logs/step.py
@@ -19,7 +19,7 @@ import errno
 import re
 from logging import getLogger
 
-from mrjob.py2 import to_string
+from mrjob.py2 import to_unicode
 from .ids import _add_implied_job_id
 from .ids import _add_implied_task_id
 from .log4j import _parse_hadoop_log4j_records
@@ -203,7 +203,7 @@ def _interpret_hadoop_jar_command_stderr(stderr, record_callback=None):
     def yield_lines():
         try:
             for line in stderr:
-                yield to_string(line)
+                yield to_unicode(line)
         except IOError as e:
             # this is just the PTY's way of saying goodbye
             if e.errno == errno.EIO:

--- a/mrjob/logs/wrap.py
+++ b/mrjob/logs/wrap.py
@@ -15,7 +15,7 @@
 """Utilities for ls()ing and cat()ing logs without raising exceptions."""
 from logging import getLogger
 
-from mrjob.py2 import to_string
+from mrjob.py2 import to_unicode
 
 from .ids import _sort_by_recency
 
@@ -29,7 +29,7 @@ def _cat_log(fs, path):
         if not fs.exists(path):
             return
         for line in fs.cat(path):
-            yield to_string(line)
+            yield to_unicode(line)
     except (IOError, OSError) as e:
         log.warning("couldn't cat() %s: %r" % (path, e))
 

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -21,7 +21,7 @@ from functools import wraps
 from io import BytesIO
 
 from mrjob.py2 import ParseResult
-from mrjob.py2 import to_string
+from mrjob.py2 import to_unicode
 from mrjob.py2 import urlparse as urlparse_buggy
 
 log = logging.getLogger(__name__)
@@ -151,8 +151,8 @@ def parse_mr_job_stderr(stderr, counters=None):
             group, counter, amount_str = m.groups()
 
             # don't leave these as bytes on Python 3
-            group = to_string(group)
-            counter = to_string(counter)
+            group = to_unicode(group)
+            counter = to_unicode(counter)
 
             counters.setdefault(group, {})
             counters[group].setdefault(counter, 0)
@@ -162,10 +162,10 @@ def parse_mr_job_stderr(stderr, counters=None):
         m = _STATUS_RE.match(line.rstrip(b'\r\n'))
         if m:
             # don't leave as bytes on Python 3
-            statuses.append(to_string(m.group(1)))
+            statuses.append(to_unicode(m.group(1)))
             continue
 
-        other.append(to_string(line))
+        other.append(to_unicode(line))
 
     return {'counters': counters, 'statuses': statuses, 'other': other}
 
@@ -192,7 +192,7 @@ def _find_python_traceback(lines):
 
     for line in lines:
         # don't return bytes in Python 3
-        line = to_string(line)
+        line = to_unicode(line)
 
         if in_traceback:
             tb_lines.append(line)

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -169,3 +169,23 @@ def to_string(s):
         return s.decode('utf_8')
     except UnicodeDecodeError:
         return s.decode('latin_1')
+
+
+def to_unicode(s):
+    """Convert ``bytes`` to unicode.
+
+    Use this if you need to ``print()`` or log bytes of an unknown encoding,
+    or to parse strings out of bytes of unknown encoding (e.g. a log file).
+
+    This hopes that your bytes are UTF-8 decodable, but if not, falls back
+    to latin-1, which always works.
+    """
+    if isinstance(s, bytes):
+        try:
+            return s.decode('utf_8')
+        except UnicodeDecodeError:
+            return s.decode('latin_1')
+    elif isinstance(s, string_types):  # e.g. is unicode
+        return s
+    else:
+        raise TypeError

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -23,8 +23,8 @@ that all non-byte strings be unicode. But that doesn't really make sense for
 Python 2, where str (bytes) and unicode can be used interchangeably.
 
 So really our string datatypes fall into two categories, bytes, and
-"strings", which is either ASCII ``str``\s (i.e., bytes) or ``unicode`` in
-Python 2, and ``str`` (i.e. unicode) in Python 3.
+"strings", which means either ``unicode``\s or ASCII ``str``\s in
+Python 2, and ``str``\s (i.e. unicode) in Python 3.
 
 These things should always be bytes:
 

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -23,8 +23,8 @@ that all non-byte strings be unicode. But that doesn't really make sense for
 Python 2, where str (bytes) and unicode can be used interchangeably.
 
 So really our string datatypes fall into two categories, bytes, and
-"strings", which is either ``str`` (i.e., bytes) or ``unicode`` in Python 2,
-and ``str`` (i.e. unicode) in Python 3.
+"strings", which is either ASCII ``str``\s (i.e., bytes) or ``unicode`` in
+Python 2, and ``str`` (i.e. unicode) in Python 3.
 
 These things should always be bytes:
 
@@ -73,7 +73,7 @@ We don't provide a ``unicode`` type:
 - Python 3.3+ has ``u''`` literals; please use sparingly
 
 If you need to convert bytes of unknown encoding to a string (e.g. to
-``print()`` or log them), use ``to_string()`` from this module.
+``print()`` or log them), use ``to_unicode()`` from this module.
 
 Iterables
 ---------
@@ -149,26 +149,6 @@ else:
 ParseResult
 urlopen
 urlparse
-
-
-def to_string(s):
-    """Convert ``bytes`` to ``str``, leaving ``unicode`` unchanged.
-
-    (This means on Python 2, ``to_string()`` does nothing.)
-
-    Use this if you need to ``print()`` or log bytes of an unknown encoding,
-    or to parse strings out of bytes of unknown encoding (e.g. a log file).
-    """
-    if not isinstance(s, string_types + (bytes,)):
-        raise TypeError
-
-    if PY2 or isinstance(s, str):
-        return s
-
-    try:
-        return s.decode('utf_8')
-    except UnicodeDecodeError:
-        return s.decode('latin_1')
 
 
 def to_unicode(s):

--- a/mrjob/ssh.py
+++ b/mrjob/ssh.py
@@ -17,7 +17,7 @@ import logging
 from subprocess import Popen
 from subprocess import PIPE
 
-from mrjob.py2 import to_string
+from mrjob.py2 import to_unicode
 from mrjob.util import cmd_line
 
 log = logging.getLogger(__name__)
@@ -154,7 +154,7 @@ def _ssh_ls(ssh_bin, address, ec2_key_pair_file, path,
     if sudo:
         cmd_args = ['sudo'] + cmd_args
 
-    out = to_string(_check_output(*_ssh_run_with_recursion(
+    out = to_unicode(_check_output(*_ssh_run_with_recursion(
         ssh_bin, address, ec2_key_pair_file, keyfile, cmd_args)))
     if 'No such file or directory' in out:
         raise IOError("No such file or directory: %s" % path)

--- a/mrjob/tools/emr/mrboss.py
+++ b/mrjob/tools/emr/mrboss.py
@@ -56,7 +56,7 @@ from mrjob.options import _add_basic_options
 from mrjob.options import _add_runner_options
 from mrjob.options import _alphabetize_options
 from mrjob.options import _pick_runner_opts
-from mrjob.py2 import to_string
+from mrjob.py2 import to_unicode
 from mrjob.ssh import _ssh_copy_key
 from mrjob.ssh import _ssh_run_with_recursion
 from mrjob.util import random_identifier
@@ -140,7 +140,7 @@ def _run_on_all_nodes(runner, output_dir, cmd_args, print_stderr=True):
         if print_stderr:
             print('---')
             print('Command completed on %s.' % addr)
-            print(to_string(stderr), end=' ')
+            print(to_unicode(stderr), end=' ')
 
         if '!' in addr:
             base_dir = os.path.join(output_dir, 'slave ' + addr.split('!')[1])

--- a/tests/test_py2.py
+++ b/tests/test_py2.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from mrjob.py2 import to_string
+from mrjob.py2 import to_unicode
 
 from tests.py2 import TestCase
 
@@ -37,3 +38,24 @@ class ToStringTestCase(TestCase):
 
     def test_non_ascii_unicode(self):
         self.assertEqual(to_string(u'café'), u'café')
+
+
+class ToUnicodeTestCase(TestCase):
+
+    def test_None(self):
+        self.assertRaises(TypeError, to_unicode, None)
+
+    def test_ascii_bytes(self):
+        self.assertEqual(to_unicode(b'foo'), u'foo')
+
+    def test_utf_8_bytes(self):
+        self.assertEqual(to_unicode(b'caf\xc3\xa9'), u'café')
+
+    def test_latin_1_bytes(self):
+        self.assertEqual(to_unicode(b'caf\xe9'), u'caf\xe9')
+
+    def test_ascii_unicode(self):
+        self.assertEqual(to_unicode(u'foo'), u'foo')
+
+    def test_non_ascii_unicode(self):
+        self.assertEqual(to_unicode(u'café'), u'café')

--- a/tests/test_py2.py
+++ b/tests/test_py2.py
@@ -13,31 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mrjob.py2 import to_string
 from mrjob.py2 import to_unicode
 
 from tests.py2 import TestCase
-
-
-class ToStringTestCase(TestCase):
-
-    def test_None(self):
-        self.assertRaises(TypeError, to_string, None)
-
-    def test_ascii_bytes(self):
-        self.assertEqual(to_string(b'foo'), 'foo')
-
-    def test_utf_8_bytes(self):
-        self.assertEqual(to_string(b'caf\xc3\xa9'), 'café')
-
-    def test_latin_1_bytes(self):
-        self.assertEqual(to_string(b'caf\xe9'), 'caf\xe9')
-
-    def test_ascii_unicode(self):
-        self.assertEqual(to_string(u'foo'), u'foo')
-
-    def test_non_ascii_unicode(self):
-        self.assertEqual(to_string(u'café'), u'café')
 
 
 class ToUnicodeTestCase(TestCase):


### PR DESCRIPTION
This makes Python 2 act a bit more like Python 3, and ensures that we don't get encoding errors when trying to log non-UTF-8 bytes in Python 2 (fixes #1585).

This also fixes a specific logging issue having to do with bootstrap errors (fixes #1580).
