### PR TITLE
added extra_cluster_params, disabled emr_api_params

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -107,43 +107,57 @@ Cluster creation and configuration
       This used to be called *emr_applications*.
 
 .. mrjob-opt::
-    :config: emr_api_params
-    :switch: --emr-api-param, --no-emr-api-param
+    :config: extra_cluster_params
+    :switch: --extra-cluster-param
     :type: :ref:`dict <data-type-plain-dict>`
     :set: emr
     :default: ``{}``
 
-    Additional raw parameters to pass directly to the EMR API when creating a
+    Additional parameters to pass directly to the EMR API when creating a
     cluster. This allows old versions of `mrjob` to access new API features.
     See `the API documentation for RunJobFlow`_ for the full list of options.
 
     .. _`the API documentation for RunJobFlow`:
         http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_RunJobFlow.html
 
-    Option names and values are strings. On the command line, to set an option
-    use ``--emr-api-param KEY=VALUE``:
+    Option names are strings, and values are data structures. On the command
+    line, ``--extra-cluster-param name=value``:
 
     .. code-block:: sh
 
-        --emr-api-param Instances.Ec2SubnetId=someID
+        --extra-cluster-param SupportedProducts='["mapr-m3"]'
+        --extra-cluster-param AutoScalingRole=HankPym
 
-    and to suppress a value that would normally be passed to the API, use
-    ``--no-emr-api-param``:
+    *value* can be either a JSON or a string (unless it starts with ``{``,
+    ``[``, or ``"``, so that we don't convert malformed JSON to strings).
+    Parameters can be suppressed by setting them to ``null``:
 
     .. code-block:: sh
 
-        --no-emr-api-param VisibleToAllUsers
+        --extra-cluster-param LogUri=null
 
-    In the config file, ``emr_api_params`` is a dict; params can be suppressed
-    by setting them to ``null``:
+    This also works with Google dataproc:
+
+    .. code-block:: sh
+
+       --extra-cluster-param labels='{"name": "wrench"}'
+
+    In the config file, `extra_cluster_param` is a dict:
 
     .. code-block:: yaml
 
         runners:
           emr:
-            emr_api_params:
-              Instances.Ec2SubnetId: someID
-              VisibleToAllUsers: null
+            extra_cluster_params:
+              AutoScalingRole: HankPym
+              LogUri: null  # !clear works too
+              SupportedProducts:
+              - mapr-m3
+
+    .. versionadded:: 0.6.0
+
+       This replaces the old `emr_api_params` option, which only worked
+       with :py:mod:`boto` 2.
 
 .. mrjob-opt::
     :config: emr_configurations

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -48,6 +48,7 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
         'cloud_tmp_dir',
         'cluster_id',
         'core_instance_type',
+        'extra_cluster_params',
         'image_version',
         'instance_type',
         'master_instance_type',

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -328,3 +328,14 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
         out.extend(self._sh_pre_commands())
 
         return out
+
+    ### Launching Clusters ###
+
+    def _add_extra_cluster_params(self, params):
+        """Return a dict with the *extra_cluster_params* opt patched into
+        *params*, and ``None`` values removed."""
+        params = params.copy()
+        params.update(self._opts['extra_cluster_params'])
+        params = {k: v for k, v in params.items() if v is not None}
+
+        return params

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -122,7 +122,7 @@ _HADOOP_STREAMING_JAR_URI = (
 _GCP_CLUSTER_NAME_REGEX = '(?:[a-z](?:[-a-z0-9]{0,53}[a-z0-9])?).'
 
 
-########## BEGIN - Helper fxns for _cluster_create_args ##########
+########## BEGIN - Helper fxns for _cluster_create_kwargs ##########
 def _gcp_zone_uri(project, zone):
     return (
         'https://www.googleapis.com/compute/%(gce_api_version)s/projects/'
@@ -141,7 +141,7 @@ def _gcp_instance_group_config(
         machineTypeUri=machine_uri,
         isPreemptible=is_preemptible
     )
-########## END -  Helper fxns for _cluster_create_args ###########
+########## END -  Helper fxns for _cluster_create_kwargs ###########
 
 
 def _wait_for(msg, sleep_secs):
@@ -645,7 +645,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner):
             log.info(
                 'Creating Dataproc Hadoop cluster - %s' % self._cluster_id)
 
-            cluster_data = self._cluster_create_args()
+            cluster_data = self._cluster_create_kwargs()
 
             self._api_cluster_create(cluster_data)
 
@@ -802,7 +802,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner):
     def get_cluster_id(self):
         return self._cluster_id
 
-    def _cluster_create_args(self):
+    def _cluster_create_kwargs(self):
         gcs_init_script_uris = []
         if self._master_bootstrap_script_path:
             gcs_init_script_uris.append(
@@ -865,9 +865,14 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner):
             cluster_config['softwareConfig'] = dict(
                 imageVersion=self._opts['image_version'])
 
-        return dict(projectId=self._gcp_project,
+        kwargs = dict(projectId=self._gcp_project,
                     clusterName=self._cluster_id,
                     config=cluster_config)
+
+        kwargs.update(self._opts['extra_cluster_params'])
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
+        return kwargs
 
     ### Dataproc-specific Stuff ###
 

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -869,10 +869,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner):
                     clusterName=self._cluster_id,
                     config=cluster_config)
 
-        kwargs.update(self._opts['extra_cluster_params'])
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
-
-        return kwargs
+        return self._add_extra_cluster_params(kwargs)
 
     ### Dataproc-specific Stuff ###
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -386,9 +386,14 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             self._output_dir = self._cloud_tmp_dir + 'output/'
 
         # check AMI version
+        # TODO: warn about AMIs that only have Python 2.6
         if self._opts['image_version'].startswith('1.'):
             log.warning('1.x AMIs will probably not work because they use'
                         ' Python 2.5. Use a later AMI version or mrjob v0.4.2')
+
+        if self._opts['emr_api_params']:
+            log.warning('emr_api_params is deprecated and does nothing.'
+                        ' Please use extra_cluster_params instead')
 
         # manage local files that we want to upload to S3. We'll add them
         # to this manager just before we need them.

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -391,7 +391,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             log.warning('1.x AMIs will probably not work because they use'
                         ' Python 2.5. Use a later AMI version or mrjob v0.4.2')
 
-        if self._opts['emr_api_params']:
+        if self._opts['emr_api_params'] is not None:
             log.warning('emr_api_params is deprecated and does nothing.'
                         ' Please use extra_cluster_params instead')
 
@@ -2869,7 +2869,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 cache['image_version'] = release_label.lstrip('emr-')
 
         cache['app_versions'] = dict(
-            (a['Name'].lower(), a['Version'])
+            (a['Name'].lower(), a.get('Version'))
             for a in cluster['Applications'])
 
         if cluster['Status']['State'] in ('RUNNING', 'WAITING'):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1381,8 +1381,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             else:
                 Instances['Ec2SubnetId'] = self._opts['subnet']
 
-        if self._opts['emr_api_params']:
-            kwargs.update(self._opts['emr_api_params'])
+        if self._opts['extra_cluster_params']:
+            kwargs.update(self._opts['extra_cluster_params'])
+            kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
         return kwargs
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1386,10 +1386,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             else:
                 Instances['Ec2SubnetId'] = self._opts['subnet']
 
-        kwargs.update(self._opts['extra_cluster_params'])
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
-
-        return kwargs
+        return self._add_extra_cluster_params(kwargs)
 
     def _instance_profile(self):
         try:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1381,9 +1381,8 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             else:
                 Instances['Ec2SubnetId'] = self._opts['subnet']
 
-        if self._opts['extra_cluster_params']:
-            kwargs.update(self._opts['extra_cluster_params'])
-            kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        kwargs.update(self._opts['extra_cluster_params'])
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
         return kwargs
 

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -19,6 +19,7 @@ import mimetypes
 from mrjob.cat import decompress
 from mrjob.fs.base import Filesystem
 from mrjob.parse import urlparse
+from mrjob.py2 import PY2
 from mrjob.runner import GLOB_RE
 
 try:
@@ -48,15 +49,22 @@ _GCS_API_VERSION = 'v1'
 _BINARY_MIMETYPE = 'application/octet-stream'
 _LS_FIELDS_TO_RETURN = 'nextPageToken,items(name,size,timeCreated,md5Hash)'
 
+if PY2:
+    base64_decode = base64.decodestring
+    base64_encode = base64.encodestring
+else:
+    base64_decode = base64.decodebytes
+    base64_encode = base64.encodebytes
+
 
 def _base64_to_hex(base64_encoded):
-    base64_decoded = base64.decodestring(base64_encoded)
+    base64_decoded = base64_decode(base64_encoded)
     return binascii.hexlify(base64_decoded)
 
 
 def _hex_to_base64(hex_encoded):
     hex_decoded = binascii.unhexlify(hex_encoded)
-    return base64.encodestring(hex_decoded)
+    return base64_encode(hex_decoded)
 
 
 def _path_glob_to_parsed_gcs_uri(path_glob):

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -42,11 +42,6 @@ log = logging.getLogger(__name__)
 # sentinel value; used when running MRJob as a script
 _READ_ARGS_FROM_SYS_ARGV = '_READ_ARGS_FROM_SYS_ARGV'
 
-# options only used to modify other options; don't pass to runners
-_FAKE_OPTIONS = set([
-    'no_emr_api_params',
-])
-
 
 def _im_func(f):
     """Wrapper to get at the underlying function belonging to a method.

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -599,7 +599,8 @@ _RUNNER_OPTS = dict(
             (['--extra-cluster-param'], dict(
                 action=_KeyJSONValueAction,
                 help=('extra parameter to pass to cloud API when creating'
-                      ' a cluster. Takes the form <param>=<value>, where value'
+                      ' a cluster, to access features not currently supported'
+                      ' by mrjob. Takes the form <param>=<value>, where value'
                       ' is JSON or a string. Use <param>=null to unset a'
                       ' parameter'),
             )),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -595,6 +595,7 @@ _RUNNER_OPTS = dict(
     ),
     extra_cluster_params=dict(
         cloud_role='launch',
+        combiner=combine_dicts,
         switches=[
             (['--extra-cluster-param'], dict(
                 action=_KeyJSONValueAction,

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -19,6 +19,7 @@ objects with categorized command line parameters.
 from __future__ import print_function
 
 import json
+import re
 from argparse import Action
 from argparse import ArgumentParser
 from argparse import SUPPRESS
@@ -77,6 +78,9 @@ _OPTPARSE_TYPES = dict(
     string=str,
 )
 
+# use to identify malformed JSON
+_PROBABLY_JSON_RE = re.compile(r'^\s*[\{\[\"].*$')
+
 
 ### custom actions ###
 
@@ -109,7 +113,7 @@ class _KeyNoneValueAction(Action):
     """action to set KEY to None"""
     def __call__(self, parser, namespace, value, option_string=None):
         _default_to(namespace, self.dest, {})
-        getattr(namespace, self.dest)[k] = None
+        getattr(namespace, self.dest)[value] = None
 
 
 class _CleanupAction(Action):
@@ -156,6 +160,29 @@ class _AppendJSONAction(Action):
                 option_string, str(e)))
 
         getattr(namespace, self.dest).append(j)
+
+
+class _KeyJSONValueAction(Action):
+    """action for KEY=<json> pairs. Allows value to be a string, as long
+    as it doesn't start with ``[``, ``{``, or ``"``."""
+    # used for --extra-cluster-param
+
+    def __call__(self, parser, namespace, value, option_string=None):
+        try:
+            k, v = value.split('=', 1)
+        except ValueError:
+            parser.error('%s argument %r is not of the form KEY=VALUE' % (
+                option_string, value))
+
+        try:
+            v = json.loads(v)
+        except ValueError:
+            if _PROBABLY_JSON_RE.match(v):
+                parser.error('%s argument %r is not valid JSON' % (
+                    option_string, value))
+
+        _default_to(namespace, self.dest, {})
+        getattr(namespace, self.dest)[k] = v
 
 
 class _JSONAction(Action):
@@ -563,6 +590,18 @@ _RUNNER_OPTS = dict(
                 action='store_false',
                 help=('Disable storage of Hadoop logs in SimpleDB (the'
                       ' default)'),
+            )),
+        ],
+    ),
+    extra_cluster_params=dict(
+        cloud_role='launch',
+        switches=[
+            (['--extra-cluster-param'], dict(
+                action=_KeyJSONValueAction,
+                help=('extra parameter to pass to cloud API when creating'
+                      ' a cluster. Takes the form <param>=<value>, where value'
+                      ' is JSON or a string. Use <param>=null to unset a'
+                      ' parameter'),
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -540,19 +540,13 @@ _RUNNER_OPTS = dict(
     ),
     emr_api_params=dict(
         cloud_role='launch',
-        combiner=combine_dicts,
+        deprecated=True,
         switches=[
             (['--emr-api-param'], dict(
-                action=_KeyValueAction,
-                help=('Additional parameter to pass directly to the EMR'
-                      ' API when creating a cluster. Should take the form'
-                      ' KEY=VALUE. You can use --emr-api-param multiple'
-                      ' times'),
+                help=('deprecated. Use --extra-cluster-param instead'),
             )),
             (['--no-emr-api-param'], dict(
-                action=_KeyNoneValueAction,
-                help=('Parameter to be unset when calling EMR API.'
-                      ' You can use --no-emr-api-param multiple times.'),
+                help=('deprecated. Use --extra-cluster-param instead'),
             )),
         ],
     ),

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -274,6 +274,11 @@ class MockEMRClient(object):
         _validate_param(kwargs, 'ServiceRole', string_types)
         cluster['ServiceRole'] = kwargs.pop('ServiceRole')
 
+        # AutoScalingRole
+        if 'AutoScalingRole' in kwargs:
+            _validate_param(kwargs, 'AutoScalingRole', string_types)
+            cluster['AutoScalingRole'] = kwargs.pop('AutoScalingRole')
+
         # AmiVersion and ReleaseLabel
         for version_param in ('AmiVersion', 'ReleaseLabel'):
             if version_param in kwargs:
@@ -355,6 +360,7 @@ class MockEMRClient(object):
                  dict(Name='hadoop', Version=hadoop_version))
 
              if kwargs.get('SupportedProducts'):
+                 _validate_param(kwargs, 'SupportedProducts', (list, tuple))
                  for product in kwargs.pop('SupportedProducts'):
                      cluster['Applications'].append(dict(Name=product))
 

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -321,6 +321,11 @@ class MockEMRClient(object):
             running_ami_version, AMI_HADOOP_VERSION_UPDATES)
 
         if version_gte(running_ami_version, '4'):
+            if kwargs.get('SupportedProducts'):
+                raise _error(
+                    'Cannot specify supported products when release label is'
+                    ' used. Specify applications instead.')
+
             application_names = set(
                 a['Name'] for a in kwargs.pop('Applications', []))
 
@@ -348,6 +353,10 @@ class MockEMRClient(object):
              # 'hadoop' is lowercase if AmiVersion specified
              cluster['Applications'].append(
                  dict(Name='hadoop', Version=hadoop_version))
+
+             if kwargs.get('SupportedProducts'):
+                 for product in kwargs.pop('SupportedProducts'):
+                     cluster['Applications'].append(dict(Name=product))
 
         # Configurations
         if 'Configurations' in kwargs:

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -382,6 +382,21 @@ class ZoneTestCase(MockGoogleAPITestCase):
                           cluster['config']['workerConfig']['machineTypeUri'])
 
 
+class ExtraClusterParamsTestCase(MockGoogleAPITestCase):
+
+    # just a basic test to make extra_cluster_params is respected.
+    # more extensive tests are found in tests.test_emr
+
+    def test_set_labels(self):
+        args = ['--extra-cluster-param', 'labels={"name": "wrench"}']
+
+        with self.make_runner(*args) as runner:
+            runner.run()
+
+            cluster = runner._api_cluster_get(runner._cluster_id)
+            self.assertEqual(cluster['labels']['name'], 'wrench')
+
+
 class RegionTestCase(MockGoogleAPITestCase):
 
     def test_default(self):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -449,16 +449,11 @@ class VisibleToAllUsersTestCase(MockBoto3TestCase):
         cluster = self.run_and_get_cluster('--no-visible-to-all-users')
         self.assertEqual(cluster['VisibleToAllUsers'], False)
 
-    def test_force_to_bool(self):
-        # make sure mock_boto3 doesn't always convert to bool
-        self.assertRaises(ParamValidationError,
-                          self.run_and_get_cluster,
-                          '--emr-api-param', 'VisibleToAllUsers=1')
-
     def test_visible(self):
         cluster = self.run_and_get_cluster('--visible-to-all-users')
         self.assertEqual(cluster['VisibleToAllUsers'], True)
 
+    def test_force_to_bool(self):
         VISIBLE_MRJOB_CONF = {'runners': {'emr': {
             'check_cluster_every': 0.00,
             'cloud_fs_sync_secs': 0.00,
@@ -466,8 +461,14 @@ class VisibleToAllUsersTestCase(MockBoto3TestCase):
         }}}
 
         with mrjob_conf_patcher(VISIBLE_MRJOB_CONF):
-            visible_cluster = self.run_and_get_cluster()
-            self.assertEqual(visible_cluster['VisibleToAllUsers'], True)
+            cluster = self.run_and_get_cluster()
+            self.assertEqual(cluster['VisibleToAllUsers'], True)
+
+    def test_mock_boto3_does_not_force_to_bool(self):
+        # make sure that mrjob is converting to bool, not mock_boto3
+        self.assertRaises(ParamValidationError,
+                          self.run_and_get_cluster,
+                          '--extra-cluster-param', 'VisibleToAllUsers=1')
 
 
 class SubnetTestCase(MockBoto3TestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -600,6 +600,16 @@ class IAMTestCase(MockBoto3TestCase):
         self.assertEqual(cluster['ServiceRole'], 'EMR_DefaultRole')
 
 
+class ExtraClusterParamsTestCase(MockBoto3TestCase):
+
+    def test_set_param(self):
+        cluster = self.run_and_get_cluster(
+            '--image-version', '3.7.0',
+            '--extra-cluster-param', 'SupportedProducts=["mapr-m3"]')
+
+        self.assertIn('mapr-m3', [a['Name'] for a in cluster['Applications']])
+
+
 @unittest.skip('reworking emr_api_params for boto3, see #1574')
 class EMRAPIParamsTestCase(MockBoto3TestCase):
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -630,7 +630,7 @@ class ExtraClusterParamsTestCase(MockBoto3TestCase):
         cluster = self.run_and_get_cluster(
             '--extra-cluster-param', 'LogUri=null')
 
-        self.assertNotIn(cluster, 'LogUri')
+        self.assertNotIn('LogUri', cluster)
 
     def test_set_multiple_params(self):
         cluster = self.run_and_get_cluster(

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -602,123 +602,65 @@ class IAMTestCase(MockBoto3TestCase):
 
 class ExtraClusterParamsTestCase(MockBoto3TestCase):
 
-    def test_set_param(self):
+    def test_set_unsupported_json_param(self):
         cluster = self.run_and_get_cluster(
             '--image-version', '3.7.0',
             '--extra-cluster-param', 'SupportedProducts=["mapr-m3"]')
 
         self.assertIn('mapr-m3', [a['Name'] for a in cluster['Applications']])
 
+    def test_set_unsupported_string_param(self):
+        cluster = self.run_and_get_cluster(
+            '--extra-cluster-param', 'AutoScalingRole=HankPym')
 
-@unittest.skip('reworking emr_api_params for boto3, see #1574')
-class EMRAPIParamsTestCase(MockBoto3TestCase):
+        self.assertEqual(cluster['AutoScalingRole'], 'HankPym')
+
+    def test_bad_json_param_is_not_a_string(self):
+        self.assertRaises(ValueError, self.run_and_get_cluster,
+            '--image-version', '3.7.0',
+            '--extra-cluster-param', 'SupportedProducts=[mapr-m3]')
+
+    def test_set_existing_param(self):
+        cluster = self.run_and_get_cluster(
+            '--extra-cluster-param', 'Name=Dave')
+
+        self.assertEqual(cluster['Name'], 'Dave')
+
+    def test_unset_existing_param(self):
+        cluster = self.run_and_get_cluster(
+            '--extra-cluster-param', 'LogUri=null')
+
+        self.assertNotIn(cluster, 'LogUri')
+
+    def test_set_multiple_params(self):
+        cluster = self.run_and_get_cluster(
+            '--extra-cluster-param', 'AutoScalingRole=HankPym',
+            '--extra-cluster-param', 'Name=Dave')
+
+        self.assertEqual(cluster['AutoScalingRole'], 'HankPym')
+        self.assertEqual(cluster['Name'], 'Dave')
+
+
+class DeprecatedEMRAPIParamsTestCase(MockBoto3TestCase):
+
+    # emr_api_param is completely disabled
+
+    def setUp(self):
+        super(DeprecatedEMRAPIParamsTestCase, self).setUp()
+
+        self.log = self.start(patch('mrjob.emr.log'))
 
     def test_param_set(self):
-        cluster = self.run_and_get_cluster(
-            '--emr-api-param', 'Test.API=a', '--emr-api-param', 'Test.API2=b')
-        self.assertTrue('Test.API' in cluster._api_params)
-        self.assertTrue('Test.API2' in cluster._api_params)
-        self.assertEqual(cluster._api_params['Test.API'], 'a')
-        self.assertEqual(cluster._api_params['Test.API2'], 'b')
+        cluster = self.run_and_get_cluster('--emr-api-param', 'name=Dave')
+
+        self.assertTrue(self.log.warning.called)
+        self.assertNotEqual(cluster['Name'], 'Dave')
 
     def test_param_unset(self):
-        cluster = self.run_and_get_cluster(
-            '--no-emr-api-param', 'Test.API',
-            '--no-emr-api-param', 'Test.API2')
-        self.assertTrue('Test.API' in cluster._api_params)
-        self.assertTrue('Test.API2' in cluster._api_params)
-        self.assertIsNone(cluster._api_params['Test.API'])
-        self.assertIsNone(cluster._api_params['Test.API2'])
+        cluster = self.run_and_get_cluster('--no-emr-api-param', 'log_uri')
 
-    def test_invalid_param(self):
-        self.assertRaises(
-            ValueError, self.run_and_get_cluster,
-            '--emr-api-param', 'Test.API')
-
-    def test_overrides(self):
-        cluster = self.run_and_get_cluster(
-            '--emr-api-param', 'VisibleToAllUsers=false',
-            '--visible-to-all-users')
-        self.assertEqual(cluster.visibletoallusers, 'false')
-
-    def test_no_emr_api_param_command_line_switch(self):
-        job = MRWordCount([
-            '-r', 'emr',
-            '--emr-api-param', 'Instances.Ec2SubnetId=someID',
-            '--no-emr-api-param', 'VisibleToAllUsers'])
-
-        with job.make_runner() as runner:
-            self.assertEqual(runner._opts['emr_api_params'],
-                             {'Instances.Ec2SubnetId': 'someID',
-                              'VisibleToAllUsers': None})
-
-    def test_no_emr_api_params_is_not_a_real_option(self):
-        job = MRWordCount([
-            '-r', 'emr',
-            '--no-emr-api-param', 'VisibleToAllUsers'])
-
-        self.assertNotIn('no_emr_api_params',
-                         sorted(job._runner_kwargs()))
-        self.assertNotIn('no_emr_api_param',
-                         sorted(job._runner_kwargs()))
-
-        with job.make_runner() as runner:
-            self.assertNotIn('no_emr_api_params', sorted(runner._opts))
-            self.assertNotIn('no_emr_api_param', sorted(runner._opts))
-            self.assertEqual(runner._opts['emr_api_params'],
-                             {'VisibleToAllUsers': None})
-
-    def test_command_line_overrides_config(self):
-        # want to make sure a nulled-out param in the config file
-        # can't override a param set on the command line
-
-        API_PARAMS_MRJOB_CONF = {'runners': {'emr': {
-            'check_cluster_every': 0.00,
-            'cloud_fs_sync_secs': 0.00,
-            'emr_api_params': {
-                'Instances.Ec2SubnetId': 'someID',
-                'VisibleToAllUsers': None,
-                'Name': 'eaten_by_a_whale',
-            },
-        }}}
-
-        job = MRWordCount([
-            '-r', 'emr',
-            '--no-emr-api-param', 'Instances.Ec2SubnetId',
-            '--emr-api-param', 'VisibleToAllUsers=true'])
-
-        with mrjob_conf_patcher(API_PARAMS_MRJOB_CONF):
-            with job.make_runner() as runner:
-                self.assertEqual(runner._opts['emr_api_params'],
-                                 {'Instances.Ec2SubnetId': None,
-                                  'VisibleToAllUsers': 'true',
-                                  'Name': 'eaten_by_a_whale'})
-
-    def test_serialization(self):
-        # we can now serialize data structures from mrjob.conf
-
-        API_PARAMS_MRJOB_CONF = {'runners': {'emr': {
-            'check_cluster_every': 0.00,
-            'cloud_fs_sync_secs': 0.00,
-            'emr_api_params': {
-                'Foo': {'Bar': ['Baz', {'Qux': ['Quux', 'Quuux']}]}
-            },
-        }}}
-
-        job = MRWordCount(['-r', 'emr'])
-        job.sandbox()
-
-        with mrjob_conf_patcher(API_PARAMS_MRJOB_CONF):
-            with job.make_runner() as runner:
-                runner._launch()
-
-                api_params = runner._describe_cluster()._api_params
-                self.assertEqual(
-                    api_params.get('Foo.Bar.member.1'), 'Baz')
-                self.assertEqual(
-                    api_params.get('Foo.Bar.member.2.Qux.member.1'), 'Quux')
-                self.assertEqual(
-                    api_params.get('Foo.Bar.member.2.Qux.member.2'), 'Quuux')
+        self.assertTrue(self.log.warning.called)
+        self.assertIn('LogUri', cluster)
 
 
 class AMIAndHadoopVersionTestCase(MockBoto3TestCase):

--- a/tests/tools/emr/test_create_cluster.py
+++ b/tests/tools/emr/test_create_cluster.py
@@ -50,6 +50,7 @@ class ClusterInspectionTestCase(ToolTestCase):
                 'emr_configurations': None,
                 'emr_endpoint': None,
                 'enable_emr_debugging': None,
+                'extra_cluster_params': None,
                 'iam_endpoint': None,
                 'iam_instance_profile': None,
                 'iam_service_role': None,


### PR DESCRIPTION
This replaces `emr_api_params`, which was tied to `boto` 2 and is unusable, with `extra_cluster_params`, which speaks JSON and works on Dataproc as well as EMR. Fixes #1574.
