### PR TITLE
Goodbye, Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "pypy"
   - "3.3"

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ mrjob: the Python MapReduce library
 
 .. image:: https://github.com/Yelp/mrjob/raw/master/docs/logos/logo_medium.png
 
-mrjob is a Python 2.6+/3.3+ package that helps you write and run Hadoop
+mrjob is a Python 2.7/3.3+ package that helps you write and run Hadoop
 Streaming jobs.
 
 `Stable version (v0.5.10) documentation <http://packages.python.org/mrjob/>`_

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -292,15 +292,8 @@ Job execution context
 
     If you're on Python 3, this always defaults to ``'python3'``.
 
-    If you're on Python 2, this defaults to ``'python'``, except on EMR,
-    where it will be either ``'python2.6'`` or ``'python2.7'``.
-
-    Generally, :py:class:`~mrjob.emr.EMRJobRunner` just matches whichever
-    minor version of Python 2 you're running. However, if you're on a
-    (deprecated) 2.x AMI, it'll instead default to ``'python2.6'`` on AMI
-    version 2.4.2 and earlier (because Python 2.7 is unavailable) and
-    ``'python2.7'`` on later 2.x AMI versions (because they have
-    :command:`pip-2.7` but not :command:`pip-2.6`).
+    If you're on Python 2, this defaults to ``'python'`` (except on EMR
+    AMIs prior to 4.3.0, where it will be ``'python2.7'``).
 
     This option also affects which Python binary is used for file locking in
     :mrjob-opt:`setup` scripts, so it might be useful to set even if you're

--- a/docs/guides/emr-bootstrap-cookbook.rst
+++ b/docs/guides/emr-bootstrap-cookbook.rst
@@ -33,11 +33,11 @@ version of Python.
 Figure out which version of Python you'll be running on EMR (see
 :mrjob-opt:`python_bin` for defaults).
 
- * If it's Python 2.6, use :command:`pip`
- * If it's Python 2.7, use :command:`pip-2.7`
+ * If it's Python 2, use :command:`pip2.7` (just plain :command:`pip` also
+   works on AMI 4.3.0 and later)
  * If it's Python 3, use :command:`pip-3.4`
 
-For example, to install :py:mod:`ujson` on Python 2.7:
+For example, to install :py:mod:`ujson` on Python 2:
 
 .. code-block:: yaml
 
@@ -67,16 +67,10 @@ Or a tarball:
         bootstrap:
         - sudo pip-2.7 install /local/path/of/tarball.tar.gz#
 
-.. note::
-
-  If for some reason you must run on AMI version 2.4.2 or earlier (protip:
-  don't do that), see :ref:`below <installing-pip-on-2.x-amis>` for how to get
-  :command:`pip` working.
-
 .. warning::
 
-   If you're trying to run jobs on AMI version 3.0.0 (protip: don't do that
-   either) :command:`pip` appears not to work due to out-of-date SSL
+   If you're trying to run jobs on AMI version 3.0.0 (protip: don't do that)
+   :command:`pip` appears not to work due to out-of-date SSL
    certificate information.
 
 
@@ -124,34 +118,12 @@ by EMR:
 2.x AMIs
 --------
 
-The 2.x AMIs are based on a version of Debian that is so old it has been
-"archived," which makes their package installer, :command:`apt-get`, no
-longer work out-of-the-box.
+Probably not worth the trouble. The 2.x AMIs are based on a version of Debian
+that is so old it has been "archived," which makes their package installer,
+:command:`apt-get`, no longer work out-of-the-box. Moreover, Python system
+packages work for Python 2.6, not 2.7.
 
-.. _installing-pip-on-2.x-amis:
-
-If you *must* use the 2.x AMIs, you can get :command:`apt-get` working
-again by fixing ``/etc/apt/sources.list`` and running
-:command:`apt-get update`. For example, to install :command:`pip` for Python
-2.6:
-
-.. code-block:: yaml
-
-    runners:
-      emr:
-        bootstrap:
-        - sudo echo "deb http://archive.debian.org/debian/ squeeze main contrib non-free" > /etc/apt/sources.list
-        - sudo apt-get update
-        - sudo apt-get install -y python-pip
-
-.. note::
-
-   :command:`pip-2.7` is already installed by default on AMI version 2.4.3 and
-   later.
-
-See the `full list of Squeeze packages
-<https://packages.debian.org/squeeze/>`__ for all the (very old versions of)
-software you can install.
+Instead, just use :command:`pip-2.7` to install Python libraries.
 
 .. _installing-python-from-source:
 

--- a/docs/guides/py2-vs-py3.rst
+++ b/docs/guides/py2-vs-py3.rst
@@ -25,7 +25,7 @@ Everything else (including file paths, URIs, arguments to commands, and logging 
 python_bin
 ----------
 
-:mrjob-opt:`python_bin` defaults to :command:`python` in Python 2, and :command:`python3` in Python 3 (except in Python 2 on EMR, where it's one of :command:`python2.6` or :command:`python2.7`; see :mrjob-opt:`python_bin` for details).
+:mrjob-opt:`python_bin` defaults to :command:`python3` in Python 3, and :command:`python` in Python 2 (except on EMR AMIs prior to 4.3.0, where we use :command:`python2.7`)
 
 Your Hadoop cluster
 -------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 mrjob
 =====
 
-**mrjob lets you write MapReduce jobs in Python 2.6+/3.3+ and run them on
+**mrjob lets you write MapReduce jobs in Python 2.7/3.3+ and run them on
 several platforms.** You can:
 
 * Write multi-step MapReduce jobs in pure Python

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -169,10 +169,6 @@ _DEFAULT_EMR_REGION = 'us-west-2'
 # default AMI to use on EMR. This will be updated with each version
 _DEFAULT_IMAGE_VERSION = '4.8.2'
 
-# EMR translates the dead/deprecated "latest" AMI version to 2.4.2
-# (2.4.2 isn't actually the latest version by a long shot)
-_IMAGE_VERSION_LATEST = '2.4.2'
-
 # first AMI version that we can't run bash -e on (see #1548)
 _BAD_BASH_IMAGE_VERSION = '5.2.0'
 
@@ -306,7 +302,6 @@ class EMRRunnerOptionStore(RunnerOptionStore):
 
         self._fix_emr_configurations_opt()
         self._fix_instance_opts()
-        self._fix_image_version_latest()
         self._fix_release_label_opt()
 
     def default_options(self):
@@ -389,13 +384,6 @@ class EMRRunnerOptionStore(RunnerOptionStore):
                         self[opt_name] = None
                 except ValueError:
                     pass  # maybe EMR will accept non-floats?
-
-    def _fix_image_version_latest(self):
-        """Translate the dead/deprecated *image_version* value ``latest``
-        to ``2.4.2`` up-front, so our code doesn't have to deal with
-        non-numeric AMI versions."""
-        if self['image_version'] == 'latest':
-            self['image_version'] = _IMAGE_VERSION_LATEST
 
     def _fix_release_label_opt(self):
         """If *release_label* is not set and *image_version* is set to version

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -568,32 +568,16 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
     def _default_python_bin(self, local=False):
         """Like :py:meth:`mrjob.runner.MRJobRunner._default_python_bin`,
-        except we explicitly pick a minor version of Python 2
-        (``python2.6`` or ``python2.7``).
-
-        On 3.x and later, we just try to match the current minor
-        version of Python. On the 2.x AMIs, we try to use ``python2.7``
-        on 2.4.3 and later (because it comes with a working :command:`pip`),
-        and ``python2.6`` otherwise (because Python 2.7 isn't installed).
+        except when running Python 2, we explicitly pick :command:`python2.7`
+        on AMIs prior to 4.3.0 where's it's not the default.
         """
         if local or not PY2:
             return super(EMRJobRunner, self)._default_python_bin(local=local)
 
-        if self._image_version_gte('3'):
-            # on 3.x and 4.x AMIs, both versions of Python work, so just
-            # match whatever version we're using locally
-            if sys.version_info >= (2, 7):
-                return ['python2.7']
-            else:
-                return ['python2.6']
-        elif self._image_version_gte('2.4.3'):
-            # on 2.4.3+, use python2.7 because the default python
-            # doesn't have a working pip
-            return ['python2.7']
+        if self._image_version_gte('4.3.0'):
+            return ['python']
         else:
-            # prior to 2.4.3, Python 2.6 is the only version installed.
-            # Use "python2.6" and not "python" for consistency
-            return ['python2.6']
+            return ['python2.7']
 
     def _image_version_gte(self, version):
         """Check if the requested image version is greater than

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -75,29 +75,17 @@ def parse_s3_uri(uri):
 
 @wraps(urlparse_buggy)
 def urlparse(urlstring, scheme='', allow_fragments=True, *args, **kwargs):
-    """A wrapper for :py:func:`urlparse.urlparse` with the following
-    differences:
-
-    * Handles buckets in S3 URIs correctly. (:py:func:`~urlparse.urlparse`
-      does this correctly sometime after 2.6.1; this is just a patch for older
-      Python versions.)
-    * Splits the fragment correctly in all URIs, not just Web-related ones.
-      This behavior was fixed in the Python 2.7.4 standard library but we have
-      to back-port it for previous versions.
+    """A wrapper for :py:func:`urlparse.urlparse` that splits the fragment
+    correctly in all URIs, not just Web-related ones.
+    This behavior was fixed in the Python 2.7.4 standard library but we have
+    to back-port it for previous versions.
     """
-    # we're probably going to mess with at least one of these values and
-    # re-pack the whole thing before we return it.
-    # NB: urlparse_buggy()'s second argument changes names from
-    # 'default_scheme' to 'scheme' in Python 2.6, so urlparse_buggy() should
-    # be called with positional arguments.
     (scheme, netloc, path, params, query, fragment) = (
         urlparse_buggy(urlstring, scheme, allow_fragments, *args, **kwargs))
-    if netloc == '' and path.startswith('//'):
-        m = _NETLOC_RE.match(path)
-        netloc = m.group(1)
-        path = m.group(2)
+
     if allow_fragments and '#' in path and not fragment:
         path, fragment = path.split('#', 1)
+
     return ParseResult(scheme, netloc, path, params, query, fragment)
 
 

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Minimal utilities to make Python work for 2.6+ and 3.3+
+"""Minimal utilities to make Python work for 2.7 and 3.3+
 
 Strategies for making `mrjob` work across Python versions:
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1114,15 +1114,13 @@ class MRJobRunner(object):
         if not os.path.isdir(os.path.dirname(tar_gz_path)):
             os.makedirs(os.path.dirname(tar_gz_path))
 
-        log.info('Archiving %s -> %s' % (dir_path, tar_gz_path))
-
-        tar_gz = tarfile.open(tar_gz_path, mode='w:gz')
-
         # for remote files
         tmp_download_path = os.path.join(
             self._get_local_tmp_dir(), 'tmp-download')
 
-        try:
+        log.info('Archiving %s -> %s' % (dir_path, tar_gz_path))
+
+        with tarfile.open(tar_gz_path, mode='w:gz') as tar_gz:
             for path in self.fs.ls(dir_path):
                 # fs.ls() only lists files
                 if path == dir_path:
@@ -1148,8 +1146,6 @@ class MRJobRunner(object):
 
                 log.debug('  adding %s to %s' % (path, tar_gz_path))
                 tar_gz.add(local_path, path_in_tar_gz, recursive=False)
-        finally:
-            tar_gz.close()
 
         self._dir_archives_created.add(tar_gz_path)
 

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -415,10 +415,10 @@ def unarchive(archive_path, dest):
     within zip files can be deflated or stored.
     """
     if tarfile.is_tarfile(archive_path):
-        with contextlib.closing(tarfile.open(archive_path, 'r')) as archive:
+        with tarfile.open(archive_path, 'r') as archive:
             archive.extractall(dest)
     elif is_zipfile(archive_path):
-        with contextlib.closing(ZipFile(archive_path, 'r')) as archive:
+        with ZipFile(archive_path, 'r') as archive:
             for name in archive.namelist():
                 # the zip spec specifies that front slashes are always
                 # used as directory separators
@@ -475,20 +475,20 @@ def zip_dir(dir, out_path, filter=None, prefix=''):
     if not filter:
         filter = lambda path: True
 
-    try:
-        zip_file = ZipFile(out_path, mode='w', compression=ZIP_DEFLATED)
-    except RuntimeError:  # zlib not available
-        zip_file = ZipFile(out_path, mode='w', compression=ZIP_STORED)
+    def create_zip_file():
+        try:
+            return ZipFile(out_path, mode='w', compression=ZIP_DEFLATED)
+        except RuntimeError:  # zlib not available
+            return ZipFile(out_path, mode='w', compression=ZIP_STORED)
 
-    for dirpath, dirnames, filenames in os.walk(dir, followlinks=True):
-        for filename in filenames:
-            path = os.path.join(dirpath, filename)
-            # janky version of os.path.relpath() (Python 2.6):
-            rel_path = path[len(os.path.join(dir, '')):]
-            if filter(rel_path):
-                # copy over real files, not symlinks
-                real_path = os.path.realpath(path)
-                path_in_zip_file = os.path.join(prefix, rel_path)
-                zip_file.write(real_path, arcname=path_in_zip_file)
-
-    zip_file.close()
+    with create_zip_file() as zip_file:
+        for dirpath, dirnames, filenames in os.walk(dir, followlinks=True):
+            for filename in filenames:
+                path = os.path.join(dirpath, filename)
+                # janky version of os.path.relpath() (Python 2.6):
+                rel_path = path[len(os.path.join(dir, '')):]
+                if filter(rel_path):
+                    # copy over real files, not symlinks
+                    real_path = os.path.realpath(path)
+                    path_in_zip_file = os.path.join(prefix, rel_path)
+                    zip_file.write(real_path, arcname=path_in_zip_file)

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -21,6 +21,7 @@ import contextlib
 import glob
 import logging
 import os
+import os.path
 import pipes
 import random
 import shlex
@@ -485,8 +486,8 @@ def zip_dir(dir, out_path, filter=None, prefix=''):
         for dirpath, dirnames, filenames in os.walk(dir, followlinks=True):
             for filename in filenames:
                 path = os.path.join(dirpath, filename)
-                # janky version of os.path.relpath() (Python 2.6):
-                rel_path = path[len(os.path.join(dir, '')):]
+                rel_path = os.path.relpath(path, dir)
+
                 if filter(rel_path):
                     # copy over real files, not symlinks
                     real_path = os.path.realpath(path)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # Copyright 2009-2015 Yelp and Contributors
+# Copyright 2016-2017 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,10 +37,6 @@ try:
         'zip_safe': False,  # so that we can bootstrap mrjob
     }
 
-    # special case for Python 2.6
-    if sys.version_info < (2, 7):
-        setuptools_kwargs['test_suite'] = 'unittest2.collector'
-
     # mrjob doesn't actually support Python 3.2, but it tries to support
     # PyPy3, which is currently Python 3.2 with some key 3.3 features
     if (hasattr(sys, 'pypy_version_info') and
@@ -61,10 +58,6 @@ try:
     if sys.version_info < (3, 3):
         setuptools_kwargs['tests_require'].append('mock')
 
-        # unittest2 is a backport of unittest from Python 2.7
-        if sys.version_info < (2, 7):
-            setuptools_kwargs['tests_require'].append('unittest2')
-
 except ImportError:
     from distutils.core import setup
     setuptools_kwargs = {}
@@ -80,7 +73,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/examples/test_mr_word_freq_count.py
+++ b/tests/examples/test_mr_word_freq_count.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import TestCase
+
 from mrjob.examples.mr_word_freq_count import MRWordFreqCount
 
 from tests.job import run_job
-from tests.py2 import TestCase
 
 
 class MRWordFreqCountTestCase(TestCase):

--- a/tests/fs/test_base.py
+++ b/tests/fs/test_base.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os.path
+from unittest import TestCase
 
 from mrjob.fs.base import Filesystem
 
-from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import SandboxedTestCase

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -14,9 +14,10 @@
 import bz2
 import io
 import sys
+from unittest import skipIf
+
 from tests.py2 import patch
 from tests.py2 import mock
-from tests.py2 import skipIf
 
 try:
     from oauth2client.client import GoogleCredentials

--- a/tests/logs/test_bootstrap.py
+++ b/tests/logs/test_bootstrap.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import TestCase
+
 from tests.sandbox import PatcherTestCase
 from tests.py2 import Mock
-from tests.py2 import TestCase
 from tests.py2 import patch
 
 from mrjob.logs.bootstrap import _check_for_nonzero_return_code

--- a/tests/logs/test_counters.py
+++ b/tests/logs/test_counters.py
@@ -12,10 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import TestCase
+
 from mrjob.logs.counters import _format_counters
 from mrjob.logs.step import _parse_indented_counters
-
-from tests.py2 import TestCase
 
 
 class FormatCountersTestCase(TestCase):

--- a/tests/logs/test_errors.py
+++ b/tests/logs/test_errors.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import TestCase
+
 from mrjob.logs.errors import _format_error
 from mrjob.logs.errors import _merge_and_sort_errors
 from mrjob.logs.errors import _pick_error
-
-from tests.py2 import TestCase
 
 
 class PickErrorTestCase(TestCase):

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import TestCase
 
 from mrjob.logs.history import _interpret_history_log
 from mrjob.logs.history import _match_history_log_path
@@ -22,7 +23,6 @@ from mrjob.logs.history import _parse_yarn_history_log
 
 from tests.sandbox import PatcherTestCase
 from tests.py2 import Mock
-from tests.py2 import TestCase
 from tests.py2 import patch
 
 

--- a/tests/logs/test_log4j.py
+++ b/tests/logs/test_log4j.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import TestCase
+
 from mrjob.logs.log4j import _parse_hadoop_log4j_records
 from mrjob.py2 import StringIO
-
-from tests.py2 import TestCase
 
 
 class ParseHadoopLog4JRecordsCase(TestCase):

--- a/tests/logs/test_step.py
+++ b/tests/logs/test_step.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import errno
+from unittest import TestCase
 
 from mrjob.logs.step import _interpret_emr_step_syslog
 from mrjob.logs.step import _interpret_emr_step_stderr
@@ -26,7 +27,6 @@ from mrjob.py2 import StringIO
 from mrjob.util import log_to_stream
 
 from tests.py2 import Mock
-from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import PatcherTestCase

--- a/tests/logs/test_task.py
+++ b/tests/logs/test_task.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import TestCase
+
 from mrjob.logs.task import _interpret_task_logs
 from mrjob.logs.task import _interpret_spark_task_logs
 from mrjob.logs.task import _ls_spark_task_logs
@@ -22,8 +24,6 @@ from mrjob.logs.task import _parse_task_syslog
 
 from tests.py2 import call
 from tests.py2 import Mock
-from tests.py2 import unittest
-from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.sandbox import PatcherTestCase
 
@@ -587,10 +587,6 @@ class InterpretSparkTaskLogsTestCase(PatcherTestCase):
             self.mock_fs, self.mock_path_matches(),
             log_callback=self.mock_log_callback,
             **kwargs)
-
-    # need to port over remaining tests
-    def interpret_task_logs(self, **kwargs):
-        raise unittest.SkipTest()
 
     def test_empty(self):
         self.assertEqual(self.interpret_spark_task_logs(), {})

--- a/tests/logs/test_wrap.py
+++ b/tests/logs/test_wrap.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from io import BytesIO
+from unittest import TestCase
 
 from mrjob.logs.wrap import _cat_log
 from mrjob.logs.wrap import _ls_logs
@@ -21,7 +22,6 @@ from mrjob.util import log_to_stream
 
 from tests.py2 import patch
 from tests.py2 import Mock
-from tests.py2 import TestCase
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import PatcherTestCase
 

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -28,8 +28,6 @@ from mrjob.parse import parse_s3_uri
 from mrjob.py2 import integer_types
 from mrjob.py2 import string_types
 
-from tests.py2 import unittest
-
 from .s3 import add_mock_s3_data
 from .util import MockClientMeta
 from .util import MockPaginator

--- a/tests/mockgoogleapiclient.py
+++ b/tests/mockgoogleapiclient.py
@@ -22,6 +22,7 @@ import sys
 from datetime import datetime
 from httplib2 import Response
 from io import BytesIO
+from unittest import skipIf
 
 try:
     from oauth2client.client import GoogleCredentials
@@ -46,7 +47,6 @@ from mrjob.fs.gcs import _LS_FIELDS_TO_RETURN
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.py2 import patch
 from tests.py2 import mock
-from tests.py2 import skipIf
 from tests.sandbox import SandboxedTestCase
 
 # list_clusters() only returns this many results at a time

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -196,7 +196,7 @@ def real_path_to_hdfs_uri(real_path, environ):
     if not real_path.startswith(hdfs_root):
         raise ValueError('path %s is not in %s' % (real_path, hdfs_root))
 
-    # janky version of os.path.relpath(), for Python 2.6
+    # for some reason, relpath() doesn't work here
     hdfs_uri = real_path[len(hdfs_root):]
     if not hdfs_uri.startswith('/'):
         hdfs_uri = '/' + hdfs_uri

--- a/tests/py2.py
+++ b/tests/py2.py
@@ -11,13 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Compatilibity layer for test code. Handles the following issues:
+"""Compatilibity layer for test code, mostly to deal with the fact
+that mock is a library in Python 2 but built into Python 3.
 
-Need to use unittest2 rather than unittest in Python 2.6 only.
-
-mock is built in to Python 3.
-
-Don't import directly from unittest/mock; use this module instead.
+Also provides utility code for mocking ``sys.stdout`` and ``sys.stderr``.
 """
 import codecs
 import sys
@@ -25,15 +22,6 @@ from io import BytesIO
 
 from mrjob.py2 import PY2
 from mrjob.py2 import StringIO
-
-# unittest2 is a backport of unittest in Python 2.7
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
-TestCase = unittest.TestCase
-TestCase  # quiet pyflakes
 
 # mock is built into unittest in Python 3.3+
 if sys.version_info < (3, 3):
@@ -52,9 +40,6 @@ call
 
 patch = mock.patch
 patch
-
-skipIf = unittest.skipIf
-skipIf
 
 
 def mock_stdout_or_stderr():

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -20,11 +20,11 @@ import stat
 from contextlib import contextmanager
 from tempfile import mkdtemp
 from shutil import rmtree
+from unittest import TestCase
 
 import mrjob
 from mrjob import runner
 
-from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.quiet import add_null_handler_to_root_logger
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -12,10 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import TestCase
+
 from mrjob.aws import EC2_INSTANCE_TYPE_TO_COMPUTE_UNITS
 from mrjob.aws import EC2_INSTANCE_TYPE_TO_MEMORY
-
-from tests.py2 import TestCase
 
 
 class EC2InstanceTypeTestCase(TestCase):

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import TestCase
+
 from mrjob import cmd
 from mrjob import launch
 from mrjob.tools.emr import audit_usage
@@ -22,7 +24,6 @@ from mrjob.tools.emr import s3_tmpwatch
 from mrjob.tools.emr import terminate_cluster
 from mrjob.tools.emr import terminate_idle_clusters
 
-from tests.py2 import TestCase
 from tests.py2 import patch
 
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test compatibility switching between different Hadoop versions"""
-
 import os
 from distutils.version import LooseVersion
+from unittest import TestCase
 
 from mrjob.compat import jobconf_from_dict
 from mrjob.compat import jobconf_from_env
@@ -26,7 +26,6 @@ from mrjob.compat import translate_jobconf_dict
 from mrjob.compat import translate_jobconf_for_all_versions
 from mrjob.compat import uses_yarn
 
-from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.sandbox import PatcherTestCase
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -17,6 +17,8 @@
 """Test configuration parsing and option combining"""
 import os
 import os.path
+from unittest import TestCase
+from unittest import skipIf
 
 import mrjob.conf
 from mrjob.conf import ClearedValue
@@ -38,13 +40,11 @@ from mrjob.conf import expand_path
 from mrjob.conf import find_mrjob_conf
 from mrjob.conf import load_opts_from_mrjob_conf
 from mrjob.conf import load_opts_from_mrjob_confs
+
+from tests.py2 import patch
 from tests.quiet import logger_disabled
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import SandboxedTestCase
-
-from tests.py2 import TestCase
-from tests.py2 import patch
-from tests.py2 import skipIf
 
 
 def load_mrjob_conf(conf_path=None):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1353,11 +1353,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
         self.assertEqual(lines[0], '#!/usr/bin/env bash -e')
 
     def _test_create_master_bootstrap_script(
-            self, image_version=None, expected_python_bin=PYTHON_BIN,
-            expect_pip_binary=None):
-
-        if expect_pip_binary is None:
-            expect_pip_binary = (PYTHON_BIN == 'python2.6')
+            self, image_version=None, expected_python_bin=PYTHON_BIN):
 
         # create a fake src tarball
         foo_py_path = os.path.join(self.tmp_dir, 'foo.py')
@@ -1442,14 +1438,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
     def test_create_master_bootstrap_script_on_2_4_11_ami(self):
         self._test_create_master_bootstrap_script(
             image_version='2.4.11',
-            expected_python_bin=('python2.7' if PY2 else PYTHON_BIN),
-            expect_pip_binary=False)
-
-    def test_create_master_bootstrap_script_on_2_4_2_ami(self):
-        self._test_create_master_bootstrap_script(
-            image_version='2.4.2',
-            expected_python_bin=('python2.7' if PY2 else PYTHON_BIN),
-            expect_pip_binary=PY2)
+            expected_python_bin=('python2.7' if PY2 else PYTHON_BIN))
 
     def test_no_bootstrap_script_if_not_needed(self):
         runner = EMRJobRunner(conf_paths=[], bootstrap_mrjob=False,
@@ -3425,13 +3414,6 @@ class DefaultPythonBinTestCase(MockBoto3TestCase):
                          ['python2.7'] if PY2 else [PYTHON_BIN])
 
     def test_2_4_3_ami(self):
-        runner = EMRJobRunner(image_version='2.4.3')
-        if PY2:
-            self.assertEqual(runner._default_python_bin(), ['python2.7'])
-        else:
-            self.assertEqual(runner._default_python_bin(), ['python3'])
-
-    def test_2_4_2_ami(self):
         runner = EMRJobRunner(image_version='2.4.3')
         if PY2:
             self.assertEqual(runner._default_python_bin(), ['python2.7'])

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -706,15 +706,6 @@ class AMIAndHadoopVersionTestCase(MockBoto3TestCase):
             self.assertEqual(runner.get_image_version(), '2.0.6')
             self.assertEqual(runner.get_hadoop_version(), '0.20.205')
 
-    def test_latest_ami_version(self):
-        # "latest" is no longer actually the latest version
-        with self.make_runner('--image-version', 'latest') as runner:
-            # we should translate "latest" ourselves (see #1269)
-            self.assertEqual(runner._opts['image_version'], '2.4.2')
-            runner.run()
-            self.assertEqual(runner.get_image_version(), '2.4.2')
-            self.assertEqual(runner.get_hadoop_version(), '1.0.3')
-
     def test_ami_version_3_0(self):
         with self.make_runner('--image-version', '3.0') as runner:
             runner.run()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -86,10 +86,8 @@ from tests.test_local import _bash_wrap
 
 # used to match command lines
 if PY2:
-    if sys.version_info < (2, 7):
-        PYTHON_BIN = 'python2.6'
-    else:
-        PYTHON_BIN = 'python2.7'
+    PYTHON_BIN = 'python'
+    # prior to AMI 4.3.0, we use python2.7
 else:
     PYTHON_BIN = 'python3'
 
@@ -1438,6 +1436,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
 
     def test_create_master_bootstrap_script_on_3_11_0_ami(self):
         self._test_create_master_bootstrap_script(
+            expected_python_bin=('python2.7' if PY2 else PYTHON_BIN),
             image_version='3.11.0')
 
     def test_create_master_bootstrap_script_on_2_4_11_ami(self):
@@ -1449,7 +1448,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
     def test_create_master_bootstrap_script_on_2_4_2_ami(self):
         self._test_create_master_bootstrap_script(
             image_version='2.4.2',
-            expected_python_bin=('python2.6' if PY2 else PYTHON_BIN),
+            expected_python_bin=('python2.7' if PY2 else PYTHON_BIN),
             expect_pip_binary=PY2)
 
     def test_no_bootstrap_script_if_not_needed(self):
@@ -3216,11 +3215,11 @@ class BuildStreamingStepTestCase(MockBoto3TestCase):
 
         self.start(patch(
             'mrjob.emr.EMRJobRunner.get_image_version',
-            return_value='3.7.0'))
+            return_value='4.8.2'))
 
         self.start(patch(
             'mrjob.emr.EMRJobRunner.get_hadoop_version',
-            return_value='2.4.0'))
+            return_value='2.7.3'))
 
         self.start(patch(
             'mrjob.emr.EMRJobRunner._get_streaming_jar_and_step_arg_prefix',
@@ -3417,11 +3416,13 @@ class DefaultPythonBinTestCase(MockBoto3TestCase):
 
     def test_4_x_release_label(self):
         runner = EMRJobRunner(release_label='emr-4.0.0')
-        self.assertEqual(runner._default_python_bin(), [PYTHON_BIN])
+        self.assertEqual(runner._default_python_bin(),
+                         ['python2.7'] if PY2 else [PYTHON_BIN])
 
     def test_3_11_0_ami(self):
         runner = EMRJobRunner(image_version='3.11.0')
-        self.assertEqual(runner._default_python_bin(), [PYTHON_BIN])
+        self.assertEqual(runner._default_python_bin(),
+                         ['python2.7'] if PY2 else [PYTHON_BIN])
 
     def test_2_4_3_ami(self):
         runner = EMRJobRunner(image_version='2.4.3')

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -22,6 +22,7 @@ import os.path
 import posixpath
 import sys
 import time
+import unittest
 from datetime import timedelta
 from io import BytesIO
 
@@ -76,7 +77,6 @@ from tests.mr_word_count import MRWordCount
 from tests.py2 import Mock
 from tests.py2 import call
 from tests.py2 import patch
-from tests.py2 import unittest
 from tests.quiet import logger_disabled
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import SandboxedTestCase

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -22,6 +22,7 @@ import pty
 from io import BytesIO
 from subprocess import check_call
 from subprocess import PIPE
+from unittest import TestCase
 
 import mrjob.step
 from mrjob.conf import combine_dicts
@@ -45,7 +46,6 @@ from tests.mr_streaming_and_spark import MRStreamingAndSpark
 from tests.mr_two_step_hadoop_format_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
 from tests.py2 import Mock
-from tests.py2 import TestCase
 from tests.py2 import call
 from tests.py2 import patch
 from tests.quiet import logger_disabled

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from unittest import TestCase
 
 from mrjob.iam import _MRJOB_SERVICE_ROLE
 
 from tests.mock_boto3.iam import MockIAMClient
-from tests.py2 import TestCase
 
 
 # IAM stuff is mostly tested by test_emr.py, but we don't test what happens if

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -21,6 +21,7 @@ import gzip
 import os
 import os.path
 from io import BytesIO
+from unittest import TestCase
 
 from mrjob import conf
 from mrjob.fs.base import Filesystem
@@ -35,7 +36,6 @@ from tests.mr_test_jobconf import MRTestJobConf
 from tests.mr_test_per_step_jobconf import MRTestPerStepJobConf
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
-from tests.py2 import TestCase
 from tests.py2 import mock
 from tests.py2 import patch
 from tests.sandbox import EmptyMrjobConfTestCase

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -21,6 +21,7 @@ import time
 from io import BytesIO
 from subprocess import Popen
 from subprocess import PIPE
+from unittest import TestCase
 
 from mrjob.conf import combine_envs
 from mrjob.job import MRJob
@@ -49,7 +50,6 @@ from tests.mr_tower_of_powers import MRTowerOfPowers
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.py2 import Mock
 from tests.py2 import MagicMock
-from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.quiet import logger_disabled
 from tests.quiet import no_handlers_for_logger

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -22,6 +22,7 @@ from collections import defaultdict
 from optparse import OptionError
 from subprocess import Popen
 from subprocess import PIPE
+from unittest import TestCase
 
 from mrjob.conf import combine_envs
 from mrjob.dataproc import DataprocJobRunner
@@ -39,7 +40,6 @@ from tests.mr_no_runner import MRNoRunner
 from tests.mr_runner import MRRunner
 from tests.py2 import MagicMock
 from tests.py2 import Mock
-from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import mrjob_pythonpath

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -22,6 +22,8 @@ import stat
 import sys
 import tempfile
 from io import BytesIO
+from unittest import TestCase
+from unittest import skipIf
 
 import mrjob
 from mrjob.local import LocalMRJobRunner
@@ -37,10 +39,8 @@ from tests.mr_job_where_are_you import MRJobWhereAreYou
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_verbose_job import MRVerboseJob
 from tests.mr_word_count import MRWordCount
-from tests.py2 import TestCase
 from tests.py2 import call
 from tests.py2 import patch
-from tests.py2 import skipIf
 from tests.quiet import logger_disabled
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import EmptyMrjobConfTestCase

--- a/tests/test_option_store.py
+++ b/tests/test_option_store.py
@@ -16,6 +16,8 @@
 import os
 from tempfile import mkdtemp
 from shutil import rmtree
+from unittest import TestCase
+from unittest import skipIf
 
 import mrjob.conf
 import mrjob.hadoop
@@ -29,8 +31,6 @@ from mrjob.runner import RunnerOptionStore
 from mrjob.sim import SimRunnerOptionStore
 from mrjob.util import log_to_stream
 
-from tests.py2 import TestCase
-from tests.py2 import skipIf
 from tests.quiet import logger_disabled
 from tests.quiet import no_handlers_for_logger
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -19,6 +19,7 @@ import sys
 from io import BytesIO
 from subprocess import PIPE
 from subprocess import Popen
+from unittest import TestCase
 
 from mrjob.parse import _find_python_traceback
 from mrjob.parse import _parse_port_range_list
@@ -29,9 +30,6 @@ from mrjob.parse import is_uri
 from mrjob.parse import parse_mr_job_stderr
 from mrjob.parse import parse_s3_uri
 from mrjob.parse import urlparse
-
-from tests.py2 import TestCase
-
 
 
 class FindPythonTracebackTestCase(TestCase):

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -15,14 +15,13 @@
 # limitations under the License.
 from datetime import datetime
 from datetime import timedelta
+from unittest import TestCase
 
 from dateutil.tz import tzutc
 
 from mrjob.aws import _boto3_now
 from mrjob.pool import _est_time_to_hour
 from mrjob.pool import _pool_hash_and_name
-
-from tests.py2 import TestCase
 
 
 class EstTimeToEndOfHourTestCase(TestCase):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 
 """Make sure all of our protocols work as advertised."""
+import unittest
+from unittest import TestCase
+from unittest import skipIf
+
 from mrjob.protocol import BytesProtocol
 from mrjob.protocol import BytesValueProtocol
 from mrjob.protocol import JSONProtocol
@@ -39,10 +43,6 @@ from mrjob.protocol import rapidjson
 from mrjob.protocol import simplejson
 from mrjob.protocol import ujson
 from mrjob.py2 import PY2
-
-from tests.py2 import TestCase
-from tests.py2 import skipIf
-from tests.py2 import unittest
 
 
 class Point(object):

--- a/tests/test_py2.py
+++ b/tests/test_py2.py
@@ -13,9 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mrjob.py2 import to_unicode
+from unittest import TestCase
 
-from tests.py2 import TestCase
+from mrjob.py2 import to_unicode
 
 
 class ToUnicodeTestCase(TestCase):

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -12,10 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import TestCase
+
 from mrjob.retry import RetryWrapper
 
 from tests.py2 import Mock
-from tests.py2 import TestCase
 
 
 class RetryWrapperTestCase(TestCase):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1746,21 +1746,8 @@ class CreateDirArchiveTestCase(SandboxedTestCase):
 
         runner._create_dir_archive(empty_dir)
 
-        tar_gz = None
-        try:
-            tar_gz = tarfile.open(tar_gz_path, 'r:gz')
-        except ReadError as e:
-            # Python 2.6 can produce valid empty tarballs (verified this
-            # by hand) but it can't read them
-            if sys.version_info < (2, 7) and e.args == ('empty header',):
-                return
-            else:
-                raise
-
-        try:
+        with tarfile.open(tar_gz_path, 'r:gz') as tar_gz:
             self.assertEqual(sorted(tar_gz.getnames()), [])
-        finally:
-            tar_gz.close()
 
     def test_file(self):
         qux_path = self.makefile('qux')

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -28,6 +28,7 @@ from io import BytesIO
 from subprocess import CalledProcessError
 from tarfile import ReadError
 from time import sleep
+from unittest import TestCase
 from zipfile import ZipFile
 from zipfile import ZIP_DEFLATED
 
@@ -45,7 +46,6 @@ from mrjob.step import OUTPUT
 from mrjob.tools.emr.audit_usage import _JOB_KEY_RE
 from mrjob.util import log_to_stream
 
-
 from tests.mock_boto3 import MockBoto3TestCase
 from tests.mr_cmd_job import MRCmdJob
 from tests.mr_counting_job import MRCountingJob
@@ -62,7 +62,6 @@ from tests.mr_spark_script import MRSparkScript
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
 from tests.py2 import Mock
-from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import EmptyMrjobConfTestCase

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from unittest import TestCase
 
 from mrjob.setup import UploadDirManager
 from mrjob.setup import WorkingDirManager
@@ -21,7 +22,6 @@ from mrjob.setup import name_uniquely
 from mrjob.setup import parse_legacy_hash_path
 from mrjob.setup import parse_setup_cmd
 
-from tests.py2 import TestCase
 from tests.py2 import patch
 
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for mrjob.step"""
+from unittest import TestCase
+
 from mrjob.step import _IDENTITY_MAPPER
 from mrjob.step import INPUT
 from mrjob.step import JarStep
@@ -23,8 +25,6 @@ from mrjob.step import SparkJarStep
 from mrjob.step import SparkStep
 from mrjob.step import SparkScriptStep
 from mrjob.step import StepFailedException
-
-from tests.py2 import TestCase
 
 
 # functions we don't really care about the values of

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -24,6 +24,7 @@ import tempfile
 from io import BytesIO
 from subprocess import PIPE
 from subprocess import Popen
+from unittest import TestCase
 
 from mrjob.py2 import PY2
 from mrjob.py2 import StringIO
@@ -40,7 +41,6 @@ from mrjob.util import unarchive
 from mrjob.util import unique
 from mrjob.util import which
 
-from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import SandboxedTestCase

--- a/tests/tools/emr/test_audit_usage.py
+++ b/tests/tools/emr/test_audit_usage.py
@@ -18,6 +18,7 @@ import sys
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
+from unittest import TestCase
 
 import boto3
 from dateutil.parser import parse
@@ -29,7 +30,6 @@ from mrjob.tools.emr.audit_usage import _subdivide_interval_by_date
 from mrjob.tools.emr.audit_usage import _subdivide_interval_by_hour
 from mrjob.tools.emr.audit_usage import main
 
-from tests.py2 import TestCase
 from tests.py2 import patch
 from tests.tools.emr import ToolTestCase
 


### PR DESCRIPTION
Removes a number of Python 2.6-specific workarounds and vastly simplifies picking Python 2 binaries on EMR. Fixes #1535.