### PR TITLE
deprecate read_file(), read_input()

### DIFF
--- a/mrjob/cat.py
+++ b/mrjob/cat.py
@@ -77,14 +77,11 @@ def gunzip_stream(fileobj, bufsize=1024):
 
 
 def decompress(readable, path, bufsize=1024):
-    """Take *readable* which support the ``.read()`` method correponding to
+    """Take a *readable* which supports the ``.read()`` method correponding to
     the given path and returns an iterator that yields chunks of bytes,
     possibly decompressing based on *path*.
 
     if *readable* appears to be a fileobj, pass it through as-is.
-
-    Unlike :py:func:`open_input`, this can deal with things that don't support
-    the full fileobj interface (e.g. :py:mod:`boto3`'s ``StreamingBody``).
     """
     if path.endswith('.gz'):
         return gunzip_stream(readable)
@@ -102,21 +99,6 @@ def decompress(readable, path, bufsize=1024):
 
 def is_compressed(path):
     return path.endswith('.bz2') or path.endswith('.gz')
-
-
-def open_input(path):
-    """Open the given *path* and return a fileobj or, if it's a compressed
-    file, a fileobj-like object."""
-    if path.endswith('.gz'):
-        return gzip.open(path, 'rb')
-    elif path.endswith('.bz2'):
-        if bz2 is None:
-            raise Exception('bz2 module was not successfully imported'
-                            ' (likely not installed).')
-
-        return bz2.BZ2File(path, 'rb')
-    else:
-        return open(path, 'rb')
 
 
 def to_chunks(readable, bufsize=1024):

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -26,8 +26,8 @@ from os.path import relpath
 from shutil import copy2
 from shutil import copytree
 
+from mrjob.cat import decompress
 from mrjob.cat import is_compressed
-from mrjob.cat import open_input
 from mrjob.compat import translate_jobconf
 from mrjob.compat import translate_jobconf_for_all_versions
 from mrjob.conf import combine_dicts
@@ -399,7 +399,7 @@ class SimMRJobRunner(MRJobRunner):
         results = []
 
         for path in input_paths:
-            with open_input(path) as src:
+            with open(path, 'rb') as src:
                 if is_compressed(path):
                     # if file is compressed, uncompress it into a single split
 
@@ -407,7 +407,8 @@ class SimMRJobRunner(MRJobRunner):
                     size = os.stat(path)[stat.ST_SIZE]
 
                     with next(split_fileobj_gen) as dest:
-                        shutil.copyfileobj(src, dest)
+                        for chunk in decompress(src, path):
+                            dest.write(chunk)
 
                     results.append(dict(
                         file=path,

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -179,7 +179,12 @@ def read_file(path, fileobj=None, yields_lines=True, cleanup=None):
                          to objects on cluster filesystems)
     :param cleanup: Optional callback to call with no arguments when EOF is
                     reached or an exception is thrown.
+
+    .. deprecated:: 0.6.0
     """
+    log.warning('read_file() is deprecated and will be removed in v0.7.0.'
+                ' Try mrjob.cat.decompress() and mrjob.util.to_lines()')
+
     # sometimes values declared in the ``try`` block aren't accessible from the
     # ``finally`` block. not sure why.
     f = None
@@ -226,6 +231,13 @@ def read_input(path, stdin=None):
     log.warning('read_input() is deprecated and will be removed in v0.7.0.'
                 ' Try mrjob.cat.decompress() and mrjob.util.to_lines()')
 
+    for line in _read_input(path, stdin=stdin):
+        yield line
+
+
+def _read_input(path, stdin=None):
+    """Helper function for _read_input() (to avoid getting recursive
+    deprecation warnings)"""
     if stdin is None:
         stdin = sys.stdin
 

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -220,7 +220,12 @@ def read_input(path, stdin=None):
 
     You can redefine *stdin* for ease of testing. *stdin* can actually be
     any iterable that yields lines (e.g. a list).
+
+    .. deprecated:: 0.6.0
     """
+    log.warning('read_input() is deprecated and will be removed in v0.7.0.'
+                ' Try mrjob.cat.decompress() and mrjob.util.to_lines()')
+
     if stdin is None:
         stdin = sys.stdin
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -30,10 +30,10 @@ from unittest import TestCase
 from unittest import skipIf
 
 import mrjob
+from mrjob.cat import decompress
 from mrjob.local import LocalMRJobRunner
 from mrjob.step import StepFailedException
 from mrjob.util import cmd_line
-from mrjob.util import read_file
 from mrjob.util import to_lines
 
 from tests.mr_cmd_job import MRCmdJob
@@ -239,7 +239,8 @@ class TestsToPort:
         # make sure all the data is preserved
         content = []
         for file_name in file_splits:
-            lines = list(read_file(file_name))
+            with open(file_name, 'rb') as f:
+                lines = list(to_lines(decompress(f, file_name)))
 
             # make sure the input_gz split got its entire contents
             if file_name == input_gz_path:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -436,19 +436,11 @@ class OnlyReadWrapper(object):
         return self.fp.read(*args, **kwargs)
 
 
-class ReadFileTestCase(TestCase):
+class DeprecatedReadFileTestCase(SandboxedTestCase):
 
     def setUp(self):
-        self.make_tmp_dir()
-
-    def tearDown(self):
-        self.rm_tmp_dir()
-
-    def make_tmp_dir(self):
-        self.tmp_dir = tempfile.mkdtemp()
-
-    def rm_tmp_dir(self):
-        shutil.rmtree(self.tmp_dir)
+        super(DeprecatedReadFileTestCase, self).setUp()
+        self.start(patch('mrjob.util.log'))
 
     def test_read_uncompressed_file(self):
         input_path = os.path.join(self.tmp_dir, 'input')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -169,7 +169,11 @@ class ParseAndSaveOptionsTestCase(TestCase):
             })
 
 
-class ReadInputTestCase(TestCase):
+class DeprecatedReadInputTestCase(SandboxedTestCase):
+
+    def setUp(self):
+        super(DeprecatedReadInputTestCase, self).setUp()
+        self.start(patch('mrjob.util.log'))
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Fixes #1605, #1609.

Also removed `open_input()`, which never appeared in a release and was only used by the sim runner.

