### PR TITLE
SSH tunnel on Dataproc

### DIFF
--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -504,8 +504,8 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
                 # this only happens if the ssh binary is not present
                 # or not executable (so tunnel_config and the args to the
                 # ssh binary don't matter)
-                log.warning("    Couldn't run %s: %s" % (
-                    cmd_line(ssh_tunnel_args[:1]), popen_exception))
+                log.warning(
+                    "    Couldn't open SSH tunnel: %s" % popen_exception)
                 self._give_up_on_ssh_tunnel = True
                 return
             else:

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -26,6 +26,7 @@ from time import sleep
 
 from mrjob.bin import MRJobBinRunner
 from mrjob.conf import combine_dicts
+from mrjob.py2 import xrange
 from mrjob.setup import WorkingDirManager
 from mrjob.setup import parse_setup_cmd
 from mrjob.util import cmd_line
@@ -459,13 +460,6 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
                             ' %d, restarting...' % self._ssh_proc.returncode)
                 self._ssh_proc = None
 
-        # create a Popen for the ssh proc
-        ssh_proc = self._launch_ssh_proc()
-
-        # is it not possible to launch a tunnel now?
-        if not ssh_proc:
-            return
-
         tunnel_config = self._ssh_tunnel_config()
 
         bind_port = None
@@ -475,7 +469,7 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
             ssh_proc = None
 
             try:
-                ssh_proc = self._launch_ssh_proc()
+                ssh_proc = self._launch_ssh_proc(bind_port)
             except OSError as ex:
                 # e.g. OSError(2, 'File not found')
                 popen_exception = ex   # warning handled below

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -841,7 +841,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 new_data = log_blob.download_as_string()[state['pos']:]
             except google.api_core.exceptions.NotFound:
                 # handle race condition where blob was just created
-                return
+                break
 
             state['buffer'] += new_data
             state['pos'] += len(new_data)

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -1069,12 +1069,11 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     def _ssh_tunnel_config(self):
         return _SSH_TUNNEL_CONFIG
 
-    def _launch_ssh_proc(self, bind_port):
-        ssh_proc = super(DataprocJobRunner, self)._launch_ssh_proc(bind_port)
+    def _launch_ssh_proc(self, args):
+        ssh_proc = super(DataprocJobRunner, self)._launch_ssh_proc(args)
 
-        if ssh_proc:
-            # enter an empty passphrase if creating a key for the first time
-            ssh_proc.stdin.write(b'\n\n')
+        # enter an empty passphrase if creating a key for the first time
+        ssh_proc.stdin.write(b'\n\n')
 
         return ssh_proc
 

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -309,6 +309,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 check_cluster_every=_DEFAULT_CHECK_CLUSTER_EVERY,
                 cleanup=['CLUSTER', 'JOB', 'LOCAL_TMP'],
                 cloud_fs_sync_secs=_DEFAULT_CLOUD_FS_SYNC_SECS,
+                gcloud_bin=['gcloud'],
                 image_version=_DEFAULT_IMAGE_VERSION,
                 instance_type=_DEFAULT_INSTANCE_TYPE,
                 master_instance_type=_DEFAULT_INSTANCE_TYPE,

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -865,7 +865,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             # it work won't work on some VPC setups
             return self._master_private_ip()
 
-    def _ssh_tunnel_args(self):
+    def _ssh_tunnel_args(self, bind_port):
         for opt_name in ('ec2_key_pair', 'ec2_key_pair_file',
                          'ssh_bin', 'ssh_bind_ports'):
             if not self._opts[opt_name]:
@@ -896,7 +896,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'ExitOnForwardFailure=yes',
             '-o', 'UserKnownHostsFile=%s' % fake_known_hosts_file,
-        ] + self._ssh_tunnel_opts() + [
+        ] + self._ssh_tunnel_opts(bind_port) + [
             '-i', self._opts['ec2_key_pair_file'],
             ('hadoop@%s' % host),
         ]
@@ -917,8 +917,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         super(EMRJobRunner, self).cleanup(mode=mode)
 
         # always stop our SSH tunnel if it's still running
-        if self._ssh_proc:
-            self._kill_ssh_tunnel()
+        self._kill_ssh_tunnel()
 
         # stop the cluster if it belongs to us (it may have stopped on its
         # own already, but that's fine)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -20,16 +20,11 @@ import os
 import os.path
 import pipes
 import posixpath
-import random
 import re
-import signal
-import socket
 import time
 from collections import defaultdict
 from datetime import datetime
 from datetime import timedelta
-from subprocess import Popen
-from subprocess import PIPE
 
 try:
     import botocore.client
@@ -89,12 +84,10 @@ from mrjob.pool import _pool_hash_and_name
 from mrjob.py2 import PY2
 from mrjob.py2 import string_types
 from mrjob.py2 import urlopen
-from mrjob.py2 import xrange
 from mrjob.setup import UploadDirManager
 from mrjob.setup import WorkingDirManager
 from mrjob.step import StepFailedException
 from mrjob.step import _is_spark_step_type
-from mrjob.util import cmd_line
 from mrjob.util import shlex_split
 from mrjob.util import strip_microseconds
 from mrjob.util import random_identifier
@@ -410,14 +403,8 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         # when did our particular task start?
         self._emr_job_start = None
 
-        # ssh state
-        self._ssh_proc = None
-        self._gave_cant_ssh_warning = False
         # we don't upload the ssh key to master until it's needed
         self._ssh_key_is_copied = False
-
-        # store the (tunneled) URL of the job tracker/resource manager
-        self._ssh_tunnel_url = None
 
         # map from cluster ID to a dictionary containing cached info about
         # that cluster. Includes the following keys:
@@ -465,11 +452,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 region=_DEFAULT_EMR_REGION,
                 sh_bin=None,  # see _sh_bin(), below
                 ssh_bin=['ssh'],
-                # don't use a list because it makes it hard to read option
-                # values when running in verbose mode. See #1284
-                ssh_bind_ports=xrange(40001, 40841),
-                ssh_tunnel=False,
-                ssh_tunnel_is_open=False,
                 visible_to_all_users=True,
             )
         )
@@ -883,49 +865,19 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             # it work won't work on some VPC setups
             return self._master_private_ip()
 
-    def _job_tracker_url(self):
-        tunnel_config = self._ssh_tunnel_config()
-
-        return 'http://%s:%d%s' % (
-            self._job_tracker_host(),
-            tunnel_config['port'],
-            tunnel_config['path'])
-
-    def _set_up_ssh_tunnel(self):
-        """set up the ssh tunnel to the job tracker, if it's not currently
-        running.
-        """
-        if not self._opts['ssh_tunnel']:
-            return
+    def _ssh_tunnel_args(self):
+        for opt_name in ('ec2_key_pair', 'ec2_key_pair_file',
+                         'ssh_bin', 'ssh_bind_ports'):
+            if not self._opts[opt_name]:
+                log.warning(
+                    "  You must set %s in order to set up the SSH tunnel!"
+                    % opt_name)
+                self._give_up_on_ssh_tunnel = True
+                return
 
         host = self._address_of_master()
         if not host:
             return
-
-        # look up what we're supposed to do on this AMI version
-        tunnel_config = self._ssh_tunnel_config()
-
-        REQUIRED_OPTS = ['ec2_key_pair', 'ec2_key_pair_file', 'ssh_bind_ports']
-        for opt_name in REQUIRED_OPTS:
-            if not self._opts[opt_name]:
-                if not self._gave_cant_ssh_warning:
-                    log.warning(
-                        "  You must set %s in order to set up the SSH tunnel!"
-                        % opt_name)
-                    self._gave_cant_ssh_warning = True
-                return
-
-        # if there was already a tunnel, make sure it's still up
-        if self._ssh_proc:
-            self._ssh_proc.poll()
-            if self._ssh_proc.returncode is None:
-                return
-            else:
-                log.warning('  Oops, ssh subprocess exited with return code'
-                            ' %d, restarting...' % self._ssh_proc.returncode)
-                self._ssh_proc = None
-
-        log.info('  Opening ssh tunnel to %s...' % tunnel_config['name'])
 
         # if ssh detects that a host key has changed, it will silently not
         # open the tunnel, so make a fake empty known_hosts file and use that.
@@ -939,107 +891,25 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         log.debug('Created empty ssh known-hosts file: %s' % (
             fake_known_hosts_file,))
 
-        bind_port = None
-        popen_exception = None
+        return self._opts['ssh_bin'] + [
+            '-o', 'VerifyHostKeyDNS=no',
+            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'ExitOnForwardFailure=yes',
+            '-o', 'UserKnownHostsFile=%s' % fake_known_hosts_file,
+        ] + self._ssh_tunnel_opts() + [
+            '-i', self._opts['ec2_key_pair_file'],
+            ('hadoop@%s' % host),
+        ]
 
-        for bind_port in self._pick_ssh_bind_ports():
-            # this could be refactored to use SSHFilesystem._ssh_launch(),
-            # but that would probably just make this code less readable
-            args = self._opts['ssh_bin'] + [
-                '-o', 'VerifyHostKeyDNS=no',
-                '-o', 'StrictHostKeyChecking=no',
-                '-o', 'ExitOnForwardFailure=yes',
-                '-o', 'UserKnownHostsFile=%s' % fake_known_hosts_file,
-                '-L', '%d:%s:%d' % (
-                    bind_port,
-                    self._job_tracker_host(),
-                    tunnel_config['port']),
-                '-N', '-n', '-q',  # no shell, no input, no output
-                '-i', self._opts['ec2_key_pair_file'],
-            ]
-            if self._opts['ssh_tunnel_is_open']:
-                args.extend(['-g', '-4'])  # -4: listen on IPv4 only
-            args.append('hadoop@' + host)
-            log.debug('> %s' % cmd_line(args))
+    def _job_tracker_url(self):
+        """Not actually used to set up the SSH tunnel, used to run curl
+        over SSH to fetch from the job tracker directly."""
+        tunnel_config = self._ssh_tunnel_config()
 
-            ssh_proc = None
-            try:
-                ssh_proc = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-            except OSError as ex:
-                # e.g. OSError(2, 'File not found')
-                popen_exception = ex   # warning handled below
-                break
-
-            if ssh_proc:
-                time.sleep(_WAIT_FOR_SSH_TO_FAIL)
-                ssh_proc.poll()
-                # still running. We are golden
-                if ssh_proc.returncode is None:
-                    self._ssh_proc = ssh_proc
-                    break
-                else:
-                    ssh_proc.stdin.close()
-                    ssh_proc.stdout.close()
-                    ssh_proc.stderr.close()
-
-        if not self._ssh_proc:
-            if popen_exception:
-                # this only happens if the ssh binary is not present
-                # or not executable (so tunnel_config and the args to the
-                # ssh binary don't matter)
-                log.warning("    Couldn't run %s: %s" % (
-                    cmd_line(self._opts['ssh_bin']), popen_exception))
-            else:
-                log.warning(
-                    '    Failed to open ssh tunnel to %s' %
-                    tunnel_config['name'])
-        else:
-            if self._opts['ssh_tunnel_is_open']:
-                bind_host = socket.getfqdn()
-            else:
-                bind_host = 'localhost'
-            self._ssh_tunnel_url = 'http://%s:%d%s' % (
-                bind_host, bind_port, tunnel_config['path'])
-            log.info('  Connect to %s at: %s' % (
-                tunnel_config['name'], self._ssh_tunnel_url))
-
-    def _kill_ssh_tunnel(self):
-        """Send SIGKILL to SSH tunnel, if it's running."""
-        if not self._ssh_proc:
-            return
-
-        self._ssh_proc.poll()
-        if self._ssh_proc.returncode is None:
-            log.info('Killing our SSH tunnel (pid %d)' %
-                     self._ssh_proc.pid)
-
-            self._ssh_proc.stdin.close()
-            self._ssh_proc.stdout.close()
-            self._ssh_proc.stderr.close()
-
-            try:
-                os.kill(self._ssh_proc.pid, signal.SIGKILL)
-            except Exception as e:
-                log.exception(e)
-
-        self._ssh_proc = None
-        self._ssh_tunnel_url = None
-
-    def _pick_ssh_bind_ports(self):
-        """Pick a list of ports to try binding our SSH tunnel to.
-
-        We will try to bind the same port for any given cluster (Issue #67)
-        """
-        # don't perturb the random number generator
-        random_state = random.getstate()
-        try:
-            # seed random port selection on cluster ID
-            random.seed(self._cluster_id)
-            num_picks = min(_MAX_SSH_RETRIES,
-                            len(self._opts['ssh_bind_ports']))
-            return random.sample(self._opts['ssh_bind_ports'], num_picks)
-        finally:
-            random.setstate(random_state)
+        return 'http://%s:%d%s' % (
+            self._job_tracker_host(),
+            tunnel_config['port'],
+            tunnel_config['path'])
 
     ### Running the job ###
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -600,6 +600,12 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    gcloud_bin=dict(
+        combiner=combine_cmds,
+        switches=[
+            (['--gcloud-bin'], dict(help='path to gcloud binary')),
+        ],
+    ),
     hadoop_bin=dict(
         combiner=combine_cmds,
         switches=[

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -20,6 +20,7 @@ import os.path
 from contextlib import contextmanager
 from copy import deepcopy
 from io import BytesIO
+from subprocess import PIPE
 
 from google.api_core.exceptions import NotFound
 
@@ -1307,3 +1308,110 @@ class ProgressAndCounterLoggingTestCase(MockGoogleTestCase):
                 'Counters: 1\n\tFile System Counters\n\t\tFILE:'
                 ' Number of bytes read=819'),
             self.log.info.call_args_list)
+
+
+class SetUpSSHTunnelTestCase(MockGoogleTestCase):
+
+    def setUp(self, *args):
+        super(SetUpSSHTunnelTestCase, self).setUp()
+
+        self.mock_Popen = self.start(patch('mrjob.cloud.Popen'))
+        # simulate successfully binding port
+        self.mock_Popen.return_value.returncode = None
+        self.mock_Popen.return_value.pid = 99999
+
+        self.start(patch('os.kill'))  # don't clean up fake SSH proc
+
+        self.start(patch('time.sleep'))
+
+    def test_default(self):
+        job = MRWordCount(['-r', 'dataproc'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+        self.assertFalse(self.mock_Popen.called)
+
+    def test_default_ssh_tunnel(self):
+        job = MRWordCount(['-r', 'dataproc', '--ssh-tunnel'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+        self.assertEqual(self.mock_Popen.call_count, 1)
+        args_tuple, kwargs = self.mock_Popen.call_args
+        args = args_tuple[0]
+
+        self.assertEqual(kwargs, dict(stdin=PIPE, stdout=PIPE, stderr=PIPE))
+
+        self.assertEqual(args[:3], ['gcloud', 'compute', 'ssh'])
+
+        self.assertIn('-L', args)
+        self.assertIn('-N', args)
+        self.assertIn('-n', args)
+        self.assertIn('-q', args)
+
+        self.assertNotIn('-g', args)
+        self.assertNotIn('-4', args)
+
+        self.mock_Popen.stdin.called_once_with(b'\n\n')
+
+    def test_open_ssh_tunnel(self):
+        job = MRWordCount(
+            ['-r', 'dataproc', '--ssh-tunnel', '--ssh-tunnel-is-open'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+        self.assertEqual(self.mock_Popen.call_count, 1)
+        args = self.mock_Popen.call_args[0][0]
+
+        self.assertIn('-L', args)
+        self.assertIn('-N', args)
+        self.assertIn('-n', args)
+        self.assertIn('-q', args)
+
+        self.assertIn('-g', args)
+        self.assertIn('-4', args)
+
+    def test_custom_gcloud_bin(self):
+        job = MRWordCount(['-r', 'dataproc', '--ssh-tunnel',
+                           '--gcloud-bin', '/path/to/gcloud -v'])
+
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+        self.assertEqual(self.mock_Popen.call_count, 1)
+        args = self.mock_Popen.call_args[0][0]
+
+        self.assertEqual(args[:4], ['/path/to/gcloud', '-v', 'compute', 'ssh'])
+
+    def test_missing_gcloud_bin(self):
+        self.mock_Popen.side_effect = OSError(2, 'No such file or directory')
+
+        job = MRWordCount(['-r', 'dataproc', '--ssh-tunnel'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+        self.assertEqual(self.mock_Popen.call_count, 1)
+        self.assertTrue(runner._give_up_on_ssh_tunnel)
+
+    def test_error_from_gcloud_bin(self):
+        self.mock_Popen.return_value.returncode = 255
+
+        job = MRWordCount(['-r', 'dataproc', '--ssh-tunnel'])
+
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+        self.assertGreater(self.mock_Popen.call_count, 1)
+        self.assertFalse(runner._give_up_on_ssh_tunnel)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4478,7 +4478,7 @@ class SetUpSSHTunnelTestCase(MockBoto3TestCase):
     def setUp(self, *args):
         super(SetUpSSHTunnelTestCase, self).setUp()
 
-        self.mock_Popen = self.start(patch('mrjob.emr.Popen'))
+        self.mock_Popen = self.start(patch('mrjob.cloud.Popen'))
         # simulate successfully binding port
         self.mock_Popen.return_value.returncode = None
         self.mock_Popen.return_value.pid = 99999


### PR DESCRIPTION
This enables the `--ssh-tunnel` option on Dataproc, allowing you to track the process of your job through a web browser. Fixes #1670.

Also moved some common code with EMR into `mrjob/cloud.py` and added a workaround an unrelated race condition having to do with parsing job driver output.
