### PR TITLE
simplify check_input_paths

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -380,29 +380,11 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner):
         self._launch_cluster()
 
     def _prepare_for_launch(self):
-        self._check_input_exists()
         self._check_output_not_exists()
         self._create_setup_wrapper_script()
         self._add_bootstrap_files_for_upload()
         self._add_job_files_for_upload()
         self._upload_local_files_to_fs()
-
-    def _check_input_exists(self):
-        """Make sure all input exists before continuing with our job.
-        """
-        if not self._opts['check_input_paths']:
-            return
-
-        for path in self._input_paths:
-            if path == '-':
-                continue  # STDIN always exists
-
-            if is_uri(path) and not is_gcs_uri(path):
-                continue  # can't check non-GCS URIs, hope for the best
-
-            if not self.fs.exists(path):
-                raise AssertionError(
-                    'Input path %s does not exist!' % (path,))
 
     def _check_output_not_exists(self):
         """Verify the output path does not already exist. This avoids

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -717,7 +717,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
     def _prepare_for_launch(self):
         """Set up files needed for the job."""
-        self._check_input_exists()
         self._check_output_not_exists()
         self._create_setup_wrapper_script()
         self._add_bootstrap_files_for_upload()
@@ -741,21 +740,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             self._kill_ssh_tunnel()
 
         self._launch_emr_job()
-
-    def _check_input_exists(self):
-        """Make sure all input exists before continuing with our job.
-        """
-        if self._opts['check_input_paths']:
-            for path in self._input_paths:
-                if path == '-':
-                    continue  # STDIN always exists
-
-                if is_uri(path) and not is_s3_uri(path):
-                    continue  # can't check non-S3 URIs, hope for the best
-
-                if not self.fs.exists(path):
-                    raise AssertionError(
-                        'Input path %s does not exist!' % (path,))
 
     def _check_output_not_exists(self):
         """Verify the output path does not already exist. This avoids

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -342,7 +342,6 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
 
     def _run(self):
         self._find_binaries_and_jars()
-        self._check_input_exists()
         self._create_setup_wrapper_script()
         self._add_job_files_for_upload()
         self._upload_local_files_to_hdfs()
@@ -363,18 +362,6 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
 
         if self._has_spark_steps():
             self.get_spark_submit_bin()
-
-    def _check_input_exists(self):
-        """Make sure all input exists before continuing with our job.
-        """
-        for path in self._input_paths:
-            if path == '-':
-                continue  # STDIN always exists
-
-            if self._opts['check_input_paths']:
-                if not self.fs.exists(path):
-                    raise AssertionError(
-                        'Input path %s does not exist!' % (path,))
 
     def _add_job_files_for_upload(self):
         """Add files needed for running the job (setup and input)

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -211,8 +211,6 @@ class MRJobLauncher(object):
             log_to_stream(name='mrjob', debug=verbose, stream=stream)
             log_to_stream(name='__main__', debug=verbose, stream=stream)
 
-        log_to_null(name='boto3')
-
     def run_job(self):
         """Run the all steps of the job, logging errors (and debugging output
         if :option:`--verbose` is specified) to STDERR and streaming the

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -123,7 +123,6 @@ class SimMRJobRunner(MRJobRunner):
         pass
 
     def _run(self):
-        self._check_input_exists()
         if hasattr(self, '_create_setup_wrapper_script'):  # inline doesn't
             self._create_setup_wrapper_script(local=True)
 
@@ -246,16 +245,6 @@ class SimMRJobRunner(MRJobRunner):
             )
         finally:
             self._parse_task_counters('reducer', step_num)
-
-    def _check_input_exists(self):
-        if not self._opts['check_input_paths']:
-            return
-
-        for path in self._input_paths:
-            # '-' (stdin) always exists
-            if path != '-' and not self.fs.exists(path):
-                raise AssertionError(
-                    'Input path %s does not exist!' % (path,))
 
     def _create_dist_cache_dir(self, step_num):
         """Copy working directory files into a shared directory,


### PR DESCRIPTION
`check_input_paths` now automatically works the same for all runners, running before `_run()`. Fixes #1614.