### PR TITLE
fix and document precedence of various instance options

### DIFF
--- a/docs/guides/configs-reference.rst
+++ b/docs/guides/configs-reference.rst
@@ -64,8 +64,8 @@ These options can be set by overriding your job's
 ====================== ======================== ========
 Option                 Method                   Default
 ====================== ======================== ========
-*extra_args*           |add_passthru_arg| ``[]``
-*file_upload_args*     |add_file_arg|        ``[]``
+*extra_args*           |add_passthru_arg|       ``[]``
+*file_upload_args*     |add_file_arg|           ``[]``
 ====================== ======================== ========
 
 All of the above can be passed as keyword arguments to

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -293,10 +293,7 @@ Cluster creation and configuration
 
     A list of instance fleet definitions to pass to the EMR API. Pass a JSON
     string on the command line or use data structures in the config file
-    (which is itself basically JSON).
-
-    *instance_fleets* overrides :mrjob-opt:`instance_groups` and other
-    instance configuration options.
+    (which is itself basically JSON). For example:
 
     .. code-block:: yaml
 
@@ -321,6 +318,19 @@ Cluster creation and configuration
               - InstanceType: m1.large
                 BidPriceAsPercentageOfOnDemandPrice: 50
                 WeightedCapacity: 2
+
+    There are three ways to configure instances: `instance_fleets`,
+    :mrjob-opt:`instance_groups`, and individual instance options
+    (:mrjob-opt:`core_instance_bid_price`, :mrjob-opt:`core_instance_type`,
+    :mrjob-opt:`instance_type`, :mrjob-opt:`master_instance_bid_price`,
+    :mrjob-opt:`master_instance_type`, :mrjob-opt:`num_core_instances`,
+    :mrjob-opt:`num_task_instances`, :mrjob-opt:`task_instance_bid_price`,
+    :mrjob-opt:`task_instance_type`).
+
+    If there is a conflict, whichever comes later in the config
+    files takes precedence, and the command line beats config files. In
+    the case of a tie, `instance_fleets` beats `instance_groups` beats
+    other instance options.
 
 .. mrjob-opt::
     :config: instance_groups
@@ -351,6 +361,10 @@ Cluster creation and configuration
                 - VolumeSpecification:
                     SizeInGB: 100
                     VolumeType: gp2
+
+    `instance_groups` is incompatible with :mrjob-opt:`instance_fleets`
+    and other instance options. See :mrjob-opt:`instance_fleets` for
+    details.
 
 .. mrjob-opt::
     :config: max_hours_idle

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -355,7 +355,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     }
 
     # everything that controls instances number, type, or price
-    _INSTANCE_OPTS = {
+    _INSTANCE_OPT_NAMES = {
         name for name in OPT_NAMES
         if 'instance' in name and 'iam' not in name
     }
@@ -500,7 +500,8 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             if blank_out:
                 opts['instance_fleets'] = None
                 opts['instance_groups'] = None
-            elif any(opts.get(k) is not None for k in self._INSTANCE_OPTS):
+            elif any(opts.get(k) is not None
+                     for k in self._INSTANCE_OPT_NAMES):
                 blank_out = True
 
         # now combine opts, with instance_groups/fleets blanked out

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -354,6 +354,19 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'visible_to_all_users',
     }
 
+    # these override instance_fleets and instance_groups
+    _FINE_GRAINED_INSTANCE_OPTS = {
+        'core_instance_bid_price',
+        'core_instance_type',
+        'instance_type',
+        'master_instance_bid_price',
+        'master_instance_type',
+        'num_core_instances',
+        'num_task_instances',
+        'task_instance_bid_price',
+        'task_instance_type',
+    }
+
     def __init__(self, **kwargs):
         """:py:class:`~mrjob.emr.EMRJobRunner` takes the same arguments as
         :py:class:`~mrjob.runner.MRJobRunner`, plus some additional options

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -354,17 +354,10 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'visible_to_all_users',
     }
 
-    # these override instance_fleets and instance_groups
-    _FINE_GRAINED_INSTANCE_OPTS = {
-        'core_instance_bid_price',
-        'core_instance_type',
-        'instance_type',
-        'master_instance_bid_price',
-        'master_instance_type',
-        'num_core_instances',
-        'num_task_instances',
-        'task_instance_bid_price',
-        'task_instance_type',
+    # everything that controls instances number, type, or price
+    _INSTANCE_OPTS = {
+        name for name in OPT_NAMES
+        if 'instance' in name and 'iam' not in name
     }
 
     def __init__(self, **kwargs):
@@ -494,9 +487,26 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         )
 
     def _combine_opts(self, opt_list):
-        """Convert image_version of 4.x and later to release_label."""
+        """Blank out overriden *instance_fleets* and *instance_groups*
+
+        Convert image_version of 4.x and later to release_label."""
+        # copy opt_list so we can modify it
+        opt_list = [dict(opts) for opts in opt_list]
+
+        # blank out any instance_fleets/groups before the last config
+        # where they are set
+        blank_out = False
+        for opts in reversed(opt_list):
+            if blank_out:
+                opts['instance_fleets'] = None
+                opts['instance_groups'] = None
+            elif any(opts.get(k) is not None for k in self._INSTANCE_OPTS):
+                blank_out = True
+
+        # now combine opts, with instance_groups/fleets blanked out
         opts = super(EMRJobRunner, self)._combine_opts(opt_list)
 
+        # set release_label based on image_version
         if (version_gte(opts['image_version'], '4') and
                 not opts['release_label']):
             opts['release_label'] = 'emr-' + opts['image_version']


### PR DESCRIPTION
Fixes #1637.

For instance, you can now set instance configs on the command line if `instance_fleets` is specified in your config files.