### PR TITLE
quicker task log picking

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1995,11 +1995,12 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         # Unlike on 3.x, the history logs *are* available on S3, but they're
         # not useful enough to justify the wait when SSH is set up
 
-        # if version_gte(self.get_image_version(), '4'):
-        #     # denied access on some 4.x AMIs by the yarn user, see #1244
-        #     dir_name = 'hadoop-mapreduce/history'
-        #     s3_dir_name = 'hadoop-mapreduce/history'
-        if version_gte(self.get_image_version(), '3'):
+        if version_gte(self.get_image_version(), '4'):
+            # on 4.0.0 (and possibly other versions before 4.3.0)
+            # history logs aren't on the filesystem. See #1253
+            dir_name = 'hadoop-mapreduce/history'
+            s3_dir_name = 'hadoop-mapreduce/history'
+        elif version_gte(self.get_image_version(), '3'):
             # on the 3.x AMIs, the history log lives inside HDFS and isn't
             # copied to S3. We don't need it anyway; everything relevant
             # is in the step log

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2002,8 +2002,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             s3_dir_name = 'hadoop-mapreduce/history'
         elif version_gte(self.get_image_version(), '3'):
             # on the 3.x AMIs, the history log lives inside HDFS and isn't
-            # copied to S3. We don't need it anyway; everything relevant
-            # is in the step log
+            # copied to S3.
             return iter([])
         else:
             dir_name = 'hadoop/history'

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -320,7 +320,7 @@ class S3Filesystem(Filesystem):
     def get_bucket(self, bucket_name):
         """Get the (:py:mod:`boto3`) bucket, connecting through the
         appropriate endpoint."""
-        client = self.make_s3_client()
+        client = self.make_s3_client('us-east-1')
 
         try:
             region_name = _get_bucket_region(client, bucket_name)
@@ -347,17 +347,13 @@ class S3Filesystem(Filesystem):
         return self.get_bucket(bucket_name).Object(key_name)
 
     def get_all_bucket_names(self):
-        """Get a stream of the names of all buckets owned by this user
+        """Get a list of the names of all buckets owned by this user
         on S3.
 
         .. versionadded:: 0.6.0
         """
-        # we don't actually want to return these Bucket objects to
-        # the user because their client might connect to the wrong region
-        # endpoint
-        r = self.make_s3_resource()
-        for b in r.buckets.all():
-            yield b.name
+        c = self.make_s3_client(region_name='us-east-1')
+        return [b['Name'] for b in c.list_buckets()['Buckets']]
 
     def create_bucket(self, bucket_name, region=None):
         """Create a bucket on S3 with a location constraint

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -320,7 +320,7 @@ class S3Filesystem(Filesystem):
     def get_bucket(self, bucket_name):
         """Get the (:py:mod:`boto3`) bucket, connecting through the
         appropriate endpoint."""
-        client = self.make_s3_client('us-east-1')
+        client = self.make_s3_client()
 
         try:
             region_name = _get_bucket_region(client, bucket_name)
@@ -352,7 +352,7 @@ class S3Filesystem(Filesystem):
 
         .. versionadded:: 0.6.0
         """
-        c = self.make_s3_client(region_name='us-east-1')
+        c = self.make_s3_client()
         return [b['Name'] for b in c.list_buckets()['Buckets']]
 
     def create_bucket(self, bucket_name, region=None):

--- a/mrjob/logs/errors.py
+++ b/mrjob/logs/errors.py
@@ -77,7 +77,7 @@ def _merge_and_sort_errors(errors, attempt_to_container_id=None):
     for error in errors:
         # merge by container_id if we know it
         container_id = error.get('container_id') or (
-            attempt_to_container_id.get(error.get('attempt_to_container_id')))
+            attempt_to_container_id.get(error.get('attempt_id')))
 
         if container_id:
             key = ('container_id', container_id)

--- a/mrjob/logs/errors.py
+++ b/mrjob/logs/errors.py
@@ -15,7 +15,7 @@
 """Merging errors, picking the best one, and displaying it."""
 import json
 
-from .ids import _make_time_sort_key
+from .ids import _time_sort_key
 
 
 def _pick_error(log_interpretation):
@@ -48,7 +48,7 @@ def _merge_and_sort_errors(errors, container_to_attempt_id=None):
 
     We allow None in place of an error list.
     """
-    sort_key = _make_time_sort_key(container_to_attempt_id)
+    sort_key = _time_sort_key(container_to_attempt_id)
 
     key_to_error = {}
 

--- a/mrjob/logs/errors.py
+++ b/mrjob/logs/errors.py
@@ -41,11 +41,7 @@ def _pick_errors(log_interpretation):
             for error in errors or ():
                 yield error
 
-    # looks like this is only available from history logs
-    container_to_attempt_id = log_interpretation.get(
-        'history', {}).get('container_to_attempt_id')
-
-    return _merge_and_sort_errors(yield_errors(), container_to_attempt_id)
+    return _merge_and_sort_errors(yield_errors())
 
 
 def _pick_error_attempt_ids(log_interpretation):
@@ -65,20 +61,16 @@ def _is_probably_task_error(error):
             error.get('hadoop_error', {}).get('message', ''))
 
 
-def _merge_and_sort_errors(errors, container_to_attempt_id=None):
+def _merge_and_sort_errors(errors):
     """Merge errors from one or more lists of errors and then return
     them, sorted by recency.
 
-    Optionally pass in *container_to_attempt_id
-
     We allow None in place of an error list.
     """
-    sort_key = _time_sort_key(container_to_attempt_id)
-
     key_to_error = {}
 
     for error in errors:
-        key = sort_key(error)
+        key = _time_sort_key(error)
         key_to_error.setdefault(key, {})
         key_to_error[key].update(error)
 

--- a/mrjob/logs/errors.py
+++ b/mrjob/logs/errors.py
@@ -95,7 +95,8 @@ def _merge_and_sort_errors(errors, attempt_to_container_id=None):
         # key[0] is step number
         return (key[0], bool(error.get('task_error')), key[1:])
 
-    return sorted(key_to_error.itervalues(), key=sort_key, reverse=True)
+    return [error for key, error in
+            sorted(key_to_error.items(), key=sort_key, reverse=True)]
 
 
 def _format_error(error):

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -146,8 +146,8 @@ def _parse_yarn_history_log(lines):
 
     This returns a dictionary which may contain the following keys:
 
-    container_to_attempt_id: map from container_id to attempt_id (useful
-        for matching with task errors where we don't know attempt ID)
+    attempt_to_container_id: map from attempt_id to container_id (used
+        to find task logs corresponding to failed attempts)
     counters: map from group to counter to amount. If job failed, we sum
         counters for succesful tasks
     errors: a list of dictionaries with the keys:
@@ -185,9 +185,9 @@ def _parse_yarn_history_log(lines):
         # update container_id -> attempt_id mapping
         for event in events:
             if 'attemptId' in event and 'containerId' in event:
-                result.setdefault('container_to_attempt_id', {})
-                result['container_to_attempt_id'][
-                    event['containerId']] = event['attemptId']
+                result.setdefault('attempt_to_container_id', {})
+                result['attempt_to_container_id'][
+                    event['attemptId']] = event['containerId']
 
         if record_type.endswith('_ATTEMPT_FAILED'):
             for event in events:

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -146,6 +146,8 @@ def _parse_yarn_history_log(lines):
 
     This returns a dictionary which may contain the following keys:
 
+    container_to_attempt_id: map from container_id to attempt_id (useful
+        for matching with task errors where we don't know attempt ID)
     counters: map from group to counter to amount. If job failed, we sum
         counters for succesful tasks
     errors: a list of dictionaries with the keys:
@@ -179,6 +181,13 @@ def _parse_yarn_history_log(lines):
             continue
         events = [e for e in record['event'].values()
                   if isinstance(e, dict)]
+
+        # update container_id -> attempt_id mapping
+        for event in events:
+            if 'attemptId' in event and 'containerId' in event:
+                result.setdefault('container_to_attempt_id', {})
+                result['container_to_attempt_id'][
+                    event['containerId']] = event['attemptId']
 
         if record_type.endswith('_ATTEMPT_FAILED'):
             for event in events:

--- a/mrjob/logs/ids.py
+++ b/mrjob/logs/ids.py
@@ -17,16 +17,17 @@
 
 # TODO: test these!
 
-def _sort_by_recency(ds):
+def _sort_by_recency(ds, container_to_attempt_id=None):
     """Sort the given list/sequence of dicts containing IDs so that the
     most recent ones come first (e.g. to find the best error, or the best
     log file to look for an error in).
     """
-    return sorted(ds, key=_time_sort_key, reverse=True)
+    sort_key = _make_time_sort_key(container_to_attempt_id)
+    return sorted(ds, key=sort_key, reverse=True)
 
 
-def _time_sort_key(d):
-    """Sort key to sort the dictionaries containing IDs roughly by time
+def _make_time_sort_key(container_to_attempt_id=None):
+    """Sort key to sort the given dictionaries containing IDs roughly by time
     (earliest first).
 
     We consider higher attempt_nums "later" than higher task_nums (of the
@@ -37,51 +38,55 @@ def _time_sort_key(d):
     container IDs are considered more "recent" than any task/attempt ID
     (these usually come from task logs).
     """
-    container_id = d.get('container_id') or ''
+    container_to_attempt_id = container_to_attempt_id or {}
 
-    # when parsing task syslogs on YARN, we may end up with
-    # container_id and nothing else. container IDs match with job ID
-    # but aren't directly comparable to task and attempt IDs
+    def sort_key(d):
+        container_id = d.get('container_id') or ''
 
-    # But if we couldn't parse the history file (for example because
-    # we're using YARN on EMR and the only way to get it is SSHing in and
-    # finding it on HDFS), we can use the container ID to infer the
-    # job ID. After that, we just assume that errors with a container
-    # ID must be better (they usually include the task error, after all),
-    # so we treat them as more recent.
+        # when parsing task syslogs on YARN, we may end up with
+        # container_id and nothing else. container IDs match with job ID
+        # but aren't directly comparable to task and attempt IDs
 
-    # break ID like
-    # {application,attempt,task,job}_201601081945_0005[_m[_000005[_0]]]
-    # into its component parts
-    #
-    # in practice, errors don't have job or application ID attached to
-    # them (and we're only sorting errors from the same job/application)
-    attempt_parts = (d.get('attempt_id') or
-                     d.get('task_id') or d.get('job_id') or
-                     d.get('application_id') or
-                     _to_job_id(container_id) or '').split('_')
+        # if we've parsed the history file, we should be able to
+        # map every container_id to an attempt ID
+        inferred_attempt_id = container_to_attempt_id.get(container_id) or ''
+        if inferred_attempt_id:
+            container_id = ''
 
-    # a container ID like container_1450486922681_0005_01_00000 implies:
-    # timestamp and step: 1450486922681_0005
-    # attempt num: 01
-    # task num: 00000
-    container_parts = container_id.split('_')
+        # But if we couldn't parse the history file (for example because
+        # we're using YARN on EMR and the only way to get it is SSHing in and
+        # finding it on HDFS), we can use the container ID to infer the
+        # job ID. After that, we just assume that errors with a container
+        # ID must be better (they usually include the task error, after all),
+        # so we treat them as more recent.
 
-    timestamp_and_step = '_'.join(attempt_parts[1:3])
-    task_type = '_'.join(attempt_parts[3:4])
-    task_num = '_'.join(attempt_parts[4:5]) or '_'.join(container_parts[-1:])
-    attempt_num = (
-        '_'.join(attempt_parts[5:6]) or '_'.join(container_parts[-2:-1]))
+        # break ID like
+        # {application,attempt,task,job}_201601081945_0005[_m[_000005[_0]]]
+        # into its component parts
+        #
+        # in practice, errors don't have job or application ID attached to
+        # them (and we're only sorting errors from the same job/application)
+        attempt_parts = (d.get('attempt_id') or inferred_attempt_id or
+                         d.get('task_id') or d.get('job_id') or
+                         d.get('application_id') or
+                         _to_job_id(container_id) or '').split('_')
 
-    # numbers are 0-padded, so no need to convert anything to int
-    # also, 'm' (task type in attempt ID) sorts before 'r', which is
-    # what we want
-    return (
-        timestamp_and_step,
-        container_id,
-        task_type,
-        attempt_num,
-        task_num)
+        timestamp_and_step = '_'.join(attempt_parts[1:3])
+        task_type = '_'.join(attempt_parts[3:4])
+        task_num = '_'.join(attempt_parts[4:5])
+        attempt_num = '_'.join(attempt_parts[5:6])
+
+        # numbers are 0-padded, so no need to convert anything to int
+        # also, 'm' (task type in attempt ID) sorts before 'r', which is
+        # what we want
+        return (
+            timestamp_and_step,
+            container_id,
+            task_type,
+            attempt_num,
+            task_num)
+
+    return sort_key
 
 
 def _add_implied_task_id(d):

--- a/mrjob/logs/ids.py
+++ b/mrjob/logs/ids.py
@@ -17,16 +17,15 @@
 
 # TODO: test these!
 
-def _sort_by_recency(ds, container_to_attempt_id=None):
+def _sort_by_recency(ds):
     """Sort the given list/sequence of dicts containing IDs so that the
     most recent ones come first (e.g. to find the best error, or the best
     log file to look for an error in).
     """
-    sort_key = _time_sort_key(container_to_attempt_id)
-    return sorted(ds, key=sort_key, reverse=True)
+    return sorted(ds, key=_time_sort_key, reverse=True)
 
 
-def _time_sort_key(container_to_attempt_id=None):
+def _time_sort_key(d):
     """Sort key to sort the given dictionaries containing IDs roughly by time
     (earliest first).
 
@@ -38,53 +37,44 @@ def _time_sort_key(container_to_attempt_id=None):
     container IDs are considered more "recent" than any task/attempt ID
     (these usually come from task logs).
     """
-    container_to_attempt_id = container_to_attempt_id or {}
+    container_id = d.get('container_id') or ''
 
-    def sort_key(d):
-        container_id = d.get('container_id') or ''
+    # when parsing task syslogs on YARN, we may end up with
+    # container_id and nothing else. container IDs match with job ID
+    # but aren't directly comparable to task and attempt IDs
 
-        # when parsing task syslogs on YARN, we may end up with
-        # container_id and nothing else. container IDs match with job ID
-        # but aren't directly comparable to task and attempt IDs
+    # But if we couldn't parse the history file (for example because
+    # we're using YARN on EMR and the only way to get it is SSHing in and
+    # finding it on HDFS), we can use the container ID to infer the
+    # job ID. After that, we just assume that errors with a container
+    # ID must be better (they usually include the task error, after all),
+    # so we treat them as more recent.
 
-        # if we've parsed the history file, we should be able to
-        # map every container_id to an attempt ID
-        inferred_attempt_id = container_to_attempt_id.get(container_id) or ''
-        if inferred_attempt_id:
-            container_id = ''
+    # break ID like
+    # {application,attempt,task,job}_201601081945_0005[_m[_000005[_0]]]
+    # into its component parts
+    #
+    # in practice, errors don't have job or application ID attached to
+    # them (and we're only sorting errors from the same job/application)
+    attempt_parts = (d.get('attempt_id') or
+                     d.get('task_id') or d.get('job_id') or
+                     d.get('application_id') or
+                     _to_job_id(container_id) or '').split('_')
 
-        # But if we couldn't parse the history file (for example because
-        # we're using YARN on EMR and the only way to get it is SSHing in and
-        # finding it on HDFS), we can use the container ID to infer the
-        # job ID. After that, we just assume that errors with a container
-        # ID must be better (they usually include the task error, after all),
-        # so we treat them as more recent.
+    timestamp_and_step = '_'.join(attempt_parts[1:3])
+    task_type = '_'.join(attempt_parts[3:4])
+    task_num = '_'.join(attempt_parts[4:5])
+    attempt_num = '_'.join(attempt_parts[5:6])
 
-        # break ID like
-        # {application,attempt,task,job}_201601081945_0005[_m[_000005[_0]]]
-        # into its component parts
-        #
-        # in practice, errors don't have job or application ID attached to
-        # them (and we're only sorting errors from the same job/application)
-        attempt_parts = (d.get('attempt_id') or inferred_attempt_id or
-                         d.get('task_id') or d.get('job_id') or
-                         d.get('application_id') or
-                         _to_job_id(container_id) or '').split('_')
-
-        timestamp_and_step = '_'.join(attempt_parts[1:3])
-        task_type = '_'.join(attempt_parts[3:4])
-        task_num = '_'.join(attempt_parts[4:5])
-        attempt_num = '_'.join(attempt_parts[5:6])
-
-        # numbers are 0-padded, so no need to convert anything to int
-        # also, 'm' (task type in attempt ID) sorts before 'r', which is
-        # what we want
-        return (
-            timestamp_and_step,
-            container_id,
-            task_type,
-            attempt_num,
-            task_num)
+    # numbers are 0-padded, so no need to convert anything to int
+    # also, 'm' (task type in attempt ID) sorts before 'r', which is
+    # what we want
+    return (
+        timestamp_and_step,
+        container_id,
+        task_type,
+        attempt_num,
+        task_num)
 
     return sort_key
 

--- a/mrjob/logs/ids.py
+++ b/mrjob/logs/ids.py
@@ -22,11 +22,11 @@ def _sort_by_recency(ds, container_to_attempt_id=None):
     most recent ones come first (e.g. to find the best error, or the best
     log file to look for an error in).
     """
-    sort_key = _make_time_sort_key(container_to_attempt_id)
+    sort_key = _time_sort_key(container_to_attempt_id)
     return sorted(ds, key=sort_key, reverse=True)
 
 
-def _make_time_sort_key(container_to_attempt_id=None):
+def _time_sort_key(container_to_attempt_id=None):
     """Sort key to sort the given dictionaries containing IDs roughly by time
     (earliest first).
 

--- a/mrjob/logs/mixin.py
+++ b/mrjob/logs/mixin.py
@@ -123,8 +123,6 @@ class LogInterpretationMixin(object):
 
             error_attempt_ids = _pick_error_attempt_ids(log_interpretation)
 
-            log.info('error_attempt_ids: %r' % (error_attempt_ids,))
-
             self._interpret_task_logs(
                 log_interpretation, step_type, error_attempt_ids)
 
@@ -188,8 +186,6 @@ class LogInterpretationMixin(object):
 
         attempt_to_container_id = log_interpretation.get('history', {}).get(
             'attempt_to_container_id', {})
-
-        log.info('attempt_to_container_id: %r' % (attempt_to_container_id,))
 
         if yarn:
             if not application_id:

--- a/mrjob/logs/mixin.py
+++ b/mrjob/logs/mixin.py
@@ -112,7 +112,6 @@ class LogInterpretationMixin(object):
 
         return counters
 
-
     def _pick_error(self, log_interpretation, step_type):
         """Pick probable cause of failure (only call this if job fails)."""
         if not all(log_type in log_interpretation for

--- a/mrjob/logs/mixin.py
+++ b/mrjob/logs/mixin.py
@@ -30,6 +30,7 @@ from logging import getLogger
 from mrjob.compat import uses_yarn
 from mrjob.logs.counters import _pick_counters
 from mrjob.logs.errors import _pick_error
+from mrjob.logs.errors import _pick_error_attempt_ids
 from mrjob.logs.history import _interpret_history_log
 from mrjob.logs.history import _ls_history_logs
 from mrjob.logs.task import _interpret_task_logs
@@ -111,6 +112,7 @@ class LogInterpretationMixin(object):
 
         return counters
 
+
     def _pick_error(self, log_interpretation, step_type):
         """Pick probable cause of failure (only call this if job fails)."""
         if not all(log_type in log_interpretation for
@@ -118,7 +120,11 @@ class LogInterpretationMixin(object):
             log.info('Scanning logs for probable cause of failure...')
             self._interpret_step_logs(log_interpretation, step_type)
             self._interpret_history_log(log_interpretation)
-            self._interpret_task_logs(log_interpretation, step_type)
+
+            attempt_ids = _pick_error_attempt_ids(log_interpretation)
+
+            self._interpret_task_logs(log_interpretation, step_type,
+                                      attempt_ids=attempt_ids)
 
         return _pick_error(log_interpretation)
 
@@ -163,11 +169,13 @@ class LogInterpretationMixin(object):
             log_interpretation['step'] = step_interpretation
 
     def _interpret_task_logs(
-            self, log_interpretation, step_type, partial=True):
+            self, log_interpretation, step_type, attempt_ids=(), partial=True):
         """Fetch task syslogs and stderr, and add 'task' to interpretation."""
         if 'task' in log_interpretation and (
                 partial or not log_interpretation['task'].get('partial')):
             return   # already interpreted
+
+        # TODO: make use of attempt_ids
 
         step_interpretation = log_interpretation.get('step') or {}
 

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -176,6 +176,8 @@ def _ls_spark_task_logs(fs, log_dir_stream, application_id=None, job_id=None,
     stderr_logs = []
     key_to_stdout_log = {}
 
+    matches = []
+
     for match in _ls_logs(fs, log_dir_stream, _match_task_log_path,
                           application_id=application_id,
                           job_id=job_id):
@@ -186,6 +188,7 @@ def _ls_spark_task_logs(fs, log_dir_stream, application_id=None, job_id=None,
 
     for stderr_log in stderr_logs:
         stdout_log = key_to_stdout_log.get(_log_key(stderr_log))
+
         if stdout_log:
             stderr_log['stdout'] = stdout_log
 

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -103,6 +103,8 @@ def _ls_task_logs(fs, log_dir_stream, application_id=None, job_id=None,
     corresponding syslog (stderr logs without a corresponding syslog won't be
     included).
     """
+    error_attempt_ids = error_attempt_ids or ()
+
     # figure out subdirs to look for logs in
     if attempt_to_container_id:
         # YARN
@@ -160,6 +162,7 @@ def _ls_task_logs(fs, log_dir_stream, application_id=None, job_id=None,
         yield syslog
 
 
+# TODO: update to match _ls_task_logs()
 def _ls_spark_task_logs(fs, log_dir_stream, application_id=None, job_id=None,
         error_attempt_ids=None, attempt_to_container_id=None):
     """Yield matching Spark logs, optionally filtering by application_id

--- a/mrjob/logs/task.py
+++ b/mrjob/logs/task.py
@@ -25,6 +25,12 @@ from .wrap import _ls_logs
 from mrjob import parse
 
 
+# TODO: will need to construct these paths as well, to access specific logs
+#
+# on YARN, logs have paths like: s3://yelp-emr-dev-us-west-2/logs/j-29EP1LS8TB6EH/containers/application_1507334835084_0001/container_1507334835084_0001_01_076339/stderr.gz
+
+
+
 # Match a java exception, possibly preceded by 'PipeMapRed failed!', etc.
 # use this with search()
 _JAVA_TRACEBACK_RE = re.compile(

--- a/mrjob/logs/wrap.py
+++ b/mrjob/logs/wrap.py
@@ -61,7 +61,7 @@ def _ls_logs(fs, log_dir_stream, matcher, **kwargs):
     # wrapper for fs.ls() that turns IOErrors into warnings
     def _fs_ls(path):
         try:
-            log.debug('    listing %s' % log_dir)
+            log.debug('    listing logs in %s' % log_dir)
             if fs.exists(log_dir):
                 for path in fs.ls(log_dir):
                     yield path

--- a/mrjob/logs/wrap.py
+++ b/mrjob/logs/wrap.py
@@ -83,11 +83,11 @@ def _ls_logs(fs, log_dir_stream, matcher, **kwargs):
                     match['path'] = path
                     matches.append(match)
 
-                if matches:
-                    matched = True
-                    _sort_by_recency(matches)
-                    for match in matches:
-                        yield match
+            if matches:
+                matched = True
+                _sort_by_recency(matches)
+                for match in matches:
+                    yield match
 
         if matched:
             return  # e.g. don't check S3 if we can get logs via SSH

--- a/mrjob/logs/wrap.py
+++ b/mrjob/logs/wrap.py
@@ -85,7 +85,7 @@ def _ls_logs(fs, log_dir_stream, matcher, **kwargs):
 
             if matches:
                 matched = True
-                _sort_by_recency(matches)
+                matches = _sort_by_recency(matches)
                 for match in matches:
                     yield match
 

--- a/tests/logs/test_errors.py
+++ b/tests/logs/test_errors.py
@@ -17,6 +17,7 @@ from unittest import TestCase
 from mrjob.logs.errors import _format_error
 from mrjob.logs.errors import _merge_and_sort_errors
 from mrjob.logs.errors import _pick_error
+from mrjob.logs.ids import _attempt_id_to_task_id
 
 
 class PickErrorTestCase(TestCase):

--- a/tests/logs/test_errors.py
+++ b/tests/logs/test_errors.py
@@ -254,6 +254,43 @@ class MergeAndSortErrorsTestCase(TestCase):
             ]
         )
 
+    def test_attempt_to_container_id(self):
+        errors = [
+            dict(
+                attempt_id='attempt_201512232143_0008_r_000000_0',
+                hadoop_error=dict(message='BOOM'),
+            ),
+            dict(
+                attempt_id='attempt_201512232143_0008_r_000000_1',
+                hadoop_error=dict(message='BOOM again'),
+            ),
+            dict(
+                container_id='container_1450486922681_0005_01_000003',
+                task_error=dict(message='it was probably snakes'),
+            ),
+        ]
+
+        attempt_to_container_id = {
+            'attempt_201512232143_0008_r_000000_1':
+            'container_1450486922681_0005_01_000003',
+        }
+
+        self.assertEqual(
+            _merge_and_sort_errors(errors, attempt_to_container_id),
+            [
+                dict(
+                    attempt_id='attempt_201512232143_0008_r_000000_0',
+                    hadoop_error=dict(message='BOOM'),
+                ),
+                dict(
+                    attempt_id='attempt_201512232143_0008_r_000000_1',
+                    container_id='container_1450486922681_0005_01_000003',
+                    hadoop_error=dict(message='BOOM again'),
+                    task_error=dict(message='it was probably snakes'),
+                ),
+            ],
+        )
+
 
 class FormatErrorTestCase(TestCase):
 

--- a/tests/logs/test_errors.py
+++ b/tests/logs/test_errors.py
@@ -158,45 +158,6 @@ class PickErrorTestCase(TestCase):
             )
         )
 
-    def test_container_to_attempt_id(self):
-        container_id = 'container_1449525218032_0005_01_000010'
-        attempt_id = 'attempt_1449525218032_0005_m_000000_3'
-        task_id = _attempt_id_to_task_id(attempt_id)
-
-        container_to_attempt_id = {container_id: attempt_id}
-
-        log_interpretation = dict(
-            history=dict(
-                container_to_attempt_id=container_to_attempt_id,
-                errors=[
-                    dict(
-                        attempt_id=attempt_id,
-                        hadoop_error=dict(message='SwordsMischiefException'),
-                        task_id=task_id,
-                    ),
-                ],
-            ),
-            task=dict(
-                errors=[
-                    dict(
-                        container_id=container_id,
-                        hadoop_error=dict(message='SwordsMischiefException'),
-                        task_error=dict(message='en garde!'),
-                    ),
-                ],
-            ),
-        )
-
-        self.assertEqual(
-            _pick_error(log_interpretation),
-            dict(
-                attempt_id=attempt_id,
-                container_id=container_id,
-                hadoop_error=dict(message='SwordsMischiefException'),
-                task_error=dict(message='en garde!'),
-                task_id=task_id,
-            ))
-
 
 class MergeAndSortErrorsTestCase(TestCase):
 

--- a/tests/logs/test_errors.py
+++ b/tests/logs/test_errors.py
@@ -77,7 +77,7 @@ class PickErrorTestCase(TestCase):
             )
         )
 
-    def test_timestamp_beats_task_error(self):
+    def test_task_error_beats_timestamp(self):
         log_interpretation = dict(
             history=dict(
                 errors=[
@@ -97,9 +97,10 @@ class PickErrorTestCase(TestCase):
         self.assertEqual(
             _pick_error(log_interpretation),
             dict(
-                container_id='container_1450489999999_0005_01_000004',
-                hadoop_error=dict(message='elephant problems'),
-            )
+                container_id='container_1450486922681_0005_01_000003',
+                hadoop_error=dict(message='BOOM'),
+                task_error=dict(message='things exploding'),
+            ),
         )
 
     def test_merge_order(self):

--- a/tests/logs/test_errors.py
+++ b/tests/logs/test_errors.py
@@ -157,6 +157,45 @@ class PickErrorTestCase(TestCase):
             )
         )
 
+    def test_container_to_attempt_id(self):
+        container_id = 'container_1449525218032_0005_01_000010'
+        attempt_id = 'attempt_1449525218032_0005_m_000000_3'
+        task_id = _attempt_id_to_task_id(attempt_id)
+
+        container_to_attempt_id = {container_id: attempt_id}
+
+        log_interpretation = dict(
+            history=dict(
+                container_to_attempt_id=container_to_attempt_id,
+                errors=[
+                    dict(
+                        attempt_id=attempt_id,
+                        hadoop_error=dict(message='SwordsMischiefException'),
+                        task_id=task_id,
+                    ),
+                ],
+            ),
+            task=dict(
+                errors=[
+                    dict(
+                        container_id=container_id,
+                        hadoop_error=dict(message='SwordsMischiefException'),
+                        task_error=dict(message='en garde!'),
+                    ),
+                ],
+            ),
+        )
+
+        self.assertEqual(
+            _pick_error(log_interpretation),
+            dict(
+                attempt_id=attempt_id,
+                container_id=container_id,
+                hadoop_error=dict(message='SwordsMischiefException'),
+                task_error=dict(message='en garde!'),
+                task_id=task_id,
+            ))
+
 
 class MergeAndSortErrorsTestCase(TestCase):
 

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -325,7 +325,7 @@ class ParseYARNHistoryLogTestCase(TestCase):
                     ),
                 ]))
 
-    def test_container_to_attempt_mapping(self):
+    def test_attempt_to_container_mapping(self):
         lines = [
             '{"type":"MAP_ATTEMPT_STARTED","event":{'
             '"org.apache.hadoop.mapreduce.jobhistory.TaskAttemptStarted":{'
@@ -348,11 +348,11 @@ class ParseYARNHistoryLogTestCase(TestCase):
         self.assertEqual(
             _parse_yarn_history_log(lines),
             dict(
-                container_to_attempt_id={
-                    'container_1449525218032_0005_01_000010':
-                    'attempt_1449525218032_0005_m_000000_3',
-                    'container_1449525218032_0005_01_000011':
-                    'attempt_1449525218032_0005_m_000001_3',
+                attempt_to_container_id={
+                    'attempt_1449525218032_0005_m_000000_3':
+                    'container_1449525218032_0005_01_000010',
+                    'attempt_1449525218032_0005_m_000001_3':
+                    'container_1449525218032_0005_01_000011',
                 }
             )
         )

--- a/tests/logs/test_history.py
+++ b/tests/logs/test_history.py
@@ -325,6 +325,38 @@ class ParseYARNHistoryLogTestCase(TestCase):
                     ),
                 ]))
 
+    def test_container_to_attempt_mapping(self):
+        lines = [
+            '{"type":"MAP_ATTEMPT_STARTED","event":{'
+            '"org.apache.hadoop.mapreduce.jobhistory.TaskAttemptStarted":{'
+            '"taskid":"task_1449525218032_0005_m_000000","taskType":"MAP",'
+            '"attemptId":"attempt_1449525218032_0005_m_000000_3","startTime":'
+            '1449532586958,"trackerName":"0a7802e19139","httpPort":8042,'
+            '"shufflePort":13562,"containerId":'
+            '"container_1449525218032_0005_01_000010","locality":{"string":'
+            '"NODE_LOCAL"},"avataar":{"string":"VIRGIN"}}}}\n',
+            '{"type":"MAP_ATTEMPT_STARTED","event":{'
+            '"org.apache.hadoop.mapreduce.jobhistory.TaskAttemptStarted":{'
+            '"taskid":"task_1449525218032_0005_m_000001","taskType":"MAP",'
+            '"attemptId":"attempt_1449525218032_0005_m_000001_3","startTime":'
+            '1449532587976,"trackerName":"0a7802e19139","httpPort":8042,'
+            '"shufflePort":13562,"containerId":'
+            '"container_1449525218032_0005_01_000011","locality":{"string":'
+            '"NODE_LOCAL"},"avataar":{"string":"VIRGIN"}}}}\n',
+        ]
+
+        self.assertEqual(
+            _parse_yarn_history_log(lines),
+            dict(
+                container_to_attempt_id={
+                    'container_1449525218032_0005_01_000010':
+                    'attempt_1449525218032_0005_m_000000_3',
+                    'container_1449525218032_0005_01_000011':
+                    'attempt_1449525218032_0005_m_000001_3',
+                }
+            )
+        )
+
 
 class ParsePreYARNHistoryLogTestCase(TestCase):
     JOB_COUNTER_LINES = [

--- a/tests/logs/test_mixin.py
+++ b/tests/logs/test_mixin.py
@@ -240,6 +240,8 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
         self.assertFalse(self.log.warning.called)
         self.runner._ls_task_logs.assert_called_once_with(
             'streaming',
+            attempt_to_container_id={},
+            error_attempt_ids=(),
             application_id='app_1',
             job_id=None,
             output_dir=None)
@@ -267,6 +269,8 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
         self.assertFalse(self.log.warning.called)
         self.runner._ls_task_logs.assert_called_once_with(
             'spark',
+            attempt_to_container_id={},
+            error_attempt_ids=(),
             application_id='app_1',
             job_id=None,
             output_dir=None)
@@ -294,6 +298,8 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
         self.assertFalse(self.log.warning.called)
         self.runner._ls_task_logs.assert_called_once_with(
             'streaming',
+            attempt_to_container_id={},
+            error_attempt_ids=(),
             application_id=None,
             job_id='job_1',
             output_dir=None)
@@ -320,6 +326,8 @@ class InterpretTaskLogsTestCase(LogInterpretationMixinTestCase):
         self.assertFalse(self.log.warning.called)
         self.runner._ls_task_logs.assert_called_once_with(
             'streaming',
+            attempt_to_container_id={},
+            error_attempt_ids=(),
             application_id='app_1',
             job_id=None,
             output_dir='hdfs:///path/')
@@ -508,6 +516,8 @@ class LsTaskLogsTestCase(LogInterpretationMixinTestCase):
         self._ls_task_logs.assert_called_once_with(
             self.runner.fs,
             self.runner._stream_task_log_dirs.return_value,
+            attempt_to_container_id=None,
+            error_attempt_ids=None,
             application_id='app_1',
             job_id='job_1')
         self.assertFalse(self._ls_spark_task_logs.called)
@@ -547,6 +557,8 @@ class LsTaskLogsTestCase(LogInterpretationMixinTestCase):
         self._ls_spark_task_logs.assert_called_once_with(
             self.runner.fs,
             self.runner._stream_task_log_dirs.return_value,
+            attempt_to_container_id=None,
+            error_attempt_ids=None,
             application_id='app_1',
             job_id='job_1')
         self.assertFalse(self._ls_task_logs.called)

--- a/tests/logs/test_task.py
+++ b/tests/logs/test_task.py
@@ -128,6 +128,113 @@ class MatchTaskLogPathTestCase(TestCase):
             None)
 
 
+# test how _ls_task_logs() and _ls_spark_task_logs() filter by
+# error_attempt_id
+class LsTaskLogsTestCase(PatcherTestCase):
+
+    def setUp(self):
+        super(LsTaskLogsTestCase, self).setUp()
+
+        self.mock_paths = []
+
+        def mock_ls(log_dir):
+            return [p for p in self.mock_paths if p.startswith(log_dir + '/')]
+
+        def mock_join(path, *paths):
+            return '/'.join([path] + list(paths))
+
+        self.mock_fs = Mock()
+        self.mock_fs.exists = Mock(return_value=True)
+        self.mock_fs.join = Mock(side_effect=mock_join)
+        self.mock_fs.ls = Mock(side_effect=mock_ls)
+
+    def _ls_paths(self, log_dir_stream, **kwargs):
+        return [m['path'] for m in
+                _ls_task_logs(self.mock_fs, log_dir_stream, **kwargs)]
+
+    def _ls_spark_paths(self, log_dir_stream, **kwargs):
+        return [m['path'] for m in
+                _ls_spark_task_logs(self.mock_fs, log_dir_stream, **kwargs)]
+
+    def test_empty(self):
+        self.assertEqual(
+            self._ls_paths([['/logs']]),
+            [])
+
+    def test_basic(self):
+        self.mock_paths = [
+            '/logs/attempt_201512232143_0008_m_000001_3/syslog',
+            '/logs/attempt_201512232143_0008_m_000001_4/syslog',
+            '/logs/attempt_201512232143_0008_m_000001_5/syslog',
+        ]
+
+        self.assertEqual(
+            self._ls_paths([['/logs']]),
+            [self.mock_paths[2], self.mock_paths[1], self.mock_paths[0]])
+
+    def test_basic_spark(self):
+        # _ls_spark_task_logs() shares code with _ls_task_logs()
+        # the differences are tested below
+        self.mock_paths = [
+            '/logs/attempt_201512232143_0008_m_000001_3/stderr',
+            '/logs/attempt_201512232143_0008_m_000001_4/stderr',
+            '/logs/attempt_201512232143_0008_m_000001_5/stderr',
+        ]
+
+        self.assertEqual(
+            self._ls_spark_paths([['/logs']]),
+            [self.mock_paths[2], self.mock_paths[1], self.mock_paths[0]])
+
+    def test_filter_by_attempt_id(self):
+        self.mock_paths = [
+            '/logs/attempt_201512232143_0008_m_000001_3/syslog',
+            '/logs/attempt_201512232143_0008_m_000001_4/syslog',
+            '/logs/attempt_201512232143_0008_m_000001_5/syslog',
+        ]
+
+        # missing attempts are fine, don't list attempts not related to errors
+        error_attempt_ids = [
+            'attempt_201512232143_0008_m_000001_2',
+            'attempt_201512232143_0008_m_000001_3',
+            'attempt_201512232143_0008_m_000001_5',
+        ]
+
+        self.assertEqual(
+            self._ls_paths([['/logs']], error_attempt_ids=error_attempt_ids),
+            [self.mock_paths[0], self.mock_paths[2]])
+
+    def test_map_to_container_id(self):
+        self.mock_paths = [
+            '/logs/application_1450486922681_0004'
+            '/container_1450486922681_0005_01_000013/syslog',
+            '/logs/application_1450486922681_0004'
+            '/container_1450486922681_0005_01_000014/syslog',
+            '/logs/application_1450486922681_0004'
+            '/container_1450486922681_0005_01_000015/syslog',
+        ]
+
+        error_attempt_ids = [
+            'attempt_201512232143_0008_m_000001_2',
+            'attempt_201512232143_0008_m_000001_3',
+            'attempt_201512232143_0008_m_000001_5',
+        ]
+
+        attempt_to_container_id = {
+            'attempt_201512232143_0008_m_000001_2':
+            'container_1450486922681_0005_01_000008',
+            'attempt_201512232143_0008_m_000001_4':
+            'container_1450486922681_0005_01_000014',
+            'attempt_201512232143_0008_m_000001_5':
+            'container_1450486922681_0005_01_000015',
+        }
+
+        self.assertEqual(
+            self._ls_paths([['/logs/application_1450486922681_0004']],
+                           error_attempt_ids=error_attempt_ids,
+                           attempt_to_container_id=attempt_to_container_id),
+            [self.mock_paths[2]])
+
+
 class InterpretTaskLogsTestCase(PatcherTestCase):
 
     maxDiff = None

--- a/tests/logs/test_wrap.py
+++ b/tests/logs/test_wrap.py
@@ -217,7 +217,10 @@ class LsLogsTestCase(TestCase):
             return dict(path=path, **_match_task_log_path(path))
 
         # self.mock_paths[2] is actually more recent, but it's in
-        # the second directory
+        # the second directory.
+
+        # shouldn't look at s3 at all, since that's in the second batch
+        # of paths, and we already found our path in the first batch
         self.assertEqual(
             self._ls_logs([
                 ['/log/dir/userlogs', '/log/dir/userlogs2'],

--- a/tests/mock_boto3/s3.py
+++ b/tests/mock_boto3/s3.py
@@ -112,8 +112,6 @@ def add_mock_s3_data(mock_s3_fs, data, age=None, location=None):
             bucket['location'] = location
 
 
-
-
 # used for bucket CreationDate
 def _boto3_today():
     now = _boto3_now()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3512,18 +3512,16 @@ class StreamLogDirsTestCase(MockBoto3TestCase):
 
     def test_cant_stream_history_log_dirs_from_3_x_amis(self):
         runner = EMRJobRunner(image_version='3.11.0')
+        self.get_image_version.return_value = '3.11.0'
         results = runner._stream_history_log_dirs()
         self.assertRaises(StopIteration, next, results)
 
     def test_stream_history_log_dirs_from_4_x_amis(self):
-        # history log fetching is disabled until we fix #1253
         runner = EMRJobRunner(image_version='4.3.0')
-        results = runner._stream_history_log_dirs()
-        self.assertRaises(StopIteration, next, results)
-        #self._test_stream_history_log_dirs(
-        #    ssh=True, image_version='4.3.0',
-        #    expected_dir_name='hadoop-mapreduce/history',
-        #    expected_s3_dir_name='hadoop-mapreduce/history')
+        self._test_stream_history_log_dirs(
+            ssh=True, image_version='4.3.0',
+            expected_dir_name='hadoop-mapreduce/history',
+            expected_s3_dir_name='hadoop-mapreduce/history')
 
     def _test_stream_step_log_dirs(self, ssh):
         ec2_key_pair_file = '/path/to/EMR.pem' if ssh else None


### PR DESCRIPTION
Rather than checking every task log until we find an error (which can take a lot of time depending on how many tasks there are and how sparse errors are), we rely on the step and history logs to tell us which tasks had errors, and only check the corresponding task logs. This is faster and also more accurate, as it avoids finding "errors" in tasks that Hadoop terminated voluntarily. Fixes #1706.

There is unfortunately no way to get around reading the history file (on YARN, anyhow), as it is the only place where we can find the mapping from attempt ID (which errors are identified by) to container ID (which is the way task logs are organized).