### PR TITLE
use argparse instead of optparse

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,17 @@ v0.6.0, 2017-09-?? -- ???
    * is_mapper_or_reducer()
    * mr()
  * removed option groups (deprecated) from MRJobLauncher
+ * replaced optparse with argparse
+   * renamed attributes/methods (old name is a deprecated alias)
+     * add_file_option() -> add_file_arg()
+     * add_passthrough_option() -> add_passthru_arg()
+     * configure_options() -> configure_args()
+     * load_options() -> load_args()
+     * options -> args
+     * pass_through_option -> pass_arg_through()
+   * removed old args attribute (use positional args instead)
+   * removed generate_passthough_arguments()
+   * removed generate_file_upload_args()
  * removed deprecated functions:
    * mrjob.parse:
      * is_windows_path()

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,9 +37,8 @@ v0.6.0, 2017-09-?? -- ???
      * add_passthrough_option() -> add_passthru_arg()
      * configure_options() -> configure_args()
      * load_options() -> load_args()
-     * options -> parsed_args
-     * args -> parsed_args.args
      * pass_through_option -> pass_arg_through()
+     * args -> options.args
    * removed generate_passthough_arguments()
    * removed generate_file_upload_args()
    * duplicate file upload args are passed through to job

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,9 +37,9 @@ v0.6.0, 2017-09-?? -- ???
      * add_passthrough_option() -> add_passthru_arg()
      * configure_options() -> configure_args()
      * load_options() -> load_args()
-     * options -> args
+     * options -> parsed_args
+     * args -> parsed_args.args
      * pass_through_option -> pass_arg_through()
-   * removed old args attribute (use positional args instead)
    * removed generate_passthough_arguments()
    * removed generate_file_upload_args()
  * removed deprecated functions:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -42,6 +42,7 @@ v0.6.0, 2017-09-?? -- ???
      * pass_through_option -> pass_arg_through()
    * removed generate_passthough_arguments()
    * removed generate_file_upload_args()
+   * duplicate file upload args are passed through to job
  * removed deprecated functions:
    * mrjob.parse:
      * is_windows_path()

--- a/docs/job.rst
+++ b/docs/job.rst
@@ -76,24 +76,17 @@ See :ref:`writing-cl-opts` for information on adding command line options to
 your job. See :doc:`guides/configs-reference` for a complete list of all
 configuration options.
 
-.. automethod:: MRJob.configure_options
-.. automethod:: MRJob.add_passthrough_option
-.. automethod:: MRJob.add_file_option
-.. automethod:: MRJob.pass_through_option
-.. automethod:: MRJob.load_options
+.. automethod:: MRJob.configure_args
+.. automethod:: MRJob.add_passthru_arg
+.. automethod:: MRJob.add_file_arg
+.. automethod:: MRJob.pass_arg_through
+.. automethod:: MRJob.load_args
 .. automethod:: MRJob.is_task
-
-.. autoattribute:: MRJob.OPTION_CLASS
-
-   Redefine this if you want to use a subclass of :py:class:`optparse.Option`
-   for option parsing.
 
 .. _job-configuration:
 
 Job runner configuration
 ------------------------
-.. automethod:: MRJob.generate_passthrough_arguments
-.. automethod:: MRJob.generate_file_upload_args
 .. automethod:: MRJob.mr_job_script
 
 Running specific parts of jobs

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -4,6 +4,17 @@ What's New
 For a complete list of changes, see `CHANGES.txt
 <https://github.com/Yelp/mrjob/blob/master/CHANGES.txt>`_
 
+.. _v0.6.0:
+
+0.6.0
+-----
+
+Note that because :py:mod:`argparse` has different parsing rules than
+:py:mod:`optparse`, you have to use equal signs when passing an argument
+starting with a hyphen to another argument. For
+example, you now *must* use the form ``--hadoop-arg=-verbose``, not
+``--hadoop-arg -verbose``.
+
 .. _v0.5.11:
 
 0.5.11

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -55,7 +55,13 @@ class InlineMRJobRunner(SimMRJobRunner):
         starting up a standalone Hadoop instance and running your job with
         ``-r hadoop``."""
         super(InlineMRJobRunner, self).__init__(**kwargs)
-        if not (mrjob_cls is None or issubclass(mrjob_cls, MRJob)):
+        # if we run python -m mrjob.job, mrjob_cls is __main__.MRJob
+        # which is identical to (but not a subclass of) mrjob.job.MRJob
+        #
+        # the base MRJob still isn't runnable, but this yields a more
+        # useful error about the step having no mappers or reducers
+        if not (mrjob_cls is None or issubclass(mrjob_cls, MRJob)
+                or mrjob_cls.__module__ == '__main__'):
             raise TypeError
 
         self._mrjob_cls = mrjob_cls

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -54,6 +54,9 @@ class MRJob(MRJobLauncher):
     """The base class for all MapReduce jobs. See :py:meth:`__init__`
     for details."""
 
+    # script path is whatever file our subclass of MRJob is in
+    _FIRST_ARG_IS_SCRIPT_PATH = False
+
     def __init__(self, args=None):
         """Entry point for running your job from other Python code.
 

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -426,20 +426,20 @@ class MRJob(MRJobLauncher):
     def execute(self):
         # MRJob does Hadoop Streaming stuff, or defers to Launcher (superclass)
         # if not otherwise instructed
-        if self.parsed_args.show_steps:
+        if self.options.show_steps:
             self.show_steps()
 
-        elif self.parsed_args.run_mapper:
-            self.run_mapper(self.parsed_args.step_num)
+        elif self.options.run_mapper:
+            self.run_mapper(self.options.step_num)
 
-        elif self.parsed_args.run_combiner:
-            self.run_combiner(self.parsed_args.step_num)
+        elif self.options.run_combiner:
+            self.run_combiner(self.options.step_num)
 
-        elif self.parsed_args.run_reducer:
-            self.run_reducer(self.parsed_args.step_num)
+        elif self.options.run_reducer:
+            self.run_reducer(self.options.step_num)
 
-        elif self.parsed_args.run_spark:
-            self.run_spark(self.parsed_args.step_num)
+        elif self.options.run_spark:
+            self.run_spark(self.options.step_num)
 
         else:
             super(MRJob, self).execute()
@@ -464,7 +464,7 @@ class MRJob(MRJobLauncher):
     def _runner_class(self):
         """Runner class as indicated by ``--runner``. Defaults to ``'inline'``.
         """
-        if not self.parsed_args.runner or self.parsed_args.runner == 'inline':
+        if not self.options.runner or self.options.runner == 'inline':
             from mrjob.inline import InlineMRJobRunner
             return InlineMRJobRunner
 
@@ -618,9 +618,9 @@ class MRJob(MRJobLauncher):
         """
         step = self._get_step(step_num, SparkStep)
 
-        if len(self.parsed_args.args) != 2:
+        if len(self.options.args) != 2:
             raise ValueError('Wrong number of args')
-        input_path, output_path = self.parsed_args.args
+        input_path, output_path = self.options.args
 
         spark_method = step.spark
         spark_method(input_path, output_path)
@@ -669,7 +669,7 @@ class MRJob(MRJobLauncher):
         - If path is ``-``, read from STDIN.
         - Recursively read all files in a directory
         """
-        paths = self.parsed_args.args or ['-']
+        paths = self.options.args or ['-']
         for path in paths:
             for line in read_input(path, stdin=self.stdin):
                 yield line
@@ -828,17 +828,17 @@ class MRJob(MRJobLauncher):
         This is mostly useful inside :py:meth:`load_args`, to disable
         loading args when we aren't running inside Hadoop.
         """
-        return (self.parsed_args.run_mapper or
-                self.parsed_args.run_combiner or
-                self.parsed_args.run_reducer or
-                self.parsed_args.run_spark)
+        return (self.options.run_mapper or
+                self.options.run_combiner or
+                self.options.run_reducer or
+                self.options.run_spark)
 
-    def _print_help(self, parsed_args):
+    def _print_help(self, options):
         """Implement --help --steps"""
-        if parsed_args.show_steps:
+        if options.show_steps:
             _print_help_for_steps()
         else:
-            super(MRJob, self)._print_help(parsed_args)
+            super(MRJob, self)._print_help(options)
 
     ### protocols ###
 
@@ -1021,7 +1021,7 @@ class MRJob(MRJobLauncher):
             else:
                 paths_from_libjars.append(os.path.join(script_dir, path))
 
-        return combine_lists(paths_from_libjars, self.parsed_args.libjars)
+        return combine_lists(paths_from_libjars, self.options.libjars)
 
     ### Partitioning ###
 
@@ -1093,7 +1093,7 @@ class MRJob(MRJobLauncher):
         """
 
         # deal with various forms of bad behavior by users
-        unfiltered_jobconf = combine_dicts(self.JOBCONF, self.parsed_args.jobconf)
+        unfiltered_jobconf = combine_dicts(self.JOBCONF, self.options.jobconf)
         filtered_jobconf = {}
 
         def format_hadoop_version(v_float):

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -22,7 +22,6 @@ import json
 import logging
 import os.path
 import sys
-from optparse import OptionGroup
 
 # don't use relative imports, to allow this script to be invoked as __main__
 from mrjob.conf import combine_dicts
@@ -30,7 +29,7 @@ from mrjob.conf import combine_lists
 from mrjob.launch import MRJobLauncher
 from mrjob.launch import _im_func
 from mrjob.launch import _READ_ARGS_FROM_SYS_ARGV
-from mrjob.options import _add_step_options
+from mrjob.options import _add_step_args
 from mrjob.options import _print_help_for_steps
 from mrjob.protocol import JSONProtocol
 from mrjob.protocol import RawValueProtocol
@@ -78,7 +77,7 @@ class MRJob(MRJobLauncher):
 
     @classmethod
     def _usage(cls):
-        return "usage: %prog [options] [input files]"
+        return "usage: %(prog)s [options]"
 
     ### Defining one-step streaming jobs ###
 
@@ -424,20 +423,20 @@ class MRJob(MRJobLauncher):
     def execute(self):
         # MRJob does Hadoop Streaming stuff, or defers to Launcher (superclass)
         # if not otherwise instructed
-        if self.options.show_steps:
+        if self.parsed_args.show_steps:
             self.show_steps()
 
-        elif self.options.run_mapper:
-            self.run_mapper(self.options.step_num)
+        elif self.parsed_args.run_mapper:
+            self.run_mapper(self.parsed_args.step_num)
 
-        elif self.options.run_combiner:
-            self.run_combiner(self.options.step_num)
+        elif self.parsed_args.run_combiner:
+            self.run_combiner(self.parsed_args.step_num)
 
-        elif self.options.run_reducer:
-            self.run_reducer(self.options.step_num)
+        elif self.parsed_args.run_reducer:
+            self.run_reducer(self.parsed_args.step_num)
 
-        elif self.options.run_spark:
-            self.run_spark(self.options.step_num)
+        elif self.parsed_args.run_spark:
+            self.run_spark(self.parsed_args.step_num)
 
         else:
             super(MRJob, self).execute()
@@ -462,7 +461,7 @@ class MRJob(MRJobLauncher):
     def _runner_class(self):
         """Runner class as indicated by ``--runner``. Defaults to ``'inline'``.
         """
-        if not self.options.runner or self.options.runner == 'inline':
+        if not self.parsed_args.runner or self.parsed_args.runner == 'inline':
             from mrjob.inline import InlineMRJobRunner
             return InlineMRJobRunner
 
@@ -616,9 +615,9 @@ class MRJob(MRJobLauncher):
         """
         step = self._get_step(step_num, SparkStep)
 
-        if len(self.args) != 2:
+        if len(self.parsed_args.args) != 2:
             raise ValueError('Wrong number of args')
-        input_path, output_path = self.args
+        input_path, output_path = self.parsed_args.args
 
         spark_method = step.spark
         spark_method(input_path, output_path)
@@ -802,47 +801,41 @@ class MRJob(MRJobLauncher):
 
     ### Command-line arguments ###
 
-    def configure_options(self):
+    def configure_args(self):
         """Define arguments for this script. Called from :py:meth:`__init__()`.
 
         Re-define to define custom command-line arguments or pass
         through existing ones::
 
-            def configure_options(self):
-                super(MRYourJob, self).configure_options()
+            def configure_args(self):
+                super(MRYourJob, self).configure_args()
 
-                self.add_passthrough_option(...)
-                self.add_file_option(...)
-                self.pass_through_option(...)
+                self.add_passthru_arg(...)
+                self.add_file_arg(...)
+                self.pass_arg_through(...)
                 ...
         """
+        super(MRJob, self).configure_args()
 
-        super(MRJob, self).configure_options()
-
-        # To run mappers or reducers
-        self._mux_opt_group = OptionGroup(
-            self.option_parser, 'Running specific parts of the job')
-        self.option_parser.add_option_group(self._mux_opt_group)
-
-        _add_step_options(self._mux_opt_group)
+        _add_step_args(self.arg_parser)
 
     def is_task(self):
         """True if this is a mapper, combiner, reducer, or Spark script.
 
-        This is mostly useful inside :py:meth:`load_options`, to disable
-        loading options when we aren't running inside Hadoop.
+        This is mostly useful inside :py:meth:`load_args`, to disable
+        loading args when we aren't running inside Hadoop.
         """
-        return (self.options.run_mapper or
-                self.options.run_combiner or
-                self.options.run_reducer or
-                self.options.run_spark)
+        return (self.args.run_mapper or
+                self.args.run_combiner or
+                self.args.run_reducer or
+                self.args.run_spark)
 
-    def _print_help(self, options):
+    def _print_help(self, parsed_args):
         """Implement --help --steps"""
-        if options.show_steps:
+        if parsed_args.show_steps:
             _print_help_for_steps()
         else:
-            super(MRJob, self)._print_help(options)
+            super(MRJob, self)._print_help(parsed_args)
 
     ### protocols ###
 
@@ -1025,7 +1018,7 @@ class MRJob(MRJobLauncher):
             else:
                 paths_from_libjars.append(os.path.join(script_dir, path))
 
-        return combine_lists(paths_from_libjars, self.options.libjars)
+        return combine_lists(paths_from_libjars, self.args.libjars)
 
     ### Partitioning ###
 
@@ -1097,7 +1090,7 @@ class MRJob(MRJobLauncher):
         """
 
         # deal with various forms of bad behavior by users
-        unfiltered_jobconf = combine_dicts(self.JOBCONF, self.options.jobconf)
+        unfiltered_jobconf = combine_dicts(self.JOBCONF, self.args.jobconf)
         filtered_jobconf = {}
 
         def format_hadoop_version(v_float):

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -666,7 +666,7 @@ class MRJob(MRJobLauncher):
         - If path is ``-``, read from STDIN.
         - Recursively read all files in a directory
         """
-        paths = self.args or ['-']
+        paths = self.parsed_args.args or ['-']
         for path in paths:
             for line in read_input(path, stdin=self.stdin):
                 yield line
@@ -825,10 +825,10 @@ class MRJob(MRJobLauncher):
         This is mostly useful inside :py:meth:`load_args`, to disable
         loading args when we aren't running inside Hadoop.
         """
-        return (self.args.run_mapper or
-                self.args.run_combiner or
-                self.args.run_reducer or
-                self.args.run_spark)
+        return (self.parsed_args.run_mapper or
+                self.parsed_args.run_combiner or
+                self.parsed_args.run_reducer or
+                self.parsed_args.run_spark)
 
     def _print_help(self, parsed_args):
         """Implement --help --steps"""
@@ -1018,7 +1018,7 @@ class MRJob(MRJobLauncher):
             else:
                 paths_from_libjars.append(os.path.join(script_dir, path))
 
-        return combine_lists(paths_from_libjars, self.args.libjars)
+        return combine_lists(paths_from_libjars, self.parsed_args.libjars)
 
     ### Partitioning ###
 
@@ -1090,7 +1090,7 @@ class MRJob(MRJobLauncher):
         """
 
         # deal with various forms of bad behavior by users
-        unfiltered_jobconf = combine_dicts(self.JOBCONF, self.args.jobconf)
+        unfiltered_jobconf = combine_dicts(self.JOBCONF, self.parsed_args.jobconf)
         filtered_jobconf = {}
 
         def format_hadoop_version(v_float):

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -28,6 +28,7 @@ from optparse import OptionGroup
 from mrjob.conf import combine_dicts
 from mrjob.conf import combine_lists
 from mrjob.launch import MRJobLauncher
+from mrjob.launch import _im_func
 from mrjob.launch import _READ_ARGS_FROM_SYS_ARGV
 from mrjob.options import _add_step_options
 from mrjob.options import _print_help_for_steps
@@ -44,20 +45,6 @@ from mrjob.util import to_lines
 
 
 log = logging.getLogger(__name__)
-
-
-def _im_func(f):
-    """Wrapper to get at the underlying function belonging to a method.
-
-    Python 2 is slightly different because classes have "unbound methods"
-    which wrap the underlying function, whereas on Python 3 they're just
-    functions. (Methods work the same way on both versions.)
-    """
-    # "im_func" is the old Python 2 name for __func__
-    if hasattr(f, '__func__'):
-        return f.__func__
-    else:
-        return f
 
 
 class UsageError(Exception):
@@ -849,13 +836,6 @@ class MRJob(MRJobLauncher):
                 self.options.run_combiner or
                 self.options.run_reducer or
                 self.options.run_spark)
-
-    def _process_args(self, args):
-        """mrjob.launch takes the first arg as the script path, but mrjob.job
-        uses all args as input files. This method determines the behavior:
-        MRJob uses all args as input files.
-        """
-        self.args = args
 
     def _print_help(self, options):
         """Implement --help --steps"""

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -27,6 +27,7 @@ from mrjob.conf import combine_dicts
 from mrjob.options import _add_basic_args
 from mrjob.options import _add_job_args
 from mrjob.options import _add_runner_args
+from mrjob.options import _optparse_kwargs_to_argparse
 from mrjob.options import _print_help_for_runner
 from mrjob.options import _print_basic_help
 from mrjob.step import StepFailedException
@@ -58,31 +59,6 @@ def _im_func(f):
         return f.__func__
     else:
         return f
-
-
-def _optparse_kwargs_to_argparse(**kwargs):
-    """Translate old keyword args to OptionParser.add_option() so they can be
-    passed to ArgumentParser.add_argument().
-
-    The two methods take almost identical arguments, so this is mostly a
-    matter of filtering.
-    """
-    if any(k.startswith('callback') for k in kwargs):
-        raise ValueError(
-            'mrjob does not emulate callback arguments to add_option(); please'
-            ' use argparse actions instead.')
-
-    # opt_group was a mrjob-specific feature that we've abandoned
-    if 'opt_group' in kwargs:
-        log.warning(
-            'ignoring opt_group keyword arg (mrjob no longer supports'
-            ' opt groups')
-        kwargs.pop('opt_group')
-
-    # pretty much everything else is the same. if people want to pass argparse
-    # kwargs through the old optparse interface (e.g. *action* or *required*)
-    # more power to 'em.
-    return kwargs
 
 
 class MRJobLauncher(object):
@@ -296,7 +272,7 @@ class MRJobLauncher(object):
         # if script path isn't set, expect it on the command line
         if self._script_path is None:
             self.arg_parser.add_argument(
-                'script_path', dest='script_path',
+                dest='script_path',
                 help='path of script to launch')
 
         _add_basic_args(self.arg_parser)

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -230,8 +230,8 @@ class MRJobLauncher(object):
         # to log to it in Python 3
         log_stream = codecs.getwriter('utf_8')(self.stderr)
 
-        self.set_up_logging(quiet=self.parsed_args.quiet,
-                            verbose=self.parsed_args.verbose,
+        self.set_up_logging(quiet=self.options.quiet,
+                            verbose=self.options.verbose,
                             stream=log_stream)
 
         with self.make_runner() as runner:
@@ -243,7 +243,7 @@ class MRJobLauncher(object):
                 log.error(str(e))
                 sys.exit(1)
 
-            if not self.parsed_args.no_output:
+            if not self.options.no_output:
                 for chunk in runner.cat_output():
                     self.stdout.write(chunk)
                 self.stdout.flush()
@@ -288,7 +288,7 @@ class MRJobLauncher(object):
         _add_runner_args(self.arg_parser)
 
     def load_args(self, args):
-        """Load command-line options into ``self.parsed_args`` and
+        """Load command-line options into ``self.options`` and
         ``self._script_path``.
 
         Called from :py:meth:`__init__()` after :py:meth:`configure_args`.
@@ -302,18 +302,18 @@ class MRJobLauncher(object):
             def load_args(self, args):
                 super(MRYourJob, self).load_args(args)
 
-                self.stop_words = self.parsed_args.stop_words.split(',')
+                self.stop_words = self.options.stop_words.split(',')
                 ...
         """
-        self.parsed_args = self.arg_parser.parse_args(args)
+        self.options = self.arg_parser.parse_args(args)
 
-        if self.parsed_args.help:
-            self._print_help(self.parsed_args)
+        if self.options.help:
+            self._print_help(self.options)
             sys.exit(0)
 
         if self._FIRST_ARG_IS_SCRIPT_PATH:
             # should always be set, just hedging
-            self._script_path = self.parsed_args.script_path
+            self._script_path = self.options.script_path
 
     def add_file_arg(self, *args, **kwargs):
         """Add a command-line option that sends an external file
@@ -394,17 +394,9 @@ class MRJobLauncher(object):
     def args(self):
         class_name = self.__class__.__name__
         log.warning(
-            '%s.args is a deprecated alias for %s.parsed_args.args, and will'
+            '%s.args is a deprecated alias for %s.options.args, and will'
             ' be removed in v0.7.0' % (class_name, class_name))
-        return self.parsed_args
-
-    @property
-    def options(self):
-        class_name = self.__class__.__name__
-        log.warning(
-            '%s.options is a deprecated alias for %s.parsed_args, and will'
-            ' be removed in v0.7.0' % (class_name, class_name))
-        return self.parsed_args
+        return self.options
 
     def configure_options(self):
         """.. deprecated:: 0.6.0
@@ -465,19 +457,19 @@ class MRJobLauncher(object):
 
         Defaults to ``'local'`` and disallows use of inline runner.
         """
-        if self.parsed_args.runner == 'dataproc':
+        if self.options.runner == 'dataproc':
             from mrjob.dataproc import DataprocJobRunner
             return DataprocJobRunner
 
-        elif self.parsed_args.runner == 'emr':
+        elif self.options.runner == 'emr':
             from mrjob.emr import EMRJobRunner
             return EMRJobRunner
 
-        elif self.parsed_args.runner == 'hadoop':
+        elif self.options.runner == 'hadoop':
             from mrjob.hadoop import HadoopJobRunner
             return HadoopJobRunner
 
-        elif self.parsed_args.runner == 'inline':
+        elif self.options.runner == 'inline':
             raise ValueError("inline is not supported in the multi-lingual"
                              " launcher.")
 
@@ -527,23 +519,23 @@ class MRJobLauncher(object):
                 file_upload_args.append((option_string, args[0]))
 
         return dict(
-            conf_paths=self.parsed_args.conf_paths,
+            conf_paths=self.options.conf_paths,
             extra_args=extra_args,
             file_upload_args=file_upload_args,
             hadoop_input_format=self.hadoop_input_format(),
             hadoop_output_format=self.hadoop_output_format(),
-            input_paths=self.parsed_args.args,
+            input_paths=self.options.args,
             mr_job_script=self._script_path,
-            output_dir=self.parsed_args.output_dir,
+            output_dir=self.options.output_dir,
             partitioner=self.partitioner(),
             stdin=self.stdin,
-            step_output_dir=self.parsed_args.step_output_dir,
+            step_output_dir=self.options.step_output_dir,
         )
 
     def _kwargs_from_switches(self, keys):
         return dict(
-            (key, getattr(self.parsed_args, key))
-            for key in keys if hasattr(self.parsed_args, key)
+            (key, getattr(self.options, key))
+            for key in keys if hasattr(self.options, key)
         )
 
     def _job_kwargs(self):

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -523,8 +523,8 @@ class MRJobLauncher(object):
 
         return dict(
             conf_paths=self.parsed_args.conf_paths,
-            extra_args=[],
-            file_upload_args=[],
+            extra_args=extra_args,
+            file_upload_args=file_upload_args,
             hadoop_input_format=self.hadoop_input_format(),
             hadoop_output_format=self.hadoop_output_format(),
             input_paths=self.parsed_args.args,

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -413,7 +413,7 @@ class MRJobLauncher(object):
         """
         pass  # deprecation warning is in __init__()
 
-    def load_options(self):
+    def load_options(self, args):
         """.. deprecated:: 0.6.0
 
         Use `:py:meth:`load_args` instead.

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -360,7 +360,7 @@ class MRJobLauncher(object):
         :py:meth:`add_file_arg` instead.
 
         If you want to pass through a built-in option (e.g. ``--runner``, use
-        :py:meth:`pass_arg_thru` instead.
+        :py:meth:`pass_arg_through` instead.
         """
         pass_opt = self.arg_parser.add_argument(*args, **kwargs)
 
@@ -374,6 +374,7 @@ class MRJobLauncher(object):
         for action in self.arg_parser._get_optional_actions():
             if opt_str in action.option_strings or opt_str == action.dest:
                 self._passthru_arg_dests.add(action.dest)
+                break
         else:
             raise ValueError('unknown arg: %s', opt_str)
 
@@ -451,7 +452,7 @@ class MRJobLauncher(object):
             'pass_through_option() is deprecated and will be removed in'
             ' v0.7.0. Use pass_arg_through() instead.')
 
-        self.pass_arg_thru(opt_str)
+        self.pass_arg_through(opt_str)
 
     ### runners ###
 

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -69,6 +69,8 @@ class MRJobLauncher(object):
     effectively part of the :py:class:`~mrjob.job.MRJob` class itself and
     should not be used externally in any way.
     """
+    # only MRJobLauncher expects the first argument to be script_path
+    _FIRST_ARG_IS_SCRIPT_PATH = True
 
     def __init__(self, script_path=None, args=None, from_cl=False):
         """
@@ -271,7 +273,7 @@ class MRJobLauncher(object):
             help='include help for deprecated options')
 
         # if script path isn't set, expect it on the command line
-        if self._script_path is None:
+        if self._FIRST_ARG_IS_SCRIPT_PATH:
             self.arg_parser.add_argument(
                 dest='script_path',
                 help='path of script to launch')
@@ -309,9 +311,9 @@ class MRJobLauncher(object):
             self._print_help(self.parsed_args)
             sys.exit(0)
 
-        if self._script_path is None:
+        if self._FIRST_ARG_IS_SCRIPT_PATH:
             # should always be set, just hedging
-            self._script_path = getattr(self.parsed_args, 'script_path', None)
+            self._script_path = self.parsed_args.script_path
 
     def add_file_arg(self, *args, **kwargs):
         """Add a command-line option that sends an external file
@@ -340,7 +342,7 @@ class MRJobLauncher(object):
             raise ArgumentError(
                 "file options must use the actions 'store' or 'append'")
 
-        pass_opt = self.arg_parser.add_option(*args, **kwargs)
+        pass_opt = self.arg_parser.add_argument(*args, **kwargs)
 
         self._file_arg_dests.add(pass_opt.dest)
 

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -514,9 +514,14 @@ class MRJobLauncher(object):
 
         for dest, option_string, args in raw_args:
             if dest in self._passthru_arg_dests:
-                if option_string:
-                    extra_args.append(option_string)
-                extra_args.extend(args)
+                # special case for --hadoop-arg=-verbose etc.
+                if (option_string and len(args) == 1 and
+                        args[0].startswith('-')):
+                    extra_args.append('%s=%s' % (option_string, args[0]))
+                else:
+                    if option_string:
+                        extra_args.append(option_string)
+                    extra_args.extend(args)
 
             elif dest in self._file_arg_dests:
                 file_upload_args.append((option_string, args[0]))

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -154,10 +154,6 @@ class MRJobLauncher(object):
     def _print_help(self, options):
         """Print help for this job. This will either print runner
         or basic help. Override to allow other kinds of help."""
-        self.arg_parser.print_help()
-        return
-
-        # TODO: fix the below
         if options.runner:
             _print_help_for_runner(
                 self._runner_opt_names(), options.deprecated)

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1312,12 +1312,6 @@ def _print_basic_help(option_parser, usage, include_deprecated=False):
         print()
 
 
-# TODO: this is just here so that imports work. ArgumentParser already
-# does this automatically
-def _alphabetize_options(arg_parser):
-    pass
-
-
 def _optparse_kwargs_to_argparse(**kwargs):
     """Translate old keyword args to OptionParser.add_option() so they can be
     passed to ArgumentParser.add_argument().

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -132,11 +132,11 @@ class _CleanupAction(Action):
             else:
                 parser.error(
                     '%s got %s, which is not one of: %s' %
-                    (opt_str, choice, ', '.join(CLEANUP_CHOICES)))
+                    (option_string, choice, ', '.join(CLEANUP_CHOICES)))
 
         if 'NONE' in result and len(set(result)) > 1:
             parser.error(
-                '%s: Cannot clean up both nothing and something!' % opt_str)
+                '%s: Cannot clean up both nothing and something!' % option_string)
 
         setattr(namespace, self.dest, result)
 
@@ -155,15 +155,15 @@ class _SubnetsAction(Action):
 class _AppendJSONAction(Action):
     """action to parse JSON and append it to a list."""
     def __call__(self, parser, namespace, value, option_string=None):
-        _default_to(namespace, option.dest, [])
+        _default_to(namespace, self.dest, [])
 
         try:
             j = json.loads(value)
         except ValueError as e:
             parser.error('Malformed JSON passed to %s: %s' % (
-                opt_str, str(e)))
+                option_string, str(e)))
 
-        getattr(namespace, option.dest).append(j)
+        getattr(namespace, self.dest).append(j)
 
 
 class _JSONAction(Action):
@@ -174,9 +174,9 @@ class _JSONAction(Action):
             j = json.loads(value)
         except ValueError as e:
             parser.error('Malformed JSON passed to %s: %s' % (
-                opt_str, str(e)))
+                option_string, str(e)))
 
-        setattr(namespace, option.dest, j)
+        setattr(namespace, self.dest, j)
 
 
 class _PortRangeAction(Action):
@@ -189,7 +189,7 @@ class _PortRangeAction(Action):
             parser.error('%s: invalid port range list %r: \n%s' %
                          (option_string, value, e.args[0]))
 
-        setattr(namespace, option.dest, ports)
+        setattr(namespace, self.dest, ports)
 
 
 ### mux opts ###

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1312,6 +1312,15 @@ def _print_basic_help(option_parser, usage, include_deprecated=False):
         print()
 
 
+# TODO: implement this
+def _parse_raw_args(parser, args):
+    """Simulate parsing by *parser*, return a list of tuples of
+    (dest, switch, args)"""
+    pass
+
+
+
+
 def _optparse_kwargs_to_argparse(**kwargs):
     """Translate old keyword args to OptionParser.add_option() so they can be
     passed to ArgumentParser.add_argument().

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -32,14 +32,6 @@ from mrjob.conf import combine_paths
 from mrjob.conf import combine_path_lists
 from mrjob.parse import _parse_port_range_list
 
-# shims until we update tools
-_add_basic_options = None
-_add_runner_options = None
-_alphabetize_options = None
-
-
-
-
 log = getLogger(__name__)
 
 #: cleanup options:

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -593,7 +593,9 @@ _RUNNER_OPTS = dict(
             (['--hadoop-arg'], dict(
                 action='append',
                 help=('Argument of any type to pass to hadoop '
-                      'streaming. You can use --hadoop-arg multiple times.'),
+                      'streaming. Use an equals sign to avoid confusing the'
+                      ' parser (e.g. --hadoop-arg=-verbose).'
+                      ' You can use --hadoop-arg multiple times.'),
             )),
         ],
     ),
@@ -931,6 +933,8 @@ _RUNNER_OPTS = dict(
             (['--spark-arg'], dict(
                 action='append',
                 help=('Argument of any type to pass to spark-submit.'
+                      ' Use an equals sign to avoid confusing the parser'
+                      ' (e.g. --spark-arg=--verbose).'
                       ' You can use --spark-arg multiple times.'),
             )),
         ],

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -33,6 +33,14 @@ from mrjob.conf import combine_paths
 from mrjob.conf import combine_path_lists
 from mrjob.parse import _parse_port_range_list
 
+# shims until we update tools
+_add_basic_options = None
+_add_runner_options = None
+_alphabetize_options = None
+
+
+
+
 log = getLogger(__name__)
 
 #: cleanup options:
@@ -1332,7 +1340,9 @@ def _parse_raw_args(parser, args):
 
     for action in actions:
         raw_parser.add_argument(*action.option_strings,
-                                action=RawArgAction, nargs=action.nargs)
+                                action=RawArgAction,
+                                dest=action.dest,
+                                nargs=action.nargs)
 
     # leave errors to the real parser
     raw_parser.parse_known_args(args)
@@ -1353,10 +1363,10 @@ def _optparse_kwargs_to_argparse(**kwargs):
             ' use argparse actions instead.')
 
     # translate type from string (optparse) to type (argparse)
-    if k.get('type') is not None:
-        if k['type'] not in _OPTPARSE_TYPES:
-            raise OptionError('invalid option type: %r' % k['type'])
-        k['type'] = _OPTPARSE_TYPES[k['type']]
+    if kwargs.get('type') is not None:
+        if kwargs['type'] not in _OPTPARSE_TYPES:
+            raise OptionError('invalid option type: %r' % kwargs['type'])
+        kwargs['type'] = _OPTPARSE_TYPES[kwargs['type']]
 
     # opt_group was a mrjob-specific feature that we've abandoned
     if 'opt_group' in kwargs:

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1312,13 +1312,32 @@ def _print_basic_help(option_parser, usage, include_deprecated=False):
         print()
 
 
-# TODO: implement this
 def _parse_raw_args(parser, args):
     """Simulate parsing by *parser*, return a list of tuples of
-    (dest, switch, args)"""
-    pass
+    (dest, option_string, args).
 
+    If *args* contains unknown args or is otherwise malformed, we don't
+    raise an error (we leave this to the actual argument parser).
+    """
+    results = []
 
+    class RawArgAction(Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            # ignore *namespace*, append to *results*
+            results.append((self.dest, option_string, values))
+
+    raw_parser = ArgumentParser(add_help=False)
+
+    actions = parser._get_optional_actions() + parser._get_positional_actions()
+
+    for action in actions:
+        raw_parser.add_argument(*action.option_strings,
+                                action=RawArgAction, nargs=action.nargs)
+
+    # leave errors to the real parser
+    raw_parser.parse_known_args(args)
+
+    return results
 
 
 def _optparse_kwargs_to_argparse(**kwargs):

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1333,15 +1333,22 @@ def _parse_raw_args(parser, args):
             # ignore *namespace*, append to *results*
             results.append((self.dest, option_string, values))
 
+    def error(msg):
+        raise ValueError(msg)
+
     raw_parser = ArgumentParser(add_help=False)
+    raw_parser.error = error
 
     actions = parser._get_optional_actions() + parser._get_positional_actions()
 
     for action in actions:
+        # single args become single item lists
+        nargs = 1 if action.nargs is None else action.nargs
+
         raw_parser.add_argument(*action.option_strings,
                                 action=RawArgAction,
                                 dest=action.dest,
-                                nargs=action.nargs)
+                                nargs=nargs)
 
     # leave errors to the real parser
     raw_parser.parse_known_args(args)

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -22,7 +22,6 @@ import json
 from argparse import Action
 from argparse import ArgumentParser
 from argparse import SUPPRESS
-from optparse import OptionError
 from logging import getLogger
 
 from mrjob.conf import combine_cmds
@@ -108,7 +107,7 @@ class _KeyValueAction(Action):
             k, v = value.split('=', 1)
         except ValueError:
             parser.error('%s argument %r is not of the form KEY=VALUE' % (
-                opt_str, value))
+                option_string, value))
 
         _default_to(namespace, self.dest, {})
         getattr(namespace, self.dest)[k] = v
@@ -188,7 +187,7 @@ class _PortRangeAction(Action):
             ports = _parse_port_range_list(value)
         except ValueError as e:
             parser.error('%s: invalid port range list %r: \n%s' %
-                         (opt_str, value, e.args[0]))
+                         (option_string, value, e.args[0]))
 
         setattr(namespace, option.dest, ports)
 
@@ -1358,14 +1357,14 @@ def _optparse_kwargs_to_argparse(**kwargs):
     matter of filtering.
     """
     if any(k.startswith('callback') for k in kwargs):
-        raise OptionError(
+        raise ValueError(
             'mrjob does not emulate callback arguments to add_option(); please'
             ' use argparse actions instead.')
 
     # translate type from string (optparse) to type (argparse)
     if kwargs.get('type') is not None:
         if kwargs['type'] not in _OPTPARSE_TYPES:
-            raise OptionError('invalid option type: %r' % kwargs['type'])
+            raise ValueError('invalid option type: %r' % kwargs['type'])
         kwargs['type'] = _OPTPARSE_TYPES[kwargs['type']]
 
     # opt_group was a mrjob-specific feature that we've abandoned

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -49,18 +49,17 @@ from __future__ import print_function
 import math
 import logging
 import re
+from argparse import ArgumentParser
 from datetime import datetime
 from datetime import timedelta
 from time import sleep
-from optparse import OptionParser
 
 from mrjob.aws import _boto3_now
 from mrjob.aws import _boto3_paginate
 from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
-from mrjob.options import _add_basic_options
-from mrjob.options import _add_runner_options
-from mrjob.options import _alphabetize_options
+from mrjob.options import _add_basic_args
+from mrjob.options import _add_runner_args
 from mrjob.options import _filter_by_role
 from mrjob.pool import _legacy_pool_hash_and_name
 from mrjob.pool import _pool_hash_and_name
@@ -80,12 +79,9 @@ log = logging.getLogger(__name__)
 
 
 def main(args=None):
-    # parser command-line args
-    option_parser = _make_option_parser()
-    options, args = option_parser.parse_args(args)
-
-    if args:
-        option_parser.error('takes no arguments')
+    # parse command-line args
+    arg_parser = _make_arg_parser()
+    options = arg_parser.parse_args(args)
 
     MRJob.set_up_logging(quiet=options.quiet, verbose=options.verbose)
 
@@ -101,24 +97,23 @@ def main(args=None):
     _print_report(stats, now=now)
 
 
-def _make_option_parser():
-    usage = '%prog [options]'
+def _make_arg_parser():
+    usage = '%(prog)s [options]'
     description = 'Print a giant report on EMR usage.'
 
-    option_parser = OptionParser(usage=usage, description=description)
+    arg_parser = ArgumentParser(usage=usage, description=description)
 
-    option_parser.add_option(
-        '--max-days-ago', dest='max_days_ago', type='float', default=None,
+    arg_parser.add_argument(
+        '--max-days-ago', dest='max_days_ago', type=float, default=None,
         help=('Max number of days ago to look at jobs. By default, we go back'
               ' as far as EMR supports (currently about 2 months)'))
 
-    _add_basic_options(option_parser)
-    _add_runner_options(
-        option_parser,
+    _add_basic_args(arg_parser)
+    _add_runner_args(
+        arg_parser,
         _filter_by_role(EMRJobRunner.OPT_NAMES, 'connect'))
 
-    _alphabetize_options(option_parser)
-    return option_parser
+    return arg_parser
 
 
 def _runner_kwargs(options):

--- a/mrjob/tools/emr/create_cluster.py
+++ b/mrjob/tools/emr/create_cluster.py
@@ -180,13 +180,12 @@ Options::
 """
 from __future__ import print_function
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
-from mrjob.options import _add_basic_options
-from mrjob.options import _add_runner_options
-from mrjob.options import _alphabetize_options
+from mrjob.options import _add_basic_args
+from mrjob.options import _add_runner_args
 from mrjob.options import _filter_by_role
 
 
@@ -203,11 +202,8 @@ def _runner_kwargs(cl_args=None):
     :py:class:`EMRJobRunner`
     """
     # parser command-line args
-    option_parser = _make_option_parser()
-    options, args = option_parser.parse_args(cl_args)
-
-    if args:
-        option_parser.error('takes no arguments')
+    arg_parser = _make_arg_parser()
+    options = arg_parser.parse_args(cl_args)
 
     MRJob.set_up_logging(quiet=options.quiet, verbose=options.verbose)
 
@@ -220,22 +216,21 @@ def _runner_kwargs(cl_args=None):
     return kwargs
 
 
-def _make_option_parser():
-    usage = '%prog [options]'
+def _make_arg_parser():
+    usage = '%(prog)s [options]'
     description = (
         'Create a persistent EMR cluster to run jobs in, and print its ID to'
         ' stdout. WARNING: Do not run'
         ' this without mrjob terminate-idle-clusters in your'
         ' crontab; clusters left idle can quickly become expensive!')
-    option_parser = OptionParser(usage=usage, description=description)
+    arg_parser = ArgumentParser(usage=usage, description=description)
 
-    _add_basic_options(option_parser)
-    _add_runner_options(
-        option_parser,
+    _add_basic_args(arg_parser)
+    _add_runner_args(
+        arg_parser,
         _filter_by_role(EMRJobRunner.OPT_NAMES, 'connect', 'launch'))
 
-    _alphabetize_options(option_parser)
-    return option_parser
+    return arg_parser
 
 
 if __name__ == '__main__':

--- a/mrjob/tools/emr/report_long_jobs.py
+++ b/mrjob/tools/emr/report_long_jobs.py
@@ -48,17 +48,16 @@ Options::
 """
 from __future__ import print_function
 
+from argparse import ArgumentParser
 from datetime import timedelta
 import logging
-from optparse import OptionParser
 
 from mrjob.aws import _boto3_now
 from mrjob.aws import _boto3_paginate
 from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
-from mrjob.options import _add_basic_options
-from mrjob.options import _add_runner_options
-from mrjob.options import _alphabetize_options
+from mrjob.options import _add_basic_args
+from mrjob.options import _add_runner_args
 from mrjob.options import _filter_by_role
 from mrjob.util import strip_microseconds
 
@@ -71,11 +70,8 @@ log = logging.getLogger(__name__)
 def main(args=None):
     now = _boto3_now()
 
-    option_parser = _make_option_parser()
-    options, args = option_parser.parse_args(args)
-
-    if args:
-        option_parser.error('takes no arguments')
+    arg_parser = _make_arg_parser()
+    options = arg_parser.parse_args(args)
 
     MRJob.set_up_logging(quiet=options.quiet, verbose=options.verbose)
 
@@ -246,35 +242,33 @@ def _format_timedelta(time):
         return result
 
 
-def _make_option_parser():
-    usage = '%prog [options]'
+def _make_arg_parser():
+    usage = '%(prog)s [options]'
     description = ('Report jobs running for more than a certain number of'
                    ' hours (by default, %.1f). This can help catch buggy jobs'
                    ' and Hadoop/EMR operational issues.' % DEFAULT_MIN_HOURS)
 
-    option_parser = OptionParser(usage=usage, description=description)
+    arg_parser = ArgumentParser(usage=usage, description=description)
 
-    option_parser.add_option(
-        '--min-hours', dest='min_hours', type='float',
+    arg_parser.add_option(
+        '--min-hours', dest='min_hours', type=float,
         default=DEFAULT_MIN_HOURS,
         help=('Minimum number of hours a job can run before we report it.'
               ' Default: %default'))
 
-    option_parser.add_option(
+    arg_parser.add_option(
         '-x', '--exclude', action='append',
         help=('Exclude clusters that match the specified tags.'
               ' Specifed in the form TAG_KEY,TAG_VALUE.')
     )
 
-    _add_basic_options(option_parser)
-    _add_runner_options(
-        option_parser,
+    _add_basic_args(arg_parser)
+    _add_runner_args(
+        arg_parser,
         _filter_by_role(EMRJobRunner.OPT_NAMES, 'connect')
     )
 
-    _alphabetize_options(option_parser)
-
-    return option_parser
+    return arg_parser
 
 
 if __name__ == '__main__':

--- a/mrjob/tools/emr/report_long_jobs.py
+++ b/mrjob/tools/emr/report_long_jobs.py
@@ -250,13 +250,13 @@ def _make_arg_parser():
 
     arg_parser = ArgumentParser(usage=usage, description=description)
 
-    arg_parser.add_option(
+    arg_parser.add_argument(
         '--min-hours', dest='min_hours', type=float,
         default=DEFAULT_MIN_HOURS,
         help=('Minimum number of hours a job can run before we report it.'
               ' Default: %default'))
 
-    arg_parser.add_option(
+    arg_parser.add_argument(
         '-x', '--exclude', action='append',
         help=('Exclude clusters that match the specified tags.'
               ' Specifed in the form TAG_KEY,TAG_VALUE.')

--- a/mrjob/tools/emr/terminate_cluster.py
+++ b/mrjob/tools/emr/terminate_cluster.py
@@ -79,6 +79,10 @@ def _make_arg_parser():
         action='store_true',
         help="Don't actually delete any files; just log that we would")
 
+    arg_parser.add_argument(
+        dest='cluster_id',
+        help='ID of cluster to terminate')
+
     _add_basic_args(arg_parser)
     _add_runner_args(
         arg_parser,

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -124,6 +124,8 @@ def parse_and_save_options(option_parser, args):
     in *args* that correspond to that *dest*.
 
     This won't modify *option_parser*.
+
+    .. deprecated:: 0.6.0
     """
     arg_map = {}
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1065,7 +1065,7 @@ class SparkScriptArgsTestCase(SandboxedTestCase):
                  '<step 0 output>'])
 
     def test_spark_passthrough_arg(self):
-        job = MRNullSpark(['-r', 'local', '--extra-spark-arg', '--verbose'])
+        job = MRNullSpark(['-r', 'local', '--extra-spark-arg=--verbose'])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1073,8 +1073,7 @@ class SparkScriptArgsTestCase(SandboxedTestCase):
                 runner._spark_script_args(0),
                 ['--step-num=0',
                  '--spark',
-                 '--extra-spark-arg',
-                 '--verbose',
+                 '--extra-spark-arg=--verbose',
                  '<step 0 input>',
                  '<step 0 output>'])
 
@@ -1304,7 +1303,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
 
     def test_option_spark_args(self):
         job = MRNullSpark(['-r', 'local',
-                           '--spark-arg', '--name', '--spark-arg', 'Dave'])
+                           '--spark-arg=--name', '--spark-arg', 'Dave'])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1319,7 +1318,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
     def test_job_spark_args(self):
         # --extra-spark-arg is a passthrough option for MRNullSpark
         job = MRNullSpark(['-r', 'local',
-                           '--extra-spark-arg', '-v'])
+                           '--extra-spark-arg=-v'])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1334,8 +1333,8 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
     def test_job_spark_args_come_after_option_spark_args(self):
         job = MRNullSpark(
             ['-r', 'local',
-             '--extra-spark-arg', '-v',
-             '--spark-arg', '--name', '--spark-arg', 'Dave'])
+             '--extra-spark-arg=-v',
+             '--spark-arg=--name', '--spark-arg', 'Dave'])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4798,7 +4798,7 @@ class SparkScriptStepTestCase(MockBoto3TestCase):
 
         job = MRSparkScript(['-r', 'emr', '--script', self.fake_script,
                              '--script-arg', INPUT,
-                             '--script-arg', '-o',
+                             '--script-arg=-o',
                              '--script-arg', OUTPUT,
                              input1, input2])
         job.sandbox()

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -636,7 +636,7 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
         mr_job = MRTwoStepJob(['-r', 'hadoop', '-v',
                                '--no-conf', '--libjar', 'containsJars.jar',
-                               '--hadoop-arg', '-verbose'] + list(args)
+                               '--hadoop-arg=-verbose'] + list(args)
                               + ['-', local_input_path, remote_input_path]
                               + ['--jobconf', 'x=y'])
         mr_job.sandbox(stdin=stdin)
@@ -1290,7 +1290,7 @@ class HadoopExtraArgsTestCase(MockHadoopTestCase):
 
     def test_hadoop_extra_args(self):
         # hadoop_extra_args doesn't exist in default runner
-        job = MRWordCount(['-r', self.RUNNER, '--hadoop-arg', '-foo'])
+        job = MRWordCount(['-r', self.RUNNER, '--hadoop-arg=-foo'])
         with job.make_runner() as runner:
             self.assertEqual(runner._hadoop_args_for_step(0), ['-foo'])
 
@@ -1298,7 +1298,7 @@ class HadoopExtraArgsTestCase(MockHadoopTestCase):
         job = MRWordCount(
             ['-r', self.RUNNER,
              '--cmdenv', 'FOO=bar',
-             '--hadoop-arg', '-libjar', '--hadoop-arg', 'qux.jar',
+             '--hadoop-arg=-libjar', '--hadoop-arg', 'qux.jar',
              '--jobconf', 'baz=qux'])
         job.HADOOP_INPUT_FORMAT = 'FooInputFormat'
         job.HADOOP_OUTPUT_FORMAT = 'BarOutputFormat'

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1231,7 +1231,7 @@ class PrintHelpTestCase(SandboxedTestCase):
         # currently there are no deprecated options to test against
         #self.assertNotIn('--partitioner', output)
         self.assertIn('add --deprecated', output)
-        self.assertNotIn('--deprecated=DEPRECATED', output)
+        self.assertNotIn('--deprecated DEPRECATED', output)
 
     def test_basic_help_deprecated(self):
         MRJob(['--help', '--deprecated'])
@@ -1250,7 +1250,7 @@ class PrintHelpTestCase(SandboxedTestCase):
         # currently there are no deprecated options to test against
         #self.assertIn('--partitioner', output)
         self.assertNotIn('add --deprecated', output)
-        self.assertIn('--deprecated=DEPRECATED', output)
+        self.assertIn('--deprecated DEPRECATED', output)
 
     def test_runner_help(self):
         MRJob(['--help', '-r', 'emr'])

--- a/tests/tools/emr/test_terminate_cluster.py
+++ b/tests/tools/emr/test_terminate_cluster.py
@@ -15,16 +15,15 @@
 """Test the cluster termination tool"""
 from mrjob.emr import EMRJobRunner
 from mrjob.tools.emr.terminate_cluster import main as terminate_main
-from mrjob.tools.emr.terminate_cluster import _make_option_parser
+from mrjob.tools.emr.terminate_cluster import _make_arg_parser
 
 from tests.tools.emr import ToolTestCase
 
 
 class TerminateToolTestCase(ToolTestCase):
 
-    def test_make_option_parser(self):
-        _make_option_parser()
-        self.assertEqual(True, True)
+    def test_make_arg_parser(self):
+        _make_arg_parser()
 
     def test_terminate_cluster(self):
         cluster_id = self.make_cluster(pool_clusters=True)


### PR DESCRIPTION
MRJob now uses `argparse` instead of `optparse` (fixes #1587). `MRJobLauncher` methods have been renamed to reflect this (for example `configure_args()` not `configure_options()`). The old methods are still around as shims.

Kept the attribute `MRJobLauncher.options`, both because it means less to update, and because `argparse`'s naming conventions don't distinguish well between command-line arguments and parsed arguments (they're both "args"). Because `argparse` handles position arguments as well, `MRJobLauncher.args` is now a deprecated shim for `MRJobLauncher.options.args` (they're still just called "args" because they can be either input files or an input and output URI passed to spark jobs, depending on context).

There's still some work to do in terms of updating tests and examples (see #1645) and updating help printouts of mrjob tools (see #1646).