### PR TITLE
deprecate file_upload_args

### DIFF
--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -31,6 +31,7 @@ from mrjob.options import _optparse_kwargs_to_argparse
 from mrjob.options import _parse_raw_args
 from mrjob.options import _print_help_for_runner
 from mrjob.options import _print_basic_help
+from mrjob.setup import parse_legacy_hash_path
 from mrjob.step import StepFailedException
 from mrjob.util import log_to_null
 from mrjob.util import log_to_stream
@@ -495,10 +496,12 @@ class MRJobLauncher(object):
         raw_args = _parse_raw_args(self.arg_parser, self._cl_args)
 
         extra_args = []
-        file_upload_args = []
 
         for dest, option_string, args in raw_args:
-            if dest in self._passthru_arg_dests:
+            if dest in self._file_arg_dests:
+                extra_args.append(option_string)
+                extra_args.append(parse_legacy_hash_path('file', args[0]))
+            elif dest in self._passthru_arg_dests:
                 # special case for --hadoop-arg=-verbose etc.
                 if (option_string and len(args) == 1 and
                         args[0].startswith('-')):
@@ -508,13 +511,9 @@ class MRJobLauncher(object):
                         extra_args.append(option_string)
                     extra_args.extend(args)
 
-            elif dest in self._file_arg_dests:
-                file_upload_args.append((option_string, args[0]))
-
         return dict(
             conf_paths=self.options.conf_paths,
             extra_args=extra_args,
-            file_upload_args=file_upload_args,
             hadoop_input_format=self.hadoop_input_format(),
             hadoop_output_format=self.hadoop_output_format(),
             input_paths=self.options.args,

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -267,7 +267,7 @@ class MRJobRunner(object):
             for arg, path in file_upload_args:
                 arg_file = parse_legacy_hash_path('file', path)
                 self._working_dir_mgr.add(**arg_file)
-                self._extra_args.append((arg, arg_file))
+                self._extra_args.extend([arg, arg_file])
                 self._spark_files.append((arg_file['name'], arg_file['path']))
 
         # set up uploading

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -252,14 +252,22 @@ class MRJobRunner(object):
 
         # extra args to our job
         self._extra_args = list(extra_args) if extra_args else []
+        for extra_arg in self._extra_args:
+            if isinstance(extra_arg, dict):
+                if extra_arg.get('type') != 'file':
+                    raise NotImplementedError
+                self._working_dir_mgr.add(**extra_arg)
+                self._spark_files.append(
+                    (extra_arg['name'], extra_arg['path']))
 
         # extra file arguments to our job
-        self._file_upload_args = []
         if file_upload_args:
+            log.warning('file_upload_args is deprecated and will be removed'
+                        ' in v0.6.0. Pass dicts to extra_args instead.')
             for arg, path in file_upload_args:
                 arg_file = parse_legacy_hash_path('file', path)
                 self._working_dir_mgr.add(**arg_file)
-                self._file_upload_args.append((arg, arg_file))
+                self._extra_args.append((arg, arg_file))
                 self._spark_files.append((arg_file['name'], arg_file['path']))
 
         # set up uploading
@@ -806,25 +814,18 @@ class MRJobRunner(object):
         :param local: if this is True, use files' local paths rather than
             the path they'll have inside Hadoop streaming
         """
-        return (self._get_file_upload_args(local=local) +
-                self._extra_args)
+        result = []
 
-    def _get_file_upload_args(self, local=False):
-        """Arguments used to pass through config files, etc from the job
-        runner through to the local directory where the script is run.
-
-        :type local: boolean
-        :param local: if this is True, use files' local paths rather than
-            the path they'll have inside Hadoop streaming
-        """
-        args = []
-        for arg, path_dict in self._file_upload_args:
-            args.append(arg)
-            if local:
-                args.append(path_dict['path'])
+        for extra_arg in self._extra_args:
+            if isinstance(extra_arg, dict):
+                if local:
+                    result.append(extra_arg['path'])
+                else:
+                    result.append(self._working_dir_mgr.name(**extra_arg))
             else:
-                args.append(self._working_dir_mgr.name(**path_dict))
-        return args
+                result.append(extra_arg)
+
+        return result
 
     def _dir_archive_path(self, dir_path):
         """Assign a path for the archive of *dir_path* but don't

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -310,23 +310,28 @@ class CommandLineArgsTestCase(TestCase):
         mr_job = MRCustomJobLauncher(args=[''])
         self.assertEqual(mr_job.options.foo_config, None)
         self.assertEqual(mr_job.options.accordian_files, [])
-        self.assertEqual(mr_job._non_option_kwargs()['file_upload_args'], [])
+        self.assertEqual(mr_job._non_option_kwargs()['extra_args'], [])
 
     def test_explicit_file_options(self):
         mr_job = MRCustomJobLauncher(args=[
             '',
-            '--foo-config', '/tmp/.fooconf',
+            '--foo-config', '/tmp/.fooconf#dot-fooconf',
             '--foo-config', '/etc/fooconf',
             '--accordian-file', 'WeirdAl.mp3',
             '--accordian-file', '/home/dave/JohnLinnell.ogg'])
         self.assertEqual(mr_job.options.foo_config, '/etc/fooconf')
         self.assertEqual(mr_job.options.accordian_files, [
             'WeirdAl.mp3', '/home/dave/JohnLinnell.ogg'])
-        self.assertEqual(mr_job._non_option_kwargs()['file_upload_args'], [
-            ('--foo-config', '/tmp/.fooconf'),
-            ('--foo-config', '/etc/fooconf'),
-            ('--accordian-file', 'WeirdAl.mp3'),
-            ('--accordian-file', '/home/dave/JohnLinnell.ogg')])
+        self.assertEqual(mr_job._non_option_kwargs()['extra_args'], [
+            '--foo-config', dict(
+                path='/tmp/.fooconf', name='dot-fooconf', type='file'),
+            '--foo-config', dict(
+                path='/etc/fooconf', name=None, type='file'),
+            '--accordian-file', dict(
+                path='WeirdAl.mp3', name=None, type='file'),
+            '--accordian-file', dict(
+                path='/home/dave/JohnLinnell.ogg', name=None, type='file')
+        ])
 
     def test_no_conf_overrides(self):
         mr_job = MRCustomJobLauncher(args=['', '-c', 'blah.conf', '--no-conf'])
@@ -452,9 +457,12 @@ class DeprecatedOptionHooksTestCase(SandboxedTestCase):
             mr_job.options.accordian_files, [
             'WeirdAl.mp3', '/home/dave/JohnLinnell.ogg'])
 
-        self.assertEqual(mr_job._non_option_kwargs()['file_upload_args'], [
-            ('--accordian-file', 'WeirdAl.mp3'),
-            ('--accordian-file', '/home/dave/JohnLinnell.ogg')])
+        self.assertEqual(mr_job._non_option_kwargs()['extra_args'], [
+            '--accordian-file', dict(
+                path='WeirdAl.mp3', name=None, type='file'),
+            '--accordian-file', dict(
+                path='/home/dave/JohnLinnell.ogg', name=None, type='file'),
+        ])
 
     def test_pass_through_option_method(self):
         mr_job = MRDeprecatedCustomJobLauncher(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1071,3 +1071,26 @@ class OptDebugPrintoutTestCase(ConfigFilesTestCase):
 
         self.assertIn("'owner'", stderr.getvalue())
         self.assertIn("'dave'", stderr.getvalue())
+
+
+class DeprecatedFileUploadArgsTestCase(SandboxedTestCase):
+
+    def setUp(self):
+        super(DeprecatedFileUploadArgsTestCase, self).setUp()
+
+        self.log = self.start(patch('mrjob.runner.log'))
+
+    def test_deprecated_file_upload_args(self):
+        old_runner = InlineMRJobRunner(
+            file_upload_args=[('--foo-config', '/tmp/.fooconf#dot-fooconf')])
+
+        new_runner = InlineMRJobRunner(
+            extra_args=['--foo-config', dict(
+                path='/tmp/.fooconf', name='dot-fooconf', type='file')])
+
+        self.assertEqual(old_runner._extra_args, new_runner._extra_args)
+        self.assertEqual(old_runner._spark_files, new_runner._spark_files)
+        self.assertEqual(old_runner._working_dir_mgr._name_to_typed_path,
+                         new_runner._working_dir_mgr._name_to_typed_path)
+
+        self.assertTrue(self.log.warning.called)


### PR DESCRIPTION
This makes the `extra_args` init keyword to `MRJobRunner` do the work of `file_upload_args`, using path dicts. Fixes #1656.