### PR TITLE
update code using deprecated optparse hooks

### DIFF
--- a/docs/guides/configs-reference.rst
+++ b/docs/guides/configs-reference.rst
@@ -53,7 +53,7 @@ Option                 Attribute                Method                   Default
 ====================== ======================== ======================== ========
 
 These options can be set by overriding your job's
-:py:meth:`~mrjob.job.MRJob.configure_options` to call the appropriate method:
+:py:meth:`~mrjob.job.MRJob.configure_args` to call the appropriate method:
 
 .. |extra_args| replace:: :py:meth:`extra_args <mrjob.runner.MRJobRunner.__init__>`
 .. |file_upload_args| replace:: :py:meth:`file_upload_args <mrjob.runner.MRJobRunner.__init__>`

--- a/docs/guides/configs-reference.rst
+++ b/docs/guides/configs-reference.rst
@@ -58,14 +58,14 @@ These options can be set by overriding your job's
 .. |extra_args| replace:: :py:meth:`extra_args <mrjob.runner.MRJobRunner.__init__>`
 .. |file_upload_args| replace:: :py:meth:`file_upload_args <mrjob.runner.MRJobRunner.__init__>`
 
-.. |add_passthrough_option| replace:: :py:meth:`~mrjob.job.MRJob.add_passthrough_option`
-.. |add_file_option| replace:: :py:meth:`~mrjob.job.MRJob.add_file_option`
+.. |add_passthru_arg| replace:: :py:meth:`~mrjob.job.MRJob.add_passthru_arg`
+.. |add_file_arg| replace:: :py:meth:`~mrjob.job.MRJob.add_file_arg`
 
 ====================== ======================== ========
 Option                 Method                   Default
 ====================== ======================== ========
-*extra_args*           |add_passthrough_option| ``[]``
-*file_upload_args*     |add_file_option|        ``[]``
+*extra_args*           |add_passthru_arg| ``[]``
+*file_upload_args*     |add_file_arg|        ``[]``
 ====================== ======================== ========
 
 All of the above can be passed as keyword arguments to

--- a/docs/guides/setup-cookbook.rst
+++ b/docs/guides/setup-cookbook.rst
@@ -103,7 +103,7 @@ Making data files available to your job
 ---------------------------------------
 
 Best practice for one or a few files is to use passthrough options; see
-:py:meth:`~mrjob.job.MRJob.add_passthrough_option`.
+:py:meth:`~mrjob.job.MRJob.add_passthru_arg`.
 
 You can also use :mrjob-opt:`upload_files` to upload file(s) into a task's
 working directory (or :mrjob-opt:`upload_archives` for tarballs and other

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -620,7 +620,7 @@ several contexts: once for the initial invocation, and once for each task. If
 you just add an option to your job's option parser, that option's value won't
 be propagated to other runs of your script. Instead, you can use mrjob's option
 API: :py:meth:`~mrjob.job.MRJob.add_passthrough_option` and
-:py:meth:`~mrjob.job.MRJob.add_file_option`.
+:py:meth:`~mrjob.job.MRJob.add_file_arg`.
 
 .. _passthrough-opts:
 
@@ -714,7 +714,7 @@ you could do this::
 
         def configure_args(self):
             super(SqliteJob, self).configure_args()
-            self.add_file_option('--database')
+            self.add_file_arg('--database')
 
         def mapper_init(self):
             # make sqlite3 database available to mapper

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -499,8 +499,8 @@ instance. Here's an example that sneaks a peek at :ref:`writing-cl-opts`::
 
     class CommandLineProtocolJob(MRJob):
 
-        def configure_options(self):
-            super(CommandLineProtocolJob, self).configure_options()
+        def configure_args(self):
+            super(CommandLineProtocolJob, self).configure_args()
             self.add_passthrough_option(
                 '--output-format', default='raw', choices=['raw', 'json'],
                 help="Specify the output format of the job")
@@ -634,8 +634,8 @@ command line-switchable protocol example from before uses this feature::
 
     class CommandLineProtocolJob(MRJob):
 
-        def configure_options(self):
-            super(CommandLineProtocolJob, self).configure_options()
+        def configure_args(self):
+            super(CommandLineProtocolJob, self).configure_args()
             self.add_passthrough_option(
                 '--output-format', default='raw', choices=['raw', 'json'],
                 help="Specify the output format of the job")
@@ -677,8 +677,8 @@ locally::
 
     class MRRunnerAwareJob(MRJob):
 
-        def configure_options(self):
-            super(MRRunnerAwareJob, self).configure_options()
+        def configure_args(self):
+            super(MRRunnerAwareJob, self).configure_args()
 
             self.pass_through_option('--runner')
 
@@ -712,8 +712,8 @@ you could do this::
 
     class SqliteJob(MRJob):
 
-        def configure_options(self):
-            super(SqliteJob, self).configure_options()
+        def configure_args(self):
+            super(SqliteJob, self).configure_args()
             self.add_file_option('--database')
 
         def mapper_init(self):

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -501,7 +501,7 @@ instance. Here's an example that sneaks a peek at :ref:`writing-cl-opts`::
 
         def configure_args(self):
             super(CommandLineProtocolJob, self).configure_args()
-            self.add_passthrough_option(
+            self.add_passthrough_arg(
                 '--output-format', default='raw', choices=['raw', 'json'],
                 help="Specify the output format of the job")
 
@@ -619,7 +619,7 @@ Recall from :ref:`how-your-program-is-run` that your script is executed in
 several contexts: once for the initial invocation, and once for each task. If
 you just add an option to your job's option parser, that option's value won't
 be propagated to other runs of your script. Instead, you can use mrjob's option
-API: :py:meth:`~mrjob.job.MRJob.add_passthrough_option` and
+API: :py:meth:`~mrjob.job.MRJob.add_passthru_arg` and
 :py:meth:`~mrjob.job.MRJob.add_file_arg`.
 
 .. _passthrough-opts:
@@ -636,7 +636,7 @@ command line-switchable protocol example from before uses this feature::
 
         def configure_args(self):
             super(CommandLineProtocolJob, self).configure_args()
-            self.add_passthrough_option(
+            self.add_passthru_arg(
                 '--output-format', default='raw', choices=['raw', 'json'],
                 help="Specify the output format of the job")
 
@@ -651,7 +651,7 @@ passed ``--output-format`` on the command line. When your script is run in any
 other context, such as on Hadoop, it adds ``--output-format=json`` to its
 command string.
 
-:py:meth:`~mrjob.job.MRJob.add_passthrough_option` takes the same arguments as
+:py:meth:`~mrjob.job.MRJob.add_passthru_arg` takes the same arguments as
 :py:meth:`optparse.OptionParser.add_option`. For more information, see the
 `optparse docs`_.
 

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -668,7 +668,7 @@ Passing through existing options
 
 Occasionally, it'll be useful for mappers, reducers, etc. to be able to see
 the value of other command-line options. For this, use
-:py:meth:`~mrjob.job.MRJob.pass_through_option` with the corresponding
+:py:meth:`~mrjob.job.MRJob.pass_arg_through` with the corresponding
 command-line switch.
 
 For example, you might wish to fetch supporting data for your job from
@@ -680,7 +680,7 @@ locally::
         def configure_args(self):
             super(MRRunnerAwareJob, self).configure_args()
 
-            self.pass_through_option('--runner')
+            self.pass_arg_through('--runner')
 
         def mapper_init(self):
             if self.options.runner == 'emr':

--- a/mrjob/examples/contrib/mr_pegasos_svm.py
+++ b/mrjob/examples/contrib/mr_pegasos_svm.py
@@ -52,8 +52,8 @@ class MRsvm(MRJob):
         self.numMappers = 1             #number of mappers
         self.t = 1                      #iteration number
 
-    def configure_options(self):
-        super(MRsvm, self).configure_options()
+    def configure_args(self):
+        super(MRsvm, self).configure_args()
         self.add_passthrough_option(
             '--iterations', dest='iterations', default=2, type='int',
             help='T: number of iterations to run')

--- a/mrjob/examples/contrib/mr_pegasos_svm.py
+++ b/mrjob/examples/contrib/mr_pegasos_svm.py
@@ -54,11 +54,11 @@ class MRsvm(MRJob):
 
     def configure_args(self):
         super(MRsvm, self).configure_args()
-        self.add_passthrough_option(
-            '--iterations', dest='iterations', default=2, type='int',
+        self.add_passthrough_arg(
+            '--iterations', dest='iterations', default=2, type=int,
             help='T: number of iterations to run')
-        self.add_passthrough_option(
-            '--batchsize', dest='batchsize', default=100, type='int',
+        self.add_passthrough_arg(
+            '--batchsize', dest='batchsize', default=100, type=int,
             help='k: number of data points in a batch')
 
     def map(self, mapperId, inVals): #needs exactly 2 arguments

--- a/mrjob/examples/mr_grep.py
+++ b/mrjob/examples/mr_grep.py
@@ -18,8 +18,8 @@ from mrjob.util import cmd_line
 
 class MRGrepJob(MRJob):
 
-    def configure_options(self):
-        super(MRGrepJob, self).configure_options()
+    def configure_args(self):
+        super(MRGrepJob, self).configure_args()
 
         self.add_passthrough_option(
             '-e', '--expression', type='str', default=None,

--- a/mrjob/examples/mr_grep.py
+++ b/mrjob/examples/mr_grep.py
@@ -21,8 +21,8 @@ class MRGrepJob(MRJob):
     def configure_args(self):
         super(MRGrepJob, self).configure_args()
 
-        self.add_passthrough_option(
-            '-e', '--expression', type='str', default=None,
+        self.add_passthrough_arg(
+            '-e', '--expression',
             help=( 'Expression to search for. Required.'))
 
     def mapper_cmd(self):
@@ -33,4 +33,3 @@ class MRGrepJob(MRJob):
 
 if __name__ == '__main__':
     MRGrepJob().run()
-

--- a/mrjob/examples/mr_log_sampler.py
+++ b/mrjob/examples/mr_log_sampler.py
@@ -40,8 +40,8 @@ class MRLogSampler(MRJob):
     # record doesn't get Unicode-encoded
     INTERNAL_PROTOCOL = ReprProtocol
 
-    def configure_options(self):
-        super(MRLogSampler, self).configure_options()
+    def configure_args(self):
+        super(MRLogSampler, self).configure_args()
         self.add_passthrough_option(
             '--sample-size',
             type=int,

--- a/mrjob/examples/mr_log_sampler.py
+++ b/mrjob/examples/mr_log_sampler.py
@@ -42,12 +42,12 @@ class MRLogSampler(MRJob):
 
     def configure_args(self):
         super(MRLogSampler, self).configure_args()
-        self.add_passthrough_option(
+        self.add_passthrough_arg(
             '--sample-size',
             type=int,
             help='Number of entries to sample.'
         )
-        self.add_passthrough_option(
+        self.add_passthrough_arg(
             '--expected-length',
             type=int,
             help=("Number of entries you expect in the log. If not specified,"

--- a/mrjob/examples/mr_page_rank.py
+++ b/mrjob/examples/mr_page_rank.py
@@ -48,8 +48,8 @@ class MRPageRank(MRJob):
 
     INPUT_PROTOCOL = JSONProtocol  # read the same format we write
 
-    def configure_options(self):
-        super(MRPageRank, self).configure_options()
+    def configure_args(self):
+        super(MRPageRank, self).configure_args()
 
         self.add_passthrough_option(
             '--iterations', dest='iterations', default=10, type='int',

--- a/mrjob/examples/mr_page_rank.py
+++ b/mrjob/examples/mr_page_rank.py
@@ -51,13 +51,13 @@ class MRPageRank(MRJob):
     def configure_args(self):
         super(MRPageRank, self).configure_args()
 
-        self.add_passthrough_option(
-            '--iterations', dest='iterations', default=10, type='int',
+        self.add_passthrough_arg(
+            '--iterations', dest='iterations', default=10, type=int,
             help='number of iterations to run')
 
-        self.add_passthrough_option(
+        self.add_passthrough_arg(
             '--damping-factor', dest='damping_factor', default=0.85,
-            type='float',
+            type=float,
             help='probability a web surfer will continue clicking on links')
 
     def send_score(self, node_id, node):

--- a/mrjob/examples/mr_postfix_bounce/mr_postfix_bounce.py
+++ b/mrjob/examples/mr_postfix_bounce/mr_postfix_bounce.py
@@ -131,7 +131,7 @@ def process_postfix_log_dict(decoded, bounce_rules):
 class MRPostfixBounce(MRJob):
     def configure_args(self):
         super(MRPostfixBounce, self).configure_args()
-        self.add_file_option(
+        self.add_file_arg(
             '--bounce-processing-rules',
             dest='bounce_processing_rules',
             default='bounce_processing_rules.json',

--- a/mrjob/examples/mr_postfix_bounce/mr_postfix_bounce.py
+++ b/mrjob/examples/mr_postfix_bounce/mr_postfix_bounce.py
@@ -129,8 +129,8 @@ def process_postfix_log_dict(decoded, bounce_rules):
 
 
 class MRPostfixBounce(MRJob):
-    def configure_options(self):
-        super(MRPostfixBounce, self).configure_options()
+    def configure_args(self):
+        super(MRPostfixBounce, self).configure_args()
         self.add_file_option(
             '--bounce-processing-rules',
             dest='bounce_processing_rules',

--- a/mrjob/examples/mr_text_classifier.py
+++ b/mrjob/examples/mr_text_classifier.py
@@ -156,33 +156,33 @@ class MRTextClassifier(MRJob):
         """Add command-line options specific to this script."""
         super(MRTextClassifier, self).configure_args()
 
-        self.add_passthrough_option(
-            '--min-df', dest='min_df', default=2, type='int',
+        self.add_passthrough_arg(
+            '--min-df', dest='min_df', default=2, type=int,
             help=('min number of documents an n-gram must appear in for us to'
                   ' count it. Default: %default'))
-        self.add_passthrough_option(
-            '--max-df', dest='max_df', default=10000000, type='int',
+        self.add_passthrough_arg(
+            '--max-df', dest='max_df', default=10000000, type=int,
             help=('max number of documents an n-gram may appear in for us to'
                   ' count it (this keeps reducers from running out of memory).'
                   ' Default: %default'))
-        self.add_passthrough_option(
+        self.add_passthrough_arg(
             '--max-ngram-size', dest='max_ngram_size',
-            default=DEFAULT_MAX_NGRAM_SIZE, type='int',
+            default=DEFAULT_MAX_NGRAM_SIZE, type=int,
             help='maximum phrase length to consider')
-        self.add_passthrough_option(
+        self.add_passthrough_arg(
             '--stop-words', dest='stop_words',
             default=', '.join(DEFAULT_STOP_WORDS),
             help=("comma-separated list of words to ignore. For example, "
                   "--stop-words 'in, the' would cause 'hole in the wall' to be"
                   " parsed as ['hole', 'wall']. Default: %default"))
-        self.add_passthrough_option(
+        self.add_passthrough_arg(
             '--short-doc-threshold', dest='short_doc_threshold',
-            type='int', default=None,
+            type=int, default=None,
             help=('Normally, for each n-gram size, we take the average score'
                   ' over all n-grams that appear. This allows us to penalize'
                   ' short documents by using this threshold as the denominator'
                   ' rather than the actual number of n-grams.'))
-        self.add_passthrough_option(
+        self.add_passthrough_arg(
             '--no-test-set', dest='no_test_set',
             action='store_true', default=False,
             help=("Choose about half of the documents to be the testing set"

--- a/mrjob/examples/mr_text_classifier.py
+++ b/mrjob/examples/mr_text_classifier.py
@@ -152,9 +152,9 @@ class MRTextClassifier(MRJob):
                 MRStep(reducer=self.score_documents_by_ngram),
                 MRStep(reducer=self.score_documents)]
 
-    def configure_options(self):
+    def configure_args(self):
         """Add command-line options specific to this script."""
-        super(MRTextClassifier, self).configure_options()
+        super(MRTextClassifier, self).configure_args()
 
         self.add_passthrough_option(
             '--min-df', dest='min_df', default=2, type='int',

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -98,12 +98,12 @@ class MRJobLauncher(object):
                                          add_help=False)
         self.configure_args()
 
-        if (_im_func(self.configure_options) !=
-                _im_func(MRJobLauncher.configure_options)):
-            log.warning('configure_options() is deprecated and will be'
+        if (_im_func(self.configure_args) !=
+                _im_func(MRJobLauncher.configure_args)):
+            log.warning('configure_args() is deprecated and will be'
                          ' removed in v0.7.0; please use configure_args()'
                          ' instead.')
-            self.configure_options()
+            self.configure_args()
 
         # don't pass None to parse_args unless we're actually running
         # the MRJob script
@@ -312,8 +312,8 @@ class MRJobLauncher(object):
         """Add a command-line option that sends an external file
         (e.g. a SQLite DB) to Hadoop::
 
-             def configure_options(self):
-                super(MRYourJob, self).configure_options()
+             def configure_args(self):
+                super(MRYourJob, self).configure_args()
                 self.add_file_option('--scoring-db', help=...)
 
         This does the right thing: the file will be uploaded to the working
@@ -391,7 +391,7 @@ class MRJobLauncher(object):
             ' be removed in v0.7.0' % (class_name, class_name))
         return self.options
 
-    def configure_options(self):
+    def configure_args(self):
         """.. deprecated:: 0.6.0
 
         Use `:py:meth:`configure_args` instead.

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -349,7 +349,7 @@ class MRJobLauncher(object):
             def configure_args(self):
                 super(MRYourJob, self).configure_args()
                 self.add_passthru_arg(
-                    '--max-ngram-size', type='int', default=4, help='...')
+                    '--max-ngram-size', type=int, default=4, help='...')
 
         If you want to pass files through to the mapper/reducer, use
         :py:meth:`add_file_arg` instead.

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -98,12 +98,12 @@ class MRJobLauncher(object):
                                          add_help=False)
         self.configure_args()
 
-        if (_im_func(self.configure_args) !=
-                _im_func(MRJobLauncher.configure_args)):
-            log.warning('configure_args() is deprecated and will be'
+        if (_im_func(self.configure_options) !=
+                _im_func(MRJobLauncher.configure_options)):
+            log.warning('configure_options() is deprecated and will be'
                          ' removed in v0.7.0; please use configure_args()'
                          ' instead.')
-            self.configure_args()
+            self.configure_options()
 
         # don't pass None to parse_args unless we're actually running
         # the MRJob script
@@ -123,12 +123,12 @@ class MRJobLauncher(object):
 
         self.load_args(self._cl_args)
 
-        if (_im_func(self.load_args) !=
-                _im_func(MRJobLauncher.load_args)):
-            log.warning('load_args() is deprecated and will be'
+        if (_im_func(self.load_options) !=
+                _im_func(MRJobLauncher.load_options)):
+            log.warning('load_options() is deprecated and will be'
                          ' removed in v0.7.0; please use load_args()'
                          ' instead.')
-            self.load_args(self._cl_args)
+            self.load_options(self._cl_args)
 
         # Make it possible to redirect stdin, stdout, and stderr, for testing
         # See sandbox(), below.
@@ -391,14 +391,14 @@ class MRJobLauncher(object):
             ' be removed in v0.7.0' % (class_name, class_name))
         return self.options
 
-    def configure_args(self):
+    def configure_options(self):
         """.. deprecated:: 0.6.0
 
         Use `:py:meth:`configure_args` instead.
         """
         pass  # deprecation warning is in __init__()
 
-    def load_args(self, args):
+    def load_options(self, args):
         """.. deprecated:: 0.6.0
 
         Use `:py:meth:`load_args` instead.

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -389,7 +389,7 @@ class MRJobLauncher(object):
         log.warning(
             '%s.args is a deprecated alias for %s.options.args, and will'
             ' be removed in v0.7.0' % (class_name, class_name))
-        return self.options
+        return self.options.args
 
     def configure_options(self):
         """.. deprecated:: 0.6.0

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -314,7 +314,7 @@ class MRJobLauncher(object):
 
              def configure_args(self):
                 super(MRYourJob, self).configure_args()
-                self.add_file_option('--scoring-db', help=...)
+                self.add_file_arg('--scoring-db', help=...)
 
         This does the right thing: the file will be uploaded to the working
         dir of the script on Hadoop, and the script will be passed the same

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -123,12 +123,12 @@ class MRJobLauncher(object):
 
         self.load_args(self._cl_args)
 
-        if (_im_func(self.load_options) !=
-                _im_func(MRJobLauncher.load_options)):
-            log.warning('load_options() is deprecated and will be'
+        if (_im_func(self.load_args) !=
+                _im_func(MRJobLauncher.load_args)):
+            log.warning('load_args() is deprecated and will be'
                          ' removed in v0.7.0; please use load_args()'
                          ' instead.')
-            self.load_options(self._cl_args)
+            self.load_args(self._cl_args)
 
         # Make it possible to redirect stdin, stdout, and stderr, for testing
         # See sandbox(), below.
@@ -398,7 +398,7 @@ class MRJobLauncher(object):
         """
         pass  # deprecation warning is in __init__()
 
-    def load_options(self, args):
+    def load_args(self, args):
         """.. deprecated:: 0.6.0
 
         Use `:py:meth:`load_args` instead.

--- a/mrjob/tools/emr/terminate_idle_clusters.py
+++ b/mrjob/tools/emr/terminate_idle_clusters.py
@@ -347,7 +347,7 @@ def _make_arg_parser():
 
     arg_parser.add_argument(
         '--max-hours-idle', dest='max_hours_idle',
-        default=None, type='float',
+        default=None, type=float,
         help=('Max number of hours a cluster can go without bootstrapping,'
               ' running a step, or having a new step created. This will fire'
               ' even if there are pending steps which EMR has failed to'
@@ -355,11 +355,11 @@ def _make_arg_parser():
               ' your jobs can take to start instances and bootstrap.'))
     arg_parser.add_argument(
         '--max-mins-locked', dest='max_mins_locked',
-        default=_DEFAULT_MAX_MINUTES_LOCKED, type='float',
+        default=_DEFAULT_MAX_MINUTES_LOCKED, type=float,
         help='Max number of minutes a cluster can be locked while idle.')
     arg_parser.add_argument(
         '--mins-to-end-of-hour', dest='mins_to_end_of_hour',
-        default=None, type='float',
+        default=None, type=float,
         help=('Terminate clusters that are within this many minutes of'
               ' the end of a full hour since the job started running'
               ' AND have no pending steps.'))

--- a/tests/mr_cmd_job.py
+++ b/tests/mr_cmd_job.py
@@ -25,8 +25,8 @@ class MRCmdJob(MRJob):
 
     OUTPUT_PROTOCOL = RawValueProtocol
 
-    def configure_options(self):
-        super(MRCmdJob, self).configure_options()
+    def configure_args(self):
+        super(MRCmdJob, self).configure_args()
         self.add_passthrough_option('--mapper-cmd', default=None)
         self.add_passthrough_option('--combiner-cmd', default=None)
         self.add_passthrough_option('--reducer-cmd', default=None)

--- a/tests/mr_cmd_job.py
+++ b/tests/mr_cmd_job.py
@@ -27,10 +27,10 @@ class MRCmdJob(MRJob):
 
     def configure_args(self):
         super(MRCmdJob, self).configure_args()
-        self.add_passthrough_option('--mapper-cmd', default=None)
-        self.add_passthrough_option('--combiner-cmd', default=None)
-        self.add_passthrough_option('--reducer-cmd', default=None)
-        self.add_passthrough_option('--reducer-cmd-2', default=None)
+        self.add_passthru_arg('--mapper-cmd', default=None)
+        self.add_passthru_arg('--combiner-cmd', default=None)
+        self.add_passthru_arg('--reducer-cmd', default=None)
+        self.add_passthru_arg('--reducer-cmd-2', default=None)
 
     def steps(self):
         kwargs = {}

--- a/tests/mr_filter_job.py
+++ b/tests/mr_filter_job.py
@@ -27,9 +27,9 @@ class MRFilterJob(MRJob):
 
     def configure_args(self):
         super(MRFilterJob, self).configure_args()
-        self.add_passthrough_option('--mapper-filter', default=None)
-        self.add_passthrough_option('--combiner-filter', default=None)
-        self.add_passthrough_option('--reducer-filter', default=None)
+        self.add_passthru_arg('--mapper-filter', default=None)
+        self.add_passthru_arg('--combiner-filter', default=None)
+        self.add_passthru_arg('--reducer-filter', default=None)
 
     def steps(self):
         kwargs = {}

--- a/tests/mr_filter_job.py
+++ b/tests/mr_filter_job.py
@@ -25,8 +25,8 @@ class MRFilterJob(MRJob):
 
     OUTPUT_PROTOCOL = RawValueProtocol
 
-    def configure_options(self):
-        super(MRFilterJob, self).configure_options()
+    def configure_args(self):
+        super(MRFilterJob, self).configure_args()
         self.add_passthrough_option('--mapper-filter', default=None)
         self.add_passthrough_option('--combiner-filter', default=None)
         self.add_passthrough_option('--reducer-filter', default=None)

--- a/tests/mr_jar_and_streaming.py
+++ b/tests/mr_jar_and_streaming.py
@@ -24,7 +24,7 @@ class MRJarAndStreaming(MRJob):
     def configure_args(self):
         super(MRJarAndStreaming, self).configure_args()
 
-        self.add_passthrough_option('--jar')
+        self.add_passthru_arg('--jar')
 
     def steps(self):
         return [

--- a/tests/mr_jar_and_streaming.py
+++ b/tests/mr_jar_and_streaming.py
@@ -21,8 +21,8 @@ from mrjob.step import OUTPUT
 
 class MRJarAndStreaming(MRJob):
 
-    def configure_options(self):
-        super(MRJarAndStreaming, self).configure_options()
+    def configure_args(self):
+        super(MRJarAndStreaming, self).configure_args()
 
         self.add_passthrough_option('--jar')
 

--- a/tests/mr_just_a_jar.py
+++ b/tests/mr_just_a_jar.py
@@ -23,8 +23,8 @@ class MRJustAJar(MRJob):
     def configure_args(self):
         super(MRJustAJar, self).configure_args()
 
-        self.add_passthrough_option('--jar')
-        self.add_passthrough_option('--main-class', default=None)
+        self.add_passthru_arg('--jar')
+        self.add_passthru_arg('--main-class', default=None)
 
     def steps(self):
         return [JarStep(jar=self.options.jar,

--- a/tests/mr_just_a_jar.py
+++ b/tests/mr_just_a_jar.py
@@ -20,8 +20,8 @@ from mrjob.step import JarStep
 
 class MRJustAJar(MRJob):
 
-    def configure_options(self):
-        super(MRJustAJar, self).configure_options()
+    def configure_args(self):
+        super(MRJustAJar, self).configure_args()
 
         self.add_passthrough_option('--jar')
         self.add_passthrough_option('--main-class', default=None)

--- a/tests/mr_null_spark.py
+++ b/tests/mr_null_spark.py
@@ -19,8 +19,8 @@ from mrjob.job import MRJob
 
 class MRNullSpark(MRJob):
 
-    def configure_options(self):
-        super(MRNullSpark, self).configure_options()
+    def configure_args(self):
+        super(MRNullSpark, self).configure_args()
 
         self.add_passthrough_option(
             '--extra-spark-arg', dest='extra_spark_args',

--- a/tests/mr_null_spark.py
+++ b/tests/mr_null_spark.py
@@ -22,11 +22,11 @@ class MRNullSpark(MRJob):
     def configure_args(self):
         super(MRNullSpark, self).configure_args()
 
-        self.add_passthrough_option(
+        self.add_passthru_arg(
             '--extra-spark-arg', dest='extra_spark_args',
             action='append', default=[])
 
-        self.add_file_option(
+        self.add_file_arg(
             '--extra-file', dest='extra_file')
 
     def spark(self):

--- a/tests/mr_runner.py
+++ b/tests/mr_runner.py
@@ -20,7 +20,7 @@ class MRRunner(MRJob):
     def configure_args(self):
         super(MRRunner, self).configure_args()
 
-        self.pass_through_option('--runner')
+        self.pass_arg_through('--runner')
 
     def mapper(self, key, value):
         return

--- a/tests/mr_runner.py
+++ b/tests/mr_runner.py
@@ -17,8 +17,8 @@ from mrjob.job import MRJob
 class MRRunner(MRJob):
     """Print out ``self.option.runner`` in tasks."""
 
-    def configure_options(self):
-        super(MRRunner, self).configure_options()
+    def configure_args(self):
+        super(MRRunner, self).configure_args()
 
         self.pass_through_option('--runner')
 

--- a/tests/mr_spark_jar.py
+++ b/tests/mr_spark_jar.py
@@ -23,14 +23,14 @@ class MRSparkJar(MRJob):
     def configure_args(self):
         super(MRSparkJar, self).configure_args()
 
-        self.add_passthrough_option(
+        self.add_passthru_arg(
             '--jar', dest='jar')
-        self.add_passthrough_option(
+        self.add_passthru_arg(
             '--jar-main-class', dest='jar_main_class')
-        self.add_passthrough_option(
+        self.add_passthru_arg(
             '--jar-arg', dest='jar_args',
             action='append', default=[])
-        self.add_passthrough_option(
+        self.add_passthru_arg(
             '--jar-spark-arg', dest='jar_spark_args',
             action='append', default=[])
 

--- a/tests/mr_spark_jar.py
+++ b/tests/mr_spark_jar.py
@@ -20,8 +20,8 @@ from mrjob.step import SparkJarStep
 
 class MRSparkJar(MRJob):
 
-    def configure_options(self):
-        super(MRSparkJar, self).configure_options()
+    def configure_args(self):
+        super(MRSparkJar, self).configure_args()
 
         self.add_passthrough_option(
             '--jar', dest='jar')

--- a/tests/mr_spark_script.py
+++ b/tests/mr_spark_script.py
@@ -23,12 +23,12 @@ class MRSparkScript(MRJob):
     def configure_args(self):
         super(MRSparkScript, self).configure_args()
 
-        self.add_passthrough_option(
+        self.add_passthru_arg(
             '--script', dest='script')
-        self.add_passthrough_option(
+        self.add_passthru_arg(
             '--script-arg', dest='script_args',
             action='append', default=[])
-        self.add_passthrough_option(
+        self.add_passthru_arg(
             '--script-spark-arg', dest='script_spark_args',
             action='append', default=[])
 

--- a/tests/mr_spark_script.py
+++ b/tests/mr_spark_script.py
@@ -20,8 +20,8 @@ from mrjob.step import SparkScriptStep
 
 class MRSparkScript(MRJob):
 
-    def configure_options(self):
-        super(MRSparkScript, self).configure_options()
+    def configure_args(self):
+        super(MRSparkScript, self).configure_args()
 
         self.add_passthrough_option(
             '--script', dest='script')

--- a/tests/mr_tower_of_powers.py
+++ b/tests/mr_tower_of_powers.py
@@ -31,10 +31,10 @@ class MRTowerOfPowers(MRJob):
     def configure_args(self):
         super(MRTowerOfPowers, self).configure_args()
 
-        self.add_file_option('--n-file')
+        self.add_file_arg('--n-file')
 
-    def load_options(self, args):
-        super(MRTowerOfPowers, self).load_options(args=args)
+    def load_args(self, args):
+        super(MRTowerOfPowers, self).load_args(args=args)
 
         with open(self.options.n_file) as f:
             self.n = int(f.read().strip())

--- a/tests/mr_tower_of_powers.py
+++ b/tests/mr_tower_of_powers.py
@@ -28,8 +28,8 @@ class MRTowerOfPowers(MRJob):
     INPUT_PROTOCOL = JSONValueProtocol
     OUTPUT_PROTOCOL = JSONValueProtocol
 
-    def configure_options(self):
-        super(MRTowerOfPowers, self).configure_options()
+    def configure_args(self):
+        super(MRTowerOfPowers, self).configure_args()
 
         self.add_file_option('--n-file')
 

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -121,7 +121,7 @@ class MRIncrementerJob(MRJob):
     def configure_args(self):
         super(MRIncrementerJob, self).configure_args()
 
-        self.add_passthrough_option('--times', type='int', default=1)
+        self.add_passthru_arg('--times', type=int, default=1)
 
     def mapper(self, _, value):
         yield None, value + 1

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -118,8 +118,8 @@ class MRIncrementerJob(MRJob):
     INPUT_PROTOCOL = JSONValueProtocol
     OUTPUT_PROTOCOL = JSONValueProtocol
 
-    def configure_options(self):
-        super(MRIncrementerJob, self).configure_options()
+    def configure_args(self):
+        super(MRIncrementerJob, self).configure_args()
 
         self.add_passthrough_option('--times', type='int', default=1)
 
@@ -138,8 +138,8 @@ class MRCustomFileOptionJob(MRJob):
 
     multiplier = 1
 
-    def configure_options(self):
-        super(MRCustomFileOptionJob, self).configure_options()
+    def configure_args(self):
+        super(MRCustomFileOptionJob, self).configure_args()
         self.add_file_option('--platform_file')
 
     def mapper_init(self):

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -140,7 +140,7 @@ class MRCustomFileOptionJob(MRJob):
 
     def configure_args(self):
         super(MRCustomFileOptionJob, self).configure_args()
-        self.add_file_option('--platform_file')
+        self.add_file_arg('--platform_file')
 
     def mapper_init(self):
         with open(self.options.platform_file) as f:

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -51,8 +51,8 @@ def _mock_context_mgr(m, return_value):
 
 class MRCustomJobLauncher(MRJobLauncher):
 
-    def configure_options(self):
-        super(MRCustomJobLauncher, self).configure_options()
+    def configure_args(self):
+        super(MRCustomJobLauncher, self).configure_args()
 
         self.add_passthrough_option(
             '--foo-size', '-F', type='int', dest='foo_size', default=5)

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -42,6 +42,7 @@ from tests.py2 import MagicMock
 from tests.py2 import Mock
 from tests.py2 import patch
 from tests.quiet import no_handlers_for_logger
+from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_pythonpath
 
 
@@ -78,6 +79,29 @@ class MRCustomJobLauncher(MRJobLauncher):
         self.add_file_arg('--foo-config', dest='foo_config', default=None)
         self.add_file_arg('--accordian-file', dest='accordian_files',
                           action='append', default=[])
+
+
+# used to test old options() hooks
+class MRDeprecatedCustomJobLauncher(MRJobLauncher):
+
+    def configure_options(self):
+        super(MRDeprecatedCustomJobLauncher, self).configure_options()
+
+        self.add_passthrough_option(
+            '--foo-size', '-F', type='int', dest='foo_size', default=5)
+        self.add_passthrough_option(
+            '--pill-type', '-T', type='choice', choices=(['red', 'blue']),
+            default='blue')
+
+        self.pass_through_option('--runner')
+
+        self.add_file_option('--accordian-file', dest='accordian_files',
+                             action='append', default=[])
+
+    def load_options(self, args):
+        super(MRDeprecatedCustomJobLauncher, self).load_options(args)
+
+        self._load_options_args = args
 
 
 ### Test cases ###
@@ -394,3 +418,55 @@ class StdStreamTestCase(TestCase):
         self.assertEqual(launcher.stdin, mock_stdin.buffer)
         self.assertEqual(launcher.stdout, mock_stdout)
         self.assertEqual(launcher.stderr, mock_stderr)
+
+
+class DeprecatedOptionHooksTestCase(SandboxedTestCase):
+
+    def setUp(self):
+        super(DeprecatedOptionHooksTestCase, self).setUp()
+
+        self.start(patch('mrjob.launch.log'))
+
+    def test_load_options(self):
+        mr_job = MRDeprecatedCustomJobLauncher(args=['', '-r', 'local'])
+
+        self.assertEqual(mr_job._load_options_args, ['', '-r', 'local'])
+
+    def test_add_passthrough_option(self):
+        mr_job = MRDeprecatedCustomJobLauncher(
+            args=['', '-F', '6', '-T', 'red'])
+
+        self.assertEqual(mr_job.options.foo_size, 6)
+        self.assertEqual(mr_job.options.pill_type, 'red')
+
+        self.assertEqual(mr_job._non_option_kwargs()['extra_args'],
+                         ['-F', '6', '-T', 'red'])
+
+    def test_add_file_option(self):
+        mr_job = MRDeprecatedCustomJobLauncher(
+            args=['',
+                  '--accordian-file', 'WeirdAl.mp3',
+                  '--accordian-file', '/home/dave/JohnLinnell.ogg'])
+
+        self.assertEqual(
+            mr_job.options.accordian_files, [
+            'WeirdAl.mp3', '/home/dave/JohnLinnell.ogg'])
+
+        self.assertEqual(mr_job._non_option_kwargs()['file_upload_args'], [
+            ('--accordian-file', 'WeirdAl.mp3'),
+            ('--accordian-file', '/home/dave/JohnLinnell.ogg')])
+
+    def test_pass_through_option_method(self):
+        mr_job = MRDeprecatedCustomJobLauncher(
+            args=['', '-r', 'local'])
+
+        self.assertEqual(mr_job.options.runner, 'local')
+
+        self.assertEqual(mr_job._non_option_kwargs()['extra_args'],
+                         ['-r', 'local'])
+
+    def test_args_property(self):
+        # argparse expects all positional args to be together
+        mr_job = MRDeprecatedCustomJobLauncher(
+            args=['-F', '6', '', 'input1.txt', 'input2.txt'])
+        self.assertEqual(mr_job.args, ['input1.txt', 'input2.txt'])

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -75,9 +75,9 @@ class MRCustomJobLauncher(MRJobLauncher):
 
         self.pass_through_option('--runner')
 
-        self.add_file_option('--foo-config', dest='foo_config', default=None)
-        self.add_file_option('--accordian-file', dest='accordian_files',
-                             action='append', default=[])
+        self.add_file_arg('--foo-config', dest='foo_config', default=None)
+        self.add_file_arg('--accordian-file', dest='accordian_files',
+                          action='append', default=[])
 
 
 ### Test cases ###

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -54,22 +54,22 @@ class MRCustomJobLauncher(MRJobLauncher):
     def configure_args(self):
         super(MRCustomJobLauncher, self).configure_args()
 
-        self.add_passthrough_option(
-            '--foo-size', '-F', type='int', dest='foo_size', default=5)
-        self.add_passthrough_option(
-            '--bar-name', '-B', type='string', dest='bar_name', default=None)
-        self.add_passthrough_option(
+        self.add_passthru_arg(
+            '--foo-size', '-F', type=int, dest='foo_size', default=5)
+        self.add_passthru_arg(
+            '--bar-name', '-B', dest='bar_name', default=None)
+        self.add_passthru_arg(
             '--enable-baz-mode', '-M', action='store_true', dest='baz_mode',
             default=False)
-        self.add_passthrough_option(
+        self.add_passthru_arg(
             '--disable-quuxing', '-Q', action='store_false', dest='quuxing',
             default=True)
-        self.add_passthrough_option(
-            '--pill-type', '-T', type='choice', choices=(['red', 'blue']),
+        self.add_passthru_arg(
+            '--pill-type', '-T', choices=(['red', 'blue']),
             default='blue')
-        self.add_passthrough_option(
-            '--planck-constant', '-C', type='float', default=6.626068e-34)
-        self.add_passthrough_option(
+        self.add_passthru_arg(
+            '--planck-constant', '-C', type=float, default=6.626068e-34)
+        self.add_passthru_arg(
             '--extra-special-arg', '-S', action='append',
             dest='extra_special_args', default=[])
 
@@ -270,10 +270,10 @@ class CommandLineArgsTestCase(TestCase):
     def test_bad_option_types(self):
         mr_job = MRJobLauncher(args=[''])
         self.assertRaises(
-            ValueError, mr_job.add_passthrough_option,
+            ValueError, mr_job.add_passthru_arg,
             '--stop-words', dest='stop_words', type='set', default=None)
         self.assertRaises(
-            ValueError, mr_job.add_passthrough_option,
+            ValueError, mr_job.add_passthru_arg,
             '--leave-a-msg', dest='leave_a_msg', action='callback',
             default=None)
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -73,7 +73,7 @@ class MRCustomJobLauncher(MRJobLauncher):
             '--extra-special-arg', '-S', action='append',
             dest='extra_special_args', default=[])
 
-        self.pass_through_option('--runner')
+        self.pass_arg_through('--runner')
 
         self.add_file_arg('--foo-config', dest='foo_config', default=None)
         self.add_file_arg('--accordian-file', dest='accordian_files',


### PR DESCRIPTION
Updated all the docs, examples, and tests that still rely on the old optparse hooks. Added an explicit test to make sure they all work, and caught at least one bug (with the `args` deprecated property). Fixes #1645.