### PR TITLE
Dataproc Quickstart

### DIFF
--- a/docs/guides/dataproc-quickstart.rst
+++ b/docs/guides/dataproc-quickstart.rst
@@ -3,30 +3,45 @@ Dataproc Quickstart
 
 .. _google-setup:
 
-Configuring Google Cloud Platform (GCP) credentials
----------------------------------------------------
+Getting started with Google Cloud
+---------------------------------
 
-Configuring your GCP credentials allows mrjob to run your jobs on
-Dataproc and use GCS.
+Using mrjob with Google Cloud Dataproc is as simple creating an account,
+enabling Google Cloud Dataproc, and creating credentials.
 
-* `Create a Google Cloud Platform account <http://cloud.google.com/>`_, see top-right
-* `Learn about Google Cloud Platform "projects" <https://cloud.google.com/docs/overview/#projects>`_
-* `Select or create a Cloud Platform Console project <https://console.cloud.google.com/project>`_
-* `Enable billing for your project <https://console.cloud.google.com/billing>`_
-* Go to the `API Manager <https://console.cloud.google.com/apis>`_ and search for / enable the following APIs...
+Creating an account
+^^^^^^^^^^^^^^^^^^^
 
-  * Google Cloud Storage
-  * Google Cloud Storage JSON API
-  * Google Cloud Dataproc API
+* Go to `cloud.google.com <https://cloud.google.com>`__.
+* Click the circle in the upper right, and select your Google account (if you
+  don't have one sign up `here <https://accounts.google.com/SignUp>`__.
+* `If you have multiple Google accounts, sign out first, and then sign into
+  the account you want to use.`
+* Click **Try it Free** in the upper right
+* Enter your name and payment information
+* Wait a few minutes while your first project is created
 
-* Under Credentials, **Create Credentials** and select **Service account key**.  Then, select **New service account**, enter a Name and select **Key type** JSON.
 
-* Install the `Google Cloud SDK <https://cloud.google.com/sdk/>`_
+Enabling Google Cloud Dataproc
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`Dataproc Documentation <https://cloud.google.com/dataproc/overview>`_
+* Go `here <https://console.cloud.google.com/apis/library/dataproc.googleapis.com/>`__ (or search for "dataproc" under **APIs & Services > Library** in the upper left-hand menu)
+* Click **Enable**
 
-`How GCP Default credentials work <https://developers.google.com/identity/protocols/application-default-credentials#howtheywork>`_
+Creating credentials
+^^^^^^^^^^^^^^^^^^^^
 
+* Go `here <https://console.cloud.google.com/apis/credentials>__` (or pick **APIs & Services > Credentials** in the upper left-hand menu)
+* Pick **Create credentials > Service account key**
+* Select **Compute engine default service account**
+* Click **Create** to download a JSON file.
+* Point **$GOOGLE_APPLICATION_CREDENTIALS** at the file you downloaded (``export GOOGLE_APPLICATION_CREDENTIALS="/path/to/Your Credentials.json"``).
+
+You do not have to download or install the :command:`gcloud` utility, but if
+you have it installed and configured, mrjob can read credentials from its
+config files rather than **$GOOGLE_APPLICATION_CREDENTIALS**. See
+`Installing Cloud SDK <https://cloud.google.com/sdk/downloads>__` for more
+information.
 
 .. _running-a-dataproc-job:
 

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -225,7 +225,8 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner):
                 'Dataproc v1 expects core/task instance types to be identical')
 
         # load credentials and project ID
-        self._credentials, auth_project_id = google.auth.default()
+        self._credentials, auth_project_id = google.auth.default(
+            scopes=_DEFAULT_GCE_SERVICE_ACCOUNT_SCOPES)
 
         self._project_id = self._opts['project_id'] or auth_project_id
 

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -46,8 +46,8 @@ class MockGoogleTestCase(SandboxedTestCase):
         # set this to False to make jobs ERROR
         self.mock_jobs_succeed = True
 
-        # mock credentials, returned by mock google.auth.default()
-        self.mock_credentials = Credentials('mock_token')
+        # mock OAuth token, returned by mock google.auth.default()
+        self.mock_token = 'mock_token'
 
         # mock project ID, returned by mock google.auth.default()
         self.mock_project_id = 'mock-project-12345'
@@ -74,8 +74,9 @@ class MockGoogleTestCase(SandboxedTestCase):
 
         self.start(patch('time.sleep'))
 
-    def auth_default(self):
-        return (self.mock_credentials, self.mock_project_id)
+    def auth_default(self, scopes=None):
+        credentials = Credentials(self.mock_token, scopes=scopes)
+        return (credentials, self.mock_project_id)
 
     def create_channel(self, target, credentials=None):
         channel = Mock()

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -381,7 +381,7 @@ class CredentialsTestCase(MockGoogleTestCase):
 
     def test_credentials_are_scoped(self):
         # if we don't set scope, we'll get an error unless we're reading
-        # credentials from gcloud
+        # credentials from gcloud (see #1742)
         with self.make_runner() as runner:
             self.assertTrue(runner._credentials.scopes)
 

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -377,6 +377,15 @@ class ProjectIDTestCase(MockGoogleTestCase):
             self.assertEqual(runner._project_id, 'alan-parsons')
 
 
+class CredentialsTestCase(MockGoogleTestCase):
+
+    def test_credentials_are_scoped(self):
+        # if we don't set scope, we'll get an error unless we're reading
+        # credentials from gcloud
+        with self.make_runner() as runner:
+            self.assertTrue(runner._credentials.scopes)
+
+
 class ExtraClusterParamsTestCase(MockGoogleTestCase):
 
     # just a basic test to make extra_cluster_params is respected.


### PR DESCRIPTION
This brings the Dataproc Quickstart up to date (fixes #1589).

Also added a small tweak to the way we load credentials, so it's possible to use mrjob with Dataproc without installing `gcloud` (fixes #1742).