### PR TITLE
Idle grace period

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -372,7 +372,7 @@ Cluster creation and configuration
     :switch: --max-mins-idle
     :type: float
     :set: emr
-    :default: 5
+    :default: 10.0
 
     Automatically terminate persistent/pooled clusters that have been idle at
     least this many minutes.
@@ -383,6 +383,12 @@ Cluster creation and configuration
        versions, you needed to set :mrjob-opt:`max_hours_idle`, set this
        option explicitly, or use :ref:`terminate-idle-clusters`.
 
+    .. versionchanged:: 0.6.2
+
+       No matter how small a value you set this to, there is a grace period
+       of 10 minutes between when the idle termination daemon launches
+       and when it may first terminate the cluster, to allow Hadoop to
+       accept your first job.
 
 .. mrjob-opt::
     :config: max_hours_idle

--- a/mrjob/bootstrap/terminate_idle_cluster_emr.sh
+++ b/mrjob/bootstrap/terminate_idle_cluster_emr.sh
@@ -43,7 +43,7 @@
 
 # full usage:
 #
-# ./terminate_idle_cluster.sh [ max_secs_idle  ]
+# ./terminate_idle_cluster_emr.sh [ max_secs_idle  ]
 #
 # Both arguments must be integers
 

--- a/mrjob/bootstrap/terminate_idle_cluster_emr.sh
+++ b/mrjob/bootstrap/terminate_idle_cluster_emr.sh
@@ -82,7 +82,7 @@ do
     else
         SECS_RUN=$(expr $UPTIME - $START)
         if expr $SECS_RUN '>' $GRACE_PERIOD_SECS > /dev/null
-            then
+        then
 
             # the cluster is idle! how long has this been going on?
             SECS_IDLE=$(expr $UPTIME - $LAST_ACTIVE)
@@ -94,6 +94,9 @@ do
             fi
         fi
     fi
+
+    # sleep so we don't peg the CPU
+    sleep 5
 done
 # close file handles to daemonize the script; otherwise bootstrapping
 # never finishes

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -112,12 +112,6 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
             else:
                 opts['max_mins_idle'] = _DEFAULT_MAX_MINS_IDLE
 
-        # warn about issues with
-        if opts['max_mins_idle'] < _DEFAULT_MAX_MINS_IDLE:
-            log.warning('Setting max_mins_idle to less than %.1f may result'
-                        ' in cluster shutting down before job can run' %
-                        _DEFAULT_MAX_MINS_IDLE)
-
         return opts
 
     def _combine_opts(self, opt_list):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -152,7 +152,7 @@ _POOLING_SLEEP_INTERVAL = 30.01  # Add .1 seconds so minutes arent spot on.
 _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH = os.path.join(
     os.path.dirname(mrjob.__file__),
     'bootstrap',
-    'terminate_idle_cluster.sh')
+    'terminate_idle_cluster_emr.sh')
 
 # default AWS region to use for EMR. Using us-west-2 because it is the default
 # for new (since October 10, 2012) accounts (see #1025)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1573,7 +1573,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
         # check for idle timeout script
         self.assertTrue(actions[3]['ScriptPath'].startswith('s3://mrjob-'))
         self.assertTrue(actions[3]['ScriptPath'].endswith(
-            'terminate_idle_cluster.sh'))
+            'terminate_idle_cluster_emr.sh'))
         self.assertEqual(actions[3]['Args'], ['600'])
         self.assertEqual(actions[3]['Name'], 'idle timeout')
 
@@ -1628,7 +1628,7 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
         # check for idle timeout script
         self.assertTrue(actions[2]['ScriptPath'].startswith('s3://mrjob-'))
         self.assertTrue(actions[2]['ScriptPath'].endswith(
-            'terminate_idle_cluster.sh'))
+            'terminate_idle_cluster_emr.sh'))
         self.assertEqual(actions[2]['Args'], ['600'])
         self.assertEqual(actions[2]['Name'], 'idle timeout')
 


### PR DESCRIPTION
The idle termination script (on both EMR and Dataproc) now waits 10 minutes after launching before terminating the cluster, to avoid race conditions where the first job never gets a chance to run. Fixes #1694.