### PR TITLE
Support for --exclude tags in report_long_jobs

### DIFF
--- a/mrjob/tools/emr/report_long_jobs.py
+++ b/mrjob/tools/emr/report_long_jobs.py
@@ -110,6 +110,10 @@ def _runner_kwargs(options):
 
 
 def _filter_clusters(cluster_summaries, emr_client, exclude_strings):
+    """ Filter out clusters that have tags matching any specified in exclude_strings.
+    :param cluster_summaries: a list of :py:mod:`boto3` cluster summary data structures
+    :param exclude_strings: A list of strings of the form TAG_KEY,TAG_VALUE
+    """
     exclude_as_dicts = []
     for exclude_string in exclude_strings:
         exclude_key, exclude_value = exclude_string.split(',')
@@ -133,8 +137,6 @@ def _find_long_running_jobs(emr_client, cluster_summaries, min_time, now=None):
                      pending longer than this
     :param now: the current UTC time, as a :py:class:`datetime.datetime`.
                 Defaults to the current time.
-    :param exclude: A list of strings of the form TAG_KEY:TAG_VALUE
-                Excludes any clusters that have tags that match
 
     For each job that is running or pending longer than *min_time*, yields
     a dictionary with the following keys:

--- a/tests/tools/emr/test_report_long_jobs.py
+++ b/tests/tools/emr/test_report_long_jobs.py
@@ -36,6 +36,7 @@ CLUSTERS = [
                 CreationDateTime=parse('2010-06-06T00:05:00Z'),
             ),
         ),
+        Tags=[],
         _steps=[],
     ),
     dict(
@@ -47,6 +48,7 @@ CLUSTERS = [
                 CreationDateTime=parse('2010-06-06T00:05:00Z'),
             ),
         ),
+        Tags=[],
         _steps=[],
     ),
     dict(
@@ -59,6 +61,7 @@ CLUSTERS = [
                 ReadyDateTime=parse('2010-06-06T00:15:00Z'),
             ),
         ),
+        Tags=[dict(Key='my_key', Value='my_value')],
         _Steps=[
             dict(
                 Name='mr_denial: Step 1 of 5',
@@ -81,6 +84,7 @@ CLUSTERS = [
                 ReadyDateTime=parse('2010-06-06T00:15:00Z'),
             ),
         ),
+        Tags=[],
         _Steps=[
             dict(
                 Name='mr_denial: Step 1 of 5',
@@ -113,6 +117,7 @@ CLUSTERS = [
                 ReadyDateTime=parse('2010-06-06T00:15:00Z'),
             ),
         ),
+        Tags=[],
         _Steps=[
             dict(
                 Name='mr_denial: Step 1 of 5',
@@ -151,6 +156,7 @@ CLUSTERS = [
                 ReadyDateTime=parse('2010-06-06T00:15:00Z'),
             ),
         ),
+        Tags=[],
         _Steps=[
             dict(
                 Name='mr_bargaining: Step 3 of 5',
@@ -170,6 +176,7 @@ CLUSTERS = [
                 ReadyDateTime=parse('2010-06-06T00:15:00Z'),
             ),
         ),
+        Tags=[],
         _Steps=[
             dict(
                 Name='mr_bargaining: Step 3 of 5',
@@ -200,6 +207,7 @@ CLUSTERS = [
             ),
         ),
         State='COMPLETED',
+        Tags=[],
         _Steps=[
             dict(
                 Name='mr_acceptance: Step 5 of 5',
@@ -260,6 +268,18 @@ class ReportLongJobsTestCase(MockBoto3TestCase):
 
         lines = [line for line in StringIO(self.stdout.getvalue())]
         self.assertEqual(len(lines), len(CLUSTERS_BY_ID) - 1)
+        self.assertNotIn('j-COMPLETED', self.stdout.getvalue())
+
+    def test_exclude(self):
+        for cluster in CLUSTERS:
+            self.add_mock_emr_cluster(cluster)
+
+        main(['-q', '--no-conf', '-x', 'my_key,my_value'])
+
+        lines = [line for line in StringIO(self.stdout.getvalue())]
+        self.assertEqual(len(lines), len(CLUSTERS_BY_ID) - 2)
+        self.assertNotIn('j-COMPLETED', self.stdout.getvalue())
+        self.assertNotIn('j-RUNNING1STEP', self.stdout.getvalue())
 
 
 class FindLongRunningJobsTestCase(MockBoto3TestCase):


### PR DESCRIPTION
Add a feature to report_long_jobs to exclude clusters with specific tags.

Internal ticket MRJOB-169