### PR TITLE
ignore instance fleets (v0.5.x)

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3533,7 +3533,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         try:
             instance_groups = list(_yield_all_instance_groups(
                 self.make_emr_conn(), self.get_cluster_id()))
-        except boto.connection.EmrResponseError as ex:
+        except boto.exception.EmrResponseError as ex:
             # don't error if we encounter an instance fleet (see #1639)
             return None
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3127,10 +3127,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             try:
                 igs = list(_yield_all_instance_groups(emr_conn, cluster.id))
             except EmrResponseError as ex:
-                if 'fleets' in ex.message.lower():
-                    return
-                else:
-                    raise
+                # don't error if we encounter an instance fleet (see #1639)
+                return
 
             for ig in igs:
                 # if you edit this code, please don't rely on any particular
@@ -3536,10 +3534,8 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
             instance_groups = list(_yield_all_instance_groups(
                 self.make_emr_conn(), self.get_cluster_id()))
         except EmrResponseError as ex:
-            if 'fleets' in ex.message.lower():
-                return None
-            else:
-                raise
+            # don't error if we encounter an instance fleet (see #1639)
+            return None
 
         for ig in instance_groups:
             # master doesn't matter if it's not running tasks

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3123,7 +3123,16 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
             # check memory and compute units, bailing out if we hit
             # an instance with too little memory
-            for ig in _yield_all_instance_groups(emr_conn, cluster.id):
+
+            try:
+                igs = list(_yield_all_instance_groups(emr_conn, cluster.id))
+            except EmrResponseError as ex:
+                if 'fleets' in ex.message.lower():
+                    return
+                else:
+                    raise
+
+            for ig in igs:
                 # if you edit this code, please don't rely on any particular
                 # ordering of instance groups (see #1316)
                 role = ig.instancegrouptype.lower()
@@ -3523,8 +3532,14 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
                             image_version, _MIN_SPARK_PY3_AMI_VERSION))
 
         # make sure there's enough memory to run Spark
-        instance_groups = list(_yield_all_instance_groups(
-            self.make_emr_conn(), self.get_cluster_id()))
+        try:
+            instance_groups = list(_yield_all_instance_groups(
+                self.make_emr_conn(), self.get_cluster_id()))
+        except EmrResponseError as ex:
+            if 'fleets' in ex.message.lower():
+                return None
+            else:
+                raise
 
         for ig in instance_groups:
             # master doesn't matter if it's not running tasks

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3126,7 +3126,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
 
             try:
                 igs = list(_yield_all_instance_groups(emr_conn, cluster.id))
-            except EmrResponseError as ex:
+            except boto.exception.EmrResponseError as ex:
                 # don't error if we encounter an instance fleet (see #1639)
                 return
 
@@ -3533,7 +3533,7 @@ class EMRJobRunner(MRJobRunner, LogInterpretationMixin):
         try:
             instance_groups = list(_yield_all_instance_groups(
                 self.make_emr_conn(), self.get_cluster_id()))
-        except EmrResponseError as ex:
+        except boto.connection.EmrResponseError as ex:
             # don't error if we encounter an instance fleet (see #1639)
             return None
 

--- a/mrjob/retry.py
+++ b/mrjob/retry.py
@@ -1,5 +1,6 @@
 # Copyright 2009-2013 Yelp, David Marin
 # Copyright 2015 Yelp
+# Copyright 2017 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -160,5 +161,6 @@ class RetryWrapper(object):
                         raise
 
         # pretend to be the original function
-        call_and_maybe_retry.__name__ == f.__name__
+        if hasattr(f, '__name__'):
+            call_and_maybe_retry.__name__ == f.__name__
         return call_and_maybe_retry

--- a/mrjob/retry.py
+++ b/mrjob/retry.py
@@ -83,7 +83,10 @@ class RetryGoRound(object):
 
         # pretend to be the original function
         f = getattr(self.__alternatives[self.__start_index], name)
-        return wraps(f)(call_and_maybe_retry)
+        if hasattr(f, '__name__'):
+            return wraps(f)(call_and_maybe_retry)
+        else:
+            return f
 
 
 class RetryWrapper(object):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -145,6 +145,11 @@ HADOOP_ENV_EMR_CONFIGURATION_VARIANT = dict(
     ],
 )
 
+if boto:
+    INSTANCE_FLEETS_ERROR = boto.exception.EmrResponseError(
+        400, 'BadRequest',
+        '<ErrorResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">\n  <Error>\n    <Type>Sender</Type>\n    <Code>InvalidRequestException</Code>\n    <Message>Instance fleets and instance groups are mutually exclusive. The EMR cluster specified in the request uses instance fleets. The ListInstanceGroups operation does not support clusters that use instance fleets. Use the ListInstanceFleets operation instead.</Message>\n  </Error>\n  <RequestId>68f8aaaf-8c3d-11e7-b4d2-c345838a0f11</RequestId>\n</ErrorResponse>\n')  # noqa
+
 
 class EMRJobRunnerEndToEndTestCase(MockBotoTestCase):
 
@@ -2705,6 +2710,15 @@ class PoolMatchingTestCase(MockBotoTestCase):
             cluster_id,
             ['-r', 'emr', '--pool-clusters', '--image-version', '3.11.0'],
             job_class=MRNullSpark)
+
+    def test_ignore_instance_fleets(self):
+        _, cluster_id = self.make_pooled_cluster()
+
+        with patch.object(MockEmrConnection, 'list_instance_groups',
+                   side_effect=INSTANCE_FLEETS_ERROR):
+            self.assertDoesNotJoin(
+                cluster_id,
+                ['-r', 'emr', '--pool-clusters'])
 
 
 class PoolingRecoveryTestCase(MockBotoTestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -6177,6 +6177,18 @@ class TestClusterSparkSupportWarning(MockBotoTestCase):
             message = runner._cluster_spark_support_warning()
             self.assertIsNone(message)
 
+    def test_cant_list_instance_groups(self):
+        job = MRNullSpark(['-r', 'emr', '--image-version', '4.0.0'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._launch()
+
+            with patch.object(MockEmrConnection, 'list_instance_groups',
+                   side_effect=INSTANCE_FLEETS_ERROR):
+                message = runner._cluster_spark_support_warning()
+                self.assertIsNone(message)
+
 
 class ImageVersionGteTestCase(MockBotoTestCase):
 


### PR DESCRIPTION
Currently spark support warnings and pooling can potentially error out if trying to inspect a cluster that uses instance fleets. This change allows us to safely ignore instance fleet clusters. Fixes #1639.