### PR TITLE
update mrjob command docstrings for v0.6.0

### DIFF
--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -501,7 +501,7 @@ instance. Here's an example that sneaks a peek at :ref:`writing-cl-opts`::
 
         def configure_args(self):
             super(CommandLineProtocolJob, self).configure_args()
-            self.add_passthrough_arg(
+            self.add_passthru_arg(
                 '--output-format', default='raw', choices=['raw', 'json'],
                 help="Specify the output format of the job")
 

--- a/mrjob/examples/contrib/mr_pegasos_svm.py
+++ b/mrjob/examples/contrib/mr_pegasos_svm.py
@@ -54,10 +54,10 @@ class MRsvm(MRJob):
 
     def configure_args(self):
         super(MRsvm, self).configure_args()
-        self.add_passthrough_arg(
+        self.add_passthru_arg(
             '--iterations', dest='iterations', default=2, type=int,
             help='T: number of iterations to run')
-        self.add_passthrough_arg(
+        self.add_passthru_arg(
             '--batchsize', dest='batchsize', default=100, type=int,
             help='k: number of data points in a batch')
 

--- a/mrjob/examples/mr_grep.py
+++ b/mrjob/examples/mr_grep.py
@@ -21,7 +21,7 @@ class MRGrepJob(MRJob):
     def configure_args(self):
         super(MRGrepJob, self).configure_args()
 
-        self.add_passthrough_arg(
+        self.add_passthru_arg(
             '-e', '--expression',
             help=( 'Expression to search for. Required.'))
 

--- a/mrjob/examples/mr_log_sampler.py
+++ b/mrjob/examples/mr_log_sampler.py
@@ -42,12 +42,12 @@ class MRLogSampler(MRJob):
 
     def configure_args(self):
         super(MRLogSampler, self).configure_args()
-        self.add_passthrough_arg(
+        self.add_passthru_arg(
             '--sample-size',
             type=int,
             help='Number of entries to sample.'
         )
-        self.add_passthrough_arg(
+        self.add_passthru_arg(
             '--expected-length',
             type=int,
             help=("Number of entries you expect in the log. If not specified,"

--- a/mrjob/examples/mr_page_rank.py
+++ b/mrjob/examples/mr_page_rank.py
@@ -51,11 +51,11 @@ class MRPageRank(MRJob):
     def configure_args(self):
         super(MRPageRank, self).configure_args()
 
-        self.add_passthrough_arg(
+        self.add_passthru_arg(
             '--iterations', dest='iterations', default=10, type=int,
             help='number of iterations to run')
 
-        self.add_passthrough_arg(
+        self.add_passthru_arg(
             '--damping-factor', dest='damping_factor', default=0.85,
             type=float,
             help='probability a web surfer will continue clicking on links')

--- a/mrjob/examples/mr_text_classifier.py
+++ b/mrjob/examples/mr_text_classifier.py
@@ -156,33 +156,33 @@ class MRTextClassifier(MRJob):
         """Add command-line options specific to this script."""
         super(MRTextClassifier, self).configure_args()
 
-        self.add_passthrough_arg(
+        self.add_passthru_arg(
             '--min-df', dest='min_df', default=2, type=int,
             help=('min number of documents an n-gram must appear in for us to'
-                  ' count it. Default: %default'))
-        self.add_passthrough_arg(
+                  ' count it. Default: %(default)s'))
+        self.add_passthru_arg(
             '--max-df', dest='max_df', default=10000000, type=int,
             help=('max number of documents an n-gram may appear in for us to'
                   ' count it (this keeps reducers from running out of memory).'
-                  ' Default: %default'))
-        self.add_passthrough_arg(
+                  ' Default: %(default)s'))
+        self.add_passthru_arg(
             '--max-ngram-size', dest='max_ngram_size',
             default=DEFAULT_MAX_NGRAM_SIZE, type=int,
             help='maximum phrase length to consider')
-        self.add_passthrough_arg(
+        self.add_passthru_arg(
             '--stop-words', dest='stop_words',
             default=', '.join(DEFAULT_STOP_WORDS),
             help=("comma-separated list of words to ignore. For example, "
                   "--stop-words 'in, the' would cause 'hole in the wall' to be"
-                  " parsed as ['hole', 'wall']. Default: %default"))
-        self.add_passthrough_arg(
+                  " parsed as ['hole', 'wall']. Default: %(default)s"))
+        self.add_passthru_arg(
             '--short-doc-threshold', dest='short_doc_threshold',
             type=int, default=None,
             help=('Normally, for each n-gram size, we take the average score'
                   ' over all n-grams that appear. This allows us to penalize'
                   ' short documents by using this threshold as the denominator'
                   ' rather than the actual number of n-grams.'))
-        self.add_passthrough_arg(
+        self.add_passthru_arg(
             '--no-test-set', dest='no_test_set',
             action='store_true', default=False,
             help=("Choose about half of the documents to be the testing set"

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -81,6 +81,9 @@ _OPTPARSE_TYPES = dict(
 # use to identify malformed JSON
 _PROBABLY_JSON_RE = re.compile(r'^\s*[\{\[\"].*$')
 
+# use to match %prog and %default
+_OPTPARSE_HELP_RE = re.compile(r'%(\w+)')
+
 
 ### custom actions ###
 
@@ -1418,6 +1421,10 @@ def _optparse_kwargs_to_argparse(**kwargs):
             'ignoring opt_group keyword arg (mrjob no longer supports'
             ' opt groups')
         kwargs.pop('opt_group')
+
+    # convert %default -> %(default)s, etc.
+    if kwargs.get('help'):
+        kwargs['help'] = _OPTPARSE_HELP_RE.sub(r'%(\1)s', kwargs['help'])
 
     # pretty much everything else is the same. if people want to pass argparse
     # kwargs through the old optparse interface (e.g. *action* or *required*)

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -81,9 +81,6 @@ _OPTPARSE_TYPES = dict(
 # use to identify malformed JSON
 _PROBABLY_JSON_RE = re.compile(r'^\s*[\{\[\"].*$')
 
-# use to match %prog and %default
-_OPTPARSE_HELP_RE = re.compile(r'%(\w+)')
-
 
 ### custom actions ###
 
@@ -1422,9 +1419,9 @@ def _optparse_kwargs_to_argparse(**kwargs):
             ' opt groups')
         kwargs.pop('opt_group')
 
-    # convert %default -> %(default)s, etc.
+    # convert %default -> %(default)s
     if kwargs.get('help'):
-        kwargs['help'] = _OPTPARSE_HELP_RE.sub(r'%(\1)s', kwargs['help'])
+        kwargs['help'] = kwargs['help'].replace('%default', '%(default)s')
 
     # pretty much everything else is the same. if people want to pass argparse
     # kwargs through the old optparse interface (e.g. *action* or *required*)

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1423,3 +1423,10 @@ def _optparse_kwargs_to_argparse(**kwargs):
     # kwargs through the old optparse interface (e.g. *action* or *required*)
     # more power to 'em.
     return kwargs
+
+
+def _alphabetize_actions(arg_parser):
+    """Alphabetize arg parser actions for the sake of nicer help printouts."""
+    # based on https://stackoverflow.com/questions/12268602/sort-argparse-help-alphabetically  # noqa
+    for g in arg_parser._action_groups:
+        g._group_actions.sort(key=lambda opt: opt.dest)

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -20,21 +20,21 @@ Usage::
 
 Options::
 
-  -h, --help            show this help message and exit
-  -c CONF_PATHS, --conf-path=CONF_PATHS
+  -c CONF_PATHS, --conf-path CONF_PATHS
                         Path to alternate mrjob.conf file to read from
   --no-conf             Don't load mrjob.conf even if it's available
-  --emr-endpoint=EMR_ENDPOINT
+  --emr-endpoint EMR_ENDPOINT
                         Force mrjob to connect to EMR on this endpoint (e.g.
                         us-west-1.elasticmapreduce.amazonaws.com). Default is
                         to infer this from region.
-  --max-days-ago=MAX_DAYS_AGO
+  -h, --help            show this help message and exit
+  --max-days-ago MAX_DAYS_AGO
                         Max number of days ago to look at jobs. By default, we
                         go back as far as EMR supports (currently about 2
                         months)
   -q, --quiet           Don't print anything to stderr
-  --region=REGION       GCE/AWS region to run Dataproc/EMR jobs in.
-  --s3-endpoint=S3_ENDPOINT
+  --region REGION       GCE/AWS region to run Dataproc/EMR jobs in.
+  --s3-endpoint S3_ENDPOINT
                         Force mrjob to connect to S3 on this endpoint (e.g. s3
                         -us-west-1.amazonaws.com). You usually shouldn't set
                         this; by default mrjob will choose the correct
@@ -60,6 +60,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_args
 from mrjob.options import _add_runner_args
+from mrjob.options import _alphabetize_actions
 from mrjob.options import _filter_by_role
 from mrjob.pool import _legacy_pool_hash_and_name
 from mrjob.pool import _pool_hash_and_name
@@ -81,6 +82,7 @@ log = logging.getLogger(__name__)
 def main(args=None):
     # parse command-line args
     arg_parser = _make_arg_parser()
+
     options = arg_parser.parse_args(args)
 
     MRJob.set_up_logging(quiet=options.quiet, verbose=options.verbose)
@@ -112,6 +114,8 @@ def _make_arg_parser():
     _add_runner_args(
         arg_parser,
         _filter_by_role(EMRJobRunner.OPT_NAMES, 'connect'))
+
+    _alphabetize_actions(arg_parser)
 
     return arg_parser
 

--- a/mrjob/tools/emr/create_cluster.py
+++ b/mrjob/tools/emr/create_cluster.py
@@ -15,30 +15,24 @@
 """Create a persistent EMR cluster to run clusters in, and print its ID to
 stdout.
 
-.. warning::
-
-    Do not run this without ``mrjob terminate-idle-clusters`` in
-    your crontab; clusters left idle can quickly become expensive!
-
 Usage::
 
     mrjob create-cluster
 
 Options::
 
-  -h, --help            show this help message and exit
-  --additional-emr-info=ADDITIONAL_EMR_INFO
+  --additional-emr-info ADDITIONAL_EMR_INFO
                         A JSON string for selecting additional features on EMR
-  --application=APPLICATIONS
+  --application APPLICATIONS
                         Additional applications to run on 4.x AMIs (e.g.
                         Ganglia, Mahout, Spark)
-  --bootstrap=BOOTSTRAP
+  --bootstrap BOOTSTRAP
                         A shell command to set up libraries etc. before any
                         steps (e.g. "sudo apt-get -qy install python3"). You
                         may interpolate files available via URL or locally
                         with Hadoop Distributed Cache syntax ("sudo yum
                         install -y foo.rpm#")
-  --bootstrap-action=BOOTSTRAP_ACTIONS
+  --bootstrap-action BOOTSTRAP_ACTIONS
                         Raw bootstrap action scripts to run before any of the
                         other bootstrap steps. You can use --bootstrap-action
                         more than once. Local scripts will be automatically
@@ -60,42 +54,39 @@ Options::
   --bootstrap-spark     Auto-install Spark on the cluster (even if not
                         needed).
   --no-bootstrap-spark  Don't auto-install Spark on the cluster.
-  --cloud-fs-sync-secs=CLOUD_FS_SYNC_SECS
+  --cloud-fs-sync-secs CLOUD_FS_SYNC_SECS
                         How long to wait for remote FS to reach eventual
                         consistency. This is typically less than a second but
                         the default is 5.0 to be safe.
-  --cloud-log-dir=CLOUD_LOG_DIR
+  --cloud-log-dir CLOUD_LOG_DIR
                         URI on remote FS to write logs into
-  --cloud-tmp-dir=CLOUD_TMP_DIR
+  --cloud-tmp-dir CLOUD_TMP_DIR
                         URI on remote FS to use as our temp directory.
-  --cloud-upload-part-size=CLOUD_UPLOAD_PART_SIZE
+  --cloud-upload-part-size CLOUD_UPLOAD_PART_SIZE
                         Upload files to S3 in parts no bigger than this many
                         megabytes. Default is 100 MiB. Set to 0 to disable
                         multipart uploading entirely.
-  -c CONF_PATHS, --conf-path=CONF_PATHS
+  -c CONF_PATHS, --conf-path CONF_PATHS
                         Path to alternate mrjob.conf file to read from
   --no-conf             Don't load mrjob.conf even if it's available
-  --core-instance-bid-price=CORE_INSTANCE_BID_PRICE
+  --core-instance-bid-price CORE_INSTANCE_BID_PRICE
                         Bid price to specify for core nodes when setting them
                         up as EC2 spot instances (you probably only want to do
                         this for task instances).
-  --core-instance-type=CORE_INSTANCE_TYPE
+  --core-instance-type CORE_INSTANCE_TYPE
                         Type of GCE/EC2 core instance(s) to launch
-  --ec2-key-pair=EC2_KEY_PAIR
+  --ec2-key-pair EC2_KEY_PAIR
                         Name of the SSH key pair you set up for EMR
-  --emr-api-param=EMR_API_PARAMS
-                        Additional parameter to pass directly to the EMR API
-                        when creating a cluster. Should take the form
-                        KEY=VALUE. You can use --emr-api-param multiple times
-  --no-emr-api-param=EMR_API_PARAMS
-                        Parameter to be unset when calling EMR API. You can
-                        use --no-emr-api-param multiple times.
-  --emr-configuration=EMR_CONFIGURATIONS
+  --emr-api-param EMR_API_PARAMS
+                        deprecated. Use --extra-cluster-param instead
+  --no-emr-api-param EMR_API_PARAMS
+                        deprecated. Use --extra-cluster-param instead
+  --emr-configuration EMR_CONFIGURATIONS
                         Configuration to use on 4.x AMIs as a JSON-encoded
                         dict; see http://docs.aws.amazon.com/ElasticMapReduce/
                         latest/ReleaseGuide/emr-configure-apps.html for
                         examples
-  --emr-endpoint=EMR_ENDPOINT
+  --emr-endpoint EMR_ENDPOINT
                         Force mrjob to connect to EMR on this endpoint (e.g.
                         us-west-1.elasticmapreduce.amazonaws.com). Default is
                         to infer this from region.
@@ -104,69 +95,89 @@ Options::
   --disable-emr-debugging
                         Disable storage of Hadoop logs in SimpleDB (the
                         default)
-  --iam-endpoint=IAM_ENDPOINT
+  --extra-cluster-param EXTRA_CLUSTER_PARAMS
+                        extra parameter to pass to cloud API when creating a
+                        cluster, to access features not currently supported by
+                        mrjob. Takes the form <param>=<value>, where value is
+                        JSON or a string. Use <param>=null to unset a
+                        parameter
+  -h, --help            show this help message and exit
+  --iam-endpoint IAM_ENDPOINT
                         Force mrjob to connect to IAM on this endpoint (e.g.
                         iam.us-gov.amazonaws.com)
-  --iam-instance-profile=IAM_INSTANCE_PROFILE
+  --iam-instance-profile IAM_INSTANCE_PROFILE
                         EC2 instance profile to use for the EMR cluster -- see
                         "Configure IAM Roles for Amazon EMR" in AWS docs
-  --iam-service-role=IAM_SERVICE_ROLE
+  --iam-service-role IAM_SERVICE_ROLE
                         IAM service role to use for the EMR cluster -- see
                         "Configure IAM Roles for Amazon EMR" in AWS docs
-  --image-version=IMAGE_VERSION
+  --image-version IMAGE_VERSION
                         EMR/Dataproc machine image to launch clusters with
-  --instance-type=INSTANCE_TYPE
-                        Type of GCE/EC2 instance(s) to launch   GCE - e.g.
+  --instance-fleets INSTANCE_FLEETS
+                        detailed JSON list of instance fleets, including EBS
+                        configuration. See docs for --instance-fleets at
+                        http://docs.aws.amazon.com/cli/latest/reference/emr
+                        /create-cluster.html
+  --instance-groups INSTANCE_GROUPS
+                        detailed JSON list of instance configs, including EBS
+                        configuration. See docs for --instance-groups at
+                        http://docs.aws.amazon.com/cli/latest/reference/emr
+                        /create-cluster.html
+  --instance-type INSTANCE_TYPE
+                        Type of GCE/EC2 instance(s) to launch GCE - e.g.
                         n1-standard-1, n1-highcpu-4, n1-highmem-4 -- See
                         https://cloud.google.com/compute/docs/machine-types
-                        EC2 - e.g. m1.medium, c3.xlarge, r3.xlarge  -- See
+                        EC2 - e.g. m1.medium, c3.xlarge, r3.xlarge -- See
                         http://aws.amazon.com/ec2/instance-types/
-  --label=LABEL         Alternate label for the job, to help us identify it.
-  --master-instance-bid-price=MASTER_INSTANCE_BID_PRICE
+  --label LABEL         Alternate label for the job, to help us identify it.
+  --master-instance-bid-price MASTER_INSTANCE_BID_PRICE
                         Bid price to specify for the master node when setting
                         it up as an EC2 spot instance (you probably only want
                         to do this for task instances).
-  --master-instance-type=MASTER_INSTANCE_TYPE
+  --master-instance-type MASTER_INSTANCE_TYPE
                         Type of GCE/EC2 master instance to launch
-  --max-hours-idle=MAX_HOURS_IDLE
+  --max-hours-idle MAX_HOURS_IDLE
+                        Please use --max-mins-idle instead
+  --max-mins-idle MAX_MINS_IDLE
                         If we create a cluster, have it automatically
-                        terminate itself after it's been idle this many hours
-  --mins-to-end-of-hour=MINS_TO_END_OF_HOUR
-                        If --max-hours-idle is set, control how close to the
+                        terminate itself after it's been idle this many
+                        minutes
+  --mins-to-end-of-hour MINS_TO_END_OF_HOUR
+                        If --max-mins-idle is set, control how close to the
                         end of an hour the cluster can automatically terminate
                         itself (default is 5 minutes)
-  --num-core-instances=NUM_CORE_INSTANCES
+  --num-core-instances NUM_CORE_INSTANCES
                         Total number of core instances to launch
-  --num-task-instances=NUM_TASK_INSTANCES
+  --num-task-instances NUM_TASK_INSTANCES
                         Total number of task instances to launch
-  --owner=OWNER         User who ran the job (default is the current user)
+  --owner OWNER         User who ran the job (default is the current user)
   --pool-clusters       Add to an existing cluster or create a new one that
-                        does not terminate when the job completes. WARNING: do
-                        not run this without --max-hours-idle or  with mrjob
-                        terminate-idle-clusters in your crontab; clusters left
-                        idle can quickly become expensive!
+                        does not terminate when the job completes.
   --no-pool-clusters    Don't run job on a pooled cluster (the default)
-  --pool-name=POOL_NAME
+  --pool-name POOL_NAME
                         Specify a pool name to join. Default is "default"
   -q, --quiet           Don't print anything to stderr
-  --region=REGION       GCE/AWS region to run Dataproc/EMR jobs in.
-  --release-label=RELEASE_LABEL
+  --region REGION       GCE/AWS region to run Dataproc/EMR jobs in.
+  --release-label RELEASE_LABEL
                         Release Label (e.g. "emr-4.0.0"). Overrides --image-
                         version
-  --s3-endpoint=S3_ENDPOINT
+  --s3-endpoint S3_ENDPOINT
                         Force mrjob to connect to S3 on this endpoint (e.g. s3
                         -us-west-1.amazonaws.com). You usually shouldn't set
                         this; by default mrjob will choose the correct
                         endpoint for each S3 bucket based on its location.
-  --subnet=SUBNET       ID of Amazon VPC subnet to launch cluster in. If not
+  --subnet SUBNET       ID of Amazon VPC subnet to launch cluster in. If not
                         set or empty string, cluster is launched in the normal
-                        AWS cloud
-  --tag=TAGS            Metadata tags to apply to the EMR cluster; should take
+                        AWS cloud.
+  --subnets SUBNET      Like --subnets, but with a comma-separated list, to
+                        specify multiple subnets in conjunction with
+                        --instance-fleets
+  --tag TAGS            Metadata tags to apply to the EMR cluster; should take
                         the form KEY=VALUE. You can use --tag multiple times
-  --task-instance-bid-price=TASK_INSTANCE_BID_PRICE
+  --task-instance-bid-price TASK_INSTANCE_BID_PRICE
                         Bid price to specify for task nodes when setting them
                         up as EC2 spot instances
-  --task-instance-type=TASK_INSTANCE_TYPE
+  --task-instance-type TASK_INSTANCE_TYPE
                         Type of GCE/EC2 task instance(s) to launch
   -v, --verbose         print more messages to stderr
   --visible-to-all-users
@@ -175,7 +186,7 @@ Options::
   --no-visible-to-all-users
                         Hide your cluster from other IAM users on the same AWS
                         account
-  --zone=ZONE           GCE zone/AWS availability zone to run Dataproc/EMR
+  --zone ZONE           GCE zone/AWS availability zone to run Dataproc/EMR
                         jobs in.
 """
 from __future__ import print_function
@@ -186,6 +197,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_args
 from mrjob.options import _add_runner_args
+from mrjob.options import _alphabetize_actions
 from mrjob.options import _filter_by_role
 
 
@@ -229,6 +241,8 @@ def _make_arg_parser():
     _add_runner_args(
         arg_parser,
         _filter_by_role(EMRJobRunner.OPT_NAMES, 'connect', 'launch'))
+
+    _alphabetize_actions(arg_parser)
 
     return arg_parser
 

--- a/mrjob/tools/emr/mrboss.py
+++ b/mrjob/tools/emr/mrboss.py
@@ -21,26 +21,26 @@ Usage::
 
 Options::
 
-  -h, --help            show this help message and exit
-  -c CONF_PATHS, --conf-path=CONF_PATHS
+  -c CONF_PATHS, --conf-path CONF_PATHS
                         Path to alternate mrjob.conf file to read from
   --no-conf             Don't load mrjob.conf even if it's available
-  --ec2-key-pair-file=EC2_KEY_PAIR_FILE
+  --ec2-key-pair-file EC2_KEY_PAIR_FILE
                         Path to file containing SSH key for EMR
-  --emr-endpoint=EMR_ENDPOINT
+  --emr-endpoint EMR_ENDPOINT
                         Force mrjob to connect to EMR on this endpoint (e.g.
                         us-west-1.elasticmapreduce.amazonaws.com). Default is
                         to infer this from region.
-  -o OUTPUT_DIR, --output-dir=OUTPUT_DIR
+  -h, --help            show this help message and exit
+  -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                         Specify an output directory (default: CLUSTER_ID)
   -q, --quiet           Don't print anything to stderr
-  --region=REGION       GCE/AWS region to run Dataproc/EMR jobs in.
-  --s3-endpoint=S3_ENDPOINT
+  --region REGION       GCE/AWS region to run Dataproc/EMR jobs in.
+  --s3-endpoint S3_ENDPOINT
                         Force mrjob to connect to S3 on this endpoint (e.g. s3
                         -us-west-1.amazonaws.com). You usually shouldn't set
                         this; by default mrjob will choose the correct
                         endpoint for each S3 bucket based on its location.
-  --ssh-bin=SSH_BIN     Name/path of ssh binary. Arguments are allowed (e.g.
+  --ssh-bin SSH_BIN     Name/path of ssh binary. Arguments are allowed (e.g.
                         --ssh-bin 'ssh -v')
   -v, --verbose         print more messages to stderr
 """
@@ -53,6 +53,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_args
 from mrjob.options import _add_runner_args
+from mrjob.options import _alphabetize_actions
 from mrjob.options import _filter_by_role
 from mrjob.py2 import to_unicode
 from mrjob.util import shlex_split
@@ -80,6 +81,8 @@ def main(cl_args=None):
         {'ec2_key_pair_file', 'ssh_bin'} | _filter_by_role(
             EMRJobRunner.OPT_NAMES, 'connect')
     )
+
+    _alphabetize_actions(arg_parser)
 
     options = arg_parser.parse_args(cl_args)
 

--- a/mrjob/tools/emr/report_long_jobs.py
+++ b/mrjob/tools/emr/report_long_jobs.py
@@ -23,27 +23,27 @@ Suggested usage: run this as a daily cron job with the ``-q`` option::
 
 Options::
 
-  -h, --help            show this help message and exit
-  -c CONF_PATHS, --conf-path=CONF_PATHS
+  -c CONF_PATHS, --conf-path CONF_PATHS
                         Path to alternate mrjob.conf file to read from
   --no-conf             Don't load mrjob.conf even if it's available
-  --emr-endpoint=EMR_ENDPOINT
+  --emr-endpoint EMR_ENDPOINT
                         Force mrjob to connect to EMR on this endpoint (e.g.
                         us-west-1.elasticmapreduce.amazonaws.com). Default is
                         to infer this from region.
-  --min-hours=MIN_HOURS
+  -x EXCLUDE, --exclude EXCLUDE
+                        Exclude clusters that match the specified tags.
+                        Specifed in the form TAG_KEY,TAG_VALUE.
+  -h, --help            show this help message and exit
+  --min-hours MIN_HOURS
                         Minimum number of hours a job can run before we report
                         it. Default: 24.0
   -q, --quiet           Don't print anything to stderr
-  --region=REGION       GCE/AWS region to run Dataproc/EMR jobs in.
-  --s3-endpoint=S3_ENDPOINT
+  --region REGION       GCE/AWS region to run Dataproc/EMR jobs in.
+  --s3-endpoint S3_ENDPOINT
                         Force mrjob to connect to S3 on this endpoint (e.g. s3
                         -us-west-1.amazonaws.com). You usually shouldn't set
                         this; by default mrjob will choose the correct
                         endpoint for each S3 bucket based on its location.
-  -x, --exclude=TAG_KEY,TAG_VALUE
-                        Exclude clusters that have the specified tag key/value
-                        pair
   -v, --verbose         print more messages to stderr
 """
 from __future__ import print_function
@@ -58,6 +58,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_args
 from mrjob.options import _add_runner_args
+from mrjob.options import _alphabetize_actions
 from mrjob.options import _filter_by_role
 from mrjob.util import strip_microseconds
 
@@ -254,7 +255,7 @@ def _make_arg_parser():
         '--min-hours', dest='min_hours', type=float,
         default=DEFAULT_MIN_HOURS,
         help=('Minimum number of hours a job can run before we report it.'
-              ' Default: %default'))
+              ' Default: %(default)s'))
 
     arg_parser.add_argument(
         '-x', '--exclude', action='append',
@@ -267,6 +268,8 @@ def _make_arg_parser():
         arg_parser,
         _filter_by_role(EMRJobRunner.OPT_NAMES, 'connect')
     )
+
+    _alphabetize_actions(arg_parser)
 
     return arg_parser
 

--- a/mrjob/tools/emr/s3_tmpwatch.py
+++ b/mrjob/tools/emr/s3_tmpwatch.py
@@ -29,13 +29,13 @@ Usage::
 
 Options::
 
-  -h, --help            show this help message and exit
-  -c CONF_PATHS, --conf-path=CONF_PATHS
+  -c CONF_PATHS, --conf-path CONF_PATHS
                         Path to alternate mrjob.conf file to read from
   --no-conf             Don't load mrjob.conf even if it's available
+  -h, --help            show this help message and exit
   -q, --quiet           Don't print anything to stderr
-  --region=REGION       GCE/AWS region to run Dataproc/EMR jobs in.
-  --s3-endpoint=S3_ENDPOINT
+  --region REGION       GCE/AWS region to run Dataproc/EMR jobs in.
+  --s3-endpoint S3_ENDPOINT
                         Force mrjob to connect to S3 on this endpoint (e.g. s3
                         -us-west-1.amazonaws.com). You usually shouldn't set
                         this; by default mrjob will choose the correct
@@ -53,6 +53,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_args
 from mrjob.options import _add_runner_args
+from mrjob.options import _alphabetize_actions
 
 
 log = logging.getLogger(__name__)
@@ -140,6 +141,8 @@ def _make_arg_parser():
         arg_parser,
         set(['region', 's3_endpoint']),
     )
+
+    _alphabetize_actions(arg_parser)
 
     return arg_parser
 

--- a/mrjob/tools/emr/terminate_cluster.py
+++ b/mrjob/tools/emr/terminate_cluster.py
@@ -23,17 +23,17 @@ Terminate an existing EMR cluster.
 
 Options::
 
-  -h, --help            show this help message and exit
-  -c CONF_PATHS, --conf-path=CONF_PATHS
+  -c CONF_PATHS, --conf-path CONF_PATHS
                         Path to alternate mrjob.conf file to read from
   --no-conf             Don't load mrjob.conf even if it's available
-  --emr-endpoint=EMR_ENDPOINT
+  --emr-endpoint EMR_ENDPOINT
                         Force mrjob to connect to EMR on this endpoint (e.g.
                         us-west-1.elasticmapreduce.amazonaws.com). Default is
                         to infer this from region.
+  -h, --help            show this help message and exit
   -q, --quiet           Don't print anything to stderr
-  --region=REGION       GCE/AWS region to run Dataproc/EMR jobs in.
-  --s3-endpoint=S3_ENDPOINT
+  --region REGION       GCE/AWS region to run Dataproc/EMR jobs in.
+  --s3-endpoint S3_ENDPOINT
                         Force mrjob to connect to S3 on this endpoint (e.g. s3
                         -us-west-1.amazonaws.com). You usually shouldn't set
                         this; by default mrjob will choose the correct
@@ -49,6 +49,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_args
 from mrjob.options import _add_runner_args
+from mrjob.options import _alphabetize_actions
 from mrjob.options import _filter_by_role
 
 log = logging.getLogger(__name__)
@@ -87,6 +88,8 @@ def _make_arg_parser():
     _add_runner_args(
         arg_parser,
         _filter_by_role(EMRJobRunner.OPT_NAMES, 'connect'))
+
+    _alphabetize_actions(arg_parser)
 
     return arg_parser
 

--- a/mrjob/tools/emr/terminate_idle_clusters.py
+++ b/mrjob/tools/emr/terminate_idle_clusters.py
@@ -24,35 +24,35 @@ Suggested usage: run this as a cron job with the ``-q`` option::
 
 Options::
 
-  -h, --help            show this help message and exit
-  -c CONF_PATHS, --conf-path=CONF_PATHS
+  -c CONF_PATHS, --conf-path CONF_PATHS
                         Path to alternate mrjob.conf file to read from
   --no-conf             Don't load mrjob.conf even if it's available
   --dry-run             Don't actually kill idle jobs; just log that we would
-  --emr-endpoint=EMR_ENDPOINT
+  --emr-endpoint EMR_ENDPOINT
                         Force mrjob to connect to EMR on this endpoint (e.g.
                         us-west-1.elasticmapreduce.amazonaws.com). Default is
                         to infer this from region.
-  --max-hours-idle=MAX_HOURS_IDLE
-                        Max number of hours a cluster can go without
+  -h, --help            show this help message and exit
+  --max-hours-idle MAX_HOURS_IDLE
+                        Please use --max-mins-idle instead.
+  --max-mins-idle MAX_MINS_IDLE
+                        Max number of minutes a cluster can go without
                         bootstrapping, running a step, or having a new step
                         created. This will fire even if there are pending
                         steps which EMR has failed to start. Make sure you set
                         this higher than the amount of time your jobs can take
                         to start instances and bootstrap.
-  --max-mins-locked=MAX_MINS_LOCKED
+  --max-mins-locked MAX_MINS_LOCKED
                         Max number of minutes a cluster can be locked while
                         idle.
-  --mins-to-end-of-hour=MINS_TO_END_OF_HOUR
-                        Terminate clusters that are within this many minutes
-                        of the end of a full hour since the job started
-                        running AND have no pending steps.
-  --pool-name=POOL_NAME
+  --mins-to-end-of-hour MINS_TO_END_OF_HOUR
+                        Deprecated, does nothing.
+  --pool-name POOL_NAME
                         Only terminate clusters in the given named pool.
   --pooled-only         Only terminate pooled clusters
   -q, --quiet           Don't print anything to stderr
-  --region=REGION       GCE/AWS region to run Dataproc/EMR jobs in.
-  --s3-endpoint=S3_ENDPOINT
+  --region REGION       GCE/AWS region to run Dataproc/EMR jobs in.
+  --s3-endpoint S3_ENDPOINT
                         Force mrjob to connect to S3 on this endpoint (e.g. s3
                         -us-west-1.amazonaws.com). You usually shouldn't set
                         this; by default mrjob will choose the correct
@@ -73,6 +73,7 @@ from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
 from mrjob.options import _add_basic_args
 from mrjob.options import _add_runner_args
+from mrjob.options import _alphabetize_actions
 from mrjob.options import _filter_by_role
 from mrjob.pool import _pool_hash_and_name
 from mrjob.util import strip_microseconds
@@ -382,6 +383,8 @@ def _make_arg_parser():
     _add_runner_args(
         arg_parser,
         _filter_by_role(EMRJobRunner.OPT_NAMES, 'connect'))
+
+    _alphabetize_actions(arg_parser)
 
     return arg_parser
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -88,7 +88,8 @@ class MRDeprecatedCustomJobLauncher(MRJobLauncher):
         super(MRDeprecatedCustomJobLauncher, self).configure_options()
 
         self.add_passthrough_option(
-            '--foo-size', '-F', type='int', dest='foo_size', default=5)
+            '--foo-size', '-F', type='int', dest='foo_size', default=5,
+            help='default is %default')
         self.add_passthrough_option(
             '--pill-type', '-T', type='choice', choices=(['red', 'blue']),
             default='blue')
@@ -478,3 +479,8 @@ class DeprecatedOptionHooksTestCase(SandboxedTestCase):
         mr_job = MRDeprecatedCustomJobLauncher(
             args=['-F', '6', '', 'input1.txt', 'input2.txt'])
         self.assertEqual(mr_job.args, ['input1.txt', 'input2.txt'])
+
+    def test_help_compatibility(self):
+        mr_job = MRDeprecatedCustomJobLauncher(args=[''])
+
+        self.assertIn('default is 5', mr_job.arg_parser.format_help())


### PR DESCRIPTION
Refresh the docstrings for mrjob subcommands (fixes #1646).

Also updated alphabetization of switches for argparse, and made a small fix for optparse option emulation (fixes #1691)