### PR TITLE
Accept input paths with an s3a prefix

### DIFF
--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -65,7 +65,7 @@ def parse_s3_uri(uri):
     If ``uri`` is not an S3 URI, raise a ValueError
     """
     components = urlparse(uri)
-    if (components.scheme not in ('s3', 's3n') or
+    if (components.scheme not in ('s3', 's3n', 's3a') or
         '/' not in components.path):  # noqa
 
         raise ValueError('Invalid S3 URI: %s' % uri)

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -117,6 +117,13 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         self.assertEqual(sorted(self.fs.ls('s3n://bucket/')),
                          ['s3n://bucket/f', 's3n://bucket/f3 win'])
 
+    def test_ls_s3a(self):
+        # hadoop fs -lsr doesn't have user and group info when reading from s3
+        self.make_mock_file('f', 'foo')
+        self.make_mock_file('f3 win', 'foo' * 10)
+        self.assertEqual(sorted(self.fs.ls('s3a://bucket/')),
+                         ['s3a://bucket/f', 's3a://bucket/f3 win'])
+
     def test_single_space(self):
         self.make_mock_file('foo bar')
         self.assertEqual(sorted(self.fs.ls('hdfs:///')),

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -128,6 +128,15 @@ class S3FSTestCase(MockBoto3TestCase):
                          ['s3n://walrus/data/bar',
                           's3n://walrus/data/baz'])
 
+    def test_ls_s3a(self):
+        self.add_mock_s3_data(
+            {'walrus': {'data/bar': b'abc123',
+                        'data/baz': b'123abc'}})
+
+        self.assertEqual(list(self.fs.ls('s3a://walrus/data/*')),
+                         ['s3a://walrus/data/bar',
+                          's3a://walrus/data/baz'])
+
     def test_du(self):
         self.add_mock_s3_data({
             'walrus': {'data/foo': b'abcde',

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -387,7 +387,7 @@ def _hadoop_ls_line(real_path, scheme, netloc, size=0, max_size=0, environ={}):
     else:
         file_type = '-'
 
-    if scheme in ('s3', 's3n'):
+    if scheme in ('s3', 's3n', 's3a'):
         # no user and group on S3 (see Pull Request #573)
         user_and_group = ''
     else:

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -105,6 +105,10 @@ class TestFullyQualifyHDFSPath(TestCase):
         self.assertEqual(fully_qualify_hdfs_path('s3n://bucket/oh/noes'),
                          's3n://bucket/oh/noes')
 
+    def test_s3a_uri(self):
+        self.assertEqual(fully_qualify_hdfs_path('s3a://bucket/oh/noes'),
+                         's3a://bucket/oh/noes')
+
     def test_other_uri(self):
         self.assertEqual(fully_qualify_hdfs_path('foo://bar/baz'),
                          'foo://bar/baz')

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -230,6 +230,7 @@ class URITestCase(TestCase):
     def test_is_s3_uri(self):
         self.assertEqual(is_s3_uri('s3://a/uri'), True)
         self.assertEqual(is_s3_uri('s3n://a/uri'), True)
+        self.assertEqual(is_s3_uri('s3a://a/uri'), True)
         self.assertEqual(is_s3_uri('hdfs://a/uri'), False)
 
     def test_parse_s3_uri(self):


### PR DESCRIPTION
More a cosmetic than functional change since `boto` is handling under the hood, but sometimes my jobs fail on the `ValueError` when I copy/paste `s3a` uris into input configuration. Since `s3n` is deprecated it makes sense to just support all the protocol prefixes.