### PR TITLE
more efficient terminate-idle-clusters

### DIFF
--- a/mrjob/tools/emr/terminate_idle_clusters.py
+++ b/mrjob/tools/emr/terminate_idle_clusters.py
@@ -152,10 +152,11 @@ def _maybe_terminate_clusters(dry_run=False,
     num_pending = 0
     num_running = 0
 
-    # We don't filter by cluster state because we want this to work even
-    # if Amazon adds another kind of idle state.
+    # include RUNNING to catch clusters with PENDING jobs that
+    # never ran (see #365).
     for cluster_summary in _boto3_paginate(
-            'Clusters', emr_client, 'list_clusters'):
+            'Clusters', emr_client, 'list_clusters',
+            ClusterStates=['WAITING', 'RUNNING']):
 
         cluster_id = cluster_summary['Id']
 


### PR DESCRIPTION
`mrjob terminate-idle-clusters` script now only looks at `WAITING` and `RUNNING` clusters, saving API calls.  Fixes #1722.

For why we look at `RUNNING` clusters, see #365. No idea if this is still a live issue (it was first addressed in 2012), but the main efficiency boost is to avoid looking at the vast majority of clusters that are already terminated.