### PR TITLE
cat.py doesn't need to be executable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -100,6 +100,7 @@ v0.6.0, 2017-06-?? -- ???
  * removed deprecated switches:
    * --partitioner
  * removed deprecated JOB_FLOW and *SCRATCH cleanup types
+ * mrjob.cat is no longer executable
 
 v0.5.10, 2017-05-12 -- loose ends
  * JSON protcols use rapidjson if ujson unavailable (#1579)

--- a/mrjob/cat.py
+++ b/mrjob/cat.py
@@ -129,24 +129,3 @@ def to_chunks(readable, bufsize=1024):
             yield chunk
         else:
             return
-
-
-def _main():
-    args = sys.argv[1:]
-    if len(args) != 1:
-        raise ValueError('please pass a single path')
-    path = args[0]
-
-    # we want to write bytes
-    if hasattr(sys.stdout, 'buffer'):
-        stdout_buffer = sys.stdout.buffer
-    else:
-        stdout_buffer = sys.stdout
-
-    with open(path, 'rb') as f:
-        for chunk in decompress(f, path):
-            stdout_buffer.write(chunk)
-
-
-if __name__ == '__main__':
-    _main()


### PR DESCRIPTION
`mrjob.cat` was a temporary shim to pass decompressed input to binaries run in local mode, which we don't need now that the sim runner has been refactored.