### PR TITLE
instance_groups option

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -272,6 +272,36 @@ Cluster creation and configuration
         2.5.
 
 .. mrjob-opt::
+    :config: instance_groups
+    :switch: --max-hours-idle
+    :set: emr
+    :default: ``None``
+
+    A list of instance group definitions to pass to the EMR API. Pass a JSON
+    string on the command line or use data structures in the config file
+    (which is itself basically JSON).
+
+    This is the primary way to configure EBS volumes. For example:
+
+    .. code-block:: yaml
+
+        runners:
+          emr:
+            instance_groups:
+            - InstanceRole: MASTER
+              InstanceCount: 1
+              InstanceType: m1.medium
+            - InstanceRole: CORE
+              InstanceCount: 10
+              InstanceType: c1.xlarge
+              EbsConfiguration:
+                EbsOptimized: true
+                EbsBlockDeviceConfigs:
+                - VolumeSpecification:
+                    SizeInGB: 100
+                    VolumeType: gp2
+
+.. mrjob-opt::
     :config: max_hours_idle
     :switch: --max-hours-idle
     :type: :ref:`string <data-type-string>`

--- a/docs/guides/pooling.rst
+++ b/docs/guides/pooling.rst
@@ -44,6 +44,11 @@ cluster's instances provide at least as much memory and at least as much CPU as
 your job requests. If there is a tie, it picks clusters that are closest to
 the end of a full hour, to minimize wasted instance hours.
 
+Pooling is also somewhat flexible about EBS volumes (see
+:mrjob-opt:`instance_groups`). Each volume must have the same volume type,
+but larger volumes or volumes with more I/O ops per second are acceptable,
+as are additional volumes of any type.
+
 mrjob's pooling won't add more than 1000 steps to a cluster, as the
 EMR API won't show more than this many steps. (For `very old AMIs <http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/AddingStepstoaJobFlow.html>`__
 there is a stricter limit of 256 steps).

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -334,6 +334,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'iam_endpoint',
         'iam_instance_profile',
         'iam_service_role',
+        'instance_groups',
         'master_instance_bid_price',
         'mins_to_end_of_hour',
         'pool_clusters',

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3033,6 +3033,7 @@ def _instance_groups_satisfy(actual_igs, requested_igs):
     # one per role)
     r = {ig['InstanceRole'].lower(): ig for ig in requested_igs}
 
+    # just require roles to match (see #1630)
     if set(a) != set(r):
         log.debug("    instance group roles don't match")
         return None

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2620,7 +2620,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
             requested_igs = self._instance_groups()
 
-            ig_sort_key = _instance_groups_satisfy(requested_igs, actual_igs)
+            ig_sort_key = _instance_groups_satisfy(actual_igs, requested_igs)
 
             if not ig_sort_key:
                 return
@@ -3056,11 +3056,11 @@ def _igs_for_same_role_satisfy(actual_igs, requested_ig):
         return False
 
     # memory
-    if not all(_ig_satisfies_mem(requested_ig, ig) for ig in actual_igs):
+    if not all(_ig_satisfies_mem(ig, requested_ig) for ig in actual_igs):
         return False
 
     # CPU (this returns # of compute units or None)
-    return _igs_satisfy_cpu(requested_ig, actual_igs)
+    return _igs_satisfy_cpu(actual_igs, requested_ig)
 
 
 def _ig_satisfies_bid_price(actual_ig, requested_ig):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3040,7 +3040,7 @@ def _instance_groups_satisfy(actual_igs, requested_igs):
     sort_keys = {}
     for role in sorted(r):
         sort_key = _igs_for_same_role_satisfy(a[role], r[role])
-        if sort_key is None:  # doesn't satisfy
+        if not sort_key:  # doesn't satisfy
             return None
         sort_keys[role] = sort_key
 
@@ -3053,11 +3053,11 @@ def _igs_for_same_role_satisfy(actual_igs, requested_ig):
     """
     # bid price/on-demand
     if not all(_ig_satisfies_bid_price(ig, requested_ig) for ig in actual_igs):
-        return False
+        return None
 
     # memory
     if not all(_ig_satisfies_mem(ig, requested_ig) for ig in actual_igs):
-        return False
+        return None
 
     # CPU (this returns # of compute units or None)
     return _igs_satisfy_cpu(actual_igs, requested_ig)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3206,20 +3206,19 @@ def _ebs_volumes_satisfy(actual_volumes, req_volumes):
 
 def _ebs_volume_satisfies(actual_volume, req_volume):
     """Does the given actual EBS volume satisfy the given request?"""
-    if req_volume.get('VolumeType'):
-        if req_volume['VolumeType'] != actual_volume.get('VolumeType'):
-            log.debug('    wrong EBS volume type')
-            return False
+    if req_volume.get('VolumeType') != actual_volume.get('VolumeType'):
+        log.debug('    wrong EBS volume type')
+        return False
 
-    if req_volume.get('SizeInGB'):
-        if not req_volume['SizeInGB'] <= actual_volume.get('SizeInGB', 0):
-            log.debug('    EBS volume too small')
-            return False
+    if not req_volume.get('SizeInGB', 0) <= actual_volume.get('SizeInGB', 0):
+        log.debug('    EBS volume too small')
+        return False
 
-    if req_volume.get('Iops'):
-        if not (req_volume['Iops'] <= actual_volume.get('Iops', 0)):
-            log.debug('    EBS volume too slow')
-            return False
+    # Iops isn't really "optional"; it has to be set if volume type is
+    # io1 and not set otherwise
+    if not (req_volume.get('Iops', 0) <= actual_volume.get('Iops', 0)):
+        log.debug('    EBS volume too slow')
+        return False
 
     return True
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3104,15 +3104,15 @@ def _ig_satisfies_bid_price(actual_ig, requested_ig):
     if actual_ig['Market'] == 'ON_DEMAND':
         return True
 
-    if requested_ig['Market'] == 'ON_DEMAND':
+    if requested_ig.get('Market', 'ON_DEMAND') == 'ON_DEMAND':
         log.debug('    spot instance, requested on-demand')
         return False
 
-    if actual_ig['BidPrice'] == requested_ig['BidPrice']:
+    if actual_ig['BidPrice'] == requested_ig.get('BidPrice'):
         return True
 
     try:
-        if float(actual_ig['BidPrice']) >= float(requested_ig['BidPrice']):
+        if float(actual_ig['BidPrice']) >= float(requested_ig.get('BidPrice')):
             return True
         else:
             # low bid prices mean cluster is more likely to be

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -647,6 +647,7 @@ _RUNNER_OPTS = dict(
         cloud_role='launch',
         switches=[
             (['--instance-groups'], dict(
+                callback=_json_callback,
                 help=('detailed JSON list of instance configs, including'
                       ' EBS configuration. See docs for --instance-groups'
                       ' at http://docs.aws.amazon.com/cli/latest/reference'

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -67,7 +67,7 @@ CLEANUP_CHOICES = [
 ### custom callbacks ###
 
 def _default_to(parser, dest, value):
-    """Helper function; set the given optino dest to *value* if it's None.
+    """Helper function; set the given option dest to *value* if it's None.
 
     This lets us create callbacks that don't require default to be set
     to a container."""
@@ -137,6 +137,16 @@ def _append_json_callback(option, opt_str, value, parser):
             opt_str, str(e)))
 
     getattr(parser.values, option.dest).append(j)
+
+
+def _json_callback(option, opt_str, value, parser):
+    try:
+        j = json.loads(value)
+    except ValueError as e:
+        parser.error('Malformed JSON passed to %s: %s' % (
+            opt_str, str(e)))
+
+    setattr(parser.values, option.dest, j)
 
 
 def _port_range_callback(option, opt_str, value, parser):
@@ -630,6 +640,17 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--image-version'], dict(
                 help='EMR/Dataproc machine image to launch clusters with',
+            )),
+        ],
+    ),
+    instance_groups=dict(
+        cloud_role='launch',
+        switches=[
+            (['--instance-groups'], dict(
+                help=('detailed JSON list of instance configs, including'
+                      ' EBS configuration. See docs for --instance-groups'
+                      ' at http://docs.aws.amazon.com/cli/latest/reference'
+                      '/emr/create-cluster.html'),
             )),
         ],
     ),

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -639,7 +639,7 @@ class MockEMRClient(object):
                 EbsConfiguration = InstanceGroup.pop('EbsConfiguration')
 
                 if 'EbsOptimized' in EbsConfiguration:
-                    _validate_param(InstanceGroup, 'EbsOptimized', bool)
+                    _validate_param(EbsConfiguration, 'EbsOptimized', bool)
                     if EbsConfiguration['EbsOptimized']:
                         ig['EbsOptimized'] = True
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2077,6 +2077,27 @@ class PoolMatchingTestCase(MockBoto3TestCase):
             '--instance-type', 'm2.4xlarge',
             '--num-core-instances', '20'])
 
+    def test_join_pool_with_same_instance_groups(self):
+        INSTANCE_GROUPS = [
+            dict(
+                InstanceRole='MASTER',
+                InstanceCount=1,
+                InstanceType='m1.medium',
+            ),
+            dict(
+                InstanceRole='CORE',
+                InstanceCount=20,
+                InstanceType='m2.4xlarge',
+            ),
+        ]
+
+        _, cluster_id = self.make_pooled_cluster(
+            instance_groups=INSTANCE_GROUPS)
+
+        self.assertJoins(cluster_id, [
+            '-r', 'emr', '-v', '--pool-clusters',
+            '--instance-groups', json.dumps(INSTANCE_GROUPS)])
+
     def test_join_pool_with_more_of_same_instance_type(self):
         _, cluster_id = self.make_pooled_cluster(
             instance_type='m2.4xlarge',

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2098,6 +2098,31 @@ class PoolMatchingTestCase(MockBoto3TestCase):
             '-r', 'emr', '-v', '--pool-clusters',
             '--instance-groups', json.dumps(INSTANCE_GROUPS)])
 
+    def test_instance_groups_match_instance_type_and_count(self):
+        # setting instance type and count is just a shorthand
+        # for --instance-groups
+
+        INSTANCE_GROUPS = [
+            dict(
+                InstanceRole='MASTER',
+                InstanceCount=1,
+                InstanceType='m1.medium',
+            ),
+            dict(
+                InstanceRole='CORE',
+                InstanceCount=20,
+                InstanceType='m2.4xlarge',
+            ),
+        ]
+
+        _, cluster_id = self.make_pooled_cluster(
+            instance_type='m2.4xlarge',
+            num_core_instances=20)
+
+        self.assertJoins(cluster_id, [
+            '-r', 'emr', '-v', '--pool-clusters',
+            '--instance-groups', json.dumps(INSTANCE_GROUPS)])
+
     def test_join_pool_with_more_of_same_instance_type(self):
         _, cluster_id = self.make_pooled_cluster(
             instance_type='m2.4xlarge',

--- a/tests/tools/emr/test_create_cluster.py
+++ b/tests/tools/emr/test_create_cluster.py
@@ -54,6 +54,7 @@ class ClusterInspectionTestCase(ToolTestCase):
                 'iam_instance_profile': None,
                 'iam_service_role': None,
                 'image_version': None,
+                'instance_groups': None,
                 'instance_type': None,
                 'label': None,
                 'master_instance_bid_price': None,


### PR DESCRIPTION
Added an `instance_groups` option, which allows for EBS volume configuration (fixes #1357). Pooling understands instance groups.

Also fixed the way pooling deals with un-requested instance roles on a pooled cluster (see #1630).