### PR TITLE
Update parse.py to support s3a

### DIFF
--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -92,7 +92,7 @@ def parse_s3_uri(uri):
     If ``uri`` is not an S3 URI, raise a ValueError
     """
     components = urlparse(uri)
-    if (components.scheme not in ('s3', 's3n') or
+    if (components.scheme not in ('s3', 's3n', 's3a') or
         '/' not in components.path):  # noqa
 
         raise ValueError('Invalid S3 URI: %s' % uri)


### PR DESCRIPTION
Update parse.py to the 0.6.0 version to allow using s3a while retaining the 0.5.X style configurations