### PR TITLE
always auto-terminate

### DIFF
--- a/docs/guides/emr-advanced.rst
+++ b/docs/guides/emr-advanced.rst
@@ -1,118 +1,15 @@
 Advanced EMR usage
 ==================
 
-.. _reusing-clusters:
-
-Reusing Clusters
------------------
-
-It can take several minutes to create a cluster. To decrease wait time when
-running multiple jobs, you may find it convenient to reuse a single cluster.
-
-:py:mod:`mrjob` includes a utility to create persistent clusters without
-running a job. For example, this command will create a cluster with 12 EC2
-instances (1 master and 11 core), taking all other options from
-:py:mod:`mrjob.conf`::
-
-    $ mrjob create-cluster --num-core-instances=11 --max-hours-idle 1
-    ...
-    j-CLUSTERID
-
-
-You can then add jobs to the cluster with the :option:`--emr-cluster-id`
-switch or the `emr_cluster_id` variable in `mrjob.conf` (see
-:py:meth:`EMRJobRunner.__init__`)::
-
-    $ python mr_my_job.py -r emr --emr-cluster-id=j-CLUSTERID input_file.txt > out
-    ...
-    Adding our job to existing cluster j-CLUSTERID
-    ...
-
-Debugging will be difficult unless you complete SSH setup (see
-:ref:`ssh-tunneling`) since the logs will not be copied from the master node to
-S3 before either five minutes pass or the cluster terminates.
-
-.. _pooling-clusters:
-
-Pooling Clusters
------------------
-
-Manually creating clusters to reuse and specifying the cluster ID for every
-run can be tedious. In addition, it is not convenient to coordinate cluster
-use among multiple users.
-
-To mitigate these problems, :py:mod:`mrjob` provides **cluster pools.** Rather
-than having to remember to start a cluster and copying its ID, simply pass
-:option:`--pool-clusters` on the command line. The first time you do this,
-a new cluster will be created that does not terminate when the job completes.
-When you use :option:`--pool-clusters` the next time, it will identify the
-cluster and add the job to it rather than creating a new one.
-
-.. warning::
-
-    If you use cluster pools, either set :mrjob-opt:`max_hours_idle`
-    in your config file (recommended), or
-    keep :command:`mrjob terminate-idle-clusters` in your crontab.
-    Otherwise you may forget to terminate your clusters and waste a lot of
-    money.
-
-Pooling is designed so that jobs run against the same :py:mod:`mrjob.conf` can
-share the same clusters. This means that the version of :py:mod:`mrjob` and
-bootstrap configuration. Other options that affect which cluster a job can
-join:
-
-* :mrjob-opt:`image_version`\/:mrjob-opt:`release_label`: must match
-* :mrjob-opt:`applications`: require *at least* these applications
-  (extra ones okay)
-* :mrjob-opt:`emr_configurations`: must match
-* :mrjob-opt:`ec2_key_pair`: if specified, only join clusters with the same key
-  pair
-* :mrjob-opt:`subnet`: only join clusters with the same EC2 subnet ID (or
-  lack thereof)
-
-Pooled jobs will also only use clusters with the same **pool name**, so you
-can use the :mrjob-opt:`pool_name` option to partition your clusters into
-separate pools.
-
-Pooling is flexible about instance type and number of instances; it will
-attempt to select the most powerful cluster available as long as the
-cluster's instances provide at least as much memory and at least as much CPU as
-your job requests. If there is a tie, it picks clusters that are closest to
-the end of a full hour, to minimize wasted instance hours.
-
-mrjob's pooling won't add more than 1000 steps to a cluster, as the
-EMR API won't show more than this many steps. (For `very old AMIs <http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/AddingStepstoaJobFlow.html>`
-there is a stricter limit of 256 steps).
-
-:py:mod:`mrjob` also uses an S3-based
-"locking" mechanism to prevent two jobs from simultaneously joining the same
-cluster. This is somewhat ugly but works in practice, and avoids
-:py:mod:`mrjob` depending on Amazon services other than EMR and S3.
-
-.. warning::
-
-    If S3 eventual consistency takes longer than
-    :mrjob-opt:`cloud_fs_sync_secs`, then you
-    may encounter race conditions when using pooling, e.g. two jobs claiming
-    the same cluster at the same time, or the idle cluster killer shutting
-    down your job before it has started to run. Regions with read-after-write
-    consistency (i.e. every region except US Standard) should not experience
-    these issues.
-
-You can allow jobs to wait for an available cluster instead of immediately
-starting a new one by specifying a value for `--pool-wait-minutes`. mrjob will
-try to find a cluster every 30 seconds for :mrjob-opt:`pool_wait_minutes`. If
-none is found during that time, mrjob will start a new one.
-
 .. _spot-instances:
 
 Spot Instances
 --------------
 
-Amazon also has a spot market for EC2 instances. You can potentially save money
-by using the spot market. The catch is that if someone bids more for instances
-that you're using, they can be taken away from your cluster. If this happens,
-you aren't charged, but your job may fail.
+You can potentially save money purchasing EC2 instances for your EMR
+clusters from AWS's spot market. The catch is that if someone bids more for
+instances that you're using, they can be taken away from your cluster. If this
+happens, you aren't charged, but your job may fail.
 
 You can specify spot market bid prices using the *core_instance_bid_price*,
 *master_instance_bid_price*, and *task_instance_bid_price* options to
@@ -137,9 +34,9 @@ your job to finish but you'd like to save time and money if you can, in which
 case you want to run task instances on the spot market and purchase master and
 core instances the regular way.
 
-Cluster pooling interacts with bid prices more or less how you'd expect; a job
-will join a pool with spot instances only if it requested spot instances at the
-same price or lower.
+:ref:`cluster-pooling` interacts with bid prices more or less how you'd
+expect; a job will join a pool with spot instances only if it requested spot
+instances at the same price or lower.
 
 Custom Python packages
 ----------------------
@@ -162,19 +59,41 @@ number of mappers and reducers to one per node::
 
 .. note::
 
-   This doesn't work on AMI version 4.0.0 and later.
+   This doesn't work on AMI 4.0.0 and later.
 
-Setting up Ganglia
-------------------
+.. _reusing-clusters:
 
-`Ganglia <http://www.ganglia.info>`_ is a scalable distributed monitoring
-system for high-performance computing systems. You can enable it for your
-EMR cluster with Amazon's `install-ganglia`_ bootstrap action::
+Manually Reusing Clusters
+-------------------------
 
-    --bootstrap-action="s3://elasticmapreduce/bootstrap-actions/install-ganglia
+In some cases, it may be useful to have more fine-grained control than
+:ref:`cluster-pooling` provides; for example, to run several related jobs
+on the same cluster.
 
-.. _install-ganglia: http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/UsingEMR_Ganglia.html
+.. warning::
 
-.. note::
+   If you do this on mrjob versions prior to 0.6.0, make sure to set
+   :mrjob-opt:`max_hours_idle`, or your manually created clusters will
+   run forever, costing you money.
 
-   This doesn't work on AMI version 4.0.0 and later.
+:py:mod:`mrjob` includes a utility to create persistent clusters without
+running a job. For example, this command will create a cluster with 12 EC2
+instances (1 master and 11 core), taking all other options from
+:py:mod:`mrjob.conf`::
+
+    $ mrjob create-cluster --num-core-instances=11 --max-hours-idle 1
+    ...
+    j-CLUSTERID
+
+You can then add jobs to the cluster with the :option:`--emr-cluster-id`
+switch or the `emr_cluster_id` variable in `mrjob.conf` (see
+:py:meth:`EMRJobRunner.__init__`)::
+
+    $ python mr_my_job.py -r emr --emr-cluster-id=j-CLUSTERID input_file.txt > out
+    ...
+    Adding our job to existing cluster j-CLUSTERID
+    ...
+
+Debugging will be difficult unless you complete SSH setup (see
+:ref:`ssh-tunneling`) since the logs will not be copied from the master node to
+S3 before either five minutes pass or the cluster terminates.

--- a/docs/guides/emr-bootstrap-cookbook.rst
+++ b/docs/guides/emr-bootstrap-cookbook.rst
@@ -13,7 +13,7 @@ You can use :mrjob-opt:`bootstrap` and :mrjob-opt:`setup` together.
 Generally, you want to use :mrjob-opt:`bootstrap` for things that are
 part of your general production environment, and :mrjob-opt:`setup`
 for things that are specific to your particular job. This makes things
-work as expected if you are :ref:`pooling-clusters`.
+work as expected if you are using :ref:`cluster-pooling`.
 
 All these examples use :mrjob-opt:`bootstrap`. Not saying it's a good idea, but
 all these examples will work with :mrjob-opt:`setup` as well (yes, Hadoop

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -393,7 +393,7 @@ Cluster creation and configuration
     .. deprecated:: 0.6.0
 
        Hiding clusters from other users on the same account is not very useful.
-       If you don't want to share pooled clusters, try :mrjob:`pool_name`.
+       If you don't want to share pooled clusters, try :mrjob-opt:`pool_name`.
 
 .. mrjob-opt::
     :config: zone

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -276,11 +276,17 @@ Cluster creation and configuration
     :switch: --max-hours-idle
     :type: :ref:`string <data-type-string>`
     :set: emr
-    :default: ``None``
+    :default: 0.5
 
-    If we create a persistent cluster, have it automatically terminate itself
-    after it's been idle this many hours AND we're within
-    :mrjob-opt:`mins_to_end_of_hour` of an EC2 billing hour.
+    Automatically terminate persistent/pooled clusters that have been idle at
+    least this many hours, if we're within :mrjob-opt:`mins_to_end_of_hour` of
+    an EC2 billing hour.
+
+    .. versionchanged:: 0.6.0
+
+       All clusters launched by mrjob now auto-terminate when idle. In previous
+       versions, you needed to set this option explicitly, or use
+       :ref:`terminate-idle-clusters`.
 
 .. mrjob-opt::
     :config: mins_to_end_of_hour
@@ -384,13 +390,10 @@ Cluster creation and configuration
     Otherwise, the cluster will only be visible to the IAM user that created
     it.
 
-    .. warning::
+    .. deprecated:: 0.6.0
 
-        You should almost certainly not set this to ``False`` if you are
-        :ref:`pooling-clusters` with other users; other users will
-        not be able to reuse your clusters, and
-        :command:`mrjob terminate-idle-clusters` won't be
-        able to shut them down when they become idle.
+       Hiding clusters from other users on the same account is not very useful.
+       If you don't want to share pooled clusters, try :mrjob:`pool_name`.
 
 .. mrjob-opt::
     :config: zone
@@ -735,7 +738,7 @@ Choosing/creating a cluster to join
     :switch: --pool-clusters
     :type: :ref:`string <data-type-string>`
     :set: emr
-    :default: ``False``
+    :default: ``True``
 
     Try to run the job on a ``WAITING`` pooled cluster with the same
     bootstrap configuration. Prefer the one with the most compute units. Use
@@ -743,10 +746,12 @@ Choosing/creating a cluster to join
     another job. If no suitable cluster is `WAITING`, create a new pooled
     cluster.
 
-    .. warning:: Do not run this without either setting
-        :mrjob-opt:`max_hours_idle` (recommended) or putting
-        :command:`mrjob terminate-idle-clusters` in your crontab;
-        clusters left idle can quickly become expensive!
+    .. versionchanged:: 0.6.0
+
+       This used to be turned off by default. If you want to enable this
+       option in older versions of mrjob, make sure to set
+       :mrjob-opt:`max_hours_idle` too, or your clusters will run
+       (costing you money) forever.
 
     .. versionchanged:: 0.5.4
 

--- a/docs/guides/emr.rst
+++ b/docs/guides/emr.rst
@@ -5,6 +5,7 @@ Elastic MapReduce
     :maxdepth: 2
 
     emr-quickstart.rst
+    pooling.rst
     emr-opts.rst
     emr-bootstrap-cookbook.rst
     emr-troubleshooting.rst

--- a/docs/guides/pooling.rst
+++ b/docs/guides/pooling.rst
@@ -1,0 +1,69 @@
+.. _cluster-pooling:
+
+Cluster Pooling
+===============
+
+Clusters on EMR take several minutes to spin up. Also, EMR bills by the full
+hour, so if you run, say, a 10-minute job and then shut down the cluster, the
+other 50 minutes are wasted.
+
+To mitigate these problems, :py:mod:`mrjob` provides **cluster pools.** By
+default, once your job completes, the cluster will stay open to accept
+additional jobs, and eventually shut itself down after it has been idle
+for a certain amount of time (see :mrjob-opt:`max_hours_idle` and
+:mrjob-opt:`mins_to_end_of_hour`).
+
+.. note::
+
+   Cluster pooling was not turned on by default in versions prior to 0.6.0.
+   To get the same behavior in previous versions :mrjob-opt:`pool_clusters` to
+   ``True`` and :mrjob-opt:`max_hours_idle` to 0.5 (don't forget to set
+   `max_hours_idle`, or your clusters will never shut down).
+
+Pooling is designed so that jobs run against the same :py:mod:`mrjob.conf` can
+share the same clusters. This means that the version of :py:mod:`mrjob` and
+bootstrap configuration. Other options that affect which cluster a job can
+join:
+
+* :mrjob-opt:`image_version`\/:mrjob-opt:`release_label`: must match
+* :mrjob-opt:`applications`: require *at least* these applications
+  (extra ones okay)
+* :mrjob-opt:`emr_configurations`: must match
+* :mrjob-opt:`ec2_key_pair`: if specified, only join clusters with the same key
+  pair
+* :mrjob-opt:`subnet`: only join clusters with the same EC2 subnet ID (or
+  lack thereof)
+
+Pooled jobs will also only use clusters with the same **pool name**, so you
+can use the :mrjob-opt:`pool_name` option to partition your clusters into
+separate pools.
+
+Pooling is flexible about instance type and number of instances; it will
+attempt to select the most powerful cluster available as long as the
+cluster's instances provide at least as much memory and at least as much CPU as
+your job requests. If there is a tie, it picks clusters that are closest to
+the end of a full hour, to minimize wasted instance hours.
+
+mrjob's pooling won't add more than 1000 steps to a cluster, as the
+EMR API won't show more than this many steps. (For `very old AMIs <http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/AddingStepstoaJobFlow.html>`__
+there is a stricter limit of 256 steps).
+
+:py:mod:`mrjob` also uses an S3-based
+"locking" mechanism to prevent two jobs from simultaneously joining the same
+cluster. This is somewhat ugly but works in practice, and avoids
+:py:mod:`mrjob` depending on Amazon services other than EMR and S3.
+
+.. warning::
+
+    If S3 eventual consistency takes longer than
+    :mrjob-opt:`cloud_fs_sync_secs`, then you
+    may encounter race conditions when using pooling, e.g. two jobs claiming
+    the same cluster at the same time, or the idle cluster killer shutting
+    down your job before it has started to run. Regions with read-after-write
+    consistency (i.e. every region except US Standard) should not experience
+    these issues.
+
+You can allow jobs to wait for an available cluster instead of immediately
+starting a new one by specifying a value for `--pool-wait-minutes`. mrjob will
+try to find a cluster every 30 seconds for :mrjob-opt:`pool_wait_minutes`. If
+none is found during that time, mrjob will start a new one.

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -144,7 +144,7 @@ Cluster pooling
 ^^^^^^^^^^^^^^^
 
 mrjob can now add up to 1,000 steps on
-:ref:`pooled clusters <pooling-clusters>` on EMR (except on very old AMIs).
+:ref:`pooled clusters <cluster-pooling>` on EMR (except on very old AMIs).
 mrjob now prints debug messages explaining why your job matched
 a particular pooled cluster when running in verbose mode (the ``-v`` option).
 Fixed a bug that caused pooling to fail when there was no need for a master
@@ -227,7 +227,7 @@ Functionally equivalent to :ref:`v0.5.4`, except that it restores
 the deprecated *ami_version* option as an alias for :mrjob-opt:`image_version`,
 making it easier to upgrade from earlier versions of mrjob.
 
-Also slightly improves :ref:`EMR cluster pooling <pooling-clusters>` with
+Also slightly improves :ref:`cluster-pooling` on EMR with
 updated information on memory and CPU power of various EC2 instance types, and
 by treating application names (e.g. "Spark") as case-insensitive.
 
@@ -246,7 +246,7 @@ Pooling and idle cluster self-termination
    of mrjob, use version :ref:`v0.5.5` or later.
 
 This release resolves a long-standing EMR API race condition that made it
-difficult to use :ref:`cluster pooling <pooling-clusters>` and idle cluster
+difficult to use :ref:`cluster-pooling` and idle cluster
 self-termination (see :mrjob-opt:`max_hours_idle`) together. Now if your
 pooled job unknowingly runs on a cluster that was in the process of shutting
 down, it will detect that and re-launch the job on a different cluster.
@@ -622,7 +622,7 @@ Other changes
  - :py:data:`~mrjob.runner.JOB` :mrjob-opt:`cleanup` on EMR is temporarily disabled
  - mrjob now follows symlinks when :py:meth:`~mrjob.fs.local.LocalFileSystem.ls`\ ing the local filesystem (beware recursive symlinks!)
  - The :mrjob-opt:`interpreter` option disables :mrjob-opt:`bootstrap_mrjob` by default (:mrjob-opt:`interpreter` is meant for non-Python jobs)
- - :ref:`cluster pooling <pooling-clusters>` now respects :mrjob-opt:`ec2_key_pair`
+ - :ref:`cluster-pooling` now respects :mrjob-opt:`ec2_key_pair`
  - cluster self-termination (see :mrjob-opt:`max_hours_idle`) now respects non-streaming jobs
  - :py:class:`~mrjob.fs.local.LocalFilesystem` now rejects URIs rather than interpreting them as local paths
  - ``local`` and ``inline`` runners no longer have a default :mrjob-opt:`hadoop_version`, instead handling :mrjob-opt:`jobconf` in a version-agnostic way
@@ -823,7 +823,7 @@ that will terminate themselves after being idle for a certain amount of time,
 in a way that optimizes EMR/EC2's full-hour billing model.
 
 For development (not production), we now recommend always using
-:ref:`job flow pooling <pooling-clusters>`, with :mrjob-opt:`max_hours_idle`
+:ref:`job flow pooling <cluster-pooling>`, with :mrjob-opt:`max_hours_idle`
 enabled. Update your :ref:`mrjob.conf <mrjob.conf>` like this:
 
 .. code-block:: yaml
@@ -967,7 +967,7 @@ Features
     multiple automated jobs, save time and money while debugging, and generally
     make your life simpler.
 
-    More info: :ref:`pooling-clusters`
+    More info: :ref:`cluster-pooling`
 
 **SSH Log Fetching**
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -230,6 +230,11 @@ _INSTANCE_ROLES = ('master', 'core', 'task')
 # use to disable multipart uploading
 _HUGE_PART_THRESHOLD = 2 ** 256
 
+# don't make mins_to_end_of_hour less than this, or it'll break
+# idle termination
+_MIN_MINS_TO_END_OF_HOUR = 1
+
+
 # used to bail out and retry when a pooled cluster self-terminates
 class _PooledClusterSelfTerminatedException(Exception):
     pass
@@ -312,6 +317,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'bootstrap_python': None,
             'check_cluster_every': 30,
             'cleanup_on_failure': ['JOB'],
+            'max_hours_idle': 1,
             'mins_to_end_of_hour': 5.0,
             'num_core_instances': 0,
             'num_task_instances': 0,

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -322,7 +322,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'bootstrap_python': None,
             'check_cluster_every': 30,
             'cleanup_on_failure': ['JOB'],
-            'max_hours_idle': 1,
+            'max_hours_idle': 1.0,
             'mins_to_end_of_hour': 5.0,
             'num_core_instances': 0,
             'num_task_instances': 0,
@@ -806,8 +806,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             self._upload_mgr.add(bootstrap_action['path'])
 
         # Add max-hours-idle script if we need it
-        if (self._opts['max_hours_idle'] and
-                (persistent or self._opts['pool_clusters'])):
+        if persistent or self._opts['pool_clusters']:
             self._upload_mgr.add(_MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH)
 
     def _add_master_node_setup_files_for_upload(self):
@@ -1341,19 +1340,18 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         if persistent or self._opts['pool_clusters']:
             Instances['KeepJobFlowAliveWhenNoSteps'] = True
 
-            # only use idle termination script on persistent clusters
+            # use idle termination script on persistent clusters
             # add it last, so that we don't count bootstrapping as idle time
-            if self._opts['max_hours_idle']:
-                uri = self._upload_mgr.uri(
-                    _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH)
-                # script takes args in (integer) seconds
-                ba_args = [str(int(self._opts['max_hours_idle'] * 3600)),
-                           str(int(self._opts['mins_to_end_of_hour'] * 60))]
-                BootstrapActions.append(dict(
-                    Name='idle timeout',
-                    ScriptBootstrapAction=dict(
-                        Path=uri,
-                        Args=ba_args)))
+            uri = self._upload_mgr.uri(
+                _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH)
+            # script takes args in (integer) seconds
+            ba_args = [str(int(self._opts['max_hours_idle'] * 3600)),
+                       str(int(self._opts['mins_to_end_of_hour'] * 60))]
+            BootstrapActions.append(dict(
+                Name='idle timeout',
+                ScriptBootstrapAction=dict(
+                    Path=uri,
+                    Args=ba_args)))
 
         if self._opts['ec2_key_pair']:
             Instances['Ec2KeyName'] = self._opts['ec2_key_pair']

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -326,6 +326,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'mins_to_end_of_hour': 5.0,
             'num_core_instances': 0,
             'num_task_instances': 0,
+            'pool_clusters': True,
             'pool_name': 'default',
             'pool_wait_minutes': 0,
             'cloud_fs_sync_secs': 5.0,

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -305,6 +305,11 @@ class EMRRunnerOptionStore(RunnerOptionStore):
         if not self['region']:
             self['region'] = _DEFAULT_EMR_REGION
 
+        # don't allow mins_to_end_of_hour to be small
+        if not self['mins_to_end_of_hour'] >= _MIN_MINS_TO_END_OF_HOUR:
+            raise ValueError('mins_to_end_of_hour must be at least %.1f' %
+                             _MIN_MINS_TO_END_OF_HOUR)
+
         self._fix_emr_configurations_opt()
         self._fix_instance_opts()
         self._fix_release_label_opt()

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -322,7 +322,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'bootstrap_python': None,
             'check_cluster_every': 30,
             'cleanup_on_failure': ['JOB'],
-            'max_hours_idle': 1.0,
+            'max_hours_idle': 0.5,
             'mins_to_end_of_hour': 5.0,
             'num_core_instances': 0,
             'num_task_instances': 0,

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1097,6 +1097,7 @@ _RUNNER_OPTS = dict(
     ),
     visible_to_all_users=dict(
         cloud_role='launch',
+        deprecated=True,
         runners=['emr'],
         switches=[
             (['--visible-to-all-users'], dict(

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1438,7 +1438,8 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
 
     def test_no_bootstrap_script_if_not_needed(self):
         runner = EMRJobRunner(conf_paths=[], bootstrap_mrjob=False,
-                              bootstrap_python=False)
+                              bootstrap_python=False,
+                              pool_clusters=False)
 
         runner._add_bootstrap_files_for_upload()
         self.assertIsNone(runner._master_bootstrap_script_path)
@@ -1479,7 +1480,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
 
         actions = _list_all_bootstrap_actions(runner)
 
-        self.assertEqual(len(actions), 3)
+        self.assertEqual(len(actions), 4)
 
         self.assertEqual(
             actions[0]['ScriptPath'],
@@ -1496,8 +1497,16 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
         # check for master bootstrap script
         self.assertTrue(actions[2]['ScriptPath'].startswith('s3://mrjob-'))
         self.assertTrue(actions[2]['ScriptPath'].endswith('b.sh'))
-        self.assertEqual(actions[2]['Args'], [])
+        self.assertTrue(actions[2]['Args'][0].startswith('pool-'))
+        self.assertTrue(actions[2]['Args'][1].startswith('default'))
         self.assertEqual(actions[2]['Name'], 'master')
+
+        # check for idle timeout script
+        self.assertTrue(actions[3]['ScriptPath'].startswith('s3://mrjob-'))
+        self.assertTrue(actions[3]['ScriptPath'].endswith(
+            'terminate_idle_cluster.sh'))
+        self.assertEqual(actions[3]['Args'], ['3600', '300'])
+        self.assertEqual(actions[3]['Name'], 'idle timeout')
 
         # make sure master bootstrap script is on S3
         self.assertTrue(runner.fs.exists(actions[2]['ScriptPath']))
@@ -1526,13 +1535,14 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
 
         runner = EMRJobRunner(conf_paths=[],
                               bootstrap_actions=bootstrap_actions,
-                              cloud_fs_sync_secs=0.00)
+                              cloud_fs_sync_secs=0.00,
+                              pool_clusters=False)
 
         cluster_id = runner.make_persistent_cluster()
 
         actions = _list_all_bootstrap_actions(runner)
 
-        self.assertEqual(len(actions), 2)
+        self.assertEqual(len(actions), 3)
 
         self.assertTrue(actions[0]['ScriptPath'].startswith('s3://mrjob-'))
         self.assertTrue(actions[0]['ScriptPath'].endswith('/apt-install.sh'))
@@ -1546,8 +1556,16 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
         self.assertEqual(actions[1]['Args'], [])
         self.assertEqual(actions[1]['Name'], 'master')
 
-        # make sure master bootstrap script is on S3
+        # check for idle timeout script
+        self.assertTrue(actions[2]['ScriptPath'].startswith('s3://mrjob-'))
+        self.assertTrue(actions[2]['ScriptPath'].endswith(
+            'terminate_idle_cluster.sh'))
+        self.assertEqual(actions[2]['Args'], ['3600', '300'])
+        self.assertEqual(actions[2]['Name'], 'idle timeout')
+
+        # make sure scripts are on S3
         self.assertTrue(runner.fs.exists(actions[1]['ScriptPath']))
+        self.assertTrue(runner.fs.exists(actions[2]['ScriptPath']))
 
 
 class MasterNodeSetupScriptTestCase(MockBoto3TestCase):
@@ -3858,17 +3876,17 @@ class ActionOnFailureTestCase(MockBoto3TestCase):
     def test_default(self):
         runner = EMRJobRunner()
         self.assertEqual(runner._action_on_failure(),
-                         'TERMINATE_CLUSTER')
+                         'CANCEL_AND_WAIT')
 
     def test_default_with_cluster_id(self):
         runner = EMRJobRunner(cluster_id='j-CLUSTER')
         self.assertEqual(runner._action_on_failure(),
                          'CANCEL_AND_WAIT')
 
-    def test_default_with_pooling(self):
-        runner = EMRJobRunner(pool_clusters=True)
+    def test_default_without_pooling(self):
+        runner = EMRJobRunner(pool_clusters=False)
         self.assertEqual(runner._action_on_failure(),
-                         'CANCEL_AND_WAIT')
+                         'TERMINATE_CLUSTER')
 
     def test_option(self):
         runner = EMRJobRunner(emr_action_on_failure='CONTINUE')

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1505,7 +1505,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
         self.assertTrue(actions[3]['ScriptPath'].startswith('s3://mrjob-'))
         self.assertTrue(actions[3]['ScriptPath'].endswith(
             'terminate_idle_cluster.sh'))
-        self.assertEqual(actions[3]['Args'], ['3600', '300'])
+        self.assertEqual(actions[3]['Args'], ['1800', '300'])
         self.assertEqual(actions[3]['Name'], 'idle timeout')
 
         # make sure master bootstrap script is on S3
@@ -1560,7 +1560,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
         self.assertTrue(actions[2]['ScriptPath'].startswith('s3://mrjob-'))
         self.assertTrue(actions[2]['ScriptPath'].endswith(
             'terminate_idle_cluster.sh'))
-        self.assertEqual(actions[2]['Args'], ['3600', '300'])
+        self.assertEqual(actions[2]['Args'], ['1800', '300'])
         self.assertEqual(actions[2]['Name'], 'idle timeout')
 
         # make sure scripts are on S3
@@ -2911,7 +2911,7 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
 
         with mr_job.make_runner() as runner:
             runner.run()
-            self.assertRanIdleTimeoutScriptWith(runner, ['3600', '300'])
+            self.assertRanIdleTimeoutScriptWith(runner, ['1800', '300'])
 
     def test_non_pooled_cluster(self):
         mr_job = MRWordCount(['-r', 'emr', '--no-pool-clusters'])
@@ -2944,7 +2944,7 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
 
         with mr_job.make_runner() as runner:
             runner.make_persistent_cluster()
-            self.assertRanIdleTimeoutScriptWith(runner, ['3600', '600'])
+            self.assertRanIdleTimeoutScriptWith(runner, ['1800', '600'])
 
     def test_too_small_mins_to_end_of_hour(self):
         mr_job = MRWordCount(['-r', 'emr', '--mins-to-end-of-hour', '0.1'])


### PR DESCRIPTION
This change ensures that pooling is turned on by default, and that any cluster started by mrjob will eventually self-terminate when idle (either because of our bootstrap script or because pooling is turned off). Fixes #1531.

Also deprecated `visible_to_all_users` (fixes #1598).

