### PR TITLE
Fixing small typo in "concepts" guide

### DIFF
--- a/docs/guides/concepts.rst
+++ b/docs/guides/concepts.rst
@@ -23,10 +23,10 @@ shared by all processing nodes. The framework takes care of scheduling tasks,
 monitoring them, and re-executing the failed tasks.
 
 The MapReduce framework consists of a single master "job tracker" (Hadoop 1)
-or "resource manager" (Hadoop 2) and a number of worker nodes. The master
-The master is responsible for scheduling the jobs' component tasks on the
-worker nodes and re-executing the failed tasks. The worker nodes execute the
-tasks as directed by the master.
+or "resource manager" (Hadoop 2) and a number of worker nodes. The master is 
+responsible for scheduling the jobs' component tasks on the worker nodes and 
+re-executing the failed tasks. The worker nodes execute the tasks as directed 
+by the master.
 
 As the job author, you write :term:`map <mapper>`, :term:`combine <combiner>`,
 and :term:`reduce <reducer>` functions that are submitted to the job tracker


### PR DESCRIPTION
The original text was:
"The master The master is responsible for scheduling..."
Updated to:
"The master is responsible for scheduling..."

The diff gets all wonky, b/c I fixed the surrounding text to match the column-width formatting of the rest of the doc.