### PR TITLE
Turn off pooling by default

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -366,32 +366,48 @@ Cluster creation and configuration
     and other instance options. See :mrjob-opt:`instance_fleets` for
     details.
 
+
 .. mrjob-opt::
-    :config: max_hours_idle
-    :switch: --max-hours-idle
-    :type: :ref:`string <data-type-string>`
+    :config: max_mins_idle
+    :switch: --max-mins-idle
+    :type: float
     :set: emr
-    :default: 0.5
+    :default: 5
 
     Automatically terminate persistent/pooled clusters that have been idle at
-    least this many hours, if we're within :mrjob-opt:`mins_to_end_of_hour` of
-    an EC2 billing hour.
+    least this many minutes.
 
     .. versionchanged:: 0.6.0
 
        All clusters launched by mrjob now auto-terminate when idle. In previous
-       versions, you needed to set this option explicitly, or use
-       :ref:`terminate-idle-clusters`.
+       versions, you needed to set :mrjob-opt:`max_hours_idle`, set this
+       option explicitly, or use :ref:`terminate-idle-clusters`.
+
+
+.. mrjob-opt::
+    :config: max_hours_idle
+    :switch: --max-hours-idle
+    :type: float
+    :set: emr
+    :default: None
+
+    .. deprecated:: 0.6.0
+
+        Starting with v0.6.0, you should use :mrjob-opt:`max_mins_idle`
+        instead.
 
 .. mrjob-opt::
     :config: mins_to_end_of_hour
     :switch: --mins-to-end-of-hour
-    :type: :ref:`string <data-type-string>`
+    :type: float
     :set: emr
     :default: 5.0
 
-    If :mrjob-opt:`max_hours_idle` is set, controls how close to the end of an
-    EC2 billing hour the cluster can automatically terminate itself.
+    .. deprecated:: 0.6.0
+
+        This option was created back when EMR billed by the full hour, and
+        does nothing as of v0.6.0. If using versions prior to v0.6.0, it's
+        recommended you set this to 60.0 to effectively disable this feature.
 
 .. mrjob-opt::
     :config: region

--- a/docs/guides/pooling.rst
+++ b/docs/guides/pooling.rst
@@ -3,22 +3,20 @@
 Cluster Pooling
 ===============
 
-Clusters on EMR take several minutes to spin up. Also, EMR bills by the full
-hour, so if you run, say, a 10-minute job and then shut down the cluster, the
-other 50 minutes are wasted.
+Clusters on EMR take several minutes to spin up, which can make development
+painfully slow.
 
-To mitigate these problems, :py:mod:`mrjob` provides **cluster pools.** By
-default, once your job completes, the cluster will stay open to accept
+To get around this, :py:mod:`mrjob` provides
+**cluster pooling.**. If you set :mrjob-opt:`pool_clusters` to true,
+once your job completes, the cluster will stay open to accept
 additional jobs, and eventually shut itself down after it has been idle
-for a certain amount of time (see :mrjob-opt:`max_hours_idle` and
-:mrjob-opt:`mins_to_end_of_hour`).
+for a certain amount of time (by default, ten minutes; see
+:mrjob-opt:`max_mins_idle`).
 
 .. note::
 
-   Cluster pooling was not turned on by default in versions prior to 0.6.0.
-   To get the same behavior in previous versions :mrjob-opt:`pool_clusters` to
-   ``True`` and :mrjob-opt:`max_hours_idle` to 0.5 (don't forget to set
-   `max_hours_idle`, or your clusters will never shut down).
+   When using cluster pooling prior to v0.6.0, make sure to set
+   :mrjob-opt:`max_hours_idle`, or your cluster will never shut down.
 
 Pooling is designed so that jobs run against the same :py:mod:`mrjob.conf` can
 share the same clusters. This means that the version of :py:mod:`mrjob` and
@@ -41,8 +39,7 @@ separate pools.
 Pooling is flexible about instance type and number of instances; it will
 attempt to select the most powerful cluster available as long as the
 cluster's instances provide at least as much memory and at least as much CPU as
-your job requests. If there is a tie, it picks clusters that are closest to
-the end of a full hour, to minimize wasted instance hours.
+your job requests.
 
 Pooling is also somewhat flexible about EBS volumes (see
 :mrjob-opt:`instance_groups`). Each volume must have the same volume type,

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -109,8 +109,8 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
         opts = super(HadoopInTheCloudJobRunner, self)._fix_opts(
             opts, source=source)
 
-        if (opts['max_mins_idle'] is None
-            and opts['max_hours_idle'] is not None):
+        if (opts.get('max_mins_idle') is None and
+                opts.get('max_hours_idle') is not None):
 
             opts['max_mins_idle'] = opts['max_hours_idle'] * 60
 

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -18,6 +18,7 @@ import pipes
 from os.path import basename
 
 from mrjob.bin import MRJobBinRunner
+from mrjob.conf import combine_dicts
 from mrjob.setup import WorkingDirManager
 from mrjob.setup import parse_setup_cmd
 from mrjob.util import cmd_line

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -52,6 +52,7 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
         'image_version',
         'instance_type',
         'master_instance_type',
+        'max_mins_idle',
         'max_hours_idle',
         'num_core_instances',
         'num_task_instances',
@@ -65,6 +66,10 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
 
     def __init__(self, **kwargs):
         super(HadoopInTheCloudJobRunner, self).__init__(**kwargs)
+
+        if self._opts.get('max_hours_idle'):
+            log.warning('max_hours_idle is deprecated and will be removed'
+                        ' in v0.7.0. Please use max_mins_idle instead')
 
         # if *cluster_id* is not set, ``self._cluster_id`` will be
         # set when we create or join a cluster
@@ -91,6 +96,24 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
 
 
     ### Options ###
+
+    def _default_opts(self):
+        return combine_dicts(
+            super(HadoopInTheCloudJobRunner, self)._default_opts(),
+            dict(max_mins_idle=5.0),
+        )
+
+    def _fix_opts(self, opts, source=None):
+        # patch max_hours_idle into max_mins_idle (see #1663)
+        opts = super(HadoopInTheCloudJobRunner, self)._fix_opts(
+            opts, source=source)
+
+        if (opts['max_mins_idle'] is None
+            and opts['max_hours_idle'] is not None):
+
+            opts['max_mins_idle'] = opts['max_hours_idle'] * 60
+
+        return opts
 
     def _combine_opts(self, opt_list):
         """Propagate *instance_type* to other instance type opts, if not

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -474,7 +474,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 mins_to_end_of_hour=5.0,
                 num_core_instances=0,
                 num_task_instances=0,
-                pool_clusters=True,
+                pool_clusters=False,
                 pool_name='default',
                 pool_wait_minutes=0,
                 region=_DEFAULT_EMR_REGION,

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -807,7 +807,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         for bootstrap_action in self._bootstrap_actions():
             self._upload_mgr.add(bootstrap_action['path'])
 
-        # Add max-hours-idle script if we need it
+        # Add max-mins-idle script if we need it
         if persistent or self._opts['pool_clusters']:
             self._upload_mgr.add(_MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH)
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -152,7 +152,7 @@ _WAIT_FOR_SSH_TO_FAIL = 1.0
 _POOLING_SLEEP_INTERVAL = 30.01  # Add .1 seconds so minutes arent spot on.
 
 # bootstrap action which automatically terminates idle clusters
-_MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH = os.path.join(
+_MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH = os.path.join(
     os.path.dirname(mrjob.__file__),
     'bootstrap',
     'terminate_idle_cluster.sh')
@@ -470,7 +470,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 cloud_fs_sync_secs=5.0,
                 cloud_upload_part_size=100,  # 100 MB
                 image_version=_DEFAULT_IMAGE_VERSION,
-                max_hours_idle=0.5,
                 mins_to_end_of_hour=5.0,
                 num_core_instances=0,
                 num_task_instances=0,
@@ -810,7 +809,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
         # Add max-hours-idle script if we need it
         if persistent or self._opts['pool_clusters']:
-            self._upload_mgr.add(_MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH)
+            self._upload_mgr.add(_MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH)
 
     def _add_master_node_setup_files_for_upload(self):
         """Add files necesary for the master node setup script to
@@ -1354,9 +1353,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             # use idle termination script on persistent clusters
             # add it last, so that we don't count bootstrapping as idle time
             uri = self._upload_mgr.uri(
-                _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH)
+                _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH)
             # script takes args in (integer) seconds
-            ba_args = [str(int(self._opts['max_hours_idle'] * 3600)),
+            ba_args = [str(int(self._opts['max_mins_idle'] * 60)),
                        str(int(self._opts['mins_to_end_of_hour'] * 60))]
             BootstrapActions.append(dict(
                 Name='idle timeout',
@@ -1924,8 +1923,8 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         if self._created_cluster:
             return
 
-        # don't check for max_hours_idle because it's possible to
-        # join a self-terminating cluster without having max_hours_idle set
+        # don't check for max_mins_idle because it's possible to
+        # join a self-terminating cluster without having max_mins_idle set
         # on this runner (pooling only cares about the master bootstrap script,
         # not other bootstrap actions)
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -820,7 +820,7 @@ _RUNNER_OPTS = dict(
         deprecated=True,
         switches=[
             (['--mins-to-end-of-hour'], dict(
-                help=("If --max-hours-idle is set, control how close to the"
+                help=("If --max-mins-idle is set, control how close to the"
                       " end of an hour the cluster can automatically"
                       " terminate itself (default is 5 minutes)"),
                 type=float,
@@ -859,10 +859,7 @@ _RUNNER_OPTS = dict(
             (['--pool-clusters'], dict(
                 action='store_true',
                 help=('Add to an existing cluster or create a new one that'
-                      ' does not terminate when the job completes.\n'
-                      'WARNING: do not run this without --max-hours-idle or '
-                      ' with mrjob terminate-idle-clusters in your crontab;'
-                      ' clusters left idle can quickly become expensive!'),
+                      ' does not terminate when the job completes.'),
             )),
             (['--no-pool-clusters'], dict(
                 action='store_false',

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -794,19 +794,30 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
-    max_hours_idle=dict(
+    max_mins_idle=dict(
         cloud_role='launch',
         switches=[
-            (['--max-hours-idle'], dict(
+            (['--max-mins-idle'], dict(
                 help=("If we create a cluster, have it automatically"
                       " terminate itself after it's been idle this many"
-                      " hours"),
+                      " minutes"),
+                type=float,
+            )),
+        ],
+    ),
+    max_hours_idle=dict(
+        cloud_role='launch',
+        deprecated=True,
+        switches=[
+            (['--max-hours-idle'], dict(
+                help='Please use --max-mins-idle instead',
                 type=float,
             )),
         ],
     ),
     mins_to_end_of_hour=dict(
         cloud_role='launch',
+        deprecated=True,
         switches=[
             (['--mins-to-end-of-hour'], dict(
                 help=("If --max-hours-idle is set, control how close to the"

--- a/mrjob/tools/emr/terminate_idle_clusters.py
+++ b/mrjob/tools/emr/terminate_idle_clusters.py
@@ -96,7 +96,7 @@ def main(cl_args=None):
     if max_mins_idle is None and options.max_hours_idle is not None:
         log.warning('--max-hours-idle is deprecated and will be removed'
                     ' in v0.7.0. Please use --max-mins-idle instead.')
-        max_hours_idle = options.max_hours_idle * 60
+        max_mins_idle = options.max_hours_idle * 60
 
     _maybe_terminate_clusters(
         dry_run=options.dry_run,

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -896,7 +896,7 @@ class MaxMinsIdleTestCase(MockGoogleAPITestCase):
             })
 
     def test_persistent_cluster(self):
-        mr_job = MRWordCount(['-r', 'dataproc', '--max-hours-idle', '0.01'])
+        mr_job = MRWordCount(['-r', 'dataproc', '--max-mins-idle', '0.6'])
         mr_job.sandbox()
 
         with mr_job.make_runner() as runner:

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -29,7 +29,7 @@ from mrjob.dataproc import DataprocJobRunner
 from mrjob.dataproc import _DATAPROC_API_REGION
 from mrjob.dataproc import _DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS
 from mrjob.dataproc import _DEFAULT_IMAGE_VERSION
-from mrjob.dataproc import _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH
+from mrjob.dataproc import _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH
 from mrjob.fs.gcs import parse_gcs_uri
 from mrjob.py2 import PY2
 from mrjob.py2 import StringIO
@@ -518,7 +518,7 @@ class GCEInstanceGroupTestCase(MockGoogleAPITestCase):
         fake_bootstrap_script = 'gs://fake-bucket/fake-script.sh'
         runner._master_bootstrap_script_path = fake_bootstrap_script
         runner._upload_mgr.add(fake_bootstrap_script)
-        runner._upload_mgr.add(_MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH)
+        runner._upload_mgr.add(_MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH)
 
         cluster_id = runner._launch_cluster()
 
@@ -858,7 +858,7 @@ class DataprocNoMapperTestCase(MockGoogleAPITestCase):
                           (4, ['fish'])])
 
 
-class MaxHoursIdleTestCase(MockGoogleAPITestCase):
+class MaxMinsIdleTestCase(MockGoogleAPITestCase):
 
     def assertRanIdleTimeoutScriptWith(self, runner, expected_metadata):
         cluster_metadata, last_init_exec = (
@@ -869,7 +869,7 @@ class MaxHoursIdleTestCase(MockGoogleAPITestCase):
             self.assertEqual(cluster_metadata[key], expected_metadata[key])
 
         expected_uri = runner._upload_mgr.uri(
-            _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH)
+            _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH)
         self.assertEqual(last_init_exec, expected_uri)
 
     def _cluster_metadata_and_last_init_exec(self, runner):
@@ -906,7 +906,7 @@ class MaxHoursIdleTestCase(MockGoogleAPITestCase):
             })
 
     def test_bootstrap_script_is_actually_installed(self):
-        self.assertTrue(os.path.exists(_MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH))
+        self.assertTrue(os.path.exists(_MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH))
 
 
 class TestCatFallback(MockGoogleAPITestCase):

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -892,7 +892,7 @@ class MaxMinsIdleTestCase(MockGoogleAPITestCase):
         with mr_job.make_runner() as runner:
             runner.run()
             self.assertRanIdleTimeoutScriptWith(runner, {
-                'mrjob-max-secs-idle': '360',
+                'mrjob-max-secs-idle': '300',
             })
 
     def test_persistent_cluster(self):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -43,7 +43,7 @@ from mrjob.emr import _4_X_COMMAND_RUNNER_JAR
 from mrjob.emr import _BAD_BASH_IMAGE_VERSION
 from mrjob.emr import _DEFAULT_IMAGE_VERSION
 from mrjob.emr import _HUGE_PART_THRESHOLD
-from mrjob.emr import _MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH
+from mrjob.emr import _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH
 from mrjob.emr import _PRE_4_X_STREAMING_JAR
 from mrjob.job import MRJob
 from mrjob.parse import parse_s3_uri
@@ -1821,7 +1821,7 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
         self.assertEqual(action['Name'], 'idle timeout')
         self.assertEqual(
             action['ScriptPath'],
-            runner._upload_mgr.uri(_MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH))
+            runner._upload_mgr.uri(_MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH))
         self.assertEqual(action['Args'], args)
 
     def assertDidNotUseIdleTimeoutScript(self, runner):
@@ -1830,7 +1830,7 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
 
         self.assertNotIn('idle timeout', action_names)
         # idle timeout script should not even be uploaded
-        self.assertNotIn(_MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH,
+        self.assertNotIn(_MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH,
                          runner._upload_mgr.path_to_uri())
     def test_default(self):
         mr_job = MRWordCount(['-r', 'emr'])
@@ -1889,7 +1889,7 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
             self.assertRanIdleTimeoutScriptWith(runner, ['3600', '600'])
 
     def test_bootstrap_script_is_actually_installed(self):
-        self.assertTrue(os.path.exists(_MAX_HOURS_IDLE_BOOTSTRAP_ACTION_PATH))
+        self.assertTrue(os.path.exists(_MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH))
 
 
 class TestCatFallback(MockBoto3TestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1575,7 +1575,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
         self.assertTrue(actions[3]['ScriptPath'].startswith('s3://mrjob-'))
         self.assertTrue(actions[3]['ScriptPath'].endswith(
             'terminate_idle_cluster.sh'))
-        self.assertEqual(actions[3]['Args'], ['1800', '300'])
+        self.assertEqual(actions[3]['Args'], ['300', '300'])
         self.assertEqual(actions[3]['Name'], 'idle timeout')
 
         # make sure master bootstrap script is on S3
@@ -1630,7 +1630,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
         self.assertTrue(actions[2]['ScriptPath'].startswith('s3://mrjob-'))
         self.assertTrue(actions[2]['ScriptPath'].endswith(
             'terminate_idle_cluster.sh'))
-        self.assertEqual(actions[2]['Args'], ['1800', '300'])
+        self.assertEqual(actions[2]['Args'], ['300', '300'])
         self.assertEqual(actions[2]['Name'], 'idle timeout')
 
         # make sure scripts are on S3
@@ -1846,7 +1846,7 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
 
         with mr_job.make_runner() as runner:
             runner.run()
-            self.assertRanIdleTimeoutScriptWith(runner, ['1800', '300'])
+            self.assertRanIdleTimeoutScriptWith(runner, ['300', '300'])
 
     def test_custom_max_hours_idle(self):
         mr_job = MRWordCount(['-r', 'emr', '--max-hours-idle', '0.01'])
@@ -1871,7 +1871,7 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
 
         with mr_job.make_runner() as runner:
             runner.make_persistent_cluster()
-            self.assertRanIdleTimeoutScriptWith(runner, ['1800', '600'])
+            self.assertRanIdleTimeoutScriptWith(runner, ['300', '600'])
 
     def test_too_small_mins_to_end_of_hour(self):
         mr_job = MRWordCount(['-r', 'emr', '--mins-to-end-of-hour', '0.1'])

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1848,8 +1848,16 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
             runner.run()
             self.assertRanIdleTimeoutScriptWith(runner, ['300', '300'])
 
-    def test_custom_max_hours_idle(self):
-        mr_job = MRWordCount(['-r', 'emr', '--max-hours-idle', '0.01'])
+    def test_custom_max_mins_idle(self):
+        mr_job = MRWordCount(['-r', 'emr', '--max-mins-idle', '0.6'])
+        mr_job.sandbox()
+
+        with mr_job.make_runner() as runner:
+            runner.make_persistent_cluster()
+            self.assertRanIdleTimeoutScriptWith(runner, ['36', '300'])
+
+    def test_deprecated_max_hours_idle(self):
+        mr_job = MRWordCount(['-r', 'emr', '--max-mins-idle', '0.6'])
         mr_job.sandbox()
 
         with mr_job.make_runner() as runner:
@@ -1857,7 +1865,7 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
             self.assertRanIdleTimeoutScriptWith(runner, ['36', '300'])
 
     def test_mins_to_end_of_hour(self):
-        mr_job = MRWordCount(['-r', 'emr', '--max-hours-idle', '1',
+        mr_job = MRWordCount(['-r', 'emr', '--max-mins-idle', '60',
                               '--mins-to-end-of-hour', '10'])
         mr_job.sandbox()
 
@@ -1865,7 +1873,7 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
             runner.make_persistent_cluster()
             self.assertRanIdleTimeoutScriptWith(runner, ['3600', '600'])
 
-    def test_mins_to_end_of_hour_does_without_max_hours_idle(self):
+    def test_mins_to_end_of_hour_does_without_max_mins_idle(self):
         mr_job = MRWordCount(['-r', 'emr', '--mins-to-end-of-hour', '10'])
         mr_job.sandbox()
 
@@ -1880,7 +1888,7 @@ class MaxHoursIdleTestCase(MockBoto3TestCase):
         self.assertRaises(ValueError, mr_job.make_runner)
 
     def test_use_integers(self):
-        mr_job = MRWordCount(['-r', 'emr', '--max-hours-idle', '1.000001',
+        mr_job = MRWordCount(['-r', 'emr', '--max-mins-idle', '60.00006',
                               '--mins-to-end-of-hour', '10.000001'])
         mr_job.sandbox()
 

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -1778,16 +1778,16 @@ class PoolMatchingTestCase(MockBoto3TestCase):
         cluster = runner._describe_cluster()
         self.assertEqual(cluster['Status']['State'], 'WAITING')
 
-    def test_max_hours_idle_doesnt_affect_pool_hash(self):
-        # max_hours_idle uses a bootstrap action, but it's not included
+    def test_max_mins_idle_doesnt_affect_pool_hash(self):
+        # max_mins_idle uses a bootstrap action, but it's not included
         # in the pool hash
         _, cluster_id = self.make_pooled_cluster()
 
         self.assertJoins(cluster_id, [
-            '-r', 'emr', '--pool-clusters', '--max-hours-idle', '1'])
+            '-r', 'emr', '--pool-clusters', '--max-mins-idle', '60'])
 
-    def test_can_join_cluster_started_with_max_hours_idle(self):
-        _, cluster_id = self.make_pooled_cluster(max_hours_idle=1)
+    def test_can_join_cluster_started_with_max_mins_idle(self):
+        _, cluster_id = self.make_pooled_cluster(max_mins_idle=60)
 
         self.assertJoins(cluster_id, ['-r', 'emr', '--pool-clusters'])
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -166,8 +166,8 @@ class TestLegacyPoolHashAndName(TestCase):
         self.assertEqual(_legacy_pool_hash_and_name(actions),
                          ('0123456789abcdef0123456789abcdef', 'reflecting'))
 
-    def test_pooled_cluster_with_max_hours_idle(self):
-        # max hours idle is added AFTER the master bootstrap script,
+    def test_pooled_cluster_with_max_mins_idle(self):
+        # max-mins-idle script is added AFTER the master bootstrap script,
         # which was a problem when we just look at the last action
         actions = [
             dict(

--- a/tests/tools/emr/test_create_cluster.py
+++ b/tests/tools/emr/test_create_cluster.py
@@ -61,6 +61,7 @@ class ClusterInspectionTestCase(ToolTestCase):
                 'label': None,
                 'master_instance_bid_price': None,
                 'master_instance_type': None,
+                'max_mins_idle': None,
                 'max_hours_idle': None,
                 'mins_to_end_of_hour': None,
                 'num_core_instances': None,

--- a/tests/tools/emr/test_terminate_idle_clusters.py
+++ b/tests/tools/emr/test_terminate_idle_clusters.py
@@ -746,7 +746,7 @@ class DeprecatedMaxHoursIdleTestCase(SandboxedTestCase):
             patch('mrjob.tools.emr.terminate_idle_clusters.log'))
 
 
-    def test_max_hours_idle(self):
+    def test_deprecated_max_hours_idle(self):
         main(['--max-hours-idle', '2'])
 
         self.assertEqual(


### PR DESCRIPTION
Pooling is no longer on by default (fixes #1663).

EMR no longer bills by the hour, so disabled `mins_to_end_of_hour` (#1687) and changed `max_hours_idle` to `max_mins_idle` (#1686).