### PR TITLE
chunked uploading on dataproc runner

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -846,8 +846,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             try:
                 # TODO: use start= kwarg once google-cloud-storage 1.9 is out
                 new_data = log_blob.download_as_string()[state['pos']:]
-            except (google.api_core.exceptions.NotFound,
-                    google.api_core.exceptions.RequestRangeNotSatisfiable):
+            except google.api_core.exceptions.NotFound:
                 # handle race condition where blob was just created
                 break
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -301,7 +301,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'bootstrap_actions',
         'bootstrap_spark',
         'cloud_log_dir',
-        'cloud_upload_part_size',
         'core_instance_bid_price',
         'ec2_key_pair',
         'ec2_key_pair_file',
@@ -442,7 +441,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 check_cluster_every=30,
                 cleanup_on_failure=['JOB'],
                 cloud_fs_sync_secs=5.0,
-                cloud_upload_part_size=100,  # 100 MB
                 image_version=_DEFAULT_IMAGE_VERSION,
                 num_core_instances=0,
                 num_task_instances=0,

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -58,10 +58,12 @@ class GCSFilesystem(Filesystem):
     :py:class:`~mrjob.fs.ssh.SSHFilesystem` and
     :py:class:`~mrjob.fs.local.LocalFilesystem`.
     """
-    def __init__(self, local_tmp_dir=None, credentials=None, project_id=None):
-        self._local_tmp_dir = local_tmp_dir
+    def __init__(self, local_tmp_dir=None, credentials=None, project_id=None,
+                 chunk_size=None):
         self._credentials = credentials
+        self._local_tmp_dir = local_tmp_dir
         self._project_id = project_id
+        self._chunk_size = chunk_size
 
     @property
     def client(self):
@@ -237,12 +239,12 @@ class GCSFilesystem(Filesystem):
     def _get_blob(self, uri):
         bucket_name, blob_name = parse_gcs_uri(uri)
         bucket = self.client.get_bucket(bucket_name)
-        return bucket.get_blob(blob_name)
+        return bucket.get_blob(blob_name, chunk_size=self._chunk_size)
 
     def _blob(self, uri):
         bucket_name, blob_name = parse_gcs_uri(uri)
         bucket = self.client.get_bucket(bucket_name)
-        return bucket.blob(blob_name)
+        return bucket.blob(blob_name, chunk_size=self._chunk_size)
 
 
 # The equivalent S3 methods are in parse.py but it's cleaner to keep them

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -78,11 +78,11 @@ class MockGoogleStorageBucket(object):
     def exists(self):
         return self.name in self.client.mock_gcs_fs
 
-    def get_blob(self, blob_name):
+    def get_blob(self, blob_name, chunk_size=None):
         fs = self.client.mock_gcs_fs
 
         if self.name in fs and blob_name in fs[self.name]['blobs']:
-            blob = self.blob(blob_name)
+            blob = self.blob(blob_name, chunk_size=chunk_size)
             blob._set_md5_hash()
             return blob
 


### PR DESCRIPTION
Enabled the `cloud_upload_part_size` option on the dataproc runner, which is used to set `chunk_size` when uploading. Fixes #1404