### PR TITLE
Fix error

### DIFF
--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -409,7 +409,7 @@ class MRJobRunner(object):
         if not isinstance(opts, dict):
             raise TypeError(
                 'options for %s (from %s) must be a dict' %
-                self.runner_alias, source)
+                (self.alias, source))
 
         deprecated_aliases = _deprecated_aliases(self.OPT_NAMES)
 


### PR DESCRIPTION
I received an exception when try to use a incorrect format config file.
When you use a bad formated config file, the messages used to instance
the TypeError exception raise another exception dues to actual runners
doesn't have a runner_alias attribute.