### PR TITLE
Instance fleets, including pooling

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -272,8 +272,45 @@ Cluster creation and configuration
         2.5.
 
 .. mrjob-opt::
+    :config: instance_fleets
+    :switch: --instance-fleet
+    :set: emr
+    :default: ``None``
+
+    A list of instance fleet definitions to pass to the EMR API. Pass a JSON
+    string on the command line or use data structures in the config file
+    (which is itself basically JSON).
+
+    *instance_fleets* overrides :mrjob-opt:`instance_groups` and other
+    instance configuration options.
+
+    .. code-block:: yaml
+
+        runners:
+          emr:
+            instance_fleets:
+            - InstanceFleetType: MASTER
+              InstanceTypeConfigs:
+              - InstanceType: m1.medium
+              TargetOnDemandCapacity: 1
+            - InstanceFleetType: CORE
+              TargetSpotCapacity: 2
+              TargetOnDemandCapacity: 2
+              LaunchSpecifications:
+                SpotSpecification:
+                  TimeoutDurationMinutes: 20
+                  TimeoutAction: SWITCH_TO_ON_DEMAND
+              InstanceTypeConfigs:
+              - InstanceType: m1.medium
+                BidPriceAsPercentageOfOnDemandPrice: 50
+                WeightedCapacity: 1
+              - InstanceType: m1.large
+                BidPriceAsPercentageOfOnDemandPrice: 50
+                WeightedCapacity: 2
+
+.. mrjob-opt::
     :config: instance_groups
-    :switch: --max-hours-idle
+    :switch: --instance-groups
     :set: emr
     :default: ``None``
 

--- a/docs/guides/pooling.rst
+++ b/docs/guides/pooling.rst
@@ -49,6 +49,11 @@ Pooling is also somewhat flexible about EBS volumes (see
 but larger volumes or volumes with more I/O ops per second are acceptable,
 as are additional volumes of any type.
 
+If you are using :mrjob-opt:`instance_fleets`, your jobs will only join other
+clusters which use instance fleets. The rules are similar, but jobs will
+only join clusters whose fleets use the same set of instances or a subset;
+there is no concept of "better" instances.
+
 mrjob's pooling won't add more than 1000 steps to a cluster, as the
 EMR API won't show more than this many steps. (For `very old AMIs <http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/AddingStepstoaJobFlow.html>`__
 there is a stricter limit of 256 steps).

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2643,11 +2643,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
                 # mock_boto3 doesn't yet support this
 
-                #actual_fleets = list(_boto3_paginate(
-                #    'InstanceFleets', emr_client, 'list_instance_fleets',
-                #    ClusterId=cluster['Id']))
-
-                actual_fleets = []
+                actual_fleets = list(_boto3_paginate(
+                    'InstanceFleets', emr_client, 'list_instance_fleets',
+                    ClusterId=cluster['Id']))
 
                 req_fleets = self._opts['instance_fleets']
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -221,7 +221,7 @@ _CHEAPEST_INSTANCE_TYPE = 'm1.medium'
 _CHEAPEST_2_X_INSTANCE_TYPE = 'm1.small'
 
 # these are the only kinds of instance roles that exist
-_INSTANCE_ROLES = ('master', 'core', 'task')
+_INSTANCE_ROLES = ('MASTER', 'CORE', 'TASK')
 
 # use to disable multipart uploading
 _HUGE_PART_THRESHOLD = 2 ** 256
@@ -1164,13 +1164,13 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
     def _instance_type(self, role):
         """What instance type should we use for the given role?
-        (one of 'master', 'core', 'task')"""
+        (one of 'MASTER', 'CORE', 'TASK')"""
         if role not in _INSTANCE_ROLES:
             raise ValueError
 
         # explicitly set
-        if self._opts[role + '_instance_type']:
-            return self._opts[role + '_instance_type']
+        if self._opts[role.lower() + '_instance_type']:
+            return self._opts[role.lower() + '_instance_type']
 
         elif self._instance_is_worker(role):
             # using *instance_type* here is defensive programming;
@@ -1188,7 +1188,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         if role not in _INSTANCE_ROLES:
             raise ValueError
 
-        return (role != 'master' or
+        return (role != 'MASTER' or
                 sum(self._num_instances(role)
                     for role in _INSTANCE_ROLES) == 1)
 
@@ -1197,17 +1197,17 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         if role not in _INSTANCE_ROLES:
             raise ValueError
 
-        if role == 'master':
+        if role == 'MASTER':
             return 1  # there can be only one
         else:
-            return self._opts['num_' + role + '_instances']
+            return self._opts['num_' + role.lower() + '_instances']
 
     def _instance_bid_price(self, role):
         """What's the bid price for the given role (if any)?"""
         if role not in _INSTANCE_ROLES:
             raise ValueError
 
-        return self._opts[role + '_instance_bid_price']
+        return self._opts[role.lower() + '_instance_bid_price']
 
     def _instance_groups(self):
         """Which instance groups do we want to request?
@@ -3081,7 +3081,7 @@ def _build_instance_group(role, instance_type, num_instances, bid_price):
     """Helper method for creating instance groups. For use when
     creating a cluster using a list of InstanceGroups
 
-        - Role is either 'master', 'core', or 'task'.
+        - role is either 'MASTER', 'CORE', or 'TASK'.
         - instance_type is an EC2 instance type
         - count is an int
         - bid_price is a number, a string, or None. If None,
@@ -3099,10 +3099,10 @@ def _build_instance_group(role, instance_type, num_instances, bid_price):
 
     ig = dict(
         InstanceCount=num_instances,
-        InstanceRole=role.upper(),
+        InstanceRole=role,
         InstanceType=instance_type,
         Market='ON_DEMAND',
-        Name=role,  # just name the groups "core", "master", and "task"
+        Name=role.lower(),  # just name the groups "core", "master", and "task"
     )
 
     if bid_price:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -86,6 +86,8 @@ from mrjob.parse import is_uri
 from mrjob.parse import _parse_progress_from_job_tracker
 from mrjob.parse import _parse_progress_from_resource_manager
 from mrjob.pool import _est_time_to_hour
+from mrjob.pool import _instance_fleets_satisfy
+from mrjob.pool import _instance_groups_satisfy
 from mrjob.pool import _pool_hash_and_name
 from mrjob.py2 import PY2
 from mrjob.py2 import string_types
@@ -2639,9 +2641,19 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                     log.debug('    does not use instance fleets')
                     return
 
+                # mock_boto3 doesn't yet support this
+
+                #actual_fleets = list(_boto3_paginate(
+                #    'InstanceFleets', emr_client, 'list_instance_fleets',
+                #    ClusterId=cluster['Id']))
+
+                actual_fleets = []
+
+                req_fleets = self._opts['instance_fleets']
+
                 # TODO add logic for instance fleets
-                log.debug('    pooling not yet supported for instance fleets')
-                return
+                instance_sort_key = _instance_fleets_satisfy(
+                    actual_fleets, req_fleets)
             else:
                 if collection_type != 'INSTANCE_GROUP':
                     log.debug('    does not use instance groups')
@@ -2658,8 +2670,8 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 instance_sort_key = _instance_groups_satisfy(
                     actual_igs, requested_igs)
 
-                if not instance_sort_key:
-                    return
+            if not instance_sort_key:
+                return
 
             # prioritize "best" clusters, with time as tiebreaker
             sort_key = (instance_sort_key, _est_time_to_hour(cluster))
@@ -3100,296 +3112,3 @@ def _build_instance_group(role, instance_type, num_instances, bid_price):
         ig['BidPrice'] = str(bid_price)  # must be a string
 
     return ig
-
-
-\
-### pooled cluster matching: instance groups ###
-
-def _instance_groups_satisfy(actual_igs, requested_igs):
-    """Do the actual instance groups from a cluster satisfy the requested
-    ones, for the purpose of pooling?
-
-    The formats are slightly different; the format of *requested_igs* is here:
-    http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_InstanceGroup.html
-    and the format of *actual_igs* is here:
-    http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_ListInstanceGroups.html
-    """
-    # a is a map from role to actual instance groups
-    a = defaultdict(list)
-    for ig in actual_igs:
-        a[ig['InstanceGroupType'].lower()].append(ig)
-
-    # r is a map from role to request (should be only one per role)
-    r = {req['InstanceRole'].lower(): req for req in requested_igs}
-
-    # updated request to account for extra instance groups
-    # see #1630 for what we do when roles don't match
-    if set(a) - set(r):
-        r = _add_missing_roles_to_request(set(a) - set(r), r,
-                                          ['InstanceCount'])
-
-    if set(a) != set(r):
-        log.debug("    missing instance group roles")
-        return None
-
-    sort_keys = {}
-    for role in sorted(r):
-        sort_key = _igs_for_same_role_satisfy(a[role], r[role])
-        if not sort_key:  # doesn't satisfy
-            return None
-        sort_keys[role] = sort_key
-
-    return tuple(sort_keys.get(role) for role in ('core', 'task', 'master'))
-
-
-def _igs_for_same_role_satisfy(actual_igs, requested_ig):
-    """Does the *actual* list of instance groups satisfy the *requested*
-    one?
-    """
-    # bid price/on-demand
-    if not all(_ig_satisfies_bid_price(ig, requested_ig) for ig in actual_igs):
-        return None
-
-    # memory
-    if not all(_ig_satisfies_mem(ig, requested_ig) for ig in actual_igs):
-        return None
-
-    # EBS volumes
-    if not all(_ig_satisfies_ebs(ig, requested_ig) for ig in actual_igs):
-        return None
-
-    # CPU (this returns # of compute units or None)
-    return _igs_satisfy_cpu(actual_igs, requested_ig)
-
-
-def _ig_satisfies_bid_price(actual_ig, requested_ig):
-    """Does the actual instance group definition satisfy the bid price
-    (or lack thereof) of the requested instance group?
-    """
-    # on-demand instances satisfy every bid price
-    if actual_ig['Market'] == 'ON_DEMAND':
-        return True
-
-    if requested_ig.get('Market', 'ON_DEMAND') == 'ON_DEMAND':
-        log.debug('    spot instance, requested on-demand')
-        return False
-
-    if actual_ig['BidPrice'] == requested_ig.get('BidPrice'):
-        return True
-
-    try:
-        if float(actual_ig['BidPrice']) >= float(requested_ig.get('BidPrice')):
-            return True
-        else:
-            # low bid prices mean cluster is more likely to be
-            # yanked away
-            log.debug('    bid price too low')
-            return False
-    except ValueError:
-        log.debug('    non-float bid price')
-        return False
-
-
-def _ig_satisfies_mem(actual_ig, requested_ig):
-    """Does the actual instance group satisfy the memory requirements of
-    the requested instance group?"""
-    actual_type = actual_ig['InstanceType']
-    requested_type = requested_ig['InstanceType']
-
-    # this works even for unknown instance types
-    if actual_type == requested_type:
-        return True
-
-    try:
-        if (EC2_INSTANCE_TYPE_TO_MEMORY[actual_type] >=
-                EC2_INSTANCE_TYPE_TO_MEMORY[requested_type]):
-            return True
-        else:
-            log.debug('    too little memory')
-            return False
-    except KeyError:
-        log.debug('    unknown instance type')
-        return False
-
-
-def _ig_satisfies_ebs(actual_ig, requested_ig):
-    """Does *actual_ig* have EBS volumes that satisfy *requested_ig*.
-
-    If *requested_ig* doesn't have an EBS Configuration, we return
-    True.
-
-    If *requested_ig* requests EBS optimization, *actual_ig* should provide
-    it.
-
-    Finally, *actual_ig* should have the same or better block devices
-    as those in *requested_ig* (same volume type, at least as much IOPS
-    and volume size).
-    """
-    req_ebs_config = requested_ig.get('EbsConfiguration')
-
-    if not req_ebs_config:
-        return True
-
-    if (req_ebs_config.get('EbsOptimized')
-            and not actual_ig.get('EbsOptimized')):
-        log.debug('    need EBS-optimized instances')
-        return False
-
-    req_device_configs = req_ebs_config.get('EbsBlockDeviceConfigs')
-
-    if not req_device_configs:
-        return True
-
-    req_volumes = []
-
-    for req_device_config in req_device_configs:
-        volume = req_device_config['VolumeSpecification']
-        num_volumes = req_device_config.get('VolumesPerInstance', 1)
-
-        req_volumes.extend([volume] * num_volumes)
-
-    actual_volumes = [
-        bd.get('VolumeSpecification', {})
-        for bd in actual_ig.get('EbsBlockDevices', [])]
-
-    return _ebs_volumes_satisfy(actual_volumes, req_volumes)
-
-
-def _ebs_volumes_satisfy(actual_volumes, req_volumes):
-    """Does the given list of actual EBS volumes satisfy the given request?
-
-    Just compare them one by one (we want each actual device to be
-    bigger/faster; just having the same amount of capacity or iops
-    isn't enough).
-    """
-    if len(req_volumes) > len(actual_volumes):
-        log.debug('    more EBS volumes requested than available')
-        return False
-
-    return all(_ebs_volume_satisfies(a, r)
-               for a, r in zip(actual_volumes, req_volumes))
-
-
-def _ebs_volume_satisfies(actual_volume, req_volume):
-    """Does the given actual EBS volume satisfy the given request?"""
-    if req_volume.get('VolumeType') != actual_volume.get('VolumeType'):
-        log.debug('    wrong EBS volume type')
-        return False
-
-    if not req_volume.get('SizeInGB', 0) <= actual_volume.get('SizeInGB', 0):
-        log.debug('    EBS volume too small')
-        return False
-
-    # Iops isn't really "optional"; it has to be set if volume type is
-    # io1 and not set otherwise
-    if not (req_volume.get('Iops', 0) <= actual_volume.get('Iops', 0)):
-        log.debug('    EBS volume too slow')
-        return False
-
-    return True
-
-
-def _igs_satisfy_cpu(actual_igs, requested_ig):
-    """Does the list of actual instance groups satisfy the CPU requirements
-    of the requested instance group?
-
-    If so, return the number of compute units. Otherwise, return ``None``
-
-    If the requested instance type is unknown, just return the number
-    of actual instances of the same type.
-    """
-    requested_type = requested_ig['InstanceType']
-    num_requested = requested_ig['InstanceCount']
-
-    # count number of compute units (cu)
-    if requested_type in EC2_INSTANCE_TYPE_TO_COMPUTE_UNITS:
-        requested_cu = (
-            num_requested * EC2_INSTANCE_TYPE_TO_COMPUTE_UNITS[requested_type])
-
-        # don't require instances to be running; we'd be worse off if
-        # we started our own cluster from scratch. (This can happen if
-        # the previous job finished while some task instances were
-        # still being provisioned.)
-        actual_cu = sum(
-            ig['RequestedInstanceCount'] *
-            EC2_INSTANCE_TYPE_TO_COMPUTE_UNITS.get(ig['InstanceType'], 0.0)
-            for ig in actual_igs)
-    else:
-        # unknown instance type, just count # of matching instances
-        requested_cu = num_requested
-        actual_cu = sum(ig['RequestedInstanceCount'] for ig in actual_igs
-                         if ig['InstanceType'] == requested_type)
-
-    if actual_cu >= requested_cu:
-        return actual_cu
-    else:
-        log.debug('    not enough compute units')
-        return None
-
-
-
-### pooled cluster matching: instance fleets ###
-
-def _instance_fleets_satisfy(actual_fleets, req_fleets):
-    """Common code for :py:func:`
-    :py:func:`_instance_groups_satisfy_fleets` and
-    :py:func:`_instance_groups_satisfy`."""
-
-    # a is a map from role to actual instance fleet
-    # (unlike with groups, there can never be more than one fleet per role)
-    a = {f['InstanceFleetType'].lower(): f for f in actual_fleets}
-
-    # r is a map from role to request (should be only one per role)
-    r = {f['InstanceFleetType'].lower(): f for f in req_fleets}
-
-    # updated request to account for extra instance groups
-    # see #1630 for what we do when roles don't match
-    if set(a) - set(r):
-        r = _add_missing_roles_to_request(
-            set(a) - set(r), r,
-            ['TargetOnDemandCapacity', 'TargetSpotCapacity'])
-
-    if set(a) != set(r):
-        log.debug("    missing instance fleet roles")
-        return None
-
-    sort_keys = {}
-    for role in sorted(r):
-        sort_key = _fleet_for_same_role_satisfies(a[role], r[role])
-        if not sort_key:  # doesn't satisfy
-            return None
-        sort_keys[role] = sort_key
-
-    return tuple(sort_keys.get(role) for role in ('core', 'task', 'master'))
-
-
-def _fleet_for_same_role_satisfies(actual_fleet, req_fleet):
-    # TODO: start here
-    pass
-
-
-### pooled cluster matching: common code ###
-
-
-def _add_missing_roles_to_request(
-        missing_roles, role_to_req, req_count_fields):
-    """Helper for :py:func:`_igs_satisfy_request`. Add requests for
-    *missing_roles* to *role_to_ig* so that we have a better chance of
-    matching the cluster's actual instance groups."""
-    # see #1630 for discussion
-
-    # don't worry about modifying *role_to_req*; this is
-    # a helper func
-
-    if 'core' in missing_roles and list(role_to_req) == ['master']:
-        # both core and master have to satisfy master-only request
-        role_to_req['core'] = role_to_req['master']
-
-    if 'task' in missing_roles and 'core' in role_to_req:
-        # make sure tasks won't crash on the task instances,
-        # but don't require the same amount of CPU
-        role_to_req['task'] = dict(role_to_req['core'])
-        for req_count_field in req_count_fields:
-            role_to_req['task'][req_count_field] = 0
-
-    return role_to_req

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -334,6 +334,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'iam_endpoint',
         'iam_instance_profile',
         'iam_service_role',
+        'instance_fleets',
         'instance_groups',
         'master_instance_bid_price',
         'mins_to_end_of_hour',
@@ -1303,7 +1304,10 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         if self._opts['zone']:
             Instances['Placement'] = dict(AvailabilityZone=self._opts['zone'])
 
-        Instances['InstanceGroups'] = self._instance_groups()
+        if self._opts['instance_fleets']:
+            Instances['InstanceFleets'] = self._opts['instance_fleets']
+        else:
+            Instances['InstanceGroups'] = self._instance_groups()
 
         # bootstrap actions
         kwargs['BootstrapActions'] = BootstrapActions = []

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -126,6 +126,16 @@ def _cleanup_callback(option, opt_str, value, parser):
     setattr(parser.values, option.dest, result)
 
 
+def _subnets_callback(option, opt_str, value, parser):
+    """callback to parse a comma-separated list of subnets.
+
+    This eliminates whitespace
+    """
+    subnets = [s.strip() for s in value.split(',') if s]
+
+    setattr(parser.values, option.dest, subnets)
+
+
 def _append_json_callback(option, opt_str, value, parser):
     """callback to parse JSON and append it to a list."""
     _default_to(parser, option.dest, [])
@@ -966,7 +976,13 @@ _RUNNER_OPTS = dict(
             (['--subnet'], dict(
                 help=('ID of Amazon VPC subnet to launch cluster in. If not'
                       ' set or empty string, cluster is launched in the normal'
-                      ' AWS cloud'),
+                      ' AWS cloud.'),
+            )),
+            (['--subnets'], dict(
+                callback=_subnets_callback,
+                help=('Like --subnets, but with a comma-separated list, to'
+                      ' specify multiple subnets in conjunction with'
+                      ' --instance-fleets'),
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -665,6 +665,18 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    instance_fleets=dict(
+        cloud_role='launch',
+        switches=[
+            (['--instance-fleets'], dict(
+                callback=_json_callback,
+                help=('detailed JSON list of instance fleets, including'
+                      ' EBS configuration. See docs for --instance-fleets'
+                      ' at http://docs.aws.amazon.com/cli/latest/reference'
+                      '/emr/create-cluster.html'),
+            )),
+        ],
+    ),
     instance_type=dict(
         cloud_role='launch',
         switches=[

--- a/mrjob/pool.py
+++ b/mrjob/pool.py
@@ -285,14 +285,14 @@ def _fleet_for_same_role_satisfies(actual_fleet, req_fleet):
 
     # capacity
     actual_on_demand = actual_fleet.get('ProvisionedOnDemandCapacity', 0)
-    req_on_demand = req_fleet.get('RequestedOnDemandCapacity', 0)
+    req_on_demand = req_fleet.get('TargetOnDemandCapacity', 0)
 
     if req_on_demand > actual_on_demand:
         log.debug('    not enough on-demand capacity')
         return
 
     actual_spot = actual_fleet.get('ProvisionedSpotCapacity', 0)
-    req_spot = req_fleet.get('RequestedSpotCapacity', 0)
+    req_spot = req_fleet.get('TargetSpotCapacity', 0)
 
     # allow extra on-demand instances to serve as spot instances
     if req_spot > actual_spot + (actual_on_demand - req_on_demand):

--- a/mrjob/pool.py
+++ b/mrjob/pool.py
@@ -305,9 +305,8 @@ def _fleet_for_same_role_satisfies(actual_fleet, req_fleet):
             log.debug('    self-terminating fleet not requested')
             return
 
-        if ((actual_spot < actual_fleet.get('TargetSpotCapacity', 0)) and
-            (_get_timeout_duration(actual_fleet) <
-             _get_timeout_duration(req_fleet))):
+        if (_get_timeout_duration(actual_fleet) <
+                _get_timeout_duration(req_fleet)):
             log.debug('    fleet may self-terminate prematurely')
             return
 
@@ -326,7 +325,7 @@ def _get_timeout_duration(fleet):
     return fleet.get(
         'LaunchSpecifications', {}).get(
             'SpotSpecification', {}).get(
-                'TimeoutAction', 0.0)
+                'TimeoutDurationMinutes', 0.0)
 
 
 def _fleet_spec_satsifies(actual_spec, req_spec):

--- a/mrjob/pool.py
+++ b/mrjob/pool.py
@@ -15,11 +15,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utilities related to cluster pooling. This code used to be in mrjob.emr.
+
+In theory, this module might support pooling in general, but so far, there's
+only a need for pooling on EMR.
+
 """
+from collections import defaultdict
 from datetime import timedelta
 from logging import getLogger
 
 from mrjob.aws import _boto3_now
+from mrjob.aws import EC2_INSTANCE_TYPE_TO_COMPUTE_UNITS
+from mrjob.aws import EC2_INSTANCE_TYPE_TO_MEMORY
 
 log = getLogger(__name__)
 
@@ -76,3 +83,411 @@ def _legacy_pool_hash_and_name(bootstrap_actions):
                 return args[0][5:], args[1]
 
     return None, None
+
+
+### instance groups ###
+
+def _instance_groups_satisfy(actual_igs, requested_igs):
+    """Do the actual instance groups from a cluster satisfy the requested
+    ones, for the purpose of pooling?
+
+    The formats are slightly different; the format of *requested_igs* is here:
+    http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_InstanceGroup.html
+    and the format of *actual_igs* is here:
+    http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_ListInstanceGroups.html
+    """
+    # a is a map from role to actual instance groups
+    a = defaultdict(list)
+    for ig in actual_igs:
+        a[ig['InstanceGroupType'].lower()].append(ig)
+
+    # r is a map from role to request (should be only one per role)
+    r = {req['InstanceRole'].lower(): req for req in requested_igs}
+
+    # updated request to account for extra instance groups
+    # see #1630 for what we do when roles don't match
+    if set(a) - set(r):
+        r = _add_missing_roles_to_request(set(a) - set(r), r,
+                                          ['InstanceCount'])
+
+    if set(a) != set(r):
+        log.debug("    missing instance group roles")
+        return None
+
+    sort_keys = {}
+    for role in sorted(r):
+        sort_key = _igs_for_same_role_satisfy(a[role], r[role])
+        if not sort_key:  # doesn't satisfy
+            return None
+        sort_keys[role] = sort_key
+
+    return tuple(sort_keys.get(role) for role in ('core', 'task', 'master'))
+
+
+def _igs_for_same_role_satisfy(actual_igs, requested_ig):
+    """Does the *actual* list of instance groups satisfy the *requested*
+    one?
+    """
+    # bid price/on-demand
+    if not all(_ig_satisfies_bid_price(ig, requested_ig) for ig in actual_igs):
+        return None
+
+    # memory
+    if not all(_ig_satisfies_mem(ig, requested_ig) for ig in actual_igs):
+        return None
+
+    # EBS volumes
+    if not all(_ebs_satisfies(ig, requested_ig) for ig in actual_igs):
+        return None
+
+    # CPU (this returns # of compute units or None)
+    return _igs_satisfy_cpu(actual_igs, requested_ig)
+
+
+def _ig_satisfies_bid_price(actual_ig, requested_ig):
+    """Does the actual instance group definition satisfy the bid price
+    (or lack thereof) of the requested instance group?
+    """
+    # on-demand instances satisfy every bid price
+    if actual_ig['Market'] == 'ON_DEMAND':
+        return True
+
+    if requested_ig.get('Market', 'ON_DEMAND') == 'ON_DEMAND':
+        log.debug('    spot instance, requested on-demand')
+        return False
+
+    if actual_ig['BidPrice'] == requested_ig.get('BidPrice'):
+        return True
+
+    try:
+        if float(actual_ig['BidPrice']) >= float(requested_ig.get('BidPrice')):
+            return True
+        else:
+            # low bid prices mean cluster is more likely to be
+            # yanked away
+            log.debug('    bid price too low')
+            return False
+    except ValueError:
+        log.debug('    non-float bid price')
+        return False
+
+
+def _ig_satisfies_mem(actual_ig, requested_ig):
+    """Does the actual instance group satisfy the memory requirements of
+    the requested instance group?"""
+    actual_type = actual_ig['InstanceType']
+    requested_type = requested_ig['InstanceType']
+
+    # this works even for unknown instance types
+    if actual_type == requested_type:
+        return True
+
+    try:
+        if (EC2_INSTANCE_TYPE_TO_MEMORY[actual_type] >=
+                EC2_INSTANCE_TYPE_TO_MEMORY[requested_type]):
+            return True
+        else:
+            log.debug('    too little memory')
+            return False
+    except KeyError:
+        log.debug('    unknown instance type')
+        return False
+
+
+def _igs_satisfy_cpu(actual_igs, requested_ig):
+    """Does the list of actual instance groups satisfy the CPU requirements
+    of the requested instance group?
+
+    If so, return the number of compute units. Otherwise, return ``None``
+
+    If the requested instance type is unknown, just return the number
+    of actual instances of the same type.
+    """
+    requested_type = requested_ig['InstanceType']
+    num_requested = requested_ig['InstanceCount']
+
+    # count number of compute units (cu)
+    if requested_type in EC2_INSTANCE_TYPE_TO_COMPUTE_UNITS:
+        requested_cu = (
+            num_requested * EC2_INSTANCE_TYPE_TO_COMPUTE_UNITS[requested_type])
+
+        # don't require instances to be running; we'd be worse off if
+        # we started our own cluster from scratch. (This can happen if
+        # the previous job finished while some task instances were
+        # still being provisioned.)
+        actual_cu = sum(
+            ig['RequestedInstanceCount'] *
+            EC2_INSTANCE_TYPE_TO_COMPUTE_UNITS.get(ig['InstanceType'], 0.0)
+            for ig in actual_igs)
+    else:
+        # unknown instance type, just count # of matching instances
+        requested_cu = num_requested
+        actual_cu = sum(ig['RequestedInstanceCount'] for ig in actual_igs
+                         if ig['InstanceType'] == requested_type)
+
+    if actual_cu >= requested_cu:
+        return actual_cu
+    else:
+        log.debug('    not enough compute units')
+        return None
+
+
+
+### instance fleets ###
+
+def _instance_fleets_satisfy(actual_fleets, req_fleets):
+    """Common code for :py:func:`
+    :py:func:`_instance_groups_satisfy_fleets` and
+    :py:func:`_instance_groups_satisfy`."""
+
+    # a is a map from role to actual instance fleet
+    # (unlike with groups, there can never be more than one fleet per role)
+    a = {f['InstanceFleetType'].lower(): f for f in actual_fleets}
+
+    # r is a map from role to request (should be only one per role)
+    r = {f['InstanceFleetType'].lower(): f for f in req_fleets}
+
+    # updated request to account for extra instance groups
+    # see #1630 for what we do when roles don't match
+    if set(a) - set(r):
+        r = _add_missing_roles_to_request(
+            set(a) - set(r), r,
+            ['TargetOnDemandCapacity', 'TargetSpotCapacity'])
+
+    if set(a) != set(r):
+        log.debug("    missing instance fleet roles")
+        return None
+
+    sort_keys = {}
+    for role in sorted(r):
+        sort_key = _fleet_for_same_role_satisfies(a[role], r[role])
+        if not sort_key:  # doesn't satisfy
+            return None
+        sort_keys[role] = sort_key
+
+    return tuple(sort_keys.get(role) for role in ('core', 'task', 'master'))
+
+
+def _fleet_for_same_role_satisfies(actual_fleet, req_fleet):
+    # match up instance types
+    actual_specs = {spec['InstanceType']: spec
+                    for spec in actual_fleet['InstanceTypeSpecifications']}
+    req_specs = {spec['InstanceType']: spec
+                 for spec in req_fleet['InstanceTypeSpecifications']}
+
+    if set(actual_specs) - set(req_specs):
+        log.debug('    fleet may include wrong instance types')
+        return
+
+    if not all(_fleet_spec_satsifies(actual_specs[t], req_specs[t])
+                for t in actual_specs):
+        return
+
+    # capacity
+    actual_on_demand = actual_fleet.get('ProvisionedOnDemandCapacity', 0)
+    req_on_demand = req_fleet.get('RequestedOnDemandCapacity', 0)
+
+    if req_on_demand > actual_on_demand:
+        log.debug('    not enough on-demand capacity')
+        return
+
+    actual_spot = actual_fleet.get('ProvisionedSpotCapacity', 0)
+    req_spot = req_fleet.get('RequestedSpotCapacity', 0)
+
+    # allow extra on-demand instances to serve as spot instances
+    if req_spot > actual_spot + (actual_on_demand - req_on_demand):
+        log.debug('    not enough spot capacity')
+
+    # handle TERMINATE_CLUSTER timeout action. This really doesn't play
+    # well with pooling anyhow
+    if _get_timeout_action(actual_fleet) == 'TERMINATE_CLUSTER':
+        if _get_timeout_action(req_fleet) != 'TERMINATE_CLUSTER':
+            log.debug('    self-terminating fleet not requested')
+            return
+
+        if ((actual_spot < actual_fleet.get('TargetSpotCapacity', 0)) and
+            (_get_timeout_duration(actual_fleet) <
+             _get_timeout_duration(req_fleet))):
+            log.debug('    fleet may self-terminate prematurely')
+            return
+
+    # sort by total capacity, with on-demand as a tie-breaker
+    return (actual_on_demand + actual_spot, actual_on_demand)
+
+
+def _get_timeout_action(fleet):
+    return fleet['InstanceTypeSpecifications'].get(
+        'LaunchSpecifications', {}).get(
+            'SpotSpecification', {}).get(
+                'TimeoutAction')
+
+
+def _get_timeout_duration(fleet):
+    return fleet['InstanceTypeSpecifications'].get(
+        'LaunchSpecifications', {}).get(
+            'SpotSpecification', {}).get(
+                'TimeoutAction', 0.0)
+
+
+def _fleet_spec_satsifies(actual_spec, req_spec):
+    """Make sure the specification for the given instance type is as
+    good or better than the requested spec.
+
+    Specs must have the same weight, but "better" EBS configurations are
+    accepted.
+
+    Bid price must either be higher or the *actual* bid price
+    must be same as on-demand
+    """
+    if (actual_spec.get('WeightedCapacity', 1) !=
+            req_spec.get('WeightedCapacity', 1)):
+        log.debug('    different weighted capacity for same instance type')
+        return
+
+    if not _ebs_satisfies(actual_spec, req_spec):
+        return
+
+    # bid price is the max, don't worry about it
+    if actual_spec.get('BidPriceAsPercentageOfOnDemandPrice', 100) >= 100:
+        return True
+
+    # absolute bid price
+    req_bid_price = req_spec.get('BidPrice')
+    if req_bid_price is not None:
+        actual_bid_price = actual_spec.get('BidPrice')
+        if actual_bid_price is None:
+            log.debug('    no bid price specified')
+            return
+
+        try:
+            if not float(actual_bid_price) >= float(req_bid_price):
+                log.debug('    bid price too low')
+                return
+        except TypeError:
+            log.debug('    non-numeric bid price')
+            return
+
+    # relative bid price
+    req_bid_percent = req_spec.get('BidPriceAsPercentageOfOnDemandPrice')
+    if req_bid_percent:
+        actual_bid_percent = actual_spec.get(
+            'BidPriceAsPercentageOfOnDemandPrice')
+        if actual_bid_percent is None:
+            log.debug('    no bid price as % of on-demand price')
+            return
+
+        if req_bid_percent > actual_bid_percent:
+            log.debug('    bid price as % of on-demand price too low')
+            return
+
+    return True
+
+
+### common code for matching instance (groups or fleets) ###
+
+
+def _add_missing_roles_to_request(
+        missing_roles, role_to_req, req_count_fields):
+    """Helper for :py:func:`_igs_satisfy_request`. Add requests for
+    *missing_roles* to *role_to_ig* so that we have a better chance of
+    matching the cluster's actual instance groups."""
+    # see #1630 for discussion
+
+    # don't worry about modifying *role_to_req*; this is
+    # a helper func
+
+    if 'core' in missing_roles and list(role_to_req) == ['master']:
+        # both core and master have to satisfy master-only request
+        role_to_req['core'] = role_to_req['master']
+
+    if 'task' in missing_roles and 'core' in role_to_req:
+        # make sure tasks won't crash on the task instances,
+        # but don't require the same amount of CPU
+        role_to_req['task'] = dict(role_to_req['core'])
+        for req_count_field in req_count_fields:
+            role_to_req['task'][req_count_field] = 0
+
+    return role_to_req
+
+
+def _ebs_satisfies(actual, request):
+    """Does *actual* have EBS volumes that satisfy *request*.
+
+    *actual* is either an instance group from ``ListInstanceGroups``
+    or an instance fleet spec from ``ListInstanceFleets`` (format
+    is the same).
+
+    *request* is either the ``InstanceGroups`` or ``InstanceFleets``
+    param to ``RunJobFlow``
+
+    If *request* doesn't have an EBS Configuration, we return
+    True.
+
+    If *request* requests EBS optimization, *actual* should provide it.
+
+    Finally, *actual* should have the same or better block devices
+    as those in *request* (same volume type, at least as much IOPS
+    and volume size).
+    """
+    req_ebs_config = request.get('EbsConfiguration')
+
+    if not req_ebs_config:
+        return True
+
+    if (req_ebs_config.get('EbsOptimized')
+            and not actual.get('EbsOptimized')):
+        log.debug('    need EBS-optimized instances')
+        return False
+
+    req_device_configs = req_ebs_config.get('EbsBlockDeviceConfigs')
+
+    if not req_device_configs:
+        return True
+
+    req_volumes = []
+
+    for req_device_config in req_device_configs:
+        volume = req_device_config['VolumeSpecification']
+        num_volumes = req_device_config.get('VolumesPerInstance', 1)
+
+        req_volumes.extend([volume] * num_volumes)
+
+    actual_volumes = [
+        bd.get('VolumeSpecification', {})
+        for bd in actual.get('EbsBlockDevices', [])]
+
+    return _ebs_volumes_satisfy(actual_volumes, req_volumes)
+
+
+def _ebs_volumes_satisfy(actual_volumes, req_volumes):
+    """Does the given list of actual EBS volumes satisfy the given request?
+
+    Just compare them one by one (we want each actual device to be
+    bigger/faster; just having the same amount of capacity or iops
+    isn't enough).
+    """
+    if len(req_volumes) > len(actual_volumes):
+        log.debug('    more EBS volumes requested than available')
+        return False
+
+    return all(_ebs_volume_satisfies(a, r)
+               for a, r in zip(actual_volumes, req_volumes))
+
+
+def _ebs_volume_satisfies(actual_volume, req_volume):
+    """Does the given actual EBS volume satisfy the given request?"""
+    if req_volume.get('VolumeType') != actual_volume.get('VolumeType'):
+        log.debug('    wrong EBS volume type')
+        return False
+
+    if not req_volume.get('SizeInGB', 0) <= actual_volume.get('SizeInGB', 0):
+        log.debug('    EBS volume too small')
+        return False
+
+    # Iops isn't really "optional"; it has to be set if volume type is
+    # io1 and not set otherwise
+    if not (req_volume.get('Iops', 0) <= actual_volume.get('Iops', 0)):
+        log.debug('    EBS volume too slow')
+        return False
+
+    return True

--- a/mrjob/pool.py
+++ b/mrjob/pool.py
@@ -240,8 +240,6 @@ def _instance_fleets_satisfy(actual_fleets, req_fleets):
     :py:func:`_instance_groups_satisfy_fleets` and
     :py:func:`_instance_groups_satisfy`."""
 
-    import pdb; pdb.set_trace()
-
     # a is a map from role to actual instance fleet
     # (unlike with groups, there can never be more than one fleet per role)
     a = {f['InstanceFleetType'].lower(): f for f in actual_fleets}

--- a/mrjob/pool.py
+++ b/mrjob/pool.py
@@ -99,10 +99,10 @@ def _instance_groups_satisfy(actual_igs, requested_igs):
     # a is a map from role to actual instance groups
     a = defaultdict(list)
     for ig in actual_igs:
-        a[ig['InstanceGroupType'].lower()].append(ig)
+        a[ig['InstanceGroupType']].append(ig)
 
     # r is a map from role to request (should be only one per role)
-    r = {req['InstanceRole'].lower(): req for req in requested_igs}
+    r = {req['InstanceRole']: req for req in requested_igs}
 
     # updated request to account for extra instance groups
     # see #1630 for what we do when roles don't match
@@ -121,7 +121,7 @@ def _instance_groups_satisfy(actual_igs, requested_igs):
             return None
         sort_keys[role] = sort_key
 
-    return tuple(sort_keys.get(role) for role in ('core', 'task', 'master'))
+    return tuple(sort_keys.get(role) for role in ('CORE', 'TASK', 'MASTER'))
 
 
 def _igs_for_same_role_satisfy(actual_igs, requested_ig):
@@ -242,10 +242,10 @@ def _instance_fleets_satisfy(actual_fleets, req_fleets):
 
     # a is a map from role to actual instance fleet
     # (unlike with groups, there can never be more than one fleet per role)
-    a = {f['InstanceFleetType'].lower(): f for f in actual_fleets}
+    a = {f['InstanceFleetType']: f for f in actual_fleets}
 
     # r is a map from role to request (should be only one per role)
-    r = {f['InstanceFleetType'].lower(): f for f in req_fleets}
+    r = {f['InstanceFleetType']: f for f in req_fleets}
 
     # updated request to account for extra instance groups
     # see #1630 for what we do when roles don't match
@@ -265,7 +265,7 @@ def _instance_fleets_satisfy(actual_fleets, req_fleets):
             return None
         sort_keys[role] = sort_key
 
-    return tuple(sort_keys.get(role) for role in ('core', 'task', 'master'))
+    return tuple(sort_keys.get(role) for role in ('CORE', 'TASK', 'MASTER'))
 
 
 def _fleet_for_same_role_satisfies(actual_fleet, req_fleet):
@@ -395,16 +395,16 @@ def _add_missing_roles_to_request(
     # don't worry about modifying *role_to_req*; this is
     # a helper func
 
-    if 'core' in missing_roles and list(role_to_req) == ['master']:
+    if 'CORE' in missing_roles and list(role_to_req) == ['MASTER']:
         # both core and master have to satisfy master-only request
-        role_to_req['core'] = role_to_req['master']
+        role_to_req['CORE'] = role_to_req['MASTER']
 
-    if 'task' in missing_roles and 'core' in role_to_req:
+    if 'TASK' in missing_roles and 'CORE' in role_to_req:
         # make sure tasks won't crash on the task instances,
         # but don't require the same amount of CPU
-        role_to_req['task'] = dict(role_to_req['core'])
+        role_to_req['TASK'] = dict(role_to_req['CORE'])
         for req_count_field in req_count_fields:
-            role_to_req['task'][req_count_field] = 0
+            role_to_req['TASK'][req_count_field] = 0
 
     return role_to_req
 

--- a/mrjob/pool.py
+++ b/mrjob/pool.py
@@ -273,14 +273,14 @@ def _fleet_for_same_role_satisfies(actual_fleet, req_fleet):
     actual_specs = {spec['InstanceType']: spec
                     for spec in actual_fleet['InstanceTypeSpecifications']}
     req_specs = {spec['InstanceType']: spec
-                 for spec in req_fleet['InstanceTypeSpecifications']}
+                 for spec in req_fleet['InstanceTypeConfigs']}
 
     if set(actual_specs) - set(req_specs):
         log.debug('    fleet may include wrong instance types')
         return
 
     if not all(_fleet_spec_satsifies(actual_specs[t], req_specs[t])
-                for t in actual_specs):
+               for t in actual_specs):
         return
 
     # capacity
@@ -316,14 +316,14 @@ def _fleet_for_same_role_satisfies(actual_fleet, req_fleet):
 
 
 def _get_timeout_action(fleet):
-    return fleet['InstanceTypeSpecifications'].get(
+    return fleet.get(
         'LaunchSpecifications', {}).get(
             'SpotSpecification', {}).get(
                 'TimeoutAction')
 
 
 def _get_timeout_duration(fleet):
-    return fleet['InstanceTypeSpecifications'].get(
+    return fleet.get(
         'LaunchSpecifications', {}).get(
             'SpotSpecification', {}).get(
                 'TimeoutAction', 0.0)

--- a/mrjob/pool.py
+++ b/mrjob/pool.py
@@ -240,6 +240,8 @@ def _instance_fleets_satisfy(actual_fleets, req_fleets):
     :py:func:`_instance_groups_satisfy_fleets` and
     :py:func:`_instance_groups_satisfy`."""
 
+    import pdb; pdb.set_trace()
+
     # a is a map from role to actual instance fleet
     # (unlike with groups, there can never be more than one fleet per role)
     a = {f['InstanceFleetType'].lower(): f for f in actual_fleets}

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ try:
             'ujson': ['ujson'],
         },
         'install_requires': [
-            'boto3>=1.4.4',
-            'botocore>=1.5.0',
+            'boto3>=1.4.6',
+            'botocore>=1.6.0',
             #'google-api-python-client>=1.5.0'  # see below
             'PyYAML>=3.08',
         ],

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -445,9 +445,28 @@ class MockEMRClient(object):
 
         # Ec2SubnetId
         if 'Ec2SubnetId' in Instances:
+            if 'Ec2SubnetIds' in Instances:
+                # TODO: get actual error message
+                raise _error('Ec2SubnetId and Ec2SubnetIds together')
+
             _validate_param(Instances, 'Ec2SubnetId', string_types)
             cluster['Ec2InstanceAttributes']['Ec2SubnetId'] = (
                 Instances.pop('Ec2SubnetId'))
+
+        # Ec2SubnetIds
+        if 'Ec2SubnetIds' in Instances:
+            _validate_param(Instances, 'Ec2SubnetIds', list)
+            Ec2SubnetIds = Instances.pop('Ec2SubnetIds')
+            if not Ec2SubnetIds:
+                # TODO: get actual error message
+                raise _error('empty Ec2SubnetIds')
+
+            # TODO: require InstanceFleets to be set
+
+            for subnet_id in Ec2SubnetIds:
+                _validate_param_type(subnet_id, string_types)
+                # arbitrarily choose last subnet ID
+                cluster['Ec2InstanceAttributes']['Ec2SubnetIds'] = subnet_id
 
         # KeepJobFlowAliveWhenNoSteps
         if 'KeepJobFlowAliveWhenNoSteps' in Instances:

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -1470,16 +1470,15 @@ class MockEMRClient(object):
             if cluster['InstanceCollectionType'] == 'INSTANCE_FLEET':
                 for fleet in cluster['_InstanceFleets']:
                     fleet['ProvisionedOnDemandCapacity'] = fleet[
-                        'RequestedOnDemandCapacity']
+                        'TargetOnDemandCapacity']
                     fleet['ProvisionedSpotCapacity'] = fleet[
-                        'RequestedSpotCapacity']
+                        'TargetSpotCapacity']
                     fleet['Status']['State'] = 'BOOTSTRAPPING'
 
             else:
                 for ig in cluster['_InstanceGroups']:
                     ig['RunningInstanceCount'] = ig['RequestedInstanceCount']
                     ig['Status']['State'] = 'BOOTSTRAPPING'
-
 
             return
 

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -777,12 +777,10 @@ class MockEMRClient(object):
                 _validate_param(EbsConfiguration,
                                 'EbsBlockDeviceConfigs', list)
 
-                spec['EbsBlockDeviceConfigs'] = (
+                spec['EbsBlockDevices'].extend(
                     self._ebs_block_device_configs_to_block_devices(
                         operation_name,
-                        EbsConfiguration['EbsBlockDeeviceConfigs']))
-
-        spec.setdefault('EbsBlockDeviceConfigs', [])
+                        EbsConfiguration['EbsBlockDeviceConfigs']))
 
         if InstanceTypeConfig:
             raise NotImplementedError(

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -621,6 +621,25 @@ class MockEMRClient(object):
                     InstanceFleet.pop('InstanceTypeConfigs'),
                     fleet.get('Name'), fleet['InstanceFleetType']))
 
+            # LaunchSpecifications
+            if 'LaunchSpecifications' in InstanceFleet:
+                _validate_param(InstanceFleet, 'LaunchSpecifications', dict)
+                LaunchSpecifications = InstanceFleet.pop(
+                    'LaunchSpecifications')
+
+                _validate_param(LaunchSpecifications, 'SpotSpecification')
+                SpotSpecification = LaunchSpecifications['SpotSpecification']
+
+                _validate_param(
+                    SpotSpecification, 'TimeoutAction', string_types)
+                _validate_param_enum(
+                    SpotSpecification['TimeoutAction'],
+                    ['SWITCH_TO_ON_DEMAND', 'TERMINATE_CLUSTER'])
+                _validate_param(
+                    SpotSpecification, 'TimeoutDurationMinutes', int)
+
+                fleet['LaunchSpecifications'] = deepcopy(LaunchSpecifications)
+
             # target capacity
             for target_field in ('TargetOnDemandCapacity',
                                  'TargetSpotCapacity'):

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -789,6 +789,8 @@ class MockEMRClient(object):
                 'mock_boto3 does not support these InstanceTypeConfig'
                 ' params: %s' % ', '.join(sorted(InstanceTypeConfig)))
 
+        return spec
+
     def _ebs_block_device_configs_to_block_devices(
             self, operation_name, EbsBlockDeviceConfigs):
 

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -670,7 +670,7 @@ class MockEMRClient(object):
         return specs
 
     def _instance_type_config_to_spec(
-            self, operation_name, InstanceTypeConfig, InstanceFleetType):
+            self, operation_name, InstanceTypeConfig, Name, InstanceFleetType):
 
         def _error(message):
             return _ValidationException(operation_name, message)
@@ -706,7 +706,8 @@ class MockEMRClient(object):
             if 'BidPriceAsPercentageOfOnDemandPrice' in InstanceTypeConfig:
                 raise _error('Specify at most one of bidPrice or'
                              ' bidPriceAsPercentageOfOnDemandPrice value for'
-                             ' the Spot Instance fleet : dupes request.')
+                             ' the Spot Instance fleet : %s request.' % (
+                                 Name or null))
 
             _validate_param(InstanceTypeConfig, 'BidPrice', string_types)
             BidPrice = InstanceTypeConfig.pop('BidPrice')

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -495,6 +495,7 @@ class MockEMRClient(object):
 
             self._add_instance_groups(
                 operation_name, Instances.pop('InstanceGroups'), cluster)
+            cluster['InstanceCollectionType'] = 'INSTANCE_GROUP'
         # TODO: will need to support instance fleets at some point
         else:
             # build our own instance groups
@@ -523,6 +524,7 @@ class MockEMRClient(object):
 
             self._add_instance_groups(
                 operation_name, instance_groups, cluster, now=now)
+            cluster['InstanceCollectionType'] = 'INSTANCE_GROUP'
 
         if Instances:
             raise NotImplementedError(

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -572,7 +572,7 @@ class MockEMRClient(object):
 
         new_fleets = []  # don't update _InstanceFleets if there's an error
 
-        roles = set()  # roles already handled, UPPERCASE
+        roles = set()  # roles already handled
 
         for i, InstanceFleet in enumerate(InstanceFleets):
             _validate_param_type(InstanceFleet, dict)
@@ -962,7 +962,8 @@ class MockEMRClient(object):
                     "1 validation error detected: value '%s' at"
                     " 'instances.instanceGroups.%d.member.market' failed"
                     " to satify constraint: Member must satisfy enum value"
-                    " set: [SPOT, ON_DEMAND]" % (role, i + 1))
+                    " set: [SPOT, ON_DEMAND]" % (
+                        InstanceGroup['Market'], i + 1))
                 ig['Market'] = InstanceGroup.pop('Market')
 
             # BidPrice

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -561,8 +561,8 @@ class MockEMRClient(object):
 
         # only allowed for AMI 4.8.0+ and 5.1.0+
         if not (cluster.get('ReleaseLabel') and
-                map_version(INSTANCE_FLEET_AMI_VERSIONS,
-                            cluster['ReleaseLabel'].lstrip('emr-'))):
+                map_version(cluster['ReleaseLabel'].lstrip('emr-'),
+                            INSTANCE_FLEET_AMI_VERSIONS)):
             raise _error('Instance fleets are not available for the release.')
 
         if cluster.get('_InstanceGroups') or cluster.get('_InstanceFleets'):
@@ -613,9 +613,9 @@ class MockEMRClient(object):
                 fleet['Name'] = InstanceFleet.pop['Name']
 
             # InstanceTypeConfigs
-            _validate_param(InstanceFleet, 'InstanceTypeConfigs', dict)
+            _validate_param(InstanceFleet, 'InstanceTypeConfigs', list)
             fleet['InstanceTypeSpecifications'] = (
-                self._instance_type_config_to_specs(
+                self._instance_type_configs_to_specs(
                     operation_name,
                     InstanceFleet.pop('InstanceTypeConfigs'),
                     fleet.get('Name'), fleet['InstanceFleetType']))
@@ -665,7 +665,8 @@ class MockEMRClient(object):
 
             specs.append(
                 self._instance_type_config_to_spec(
-                    InstanceTypeConfig, InstanceType))
+                    operation_name,
+                    InstanceTypeConfig, Name, InstanceFleetType))
 
         return specs
 

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -463,19 +463,20 @@ class MockEMRClient(object):
                 Instances.pop('Ec2SubnetId'))
 
         # Ec2SubnetIds
-        if 'Ec2SubnetIds' in Instances:
+        if Instances.get('Ec2SubnetIds'):
+            if 'InstanceFleets' not in Instances:
+                raise _error('Only one subnet may be specified for clusters'
+                             ' configured with instance groups or instance'
+                             ' count, master and slave instance type. Revise'
+                             ' the configuration and resubmit.')
+
             _validate_param(Instances, 'Ec2SubnetIds', list)
             Ec2SubnetIds = Instances.pop('Ec2SubnetIds')
-            if not Ec2SubnetIds:
-                # TODO: get actual error message
-                raise _error('empty Ec2SubnetIds')
-
-            # TODO: require InstanceFleets to be set
 
             for subnet_id in Ec2SubnetIds:
                 _validate_param_type(subnet_id, string_types)
                 # arbitrarily choose last subnet ID
-                cluster['Ec2InstanceAttributes']['Ec2SubnetIds'] = subnet_id
+                cluster['Ec2InstanceAttributes']['Ec2SubnetId'] = subnet_id
 
         # KeepJobFlowAliveWhenNoSteps
         if 'KeepJobFlowAliveWhenNoSteps' in Instances:

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2321,11 +2321,11 @@ class PoolMatchingTestCase(MockBoto3TestCase):
     def _ig_with_ebs_config(
             self, device_configs=(), iops=None,
             num_volumes=None,
-            optimized=None, role='master',
+            optimized=None, role='MASTER',
             volume_size=100, volume_type=None):
         """Build an instance group request with the given list of
         EBS device configs. Optionally turn on EBS optimization
-        and specify a different instance role (``'master'`` by default)."""
+        and specify a different instance role (``'MASTER'`` by default)."""
         if not device_configs:
             # io1 is the only volume type that accepts IOPS
             if volume_type is None:
@@ -2346,7 +2346,7 @@ class PoolMatchingTestCase(MockBoto3TestCase):
 
         return dict(
             EbsConfiguration=ebs_config,
-            InstanceRole=role.upper(),
+            InstanceRole=role,
             InstanceCount=1,
             InstanceType='m1.medium',
         )
@@ -2564,7 +2564,7 @@ class PoolMatchingTestCase(MockBoto3TestCase):
 
     def test_match_ebs_specs_on_multiple_roles(self):
         igs = [self._ig_with_ebs_config(volume_size=10),
-               self._ig_with_ebs_config(role='core')]
+               self._ig_with_ebs_config(role='CORE')]
 
         _, cluster_id = self.make_pooled_cluster(
             instance_groups=igs)
@@ -2576,10 +2576,10 @@ class PoolMatchingTestCase(MockBoto3TestCase):
     def test_ebs_must_match_on_all_roles(self):
         requested_igs = [
             self._ig_with_ebs_config(volume_size=10),
-            self._ig_with_ebs_config(role='core', volume_type='standard')]
+            self._ig_with_ebs_config(role='CORE', volume_type='standard')]
         actual_igs = [
             self._ig_with_ebs_config(volume_size=10),
-            self._ig_with_ebs_config(role='core', volume_type='gp2')]
+            self._ig_with_ebs_config(role='CORE', volume_type='gp2')]
 
         _, cluster_id = self.make_pooled_cluster(
             instance_groups=actual_igs)
@@ -2651,7 +2651,7 @@ class PoolMatchingTestCase(MockBoto3TestCase):
             ebs_optimized=None,
             on_demand_capacity=1, spot_capacity=0, spot_spec=None):
 
-        config = dict(InstanceFleetType=role.upper(), InstanceTypeConfigs=[])
+        config = dict(InstanceFleetType=role, InstanceTypeConfigs=[])
 
         if not instance_types:
             instance_types = ['m1.medium']

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2635,6 +2635,41 @@ class PoolMatchingTestCase(MockBoto3TestCase):
             '--master-instance-bid-price', '77.77',
             '--task-instance-bid-price', '22.00'])
 
+    def test_same_instance_fleet_config(self):
+        INSTANCE_FLEETS = [
+            dict(
+                InstanceFleetType='MASTER',
+                InstanceTypeConfigs=[
+                    dict(
+                        InstanceType='m1.medium'
+                    ),
+                ],
+                TargetOnDemandCapacity=1,
+            ),
+            dict(
+                InstanceFleetType='CORE',
+                InstanceTypeConfigs=[
+                    dict(
+                        InstanceType='m1.medium',
+                        WeightedCapacity=1,
+                    ),
+                    dict(
+                        InstanceType='m1.large',
+                        WeightedCapacity=2,
+                    ),
+                ],
+                TargetOnDemandCapacity=2,
+            ),
+        ]
+
+        _, cluster_id = self.make_pooled_cluster(
+            instance_fleets=INSTANCE_FLEETS)
+
+        self.assertJoins(cluster_id, [
+            '-r', 'emr', '-v', '--pool-clusters',
+            '--instance-fleets', json.dumps(INSTANCE_FLEETS)
+        ])
+
     def test_dont_join_full_cluster(self):
         dummy_runner, cluster_id = self.make_pooled_cluster()
 

--- a/tests/tools/emr/test_create_cluster.py
+++ b/tests/tools/emr/test_create_cluster.py
@@ -54,6 +54,7 @@ class ClusterInspectionTestCase(ToolTestCase):
                 'iam_instance_profile': None,
                 'iam_service_role': None,
                 'image_version': None,
+                'instance_fleets': None,
                 'instance_groups': None,
                 'instance_type': None,
                 'label': None,


### PR DESCRIPTION
This adds the `instance_fleets` option and reasonable pooling rules for instance fleets. (fixes #1569). Also adds the `--subnets` command-line option and allows the `subnet` opt to be a list.

This also moves a fair amount of pooling code from `mrjob/emr.py` (which is huge) to `mrjob/pool.py`.