### PR TITLE
cat byte chunks, not lines

### DIFF
--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -43,7 +43,12 @@ class Filesystem(object):
         False
 
     def cat(self, path_glob):
-        """cat all files matching **path_glob**, decompressing if necessary"""
+        """cat all files matching **path_glob**, decompressing if necessary
+
+        This yields bytes, which don't necessarily correspond to lines
+        (see #1544). If multiple files are catted, yields ``b''`` between
+        each file.
+        """
         for filename in self.ls(path_glob):
             for line in self._cat_file(filename):
                 yield line
@@ -66,6 +71,8 @@ class Filesystem(object):
         raise NotImplementedError
 
     def _cat_file(self, path):
+        """Yield the contents of the file at *path* as a series of ``bytes``,
+        not necessarily respecting line boundaries."""
         raise NotImplementedError
 
     def exists(self, path_glob):

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -49,7 +49,10 @@ class Filesystem(object):
         (see #1544). If multiple files are catted, yields ``b''`` between
         each file.
         """
-        for filename in self.ls(path_glob):
+        for i, filename in enumerate(self.ls(path_glob)):
+            if i > 0:
+                yield b''  # mark end of previous file
+
             for line in self._cat_file(filename):
                 yield line
 

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -16,6 +16,8 @@ import fnmatch
 import logging
 import mimetypes
 
+from mrjob.cat import decompress
+from mrjob.cat import to_chunks
 from mrjob.fs.base import Filesystem
 from mrjob.parse import urlparse
 from mrjob.runner import GLOB_RE
@@ -178,10 +180,8 @@ class GCSFilesystem(Filesystem):
 
             tmp_fileobj.seek(0)
 
-            line_gen = read_file(
-                gcs_uri, fileobj=tmp_fileobj, yields_lines=False)
-            for current_line in line_gen:
-                yield current_line
+            for chunk in decompress(tmp_fileobj, gcs_uri):
+                yield chunk
 
     def mkdir(self, dest):
         """Make a directory. This does nothing on GCS because there are

--- a/mrjob/fs/local.py
+++ b/mrjob/fs/local.py
@@ -16,9 +16,10 @@ import logging
 import os
 import shutil
 
+from mrjob.cat import decompress
 from mrjob.fs.base import Filesystem
 from mrjob.parse import is_uri
-from mrjob.util import read_file
+
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +44,9 @@ class LocalFilesystem(Filesystem):
                 yield path
 
     def _cat_file(self, filename):
-        return read_file(filename)
+        with open(filename, 'rb') as f:
+            for chunk in decompress(f, filename):
+                yield chunk
 
     def mkdir(self, path):
         if not os.path.isdir(path):

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -31,6 +31,7 @@ except ImportError:
     boto3 = None
 
 from mrjob.aws import _S3_REGION_WITH_NO_LOCATION_CONSTRAINT
+from mrjob.cat import decompress
 from mrjob.fs.base import Filesystem
 from mrjob.parse import is_uri
 from mrjob.parse import is_s3_uri
@@ -38,7 +39,6 @@ from mrjob.parse import parse_s3_uri
 from mrjob.parse import urlparse
 from mrjob.retry import RetryWrapper
 from mrjob.runner import GLOB_RE
-from mrjob.util import read_file
 
 
 log = logging.getLogger(__name__)
@@ -210,7 +210,7 @@ class S3Filesystem(Filesystem):
         s3_key = self._get_s3_key(filename)
         body = s3_key.get()['Body']
 
-        return read_file(filename, fileobj=body, yields_lines=False)
+        return decompress(body, filename)
 
     def mkdir(self, dest):
         """Make a directory. This does nothing on S3 because there are

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -57,6 +57,7 @@ from mrjob.setup import parse_setup_cmd
 from mrjob.step import STEP_TYPES
 from mrjob.step import _is_spark_step_type
 from mrjob.util import cmd_line
+from mrjob.util import to_lines
 from mrjob.util import zip_dir
 
 
@@ -462,11 +463,10 @@ class MRJobRunner(object):
 
                 path = base
 
-        # TODO - mtai @ davidmarin - why aren't we using self.fs.cat ?
         for filename in self.fs.ls(output_dir):
             subpath = filename[len(output_dir):]
             if not any(name.startswith('_') for name in split_path(subpath)):
-                for line in self.fs._cat_file(filename):
+                for line in to_lines(self.fs._cat_file(filename)):
                     yield line
 
     def _cleanup_mode(self, mode=None):

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -352,6 +352,7 @@ def to_lines(chunks):
         return _to_lines(chunks)
 
 
+# TODO: treat b'' as EOF
 def _to_lines(chunks):
     """Take in data as a sequence of bytes, and yield it, one line at a time.
 

--- a/tests/fs/test_base.py
+++ b/tests/fs/test_base.py
@@ -16,9 +16,27 @@ from unittest import TestCase
 
 from mrjob.fs.base import Filesystem
 
+from tests.py2 import Mock
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
 from tests.sandbox import SandboxedTestCase
+
+
+class CatTestCase(SandboxedTestCase):
+
+    def test_multiple_files(self):
+        fs = Filesystem()
+
+        fs.ls = Mock(return_value=['path1', 'path2', 'path3'])
+        fs._cat_file = Mock(return_value=[b'chunk1\n', b'chunk2'])
+
+        chunks = list(fs.cat('whatever'))
+
+        self.assertEqual(
+            chunks,
+            [b'chunk1\n', b'chunk2', b'',
+             b'chunk1\n', b'chunk2', b'',
+             b'chunk1\n', b'chunk2'])
 
 
 class JoinTestCase(SandboxedTestCase):

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -39,10 +39,10 @@ from tests.mockgoogleapiclient import MockGoogleAPITestCase
 from tests.sandbox import PatcherTestCase
 
 
-class GCSFSTestCase(MockGoogleAPITestCase):
+class CatTestCase(MockGoogleAPITestCase):
 
     def setUp(self):
-        super(GCSFSTestCase, self).setUp()
+        super(CatTestCase, self).setUp()
         self.fs = GCSFilesystem()
 
     def test_cat_uncompressed(self):
@@ -50,24 +50,44 @@ class GCSFSTestCase(MockGoogleAPITestCase):
             'gs://walrus/data/foo': b'foo\nfoo\n'
         })
 
-        self.assertEqual(list(self.fs._cat_file('gs://walrus/data/foo')),
-                         [b'foo\n', b'foo\n'])
+        self.assertEqual(
+            b''.join(self.fs._cat_file('gs://walrus/data/foo')),
+            b'foo\nfoo\n')
 
     def test_cat_bz2(self):
         self.put_gcs_multi({
             'gs://walrus/data/foo.bz2': bz2.compress(b'foo\n' * 1000)
         })
 
-        self.assertEqual(list(self.fs._cat_file('gs://walrus/data/foo.bz2')),
-                         [b'foo\n'] * 1000)
+        self.assertEqual(
+            b''.join(self.fs._cat_file('gs://walrus/data/foo.bz2')),
+            b'foo\n' * 1000)
 
     def test_cat_gz(self):
         self.put_gcs_multi({
             'gs://walrus/data/foo.gz': gzip_compress(b'foo\n' * 10000)
         })
 
-        self.assertEqual(list(self.fs._cat_file('gs://walrus/data/foo.gz')),
-                         [b'foo\n'] * 10000)
+        self.assertEqual(
+            b''.join(self.fs._cat_file('gs://walrus/data/foo.gz')),
+            b'foo\n' * 10000)
+
+    def test_chunks_file(self):
+        self.put_gcs_multi({
+            'gs://walrus/data/foo': b'foo\nfoo\n' * 1000
+        })
+
+        self.assertGreater(
+            len(list(self.fs._cat_file('gs://walrus/data/foo'))),
+            1)
+
+
+
+class GCSFSTestCase(MockGoogleAPITestCase):
+
+    def setUp(self):
+        super(GCSFSTestCase, self).setUp()
+        self.fs = GCSFilesystem()
 
     def test_ls_key(self):
         self.put_gcs_multi({

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -64,6 +64,33 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         return self.makefile(
             os.path.join(get_mock_hdfs_root(self.env), name), contents)
 
+    def test_cat_uncompressed(self):
+        self.make_mock_file('data/foo', 'foo\nfoo\n')
+
+        remote_path = self.fs.join('hdfs:///data', 'foo')
+
+        self.assertEqual(
+            b''.join(self.fs._cat_file(remote_path)),
+            b'foo\nfoo\n')
+
+    def test_cat_bz2(self):
+        self.make_mock_file('data/foo.bz2', bz2.compress(b'foo\n' * 1000))
+
+        remote_path = self.fs.join('hdfs:///data', 'foo.bz2')
+
+        self.assertEqual(
+            b''.join(self.fs._cat_file(remote_path)),
+            b'foo\n' * 1000)
+
+    def test_cat_gz(self):
+        self.make_mock_file('data/foo.gz', gzip_compress(b'foo\n' * 10000))
+
+        remote_path = self.fs.join('hdfs:///data', 'foo.gz')
+
+        self.assertEqual(
+            b''.join(self.fs._cat_file(remote_path)),
+            b'foo\n' * 10000)
+
     def test_ls_empty(self):
         self.assertEqual(list(self.fs.ls('hdfs:///')), [])
 
@@ -99,30 +126,6 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         self.make_mock_file('foo  bar')
         self.assertEqual(sorted(self.fs.ls('hdfs:///')),
                          ['hdfs:///foo  bar'])
-
-    def test_cat_uncompressed(self):
-        self.make_mock_file('data/foo', 'foo\nfoo\n')
-
-        remote_path = self.fs.join('hdfs:///data', 'foo')
-
-        self.assertEqual(list(self.fs._cat_file(remote_path)),
-                         [b'foo\n', b'foo\n'])
-
-    def test_cat_bz2(self):
-        self.make_mock_file('data/foo.bz2', bz2.compress(b'foo\n' * 1000))
-
-        remote_path = self.fs.join('hdfs:///data', 'foo.bz2')
-
-        self.assertEqual(list(self.fs._cat_file(remote_path)),
-                         [b'foo\n'] * 1000)
-
-    def test_cat_gz(self):
-        self.make_mock_file('data/foo.gz', gzip_compress(b'foo\n' * 10000))
-
-        remote_path = self.fs.join('hdfs:///data', 'foo.gz')
-
-        self.assertEqual(list(self.fs._cat_file(remote_path)),
-                         [b'foo\n'] * 10000)
 
     def test_du(self):
         self.make_mock_file('data1', 'abcd')

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -23,32 +23,50 @@ from tests.mock_boto3 import MockBoto3TestCase
 from tests.py2 import patch
 
 
-class S3FSTestCase(MockBoto3TestCase):
+class CatTestCase(MockBoto3TestCase):
 
     def setUp(self):
-        super(S3FSTestCase, self).setUp()
+        super(CatTestCase, self).setUp()
         self.fs = S3Filesystem()
 
     def test_cat_uncompressed(self):
         self.add_mock_s3_data(
             {'walrus': {'data/foo': b'foo\nfoo\n'}})
 
-        self.assertEqual(list(self.fs._cat_file('s3://walrus/data/foo')),
-                         [b'foo\n', b'foo\n'])
+        self.assertEqual(
+            b''.join(self.fs._cat_file('s3://walrus/data/foo')),
+            b'foo\nfoo\n')
 
     def test_cat_bz2(self):
         self.add_mock_s3_data(
             {'walrus': {'data/foo.bz2': bz2.compress(b'foo\n' * 1000)}})
 
-        self.assertEqual(list(self.fs._cat_file('s3://walrus/data/foo.bz2')),
-                         [b'foo\n'] * 1000)
+        self.assertEqual(
+            b''.join(self.fs._cat_file('s3://walrus/data/foo.bz2')),
+            b'foo\n' * 1000)
 
     def test_cat_gz(self):
         self.add_mock_s3_data(
             {'walrus': {'data/foo.gz': gzip_compress(b'foo\n' * 10000)}})
 
-        self.assertEqual(list(self.fs._cat_file('s3://walrus/data/foo.gz')),
-                         [b'foo\n'] * 10000)
+        self.assertEqual(
+            b''.join(self.fs._cat_file('s3://walrus/data/foo.gz')),
+            b'foo\n' * 10000)
+
+    def test_chunks_file(self):
+        self.add_mock_s3_data(
+            {'walrus': {'data/foo': b'foo\n' * 1000}})
+
+        self.assertGreater(
+            len(list(self.fs._cat_file('s3://walrus/data/foo'))),
+            1)
+
+
+class S3FSTestCase(MockBoto3TestCase):
+
+    def setUp(self):
+        super(S3FSTestCase, self).setUp()
+        self.fs = S3Filesystem()
 
     def test_ls_key(self):
         self.add_mock_s3_data(

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -34,7 +34,8 @@ class CatTestCase(MockBoto3TestCase):
             {'walrus': {'data/foo': b'foo\nfoo\n'}})
 
         self.assertEqual(
-
+            b''.join(self.fs._cat_file('s3://walrus/data/foo')),
+            b'foo\nfoo\n')
 
     def test_cat_bz2(self):
         self.add_mock_s3_data(

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -34,8 +34,7 @@ class CatTestCase(MockBoto3TestCase):
             {'walrus': {'data/foo': b'foo\nfoo\n'}})
 
         self.assertEqual(
-            b''.join(self.fs._cat_file('s3://walrus/data/foo')),
-            b'foo\nfoo\n')
+
 
     def test_cat_bz2(self):
         self.add_mock_s3_data(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -56,41 +56,43 @@ class ToLinesTestCase(TestCase):
 
     def test_buffered_lines(self):
         self.assertEqual(
-            list(to_lines(chunk for chunk in
-                          [b'The quick\nbrown fox\nju',
-                           b'mped over\nthe lazy\ndog',
-                           b's.\n'])),
-            [b'The quick\n', b'brown fox\n', b'jumped over\n', b'the lazy\n',
-             b'dogs.\n'])
-
-    def test_empty_chunks(self):
-        self.assertEqual(
-            list(to_lines(chunk for chunk in
-                          [b'',
-                           b'The quick\nbrown fox\nju',
-                           b'', b'', b'',
-                           b'mped over\nthe lazy\ndog',
-                           b'',
-                           b's.\n',
-                           b''])),
+            list(to_lines(iter([
+                b'The quick\nbrown fox\nju',
+                b'mped over\nthe lazy\ndog',
+                b's.\n',
+            ]))),
             [b'The quick\n', b'brown fox\n', b'jumped over\n', b'the lazy\n',
              b'dogs.\n'])
 
     def test_no_trailing_newline(self):
         self.assertEqual(
-            list(to_lines(chunk for chunk in
-                          [b'Alouette,\ngentille',
-                           b' Alouette.'])),
+            list(to_lines(iter([
+                b'Alouette,\ngentille',
+                b' Alouette.',
+            ]))),
             [b'Alouette,\n', b'gentille Alouette.'])
+
+    def test_eof_without_trailing_newline(self):
+        self.assertEqual(
+            list(to_lines(iter([
+                b'Alouette,\ngentille',
+                b' Alouette.',
+                b'',  # treated as EOF
+                b'Allouette,\nje te p',
+                b'lumerais.',
+            ]))),
+            [b'Alouette,\n', b'gentille Alouette.',
+             b'Allouette,\n', b'je te plumerais.'])
 
     def test_long_lines(self):
         super_long_line = b'a' * 10000 + b'\n' + b'b' * 1000 + b'\nlast\n'
         self.assertEqual(
             list(to_lines(
-                chunk for chunk in
-                (super_long_line[0 + i:1024 + i]
-                 for i in range(0, len(super_long_line), 1024)))),
+                super_long_line[0 + i:1024 + i]
+                for i in range(0, len(super_long_line), 1024)
+            )),
             [b'a' * 10000 + b'\n', b'b' * 1000 + b'\n', b'last\n'])
+
 
 
 class CmdLineTestCase(TestCase):


### PR DESCRIPTION
This makes the `cat()` method in filesystems yield chunks of bytes, which may or may not correspond to lines. Fixes #1533.

Didn't touch the SSH FS because it lacks tests and needs to be rewritten not to dump file contents to memory (see #1544).
