### PR TITLE
add cat_output()/parse_output(), deprecate old way of parsing job output

### DIFF
--- a/docs/guides/py2-vs-py3.rst
+++ b/docs/guides/py2-vs-py3.rst
@@ -15,7 +15,7 @@ Bytes vs. strings
 
 The following things are bytes in any version of Python (which means you need to use the ``bytes`` type and/or ``b'...'`` constant in Python 3):
  - data read or written by :ref:`job-protocols`
- - lines yielded by :py:meth:`~mrjob.runner.MRJobRunner.stream_output`
+ - lines yielded by :py:meth:`~mrjob.runner.MRJobRunner.cat_output`/:py:meth:`~mrjob.runner.MRJobRunner.stream_output`
  - anything read from :py:meth:`~mrjob.fs.base.Filesystem.cat`
 
 The :py:attr:`~mrjob.job.MRJob.stdin`, :py:attr:`~mrjob.job.MRJob.stdout`, and :py:attr:`~mrjob.job.MRJob.stderr` attributes of :py:class:`~mrjob.job.MRJob`\ s are always bytestreams (so, for example, ``self.stderr`` defaults to ``sys.stderr.buffer`` in Python 3).

--- a/docs/guides/runners.rst
+++ b/docs/guides/runners.rst
@@ -131,23 +131,33 @@ This pattern can also be used to write integration tests (see :doc:`testing`).
 
 ::
 
-    mr_job = MRWordCounter(args=['-r', 'emr'])
-    with mr_job.make_runner() as runner:
+   mr_job = MRWordCounter(args=['-r', 'emr'])
+   with mr_job.make_runner() as runner:
         runner.run()
+        for key, value in mr_job.parse_output(runner.cat_output()):
+            ... # do something with the parsed output
+
+You instantiate the :py:class:`~mrjob.job.MRJob`, use a context manager to
+create the runner, run the job, and cat its output, parsing that output with
+the job's output protocol.
+
+:py:meth:`~mrjob.job.MRJob.parse_output` and :py:meth:`~mrjob.job.MRJob.cat_output` were introduced in version 0.6.0. In previous versions of mrjob, you'd iterate line by line instead, like this:
+
+.. code-block:: python
+
+    ...
         for line in runner.stream_output():
             key, value = mr_job.parse_output_line(line)
             ... # do something with the parsed output
 
-You instantiate the :py:class:`~mrjob.job.MRJob`, use a context manager to
-create the runner, run the job, iterate over the output lines, and use the job
-instance to parse each line with its output protocol.
-
 Further reference:
 
 * :py:meth:`~mrjob.job.MRJob.make_runner`
+* :py:meth:`~mrjob.runner.MRJobRunner.run`
+* :py:meth:`~mrjob.job.MRJob.parse_output`
+* :py:meth:`~mrjob.runner.MRJobRunner.cat_output`
 * :py:meth:`~mrjob.job.MRJob.parse_output_line`
 * :py:meth:`~mrjob.runner.MRJobRunner.stream_output`
-* :py:meth:`~mrjob.runner.MRJobRunner.run`
 
 Limitations
 ^^^^^^^^^^^

--- a/docs/guides/testing.rst
+++ b/docs/guides/testing.rst
@@ -251,26 +251,27 @@ To run the job without leaving temp files on your system, use the
 command line arguments and ensures that job cleanup is performed regardless of
 the success or failure of the job.
 
-Run the job with :py:meth:`~mrjob.runner.MRJobRunner.run()`. The output lines
-are available as a generator through
-:py:meth:`~mrjob.runner.MRJobRunner.stream_output()` and can be interpreted
-through the job's output protocol with
-:py:meth:`~mrjob.job.MRJob.parse_output_line()`. You may choose to collect
-these lines in a list and check the contents of the list.
+Run the job with :py:meth:`~mrjob.runner.MRJobRunner.run()`. The job's output
+is available as a generator through
+:py:meth:`~mrjob.runner.MRJobRunner.cat_output()` and can be parsed with
+the job's output protocol using :py:meth:`~mrjob.job.MRJob.parse_output`::
+
+   results = []
+   with mr_job.make_runner() as runner:
+       runner.run()
+       for key, value in mrjob.parse_output(runner.cat_output()):
+           results.append(value)
+
+       # these numbers should match if mapper_init, reducer_init, and
+       # combiner_init were called as expected
+       self.assertEqual(sorted(results)[0], num_inputs * 10 * 10 * 2)
+
 
 .. warning:: Do not let your tests depend on the input lines being processed in
-    a certain order. Both mrjob and Hadoop divide input non-deterministically.
+             a certain order. Both mrjob and Hadoop divide input
+             non-deterministically.
 
-::
+.. note::
 
-            results = []
-            with mr_job.make_runner() as runner:
-                runner.run()
-                for line in runner.stream_output():
-                    # Use the job's specified protocol to read the output
-                    key, value = mr_job.parse_output_line(line)
-                    results.append(value)
-
-            # these numbers should match if mapper_init, reducer_init, and
-            # combiner_init were called as expected
-            self.assertEqual(results[0], num_inputs * 10 * 10 * 2)
+   In mrjob versions prior to 0.6.0, you have to parse output line by line;
+   see :ref:`runners-programmatically` for an example.

--- a/docs/runners-runner.rst
+++ b/docs/runners-runner.rst
@@ -11,6 +11,7 @@ Running your job
 ----------------
 
 .. automethod:: MRJobRunner.run
+.. automethod:: MRJobRunner.cat_output
 .. automethod:: MRJobRunner.stream_output
 .. automethod:: MRJobRunner.cleanup
 .. autodata:: mrjob.runner.CLEANUP_CHOICES

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -932,11 +932,7 @@ class MRJob(MRJobLauncher):
     def parse_output_line(self, line):
         """
         Parse a line from the final output of this MRJob into
-        ``(key, value)``. Used extensively in tests like this::
-
-            runner.run()
-            for line in runner.stream_output():
-                key, value = mr_job.parse_output_line(line)
+        ``(key, value)``.
 
         .. deprecated:: 0.6.0
 

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -87,6 +87,8 @@ class MRJob(MRJobLauncher):
         """
         super(MRJob, self).__init__(self.mr_job_script(), args)
 
+        self._warned_about_parse_output_line = False
+
     @classmethod
     def _usage(cls):
         return "usage: %prog [options] [input files]"
@@ -940,6 +942,11 @@ class MRJob(MRJobLauncher):
 
            Use :py:meth:`parse_output` instead.
         """
+        if not self._warned_about_parse_output_line:
+            log.warning('parse_output_line() is deprecated and will be removed'
+                        ' in v0.7.0; use parse_output() instead.')
+            self._warned_about_parse_output_line = True
+
         return self.output_protocol().read(line)
 
     ### Hadoop Input/Output Formats ###

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -40,6 +40,7 @@ from mrjob.step import SparkStep
 from mrjob.step import _JOB_STEP_FUNC_PARAMS
 from mrjob.util import expand_path
 from mrjob.util import read_input
+from mrjob.util import to_lines
 
 
 log = logging.getLogger(__name__)
@@ -917,6 +918,15 @@ class MRJob(MRJobLauncher):
     #: See :py:data:`mrjob.protocol` for the full list of protocols.
     OUTPUT_PROTOCOL = JSONProtocol
 
+    def parse_output(self, chunks):
+        """Parse the final output of this MRJob (as a stream of byte chunks)
+        into a stream of ``(key, value)``.
+        """
+        read = self.output_protocol().read
+
+        for line in to_lines(chunks):
+            yield read(line)
+
     def parse_output_line(self, line):
         """
         Parse a line from the final output of this MRJob into
@@ -925,6 +935,10 @@ class MRJob(MRJobLauncher):
             runner.run()
             for line in runner.stream_output():
                 key, value = mr_job.parse_output_line(line)
+
+        .. deprecated:: 0.6.0
+
+           Use :py:meth:`parse_output` instead.
         """
         return self.output_protocol().read(line)
 

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -235,8 +235,8 @@ class MRJobLauncher(object):
                 sys.exit(1)
 
             if not self.options.no_output:
-                for line in runner.stream_output():
-                    self.stdout.write(line)
+                for chunk in runner.cat_output():
+                    self.stdout.write(chunk)
                 self.stdout.flush()
 
     ### Command-line arguments ###

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -436,10 +436,15 @@ class MRJobRunner(object):
         self._run()
         self._ran_job = True
 
-    def stream_output(self):
-        """Stream raw lines from the job's output. You can parse these
-        using the read() method of the appropriate HadoopStreamingProtocol
-        class."""
+    def cat_output(self):
+        """Stream the jobs output, as a stream of ``bytes``. If there are
+        multiple output files, there will be an empty bytestring
+        (``b''``) between them.
+
+        .. versionadded:: 0.6.0
+
+           In previous versions, you'd use :py:meth:`stream_output`.
+        """
         output_dir = self.get_output_dir()
         if output_dir is None:
             raise AssertionError('Run the job before streaming output')
@@ -463,11 +468,31 @@ class MRJobRunner(object):
 
                 path = base
 
-        for filename in self.fs.ls(output_dir):
-            subpath = filename[len(output_dir):]
-            if not any(name.startswith('_') for name in split_path(subpath)):
-                for line in to_lines(self.fs._cat_file(filename)):
-                    yield line
+        def ls_output():
+            for filename in self.fs.ls(output_dir):
+                subpath = filename[len(output_dir):]
+                if not (any(name.startswith('_')
+                            for name in split_path(subpath))):
+                    yield filename
+
+        for i, filename in enumerate(ls_output()):
+            if i > 0:
+                yield b''  # EOF of previous file
+
+            for chunk in self.fs._cat_file(filename):
+                yield chunk
+
+    def stream_output(self):
+        """Like :py:meth:`cat_output` except that it groups bytes into
+        lines. Equivalent to ``mrjob.util.to_lines(runner.stream_output())``.
+
+        .. deprecated:: 0.6.0
+        """
+        log.warn('stream_output() is deprecated and will be removed in'
+                 ' v0.7.0. use mrjob.util.to_lines(runner.cat_output())'
+                 ' instead.')
+
+        return to_lines(self.cat_output())
 
     def _cleanup_mode(self, mode=None):
         """Actual cleanup action to take based on various options"""

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -488,9 +488,9 @@ class MRJobRunner(object):
 
         .. deprecated:: 0.6.0
         """
-        log.warn('stream_output() is deprecated and will be removed in'
-                 ' v0.7.0. use mrjob.util.to_lines(runner.cat_output())'
-                 ' instead.')
+        log.warning('stream_output() is deprecated and will be removed in'
+                    ' v0.7.0. use mrjob.util.to_lines(runner.cat_output())'
+                    ' instead.')
 
         return to_lines(self.cat_output())
 

--- a/tests/job.py
+++ b/tests/job.py
@@ -21,5 +21,4 @@ def run_job(job, raw_input=b''):
 
     with job.make_runner() as runner:
         runner.run()
-        return dict(job.parse_output_line(line)
-                    for line in runner.stream_output())
+        return dict(job.parse_output(runner.cat_output()))

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -124,9 +124,7 @@ class DataprocJobRunnerEndToEndTestCase(MockGoogleAPITestCase):
             # setup fake output
             self.put_job_output_parts(runner, fake_gcs_output)
 
-            for line in runner.stream_output():
-                key, value = mr_job.parse_output_line(line)
-                results.append((key, value))
+            results.extend(mr_job.parse_output(runner.cat_output()))
 
             local_tmp_dir = runner._get_local_tmp_dir()
             # make sure cleanup hasn't happened yet
@@ -224,7 +222,7 @@ class DataprocJobRunnerEndToEndTestCase(MockGoogleAPITestCase):
             runner.run()
 
             # this is set and unset before we can get at it unless we do this
-            list(runner.stream_output())
+            list(runner.cat_output())
 
         objects_in_bucket = self._gcs_fs.api_client._cache_objects[tmp_bucket]
         self.assertEqual(len(objects_in_bucket), tmp_len)
@@ -285,9 +283,7 @@ class ExistingClusterTestCase(MockGoogleAPITestCase):
             # attaching to another cluster
             self.assertIsNone(runner._master_bootstrap_script_path)
 
-            for line in runner.stream_output():
-                key, value = mr_job.parse_output_line(line)
-                results.append((key, value))
+            results.extend(mr_job.parse_output(runner.cat_output()))
 
         self.assertEqual(sorted(results),
                          [(1, 'bar'), (1, 'foo'), (2, None)])
@@ -840,9 +836,7 @@ class DataprocNoMapperTestCase(MockGoogleAPITestCase):
                 b'1\t["blue", "one", "red", "two"]\n',
                 b'4\t["fish"]\n'])
 
-            for line in runner.stream_output():
-                key, value = mr_job.parse_output_line(line)
-                results.append((key, value))
+            results.extend(mr_job.parse_output(runner.cat_output()))
 
         self.assertEqual(sorted(results),
                          [(1, ['blue', 'one', 'red', 'two']),

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -213,9 +213,7 @@ class EMRJobRunnerEndToEndTestCase(MockBoto3TestCase):
 
             runner.run()
 
-            for line in runner.stream_output():
-                key, value = mr_job.parse_output_line(line)
-                results.append((key, value))
+            results.extend(mr_job.parse_output(runner.cat_output()))
 
             local_tmp_dir = runner._get_local_tmp_dir()
             # make sure cleanup hasn't happened yet
@@ -324,7 +322,7 @@ class EMRJobRunnerEndToEndTestCase(MockBoto3TestCase):
             # this is set and unset before we can get at it unless we do this
             log_bucket, _ = parse_s3_uri(runner._s3_log_dir())
 
-            list(runner.stream_output())
+            list(runner.cat_output())
 
         bucket = runner.fs.get_bucket(tmp_bucket)
         self.assertEqual(len(list(bucket.objects.all())), tmp_len)
@@ -393,9 +391,7 @@ class ExistingClusterTestCase(MockBoto3TestCase):
             # attaching to another cluster
             self.assertIsNone(runner._master_bootstrap_script_path)
 
-            for line in runner.stream_output():
-                key, value = mr_job.parse_output_line(line)
-                results.append((key, value))
+            results.extend(mr_job.parse_output(runner.cat_output()))
 
         self.assertEqual(sorted(results),
                          [(1, 'bar'), (1, 'foo'), (2, None)])
@@ -1741,9 +1737,7 @@ class EMRNoMapperTestCase(MockBoto3TestCase):
         with mr_job.make_runner() as runner:
             runner.run()
 
-            for line in runner.stream_output():
-                key, value = mr_job.parse_output_line(line)
-                results.append((key, value))
+            results.extend(mr_job.parse_output(runner.cat_output()))
 
         self.assertEqual(sorted(results),
                          [(1, ['blue', 'one', 'red', 'two']),

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -645,9 +645,7 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
             runner.run()
 
-            for line in runner.stream_output():
-                key, value = mr_job.parse_output_line(line)
-                results.append((key, value))
+            results.extend(mr_job.parse_output(runner.cat_output()))
 
             local_tmp_dir = runner._get_local_tmp_dir()
             # make sure cleanup hasn't happened yet

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -160,9 +160,9 @@ class ParseOutputLine(SandboxedTestCase):
             job.parse_output_line(b'1\t2\n'),
             (1, 2))
 
-    def test_raw_value_protocol(self):
+    def test_bytes_value_protocol(self):
         job = MRJob()
-        job.OUTPUT_PROTOCOL = RawValueProtocol
+        job.OUTPUT_PROTOCOL = BytesValueProtocol
 
         self.assertEqual(
             job.parse_output_line(b'one two\n'),

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -146,7 +146,12 @@ class ParseOutputTestCase(TestCase):
              (None, b'five\n')])
 
 
-class ParseOutputLine(TestCase):
+class ParseOutputLine(SandboxedTestCase):
+
+    def setUp(self):
+        super(ParseOutputLine, self).setUp()
+
+        self.log = self.start(patch('mrjob.job.log'))
 
     def test_default_protocol(self):
         job = MRJob()
@@ -163,7 +168,15 @@ class ParseOutputLine(TestCase):
             job.parse_output_line(b'one two\n'),
             (None, b'one two\n'))
 
+    def test_deprecation_warning(self):
+        job = MRJob()
 
+        job.parse_output_line(b'1\t2\n')
+        self.assertEqual(self.log.warning.call_count, 1)
+
+        # only warn once
+        job.parse_output_line(b'3\t4\n')
+        self.assertEqual(self.log.warning.call_count, 1)
 
 
 class NoTzsetTestCase(TestCase):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -28,6 +28,7 @@ from mrjob.job import MRJob
 from mrjob.job import UsageError
 from mrjob.job import _im_func
 from mrjob.parse import parse_mr_job_stderr
+from mrjob.protocol import BytesValueProtocol
 from mrjob.protocol import JSONProtocol
 from mrjob.protocol import JSONValueProtocol
 from mrjob.protocol import PickleProtocol
@@ -126,14 +127,14 @@ class ParseOutputTestCase(TestCase):
     def test_default_protocol(self):
         job = MRJob()
 
-        data = iter([b'1\t2', b'\n{"3": ', '4}\t"fi', b've"\n'])
+        data = iter([b'1\t2', b'\n{"3": ', b'4}\t"fi', b've"\n'])
         self.assertEqual(
             list(job.parse_output(data)),
             [(1, 2), ({'3': 4}, 'five')])
 
-    def test_raw_value_protocol(self):
+    def test_bytes_value_protocol(self):
         job = MRJob()
-        job.OUTPUT_PROTOCOL = RawValueProtocol
+        job.OUTPUT_PROTOCOL = BytesValueProtocol
 
         data = iter([b'one\nt', b'wo\nthree\n', b'four\nfive\n'])
         self.assertEqual(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -122,6 +122,17 @@ class MRInitTestCase(EmptyMrjobConfTestCase):
         self.assertEqual(results[0], num_inputs * 10 * 10 * 2)
 
 
+class ParseOutputTestCase(TestCase):
+
+    def test_json(self):
+        job = MRJob()
+
+        data = iter([b'1\t2', b'\n{"3": ', '4}\t"fi', b've"\n'])
+        self.assertEqual(
+            list(job.parse_output(data)),
+            [(1, 2), ({'3': 4}, 'five')])
+
+
 class NoTzsetTestCase(TestCase):
 
     def setUp(self):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -124,13 +124,46 @@ class MRInitTestCase(EmptyMrjobConfTestCase):
 
 class ParseOutputTestCase(TestCase):
 
-    def test_json(self):
+    def test_default_protocol(self):
         job = MRJob()
 
         data = iter([b'1\t2', b'\n{"3": ', '4}\t"fi', b've"\n'])
         self.assertEqual(
             list(job.parse_output(data)),
             [(1, 2), ({'3': 4}, 'five')])
+
+    def test_raw_value_protocol(self):
+        job = MRJob()
+        job.OUTPUT_PROTOCOL = RawValueProtocol
+
+        data = iter([b'one\nt', b'wo\nthree\n', b'four\nfive\n'])
+        self.assertEqual(
+            list(job.parse_output(data)),
+            [(None, b'one\n'),
+             (None, b'two\n'),
+             (None, b'three\n'),
+             (None, b'four\n'),
+             (None, b'five\n')])
+
+
+class ParseOutputLine(TestCase):
+
+    def test_default_protocol(self):
+        job = MRJob()
+
+        self.assertEqual(
+            job.parse_output_line(b'1\t2\n'),
+            (1, 2))
+
+    def test_raw_value_protocol(self):
+        job = MRJob()
+        job.OUTPUT_PROTOCOL = RawValueProtocol
+
+        self.assertEqual(
+            job.parse_output_line(b'one two\n'),
+            (None, b'one two\n'))
+
+
 
 
 class NoTzsetTestCase(TestCase):

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -94,7 +94,7 @@ class RunJobTestCase(TestCase):
         launcher.sandbox()
 
         launcher.mock_runner = Mock()
-        launcher.mock_runner.stream_output.return_value = [b'a line\n']
+        launcher.mock_runner.cat_output.return_value = [b'a line\n']
 
         launcher.make_runner = MagicMock()  # include __enter__
         launcher.make_runner.return_value.__enter__.return_value = (
@@ -345,8 +345,7 @@ class TestPassThroughRunner(TestCase):
         with job.make_runner() as runner:
             runner.run()
 
-            for line in runner.stream_output():
-                key, value = job.parse_output_line(line)
+            for _, value in job.parse_output(runner.cat_output()):
                 return value
 
     def test_no_pass_through(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -286,15 +286,16 @@ class TestCatOutput(SandboxedTestCase):
                          [b'A', b'B', b'C'])
 
     def test_deprecated_stream_output(self):
-        self.makefile('part-00000', contents=b'one\ntwo')
-        self.makefile('part-00001', contents=b'three\nfour')
+        self.makefile('part-00000', contents=b'1\n2')
+        self.makefile('part-00001', contents=b'3\n4\n')
 
         runner = InlineMRJobRunner(conf_paths=[], output_dir=self.tmp_dir)
 
         log = self.start(patch('mrjob.runner.log'))
 
-        self.assertEqual(list(runner.stream_output()),
-                         [b'one\n', b'two', b'three\n', b'four'])
+        # should group output into lines, but not join across files
+        self.assertEqual(sorted(runner.stream_output()),
+                         [b'1\n', b'2', b'3\n', b'4\n'])
 
         # should issue deprecation warning
         self.assertEqual(log.warning.call_count, 1)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -46,6 +46,7 @@ from mrjob.step import INPUT
 from mrjob.step import OUTPUT
 from mrjob.tools.emr.audit_usage import _JOB_KEY_RE
 from mrjob.util import log_to_stream
+from mrjob.util import to_lines
 
 from tests.mock_boto3 import MockBoto3TestCase
 from tests.mr_cmd_job import MRCmdJob
@@ -265,7 +266,7 @@ class TestStreamingOutput(TestCase):
         shutil.rmtree(self.tmp_dir)
 
     # Test regression for #269
-    def test_stream_output(self):
+    def test_cat_output(self):
         a_dir_path = os.path.join(self.tmp_dir, 'a')
         b_dir_path = os.path.join(self.tmp_dir, 'b')
         l_dir_path = os.path.join(self.tmp_dir, '_logs')
@@ -295,7 +296,7 @@ class TestStreamingOutput(TestCase):
             f.write('I win')
 
         runner = InlineMRJobRunner(conf_paths=[], output_dir=self.tmp_dir)
-        self.assertEqual(sorted(runner.stream_output()),
+        self.assertEqual(sorted(to_lines(runner.cat_output())),
                          [b'A', b'B', b'C'])
 
 
@@ -1249,8 +1250,7 @@ class SetupTestCase(SandboxedTestCase):
         with job.make_runner() as r:
             r.run()
 
-            path_to_size = dict(job.parse_output_line(line)
-                                for line in r.stream_output())
+            path_to_size = dict(job.parse_output(r.cat_output()))
 
         self.assertEqual(path_to_size.get('./foo.sh'), self.foo_sh_size)
         self.assertEqual(path_to_size.get('./bar.sh'), self.foo_sh_size)
@@ -1266,8 +1266,7 @@ class SetupTestCase(SandboxedTestCase):
             with no_handlers_for_logger('mrjob.local'):
                 r.run()
 
-            path_to_size = dict(job.parse_output_line(line)
-                                for line in r.stream_output())
+            path_to_size = dict(job.parse_output(r.cat_output()))
 
         self.assertEqual(path_to_size.get('./foo.tar.gz/foo.py'),
                          self.foo_py_size)
@@ -1284,8 +1283,7 @@ class SetupTestCase(SandboxedTestCase):
             with no_handlers_for_logger('mrjob.local'):
                 r.run()
 
-            path_to_size = dict(job.parse_output_line(line)
-                                for line in r.stream_output())
+            path_to_size = dict(job.parse_output(r.cat_output()))
 
         self.assertEqual(path_to_size.get('./foo/foo.py'),
                          self.foo_py_size)
@@ -1302,8 +1300,7 @@ class SetupTestCase(SandboxedTestCase):
         with job.make_runner() as r:
             r.run()
 
-            path_to_size = dict(job.parse_output_line(line)
-                                for line in r.stream_output())
+            path_to_size = dict(job.parse_output(r.cat_output()))
 
         # foo.py should be there, and getsize() should be patched to return
         # double the number of bytes
@@ -1320,8 +1317,7 @@ class SetupTestCase(SandboxedTestCase):
         with job.make_runner() as r:
             r.run()
 
-            path_to_size = dict(job.parse_output_line(line)
-                                for line in r.stream_output())
+            path_to_size = dict(job.parse_output(r.cat_output()))
 
         # foo.py should be there, and getsize() should be patched to return
         # double the number of bytes
@@ -1338,8 +1334,7 @@ class SetupTestCase(SandboxedTestCase):
         with job.make_runner() as r:
             r.run()
 
-            path_to_size = dict(job.parse_output_line(line)
-                                for line in r.stream_output())
+            path_to_size = dict(job.parse_output(r.cat_output()))
 
         # foo.py should be there, and getsize() should be patched to return
         # double the number of bytes
@@ -1356,8 +1351,7 @@ class SetupTestCase(SandboxedTestCase):
         with job.make_runner() as r:
             r.run()
 
-            path_to_size = dict(job.parse_output_line(line)
-                                for line in r.stream_output())
+            path_to_size = dict(job.parse_output(r.cat_output()))
 
         # foo.py should be there, and getsize() should be patched to return
         # double the number of bytes
@@ -1373,8 +1367,7 @@ class SetupTestCase(SandboxedTestCase):
         with job.make_runner() as r:
             r.run()
 
-            path_to_size = dict(job.parse_output_line(line)
-                                for line in r.stream_output())
+            path_to_size = dict(job.parse_output(r.cat_output()))
 
         self.assertIn('./bar', path_to_size)
 
@@ -1387,8 +1380,7 @@ class SetupTestCase(SandboxedTestCase):
         with job.make_runner() as r:
             r.run()
 
-            path_to_size = dict(job.parse_output_line(line)
-                                for line in r.stream_output())
+            path_to_size = dict(job.parse_output(r.cat_output()))
 
             self.assertEqual(path_to_size.get('./foo.sh'), self.foo_sh_size)
             self.assertIn('./foo.sh-made-this', path_to_size)
@@ -1433,8 +1425,7 @@ class SetupTestCase(SandboxedTestCase):
             with job.make_runner() as r:
                 r.run()
 
-                path_to_size = dict(job.parse_output_line(line)
-                                    for line in r.stream_output())
+                path_to_size = dict(job.parse_output(r.cat_output()))
 
                 self.assertEqual(path_to_size.get('./stdin.txt'), 0)
                 # input gets passed through by identity mapper
@@ -1458,7 +1449,7 @@ class SetupTestCase(SandboxedTestCase):
             with job.make_runner() as r:
                 r.run()
 
-                output = b''.join(r.stream_output())
+                output = b''.join(r.cat_output())
 
                 # stray ouput should be in stderr, not the job's output
                 self.assertIn('stray output', stderr.getvalue())


### PR DESCRIPTION
This creates a new way of parsing job output that doesn't rely on output files being line-based. Fixes #1604.