### PR TITLE
Port GCS code from google-api-python-client to google-cloud-sdk

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,14 @@
+v0.6.2, 2018-03-?? -- farewell google-api-python-client
+ * runners:
+   * dataproc:
+     * replaced google-api-python-client with google-cloud-sdk
+       * GCSFilesystem method changes:
+         * api_client attr has been replaced with client
+         * create_bucket() no longer takes a project ID
+         * delete_bucket() is disabled (use get_bucket(...).delete())
+         * get_bucket() returns a google.cloud.storage.bucket.Bucket
+         * list_buckets() is disabled (use get_all_bucket_names())
+
 v0.6.1, 2017-11-27 -- mrjob diagnose
  * fixed serious error log parsing issue (#1708)
  * added mrjob diagnose utility to find why previously run jobs failed (#1707)

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -32,6 +32,12 @@ except ImportError:
     discovery = None
     google_errors = None
 
+
+try:
+    from google.api_core.exceptions import NotFound
+except:
+    NotFound = None
+
 try:
     # Python 2
     import ConfigParser as configparser
@@ -459,9 +465,8 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner):
         try:
             self.fs.get_bucket(bucket_name)
             return
-        except google_errors.HttpError as e:
-            if not e.resp.status == 404:
-                raise
+        except NotFound:
+            pass
 
         log.info('creating FS bucket %r' % bucket_name)
 
@@ -471,7 +476,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner):
         # job (tmp buckets ONLY)
         # https://cloud.google.com/storage/docs/bucket-locations
         self.fs.create_bucket(
-            self._gcp_project, bucket_name, location=location,
+            bucket_name, location=location,
             object_ttl_days=_DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS)
 
         self._wait_for_fs_sync()

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -352,7 +352,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner):
         chosen_bucket_name = None
 
         for tmp_bucket_name in self.fs.get_all_bucket_names(prefix='mrjob-'):
-            tmp_bucket = self.fs.get_bucket(tmp_bucket)
+            tmp_bucket = self.fs.get_bucket(tmp_bucket_name)
 
             # NOTE - GCP ambiguous Behavior - Bucket location is being
             # returned as UPPERCASE, ticket filed as of Apr 23, 2016 as docs
@@ -368,7 +368,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner):
         # Example default - "mrjob-us-central1-RANDOMHEX"
         if not chosen_bucket_name:
             chosen_bucket_name = '-'.join(
-                ['mrjob', gce_lower_location, random_identifier()])
+                ['mrjob', self._gce_region.lower(), random_identifier()])
 
         return 'gs://%s/tmp/' % chosen_bucket_name
 

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -164,8 +164,6 @@ class GCSFilesystem(Filesystem):
         If dest is a directory (ends with a "/"), we check if there are
         any files starting with that path.
         """
-        # TODO - mtai @ davidmarin - catch specific Exceptions, not sure what
-        # types of exceptions this can throw
         try:
             paths = self.ls(path_glob)
         except:
@@ -203,20 +201,17 @@ class GCSFilesystem(Filesystem):
         for b in self.client.list_buckets(prefix=prefix):
             yield b.name
 
-    # NOTE: disabled this
     def list_buckets(self, project, prefix=None):
         """List buckets on GCS."""
         raise NotImplementedError(
             'list_buckets() was disabled in v0.6.2. Use'
             'get_all_bucket_names() and get_bucket()')
 
-    # NOTE: returns a google-cloud-sdk bucket
     def get_bucket(self, bucket_name):
         """Return a :py:class:`google.cloud.storage.bucket.Bucket`
         Raises an exception if the bucket does not exist."""
         return self.client.get_bucket(bucket_name)
 
-    # NOTE: function signature has changed
     def create_bucket(self, name,
                       location=None, object_ttl_days=None):
         """Create a bucket on GCS, optionally setting location constraint.
@@ -237,7 +232,6 @@ class GCSFilesystem(Filesystem):
             )
         ]
 
-    # NOTE: disabled this
     def delete_bucket(self, bucket):
         raise NotImplementedError(
             'delete_bucket() was disabled in v0.6.2. Use'

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -137,6 +137,7 @@ class GCSFilesystem(Filesystem):
 
     def _cat_file(self, gcs_uri):
         blob = self._blob(gcs_uri)
+
         if not blob:
             return  # don't cat nonexistent files
 

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -271,10 +271,10 @@ class GCSFilesystem(Filesystem):
         buckets_to_return = resp.get('items') or []
         return buckets_to_return
 
-    # this will need to return a google-cloud-sdk bucket
-    def get_bucket(self, bucket):
-        req = self.api_client.buckets().get(bucket=bucket)
-        return req.execute()
+    def get_bucket(self, bucket_name):
+        """Return a :py:class:`google.cloud.storage.bucket.Bucket`
+        Raises an exception if the bucket does not exist."""
+        return self.client.get_bucket(bucket_name)
 
     # TODO: implement with google-cloud-sdk
     def create_bucket(self, project, name,

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -13,10 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import binascii
 import fnmatch
 import logging
 from base64 import b64decode
-from binascii import hexlify
 from tempfile import TemporaryFile
 
 from mrjob.cat import decompress
@@ -135,7 +135,7 @@ class GCSFilesystem(Filesystem):
         blob = self._get_blob(path)
         if not blob:
             raise IOError('Object %r does not exist' % (path,))
-        return hexlify(b64decode(blob.md5_hash))
+        return binascii.hexlify(b64decode(blob.md5_hash))
 
     def _cat_file(self, gcs_uri):
         blob = self._get_blob(gcs_uri)

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -135,7 +135,7 @@ class GCSFilesystem(Filesystem):
         blob = self._get_blob(path)
         if not blob:
             raise IOError('Object %r does not exist' % (path,))
-        return binascii.hexlify(b64decode(blob.md5_hash))
+        return binascii.hexlify(b64decode(blob.md5_hash)).decode('ascii')
 
     def _cat_file(self, gcs_uri):
         blob = self._get_blob(gcs_uri)

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -204,6 +204,8 @@ class S3Filesystem(Filesystem):
 
     def md5sum(self, path):
         k = self._get_s3_key(path)
+        if not k:
+            raise IOError('Key %r does not exist' % (path,))
         return k.e_tag.strip('"')
 
     def _cat_file(self, filename):

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ try:
         'install_requires': [
             'boto3>=1.4.6',
             'botocore>=1.6.0',
+            'google-cloud>=0.32.0',
             #'google-api-python-client>=1.5.0'  # see below
             'PyYAML>=3.08',
         ],

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -174,6 +174,13 @@ class GCSFSTestCase(MockGoogleTestCase):
         self.assertEqual(self.fs.md5sum('gs://walrus/data/foo'),
                          binascii.hexlify(md5.new(b'abcd').digest()))
 
+    def test_md5sum_of_missing_blob(self):
+        self.put_gcs_multi({
+            'gs://walrus/data/foo': b'abcd'
+        })
+
+        self.assertRaises(IOError, self.fs.md5sum, 'gs://walrus/data/bar')
+
     def test_rm(self):
         self.put_gcs_multi({
             'gs://walrus/foo': b''

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -28,6 +28,9 @@ from tests.mock_google import MockGoogleTestCase
 from tests.sandbox import PatcherTestCase
 
 
+# TODO: test md5sum() (will require a mock)
+
+
 class CatTestCase(MockGoogleTestCase):
 
     def setUp(self):

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -13,8 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import binascii
 import bz2
 import io
+import md5
 import sys
 from unittest import skipIf
 
@@ -26,9 +28,6 @@ from mrjob.fs.gcs import GCSFilesystem
 from tests.compress import gzip_compress
 from tests.mock_google import MockGoogleTestCase
 from tests.sandbox import PatcherTestCase
-
-
-# TODO: test md5sum() (will require a mock)
 
 
 class CatTestCase(MockGoogleTestCase):
@@ -166,6 +165,14 @@ class GCSFSTestCase(MockGoogleTestCase):
         })
         self.assertEqual(self.fs.exists('gs://walrus/data/foo'), True)
         self.assertEqual(self.fs.exists('gs://walrus/data/bar'), False)
+
+    def test_md5sum(self):
+        self.put_gcs_multi({
+            'gs://walrus/data/foo': b'abcd'
+        })
+
+        self.assertEqual(self.fs.md5sum('gs://walrus/data/foo'),
+                         binascii.hexlify(md5.new(b'abcd').digest()))
 
     def test_rm(self):
         self.put_gcs_multi({

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -16,8 +16,8 @@
 import binascii
 import bz2
 import io
-import md5
 import sys
+from hashlib import md5
 from unittest import skipIf
 
 from tests.py2 import patch
@@ -172,7 +172,7 @@ class GCSFSTestCase(MockGoogleTestCase):
         })
 
         self.assertEqual(self.fs.md5sum('gs://walrus/data/foo'),
-                         binascii.hexlify(md5.new(b'abcd').digest()))
+                         md5(b'abcd').hexdigest())
 
     def test_md5sum_of_missing_blob(self):
         self.put_gcs_multi({

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -77,7 +77,7 @@ class GCSFSTestCase(MockGoogleTestCase):
         super(GCSFSTestCase, self).setUp()
         self.fs = GCSFilesystem()
 
-    def test_ls_key(self):
+    def test_ls_blob(self):
         self.put_gcs_multi({
             'gs://walrus/data/foo': b''
         })
@@ -87,6 +87,17 @@ class GCSFSTestCase(MockGoogleTestCase):
 
     def test_ls_missing(self):
         self.assertEqual(list(self.fs.ls('gs://nope/not/here')), [])
+
+    def test_ls_ignores_dirs(self):
+        # Dataproc (i.e. Hadoop) will create empty blobs whose names end
+        # in '/'
+        self.put_gcs_multi({
+            'gs://walrus/data/foo/': b'',
+            'gs://walrus/data/foo/bar': b'baz',
+        })
+
+        self.assertEqual(list(self.fs.ls('gs://walrus/data')),
+                         ['gs://walrus/data/foo/bar'])
 
     def test_ls_recursively(self):
         self.put_gcs_multi({

--- a/tests/mock_boto3/s3.py
+++ b/tests/mock_boto3/s3.py
@@ -37,14 +37,14 @@ class MockS3Client(object):
                         (a region name).
     """
     def __init__(self,
+                 mock_s3_fs,
                  aws_access_key_id=None,
                  aws_secret_access_key=None,
                  aws_session_token=None,
                  endpoint_url=None,
-                 region_name=None,
-                 mock_s3_fs=None):
+                 region_name=None):
 
-        self.mock_s3_fs = mock_s3_fs or {}
+        self.mock_s3_fs = mock_s3_fs
 
         region_name = region_name or _DEFAULT_AWS_REGION
         if not endpoint_url:
@@ -132,12 +132,12 @@ class MockS3Resource(object):
 
         self.meta = MockClientMeta(
             client=MockS3Client(
+                mock_s3_fs,
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
                 aws_session_token=aws_session_token,
                 endpoint_url=endpoint_url,
                 region_name=region_name,
-                mock_s3_fs=mock_s3_fs
             )
         )
 

--- a/tests/mock_boto3/s3.py
+++ b/tests/mock_boto3/s3.py
@@ -44,7 +44,7 @@ class MockS3Client(object):
                  region_name=None,
                  mock_s3_fs=None):
 
-        self.mock_s3_fs = mock_s3_fs
+        self.mock_s3_fs = mock_s3_fs or {}
 
         region_name = region_name or _DEFAULT_AWS_REGION
         if not endpoint_url:

--- a/tests/mock_google/__init__.py
+++ b/tests/mock_google/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/mock_google/__init__.py
+++ b/tests/mock_google/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Limited mock of google-cloud-sdk for tests
+"""
+from .case import MockGoogleTestCase
+MockGoogleTestCase  # shh, pyflakes

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,11 @@
 # limitations under the License.
 """Limited mock of google-cloud-sdk for tests
 """
+from mrjob.fs.gcs import parse_gcs_uri
+
 from tests.py2 import patch
 from tests.sandbox import SandboxedTestCase
+
 
 from .storage import MockGoogleStorageClient
 
@@ -22,7 +25,20 @@ from .storage import MockGoogleStorageClient
 class MockGoogleTestCase(SandboxedTestCase):
 
     def setUp(self):
+        # Maps bucket name to a dictionary with the key
+        # *blobs*. *blobs* maps object name to
+        # a dictionary with the key *data*, which is
+        # a bytestring.
         self.mock_gcs_fs = {}
 
         self.start(patch('mrjob.fs.gcs.StorageClient',
                          MockGoogleStorageClient))
+
+    def put_gcs_multi(self, gcs_uri_to_data_map):
+        for uri, data in gcs_uri_to_data_map.items():
+            bucket_name, path = parse_gcs_uri(uri)
+
+            mock_bucket = self.mock_gcs_fs.setdefault(
+                bucket_name, dict(objects={}))
+
+            mock_bucket[path] = dict(data=data)

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -32,9 +32,9 @@ class MockGoogleTestCase(SandboxedTestCase):
         self.mock_gcs_fs = {}
 
         self.start(patch('mrjob.fs.gcs.StorageClient',
-                         self.client))
+                         self.storage_client))
 
-    def client(self):
+    def storage_client(self):
         return MockGoogleStorageClient(mock_gcs_fs=self.mock_gcs_fs)
 
     def put_gcs_multi(self, gcs_uri_to_data_map):

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -1,0 +1,28 @@
+# Copyright 2018 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Limited mock of google-cloud-sdk for tests
+"""
+from tests.py2 import patch
+from tests.sandbox import SandboxedTestCase
+
+from .storage import MockGoogleStorageClient
+
+
+class MockGoogleTestCase(SandboxedTestCase):
+
+    def setUp(self):
+        self.mock_gcs_fs = {}
+
+        self.start(patch('mrjob.fs.gcs.StorageClient',
+                         MockGoogleStorageClient))

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -25,6 +25,8 @@ from .storage import MockGoogleStorageClient
 class MockGoogleTestCase(SandboxedTestCase):
 
     def setUp(self):
+        super(MockGoogleTestCase, self).setUp()
+
         # Maps bucket name to a dictionary with the key
         # *blobs*. *blobs* maps object name to
         # a dictionary with the key *data*, which is

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -40,10 +40,14 @@ class MockGoogleTestCase(SandboxedTestCase):
         return MockGoogleStorageClient(mock_gcs_fs=self.mock_gcs_fs)
 
     def put_gcs_multi(self, gcs_uri_to_data_map):
+        client = self.storage_client()
+
         for uri, data in gcs_uri_to_data_map.items():
-            bucket_name, path = parse_gcs_uri(uri)
+            bucket_name, blob_name = parse_gcs_uri(uri)
 
-            mock_bucket = self.mock_gcs_fs.setdefault(
-                bucket_name, dict(blobs={}))
+            bucket = client.bucket(bucket_name)
+            if not bucket.exists():
+                bucket.create()
 
-            mock_bucket['blobs'][path] = dict(data=data)
+            blob = bucket.blob(blob_name)
+            blob.upload_from_string(data)

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -32,13 +32,17 @@ class MockGoogleTestCase(SandboxedTestCase):
         self.mock_gcs_fs = {}
 
         self.start(patch('mrjob.fs.gcs.StorageClient',
-                         MockGoogleStorageClient))
+                         self.client))
+
+
+    def client(self):
+        return MockGoogleStorageClient(mock_gcs_fs=self.mock_gcs_fs)
 
     def put_gcs_multi(self, gcs_uri_to_data_map):
         for uri, data in gcs_uri_to_data_map.items():
             bucket_name, path = parse_gcs_uri(uri)
 
             mock_bucket = self.mock_gcs_fs.setdefault(
-                bucket_name, dict(objects={}))
+                bucket_name, dict(blobs={}))
 
-            mock_bucket[path] = dict(data=data)
+            mock_bucket['blobs'][path] = dict(data=data)

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -34,7 +34,6 @@ class MockGoogleTestCase(SandboxedTestCase):
         self.start(patch('mrjob.fs.gcs.StorageClient',
                          self.client))
 
-
     def client(self):
         return MockGoogleStorageClient(mock_gcs_fs=self.mock_gcs_fs)
 

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -67,6 +67,9 @@ class MockGoogleStorageBlob(object):
         with open(filename, 'rb') as f:
             data = f.read()
 
+        self.upload_from_string(data)
+
+    def upload_from_string(self, data):
         fs = self.bucket.client.mock_gcs_fs
         if self.bucket.name not in fs:
             raise NotFound('POST https://www.googleapis.com/upload/storage'

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Limited mock of google.cloud.storage."""
-from google.cloud.storage.exceptions import NotFound
+from google.api_core.exceptions import NotFound
 
 
 class MockGoogleStorageClient(object):
     """Mock out google.cloud.storage.client.Client
 
     :param mock_s3_fs: Maps bucket name to a dictionary with the key
-                       *objects*. *objects* maps object name to
+                       *blobs*. *blobs* maps object name to
                        a dictionary with the key *data*, which is
                        a bytestring.
     """
@@ -56,12 +56,12 @@ class MockGoogleStorageBlob(object):
     def download_to_file(self, file_obj):
         fs = self.bucket.client.mock_gcs_fs
         if (self.bucket.name not in fs or
-                self.name not in fs[self.bucket.name]['objects']):
+                self.name not in fs[self.bucket.name]['blobs']):
             raise NotFound('GET https://www.googleapis.com/download/storage'
                            '/v1/b/%s/o/%s?alt=media: Not Found' %
                            self.bucket.name, self.name)
 
-        file_obj.write(fs[self.bucket.name]['objects'][self.name]['data'])
+        file_obj.write(fs[self.bucket.name]['blobs'][self.name]['data'])
 
     def upload_from_filename(self, filename):
         with open(filename, 'rb') as f:
@@ -76,6 +76,6 @@ class MockGoogleStorageBlob(object):
                            '/v1/b/%s/o?uploadType=multipart: Not Found' %
                            self.bucket.name)
 
-        fs_objs = fs[self.bucket.name]['objects']
+        fs_objs = fs[self.bucket.name]['blobs']
         fs_obj = fs_objs.setdefault(self.name, dict(data=b''))
         fs_obj['data'] = data

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -65,6 +65,17 @@ class MockGoogleStorageBlob(object):
         self.bucket = bucket
         self.chunk_size = chunk_size
 
+    def delete(self):
+        fs = self.bucket.client.mock_gcs_fs
+
+        if (self.bucket.name not in fs or
+                self.name not in fs[self.bucket.name]['blobs']):
+            raise NotFound('DELETE https://www.googleapis.com/storage/v1/b'
+                           '/%s/o/%s: Not Found' %
+                           (self.bucket.name, self.name))
+
+        del fs[self.bucket.name]['blobs'][self.name]
+
     def download_to_file(self, file_obj):
         fs = self.bucket.client.mock_gcs_fs
 
@@ -73,7 +84,7 @@ class MockGoogleStorageBlob(object):
         except KeyError:
             raise NotFound('GET https://www.googleapis.com/download/storage'
                            '/v1/b/%s/o/%s?alt=media: Not Found' %
-                           self.bucket.name, self.name)
+                           (self.bucket.name, self.name))
 
         file_obj.write(data)
 

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -27,7 +27,10 @@ class MockGoogleStorageClient(object):
                        a bytestring.
     """
     def __init__(self, mock_gcs_fs=None):
-        self.mock_gcs_fs = mock_gcs_fs or {}
+        if mock_gcs_fs is None:
+            mock_gcs_fs = {}
+
+        self.mock_gcs_fs = mock_gcs_fs
 
     def bucket(self, bucket_name):
         return MockGoogleStorageBucket(self, bucket_name)

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -28,10 +28,7 @@ class MockGoogleStorageClient(object):
                        a dictionary with the key *data*, which is
                        a bytestring.
     """
-    def __init__(self, mock_gcs_fs=None):
-        if mock_gcs_fs is None:
-            mock_gcs_fs = {}
-
+    def __init__(self, mock_gcs_fs):
         self.mock_gcs_fs = mock_gcs_fs
 
     def bucket(self, bucket_name):

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -76,17 +76,26 @@ class MockGoogleStorageBlob(object):
 
         del fs[self.bucket.name]['blobs'][self.name]
 
-    def download_to_file(self, file_obj):
+    def download_as_string(self):
         fs = self.bucket.client.mock_gcs_fs
 
         try:
-            data = fs[self.bucket.name]['blobs'][self.name]['data']
+            return fs[self.bucket.name]['blobs'][self.name]['data']
         except KeyError:
             raise NotFound('GET https://www.googleapis.com/download/storage'
                            '/v1/b/%s/o/%s?alt=media: Not Found' %
                            (self.bucket.name, self.name))
 
+    def download_to_file(self, file_obj):
+        data = self.download_as_string()
         file_obj.write(data)
+
+    @property
+    def size(self):
+        try:
+            return len(self.download_as_string())
+        except NotFound:
+            return None
 
     def upload_from_filename(self, filename):
         with open(filename, 'rb') as f:

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -34,6 +34,13 @@ class MockGoogleStorageClient(object):
 
         return MockGoogleStorageBucket(self, bucket_name)
 
+    def list_buckets(self, prefix=None):
+        for bucket_name in sorted(self.mock_gcs_fs):
+            if prefix and not bucket_name.startswith(prefix):
+                continue
+
+            yield self.get_bucket(bucket_name)
+
 
 class MockGoogleStorageBucket(object):
     """Mock out google.cloud.storage.client.Bucket"""

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -53,6 +53,16 @@ class MockGoogleStorageBlob(object):
         self.bucket = bucket
         self.chunk_size = chunk_size
 
+    def download_to_file(self, file_obj):
+        fs = self.bucket.client.mock_gcs_fs
+        if (self.bucket.name not in fs or
+                self.name not in fs[self.bucket.name]['objects']):
+            raise NotFound('GET https://www.googleapis.com/download/storage'
+                           '/v1/b/%s/o/%s?alt=media: Not Found' %
+                           self.bucket.name, self.name)
+
+        file_obj.write(fs[self.bucket.name]['objects'][self.name]['data'])
+
     def upload_from_filename(self, filename):
         with open(filename, 'rb') as f:
             data = f.read()

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Limited mock of google.cloud.storage."""
-import md5
 from base64 import b64encode
 from copy import deepcopy
+from hashlib import md5
 
 from google.api_core.exceptions import Conflict
 from google.api_core.exceptions import NotFound
@@ -171,7 +171,7 @@ class MockGoogleStorageBlob(object):
         # call this when we upload data, or when we _get_blob
         try:
             self.md5_hash = b64encode(
-                md5.new(self.download_as_string()).digest())
+                md5(self.download_as_string()).digest())
         except NotFound:
             pass
 

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -1,0 +1,68 @@
+# Copyright 2018 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Limited mock of google.cloud.storage."""
+from google.cloud.storage.exceptions import NotFound
+
+
+class MockGoogleStorageClient(object):
+    """Mock out google.cloud.storage.client.Client
+
+    :param mock_s3_fs: Maps bucket name to a dictionary with the key
+                       *objects*. *objects* maps object name to
+                       a dictionary with the key *data*, which is
+                       a bytestring.
+    """
+    def __init__(self, mock_gcs_fs=None):
+        self.mock_gcs_fs = mock_gcs_fs or {}
+
+    def get_bucket(self, bucket_name):
+        if bucket_name not in self.mock_gcs_fs:
+            raise NotFound(
+                'GET https://www.googleapis.com/storage/v1/b/%s'
+                '?projection=noAcl: Not Found' % bucket_name)
+
+        return MockGoogleStorageBucket(self, bucket_name)
+
+
+class MockGoogleStorageBucket(object):
+    """Mock out google.cloud.storage.client.Bucket"""
+    def __init__(self, client, name):
+        self.client = client
+        self.name = name
+
+    def blob(self, blob_name, chunk_size=None):
+        # always returns something whether it exists or not
+        return MockGoogleStorageBlob(blob_name, self, chunk_size=chunk_size)
+
+
+class MockGoogleStorageBlob(object):
+    """Mock out google.cloud.storage.blob.Blob"""
+    def __init__(self, name, bucket, chunk_size=None):
+        self.name = name
+        self.bucket = bucket
+        self.chunk_size = chunk_size
+
+    def upload_from_filename(self, filename):
+        with open(filename, 'rb') as f:
+            data = f.read()
+
+        fs = self.bucket.client.mock_gcs_fs
+        if self.bucket.name not in fs:
+            raise NotFound('POST https://www.googleapis.com/upload/storage'
+                           '/v1/b/%s/o?uploadType=multipart: Not Found' %
+                           self.bucket.name)
+
+        fs_objs = fs[self.bucket.name]['objects']
+        fs_obj = fs_objs.setdefault(self.name, dict(data=b''))
+        fs_obj['data'] = data

--- a/tests/mockgoogleapiclient.py
+++ b/tests/mockgoogleapiclient.py
@@ -156,6 +156,8 @@ def _dict_deep_update(d, u):
 class MockGoogleAPITestCase(MockGoogleTestCase):
 
     def setUp(self):
+        super(MockGoogleAPITestCase, self).setUp()
+
         self._dataproc_client = MockDataprocClient(self)
 
         self.start(patch.object(
@@ -163,8 +165,6 @@ class MockGoogleAPITestCase(MockGoogleTestCase):
 
         self.start(patch('mrjob.dataproc._read_gcloud_config',
                          lambda: _GCLOUD_CONFIG))
-
-        super(MockGoogleAPITestCase, self).setUp()
 
         # patch slow things
         self.mrjob_zip_path = None

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 """Tests for DataprocJobRunner"""
 import collections
-import copy
 import getpass
 import os
 import os.path
-
 from contextlib import contextmanager
+from copy import deepcopy
 from io import BytesIO
 
 import mrjob
@@ -30,6 +29,7 @@ from mrjob.dataproc import _DATAPROC_API_REGION
 from mrjob.dataproc import _DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS
 from mrjob.dataproc import _DEFAULT_IMAGE_VERSION
 from mrjob.dataproc import _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH
+from mrjob.fs.gcs import GCSFilesystem
 from mrjob.fs.gcs import parse_gcs_uri
 from mrjob.py2 import PY2
 from mrjob.py2 import StringIO
@@ -101,8 +101,7 @@ class DataprocJobRunnerEndToEndTestCase(MockGoogleAPITestCase):
 
         results = []
 
-        gcs_buckets_snapshot = copy.deepcopy(self._gcs_client._cache_buckets)
-        gcs_objects_snapshot = copy.deepcopy(self._gcs_client._cache_objects)
+        mock_gcs_fs_snapshot = deepcopy(self.mock_gcs_fs)
 
         fake_gcs_output = [
             b'1\t"qux"\n2\t"bar"\n',
@@ -114,10 +113,7 @@ class DataprocJobRunnerEndToEndTestCase(MockGoogleAPITestCase):
 
             # make sure that initializing the runner doesn't affect GCS
             # (Issue #50)
-            self.assertEqual(gcs_buckets_snapshot,
-                             self._gcs_client._cache_buckets)
-            self.assertEqual(gcs_objects_snapshot,
-                             self._gcs_client._cache_objects)
+            self.assertEqual(self.mock_gcs_fs, mock_gcs_fs_snapshot)
 
             runner.run()
 
@@ -224,8 +220,9 @@ class DataprocJobRunnerEndToEndTestCase(MockGoogleAPITestCase):
             # this is set and unset before we can get at it unless we do this
             list(runner.cat_output())
 
-        objects_in_bucket = self._gcs_fs.api_client._cache_objects[tmp_bucket]
-        self.assertEqual(len(objects_in_bucket), tmp_len)
+            self.assertEqual(
+                len(list(runner.fs.client.bucket(tmp_bucket).list_blobs())),
+                tmp_len)
 
     def test_cleanup_all(self):
         self._test_cloud_tmp_cleanup('ALL', 0)
@@ -418,9 +415,7 @@ class TmpBucketTestCase(MockGoogleAPITestCase):
         args, it'll create a new tmp bucket with the given location
         constraint.
         """
-        bucket_cache = self._gcs_client._cache_buckets
-
-        existing_buckets = set(bucket_cache.keys())
+        existing_buckets = set(self.mock_gcs_fs)
 
         runner = DataprocJobRunner(conf_paths=[], **runner_kwargs)
 
@@ -431,18 +426,19 @@ class TmpBucketTestCase(MockGoogleAPITestCase):
         self.assertNotIn(bucket_name, existing_buckets)
         self.assertEqual(path, 'tmp/')
 
-        current_bucket = bucket_cache[bucket_name]
-        self.assertEqual(current_bucket['location'], location)
+        current_bucket = runner.fs.get_bucket(bucket_name)
+
+        self.assertEqual(current_bucket.location, location.upper())
 
         # Verify that we setup bucket lifecycle rules of 28-day retention
-        first_lifecycle_rule = current_bucket['lifecycle']['rule'][0]
+        first_lifecycle_rule = current_bucket.lifecycle_rules[0]
         self.assertEqual(first_lifecycle_rule['action'], dict(type='Delete'))
         self.assertEqual(first_lifecycle_rule['condition'],
                          dict(age=_DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS))
 
     def _make_bucket(self, name, location=None):
-        self._gcs_fs.create_bucket(
-            project=_TEST_PROJECT, name=name, location=location)
+        fs = GCSFilesystem()
+        fs.create_bucket(name, location=location)
 
     def test_default(self):
         self.assert_new_tmp_bucket(DEFAULT_GCE_REGION)
@@ -541,7 +537,7 @@ class GCEInstanceGroupTestCase(MockGoogleAPITestCase):
         self.assertEqual(role_to_actual, role_to_expected)
 
     def set_in_mrjob_conf(self, **kwargs):
-        dataproc_opts = copy.deepcopy(self.MRJOB_CONF_CONTENTS)
+        dataproc_opts = deepcopy(self.MRJOB_CONF_CONTENTS)
         dataproc_opts['runners']['dataproc'].update(kwargs)
         patcher = mrjob_conf_patcher(dataproc_opts)
         patcher.start()

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -220,9 +220,13 @@ class DataprocJobRunnerEndToEndTestCase(MockGoogleAPITestCase):
             # this is set and unset before we can get at it unless we do this
             list(runner.cat_output())
 
-            self.assertEqual(
-                len(list(runner.fs.client.bucket(tmp_bucket).list_blobs())),
-                tmp_len)
+            fs = runner.fs
+
+        # with statement finishes, cleanup runs
+
+        self.assertEqual(
+            len(list(fs.client.bucket(tmp_bucket).list_blobs())),
+            tmp_len)
 
     def test_cleanup_all(self):
         self._test_cloud_tmp_cleanup('ALL', 0)
@@ -908,6 +912,7 @@ class MaxMinsIdleTestCase(MockGoogleAPITestCase):
 class TestCatFallback(MockGoogleAPITestCase):
 
     def test_gcs_cat(self):
+
         self.put_gcs_multi({
             'gs://walrus/one': b'one_text',
             'gs://walrus/two': b'two_text',


### PR DESCRIPTION
Ported our Google Cloud Storage code from the old `google-api-python-client` library to the new `google-cloud` one (part of #1730).

Still to do:
 * port Google Cloud Dataproc code
 * provide a way to specify credentials file through options