### PR TITLE
reduce number of google dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ install:
   - "pip install ."
   - "pip install ujson || true"
 # command to run tests
-script: python setup.py test
+script: py.test
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@ matrix:
     - python: "3.5-dev"
     - python: "nightly"
   fast_finish: true
-# command to install dependencies. We definitely want to test against
-# ujson, but it isn't available on PyPy.
 install:
   - "pip install ."
-  - "pip install ujson || true"
 # command to run tests
 script: python -m unittest discover -v
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 # command to install dependencies. We definitely want to test against
 # ujson, but it isn't available on PyPy.
 install:
-  - "pip install . || true"
+  - "pip install ."
   - "pip install ujson || true"
 # command to run tests
 script: python -m unittest discover -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ matrix:
 # command to install dependencies. We definitely want to test against
 # ujson, but it isn't available on PyPy.
 install:
-  - "pip install .; pip install ujson || true"
+  - "pip install ."
+  - "pip install ujson || true"
 # command to run tests
 script: python setup.py test
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ matrix:
 # command to install dependencies. We definitely want to test against
 # ujson, but it isn't available on PyPy.
 install:
-  - "pip install ."
+  - "pip install . || true"
   - "pip install ujson || true"
 # command to run tests
-script: py.test
+script: python -m unittest discover -v
 sudo: false

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ try:
             # we'll just have to upgrade mrjob if and when the library's
             # API changes. Might be determined by google-cloud anyhow.
             'google-cloud-dataproc',
+            'google-oauth',  # not implied on Python 3.5 and later
             'PyYAML>=3.08',
         ],
         'provides': ['mrjob'],
@@ -50,6 +51,10 @@ try:
     # mock is included in Python 3.3 as unittest.mock
     if sys.version_info < (3, 3):
         setuptools_kwargs['tests_require'].append('mock')
+
+    # grpc requires enum, which is a builtin starting in Python 3.4
+    if sys.version_info >= (3, 0) and sys.version_info < (3, 4):
+        setuptools_kwargs['install_requires'].append('enum34')
 
 except ImportError:
     from distutils.core import setup

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ try:
         'install_requires': [
             'boto3>=1.4.6',
             'botocore>=1.6.0',
-            'google-cloud>=0.32.0',
+            'google-auth',
+            'google-cloud-storage',
             # as of 2018-03-21, there is only one version of this library out
             # (0.1.0), and it's in Alpha. No real point in pinning the version;
             # we'll just have to upgrade mrjob if and when the library's

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ try:
             # we'll just have to upgrade mrjob if and when the library's
             # API changes. Might be determined by google-cloud anyhow.
             'google-cloud-dataproc',
+            'grpcio>=1.9.1',
             'PyYAML>=3.08',
         ],
         'provides': ['mrjob'],

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ try:
         setuptools_kwargs['install_requires'].append('enum34')
 
 
-
 except ImportError:
     from distutils.core import setup
     setuptools_kwargs = {}

--- a/setup.py
+++ b/setup.py
@@ -23,30 +23,38 @@ try:
     # arguments that distutils doesn't understand
     setuptools_kwargs = {
         'extras_require': {
-            # highly recommended, but requires a compiler
             'ujson': ['ujson'],
         },
         'install_requires': [
             'boto3>=1.4.6',
             'botocore>=1.6.0',
-            'google-api-core>=0.1.2',
-            'google-cloud-storage>=1.6.0',
-            # as of 2018-03-21, there is only one version of this library out
-            # (0.1.0), and it's in Alpha. No real point in pinning the version;
-            # we'll just have to upgrade mrjob if and when the library's
-            # API changes. Might be determined by google-cloud anyhow.
-            'google-cloud-dataproc',
-            'grpcio>=1.9.1',
             'PyYAML>=3.08',
         ],
         'provides': ['mrjob'],
         'test_suite': 'tests',
-        'tests_require': ['simplejson'],
+        'tests_require': ['simplejson', 'ujson'],
         'zip_safe': False,  # so that we can bootstrap mrjob
     }
 
+    # google deps do weird things on PyPy, so just install google-cloud
+    if hasattr(sys, 'pypy_version_info'):
+        setuptools_kwargs['install_requires'].extend([
+            'google-cloud>=0.32.0',
+            'google-cloud-dataproc',  # in alpha, no point in pinning version
+        ])
+    else:
+        # otherwise, only install the libraries we need (see #1746)
+        setuptools_kwargs['install_requires'].extend([
+            'google-api-core>=0.1.2',
+            'google-cloud-storage>=1.6.0',
+            'google-cloud-dataproc',
+            'grpcio>=1.9.1',
+        ])
+
+    # rapidjson exists on Python 3 only
     if sys.version_info >= (3, 0):
         setuptools_kwargs['extras_require']['rapidjson'] = ['rapidjson']
+        setuptools_kwargs['tests_require'].append('rapidjson')
 
     # mock is included in Python 3.3 as unittest.mock
     if sys.version_info < (3, 3):

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ try:
         'install_requires': [
             'boto3>=1.4.6',
             'botocore>=1.6.0',
-            'google-auth',
-            'google-cloud-storage',
+            'google-api-core>=0.1.2',
+            'google-cloud-storage>=1.6.0',
             # as of 2018-03-21, there is only one version of this library out
             # (0.1.0), and it's in Alpha. No real point in pinning the version;
             # we'll just have to upgrade mrjob if and when the library's

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ try:
             # we'll just have to upgrade mrjob if and when the library's
             # API changes. Might be determined by google-cloud anyhow.
             'google-cloud-dataproc',
-            'google-oauth',  # not implied on Python 3.5 and later
             'PyYAML>=3.08',
         ],
         'provides': ['mrjob'],
@@ -55,6 +54,8 @@ try:
     # grpc requires enum, which is a builtin starting in Python 3.4
     if sys.version_info >= (3, 0) and sys.version_info < (3, 4):
         setuptools_kwargs['install_requires'].append('enum34')
+
+
 
 except ImportError:
     from distutils.core import setup

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,10 @@ try:
             'boto3>=1.4.6',
             'botocore>=1.6.0',
             'PyYAML>=3.08',
+            'google-api-core>=0.1.2',
+            'google-cloud-storage>=1.6.0',
+            'google-cloud-dataproc',
+            'grpcio>=1.9.1',
         ],
         'provides': ['mrjob'],
         'test_suite': 'tests',
@@ -36,20 +40,12 @@ try:
         'zip_safe': False,  # so that we can bootstrap mrjob
     }
 
-    # google deps do weird things on PyPy, so just install google-cloud
+    # latest grpcio seems not to work
     if hasattr(sys, 'pypy_version_info'):
-        setuptools_kwargs['install_requires'].extend([
-            'google-cloud>=0.32.0',
-            'google-cloud-dataproc',  # in alpha, no point in pinning version
-        ])
-    else:
-        # otherwise, only install the libraries we need (see #1746)
-        setuptools_kwargs['install_requires'].extend([
-            'google-api-core>=0.1.2',
-            'google-cloud-storage>=1.6.0',
-            'google-cloud-dataproc',
-            'grpcio>=1.9.1',
-        ])
+        setuptools_kwargs['install_requires'] = [
+            x + ',<=1.10.0' if x.startswith('grpcio') else x
+            for x in setuptools_kwargs['install_requires']
+        ]
 
     # rapidjson exists on Python 3 only
     if sys.version_info >= (3, 0):

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """Limited mock of google-cloud-sdk for tests
 """
-from copy import deepcopy
 from io import BytesIO
+
+from google.oauth2.credentials import Credentials
 
 from mrjob.fs.gcs import parse_gcs_uri
 
@@ -74,10 +75,7 @@ class MockGoogleTestCase(SandboxedTestCase):
         self.start(patch('time.sleep'))
 
     def auth_default(self, scopes=None):
-        credentials = Mock()
-        credentials.token = self.mock_token
-        credentials.scopes = deepcopy(scopes)
-
+        credentials = Credentials(self.mock_token, scopes=scopes)
         return (credentials, self.mock_project_id)
 
     def create_channel(self, target, credentials=None):

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 """Limited mock of google-cloud-sdk for tests
 """
+from copy import deepcopy
 from io import BytesIO
-
-from google.oauth2.credentials import Credentials
 
 from mrjob.fs.gcs import parse_gcs_uri
 
@@ -75,7 +74,10 @@ class MockGoogleTestCase(SandboxedTestCase):
         self.start(patch('time.sleep'))
 
     def auth_default(self, scopes=None):
-        credentials = Credentials(self.mock_token, scopes=scopes)
+        credentials = Mock()
+        credentials.token = self.mock_token
+        credentials.scopes = deepcopy(scopes)
+
         return (credentials, self.mock_project_id)
 
     def create_channel(self, target, credentials=None):


### PR DESCRIPTION
After hours of struggling with setup.py and Travis CI, was able to install the specific google libraries mrjob needs for dataproc support rather than `google-cloud`, which installs everything needed for every service it supports.

This is based on #1747 and supersedes it. It also makes the tests a bit tighter, requiring the library install to pass, and always tests all JSON implementations.