### PR TITLE
`log_to_stream` docstring typo fix

### DIFF
--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -92,7 +92,7 @@ def log_to_stream(name=None, stream=None, format=None, level=None,
 
     :type name: str
     :param name: name of the logger, or ``None`` for the root logger
-    :type stderr: file object
+    :type stream: file object
     :param stderr:  stream to log to (default is ``sys.stderr``)
     :type format: str
     :param format: log message format (default is '%(message)s')

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -93,7 +93,7 @@ def log_to_stream(name=None, stream=None, format=None, level=None,
     :type name: str
     :param name: name of the logger, or ``None`` for the root logger
     :type stream: file object
-    :param stderr:  stream to log to (default is ``sys.stderr``)
+    :param stream:  stream to log to (default is ``sys.stderr``)
     :type format: str
     :param format: log message format (default is '%(message)s')
     :param level: log level to use


### PR DESCRIPTION
I had to read this like 8 times before I figured out what was going on. Figured I'd save the next person some confusion.