### PR TITLE
start fixing windows tests

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -46,6 +46,7 @@ from mrjob.parse import is_uri
 from mrjob.py2 import to_string
 from mrjob.runner import MRJobRunner
 from mrjob.runner import RunnerOptionStore
+from mrjob.runner import _fix_env
 from mrjob.setup import UploadDirManager
 from mrjob.step import StepFailedException
 from mrjob.step import _is_spark_step_type
@@ -428,7 +429,7 @@ class HadoopJobRunner(MRJobRunner, LogInterpretationMixin):
             self._warn_about_spark_archives(step)
 
             step_args = self._args_for_step(step_num)
-            env = self._env_for_step(step_num)
+            env = _fix_env(self._env_for_step(step_num))
 
             # log this *after* _args_for_step(), which can start a search
             # for the Hadoop streaming jar

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -26,6 +26,7 @@ from mrjob.logs.counters import _format_counters
 from mrjob.parse import _find_python_traceback
 from mrjob.parse import parse_mr_job_stderr
 from mrjob.py2 import string_types
+from mrjob.runner import _fix_env
 from mrjob.sim import SimMRJobRunner
 from mrjob.step import StepFailedException
 from mrjob.util import cmd_line
@@ -68,6 +69,8 @@ def _chain_procs(procs_args, **kwargs):
         # other procs should have stdout sent to next proc
         if i < len(procs_args) - 1:
             proc_kwargs['stdout'] = PIPE
+
+        proc_kwargs['env'] = _fix_env(proc_kwargs['env'])
 
         proc = Popen(args, **proc_kwargs)
         last_stdout = proc.stdout

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -728,8 +728,8 @@ class MRJobRunner(object):
                         self._mr_job_extra_args(local=True))
                 log.debug('> %s' % cmd_line(args))
                 # add . to PYTHONPATH (in case mrjob isn't actually installed)
-                env = combine_local_envs(os.environ,
-                                         {'PYTHONPATH': os.path.abspath('.')})
+                env = _fix_env(combine_local_envs(
+                    os.environ, {'PYTHONPATH': os.path.abspath('.')}))
                 steps_proc = Popen(args, stdout=PIPE, stderr=PIPE, env=env)
                 stdout, stderr = steps_proc.communicate()
 
@@ -1661,9 +1661,11 @@ class MRJobRunner(object):
         # Make sure that the tmp dir environment variables are changed if
         # the default is changed. (Make sure unicode is converted to str
         # for Windows)
-        env['TMP'] = str(self._opts['local_tmp_dir'])
-        env['TMPDIR'] = str(self._opts['local_tmp_dir'])
-        env['TEMP'] = str(self._opts['local_tmp_dir'])
+        env['TMP'] = self._opts['local_tmp_dir']
+        env['TMPDIR'] = self._opts['local_tmp_dir']
+        env['TEMP'] = self._opts['local_tmp_dir']
+
+        env = _fix_env(env)
 
         log.debug('Writing to %s' % output_path)
 
@@ -1712,3 +1714,12 @@ class MRJobRunner(object):
             for line in err:
                 log.error('STDERR: %s' % line.rstrip('\r\n'))
         raise CalledProcessError(proc.returncode, args)
+
+
+def _fix_env(env):
+    """Convert environment dictionary to strings (Python 2.7 on Windows
+    doesn't allow unicode)"""
+    def _to_str(s):
+        return s if isinstance(s, str) else s.encode('utf_8')
+
+    return dict((_to_str(k), _to_str(v)) for k, v in env.items())

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1659,10 +1659,11 @@ class MRJobRunner(object):
         env['LC_ALL'] = 'C'
 
         # Make sure that the tmp dir environment variables are changed if
-        # the default is changed.
-        env['TMP'] = self._opts['local_tmp_dir']
-        env['TMPDIR'] = self._opts['local_tmp_dir']
-        env['TEMP'] = self._opts['local_tmp_dir']
+        # the default is changed. (Make sure unicode is converted to str
+        # for Windows)
+        env['TMP'] = str(self._opts['local_tmp_dir'])
+        env['TMPDIR'] = str(self._opts['local_tmp_dir'])
+        env['TEMP'] = str(self._opts['local_tmp_dir'])
 
         log.debug('Writing to %s' % output_path)
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1718,8 +1718,11 @@ class MRJobRunner(object):
 
 def _fix_env(env):
     """Convert environment dictionary to strings (Python 2.7 on Windows
-    doesn't allow unicode)"""
+    doesn't allow unicode)."""
     def _to_str(s):
-        return s if isinstance(s, str) else s.encode('utf_8')
+        if isinstance(s, string_types) and not isinstance(s, str):
+            return s.encode('utf_8')
+        else:
+            return s
 
     return dict((_to_str(k), _to_str(v)) for k, v in env.items())

--- a/mrjob/ssh.py
+++ b/mrjob/ssh.py
@@ -48,10 +48,10 @@ def _check_output(out, err):
         if (b'No such file or directory' in err or
             b'Warning: Permanently added' not in err):  # noqa
 
-            raise IOError(err)
+            raise IOError(err.rstrip())
 
     if b'Permission denied' in out:
-        raise IOError(out)
+        raise IOError(out.rstrip())
 
     return out
 

--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -133,6 +133,9 @@ class SSHFSTestCase(MockSubprocessTestCase):
         self.make_master_file(os.path.join('data', 'foo'), 'foo\nfoo\n')
         remote_path = self.fs.join('ssh://testmaster/data', 'foo')
 
+        self.assertEqual(remote_path,
+                         'ssh:///testmaster/data/foo')
+
         self.assertEqual(list(self.fs._cat_file(remote_path)),
                          [b'foo\n', b'foo\n'])
 

--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -133,9 +133,6 @@ class SSHFSTestCase(MockSubprocessTestCase):
         self.make_master_file(os.path.join('data', 'foo'), 'foo\nfoo\n')
         remote_path = self.fs.join('ssh://testmaster/data', 'foo')
 
-        self.assertEqual(remote_path,
-                         'ssh:///testmaster/data/foo')
-
         self.assertEqual(list(self.fs._cat_file(remote_path)),
                          [b'foo\n', b'foo\n'])
 

--- a/tests/fs/test_ssh.py
+++ b/tests/fs/test_ssh.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import bz2
-import os
+import os.path
 import shutil
 
 from mrjob.fs.ssh import SSHFilesystem
@@ -252,11 +252,11 @@ class SSHFSTestCase(MockSubprocessTestCase):
         self.add_slave()
         self.add_slave()
 
-        self.assertEquals(self.fs.ssh_slave_hosts('testmaster'),
-                          ['testslave1', 'testslave2'])
+        self.assertEqual(self.fs.ssh_slave_hosts('testmaster'),
+                         ['testslave1', 'testslave2'])
 
     def test_ssh_no_slave_hosts(self):
-        self.assertEquals(self.fs.ssh_slave_hosts('testmaster'), [])
+        self.assertEqual(self.fs.ssh_slave_hosts('testmaster'), [])
 
     def test_ssh_slave_hosts_doesnt_care_about_sudo(self):
         self.require_sudo()

--- a/tests/mockgoogleapiclient.py
+++ b/tests/mockgoogleapiclient.py
@@ -198,9 +198,14 @@ class MockGoogleAPITestCase(SandboxedTestCase):
         super(MockGoogleAPITestCase, self).setUp()
 
         # patch slow things
-        def fake_create_mrjob_zip(mocked_self, *args, **kwargs):
-            mocked_self._mrjob_zip_path = self.fake_mrjob_zip_path
-            return self.fake_mrjob_zip_path
+        self.mrjob_zip_path = None
+
+        def fake_create_mrjob_zip(runner, *args, **kwargs):
+            if not self.mrjob_zip_path:
+                self.mrjob_zip_path = self.makefile('fake_mrjob.zip')
+
+            runner._mrjob_zip_path = self.mrjob_zip_path
+            return self.mrjob_zip_path
 
         self.start(patch.object(
             DataprocJobRunner, '_create_mrjob_zip',

--- a/tests/mockgoogleapiclient.py
+++ b/tests/mockgoogleapiclient.py
@@ -162,18 +162,6 @@ def _dict_deep_update(d, u):
     "googleapiclient doesn't work with PyPy 3")
 class MockGoogleAPITestCase(SandboxedTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        # we don't care what's in this file, just want mrjob to stop creating
-        # and deleting a complicated archive.
-        cls.fake_mrjob_zip_path = tempfile.mkstemp(
-            prefix='fake_mrjob_', suffix='.zip')[1]
-
-    @classmethod
-    def tearDownClass(cls):
-        if os.path.exists(cls.fake_mrjob_zip_path):
-            os.remove(cls.fake_mrjob_zip_path)
-
     def setUp(self):
         self._dataproc_client = MockDataprocClient(self)
         self._gcs_client = MockGCSClient(self)

--- a/tests/mockssh.py
+++ b/tests/mockssh.py
@@ -95,13 +95,6 @@ def path_for_host(host, environ=None):
                    (host, environ['MOCK_SSH_ROOTS']))
 
 
-def rel_posix_to_rel_local(path, environ=None):
-    """Convert a POSIX path to the current system's format"""
-    if environ is None:
-        environ = os.environ
-    return os.path.join(*path.split('/'))
-
-
 def rel_posix_to_abs_local(host, path, environ=None):
     """Convert a POSIX path to the current system's format and prepend the
     tmp directory the host's files are in

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -18,7 +18,6 @@
 import getpass
 import os
 import os.path
-import pty
 from io import BytesIO
 from subprocess import check_call
 from subprocess import PIPE
@@ -52,6 +51,13 @@ from tests.quiet import logger_disabled
 from tests.sandbox import EmptyMrjobConfTestCase
 from tests.sandbox import SandboxedTestCase
 from tests.test_runner import PYTHON_BIN
+
+# pty isn't available on Windows
+try:
+    import pty
+    pty
+except ImportError:
+    pty = Mock()
 
 
 class MockHadoopTestCase(SandboxedTestCase):
@@ -1145,8 +1151,8 @@ class RunJobInHadoopUsesEnvTestCase(MockHadoopTestCase):
             'mrjob.hadoop.HadoopJobRunner._env_for_step',
             return_value=dict(FOO='bar', BAZ='qux')))
 
-        self.mock_pty_fork = self.start(patch(
-            'pty.fork', return_value=(0, None)))
+        self.mock_pty_fork = self.start(patch.object(
+            pty, 'fork', return_value=(0, None)))
 
         # end test once we invoke Popen or execvpe()
         self.mock_Popen = self.start(patch(


### PR DESCRIPTION
Makes some changes to the test framework that make it possible for some Windows tests to run.

Was hoping to fix the tests on v0.5.x first and then on v0.6.0, but that'll be too time-consuming. Instead will focus on v0.6.0, and backport windows-related fixes.