### PR TITLE
require google-cloud-storage>=1.9.0

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -38,7 +38,6 @@ from mrjob.compat import map_version
 from mrjob.conf import combine_dicts
 from mrjob.fs.composite import CompositeFilesystem
 from mrjob.fs.gcs import GCSFilesystem
-from mrjob.fs.gcs import _download_as_string
 from mrjob.fs.gcs import is_gcs_uri
 from mrjob.fs.gcs import parse_gcs_uri
 from mrjob.fs.local import LocalFilesystem
@@ -891,9 +890,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             log_blob = self.fs._get_blob(log_uri)
 
             try:
-                # TODO: use start= kwarg once google-cloud-storage 1.9 is out
-                #new_data = log_blob.download_as_string()[state['pos']:]
-                new_data = _download_as_string(log_blob, start=state['pos'])
+                new_data = log_blob.download_as_string(start=state['pos'])
             except (google.api_core.exceptions.NotFound,
                     google.api_core.exceptions.RequestRangeNotSatisfiable):
                 # blob was just created, or no more data is available

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ try:
             'PyYAML>=3.08',
             'google-cloud>=0.32.0',
             'google-cloud-dataproc',
+            'google-cloud-storage>=1.9.0',
             'grpcio>=1.9.1',
         ],
         'provides': ['mrjob'],

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -25,7 +25,6 @@ from .dataproc import MockGoogleDataprocClusterClient
 from .dataproc import MockGoogleDataprocJobClient
 from .logging import MockGoogleLoggingClient
 from .storage import MockGoogleStorageClient
-from .storage import _mock_download_as_string_shim
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.py2 import Mock
 from tests.py2 import patch
@@ -81,11 +80,6 @@ class MockGoogleTestCase(SandboxedTestCase):
 
         self.start(patch('google.cloud.storage.client.Client',
                          self.storage_client))
-
-        self.start(patch('mrjob.dataproc._download_as_string',
-                         _mock_download_as_string_shim))
-        self.start(patch('mrjob.fs.gcs._download_as_string',
-                         _mock_download_as_string_shim))
 
         self.start(patch('time.sleep'))
 

--- a/tests/mock_google/storage.py
+++ b/tests/mock_google/storage.py
@@ -146,10 +146,6 @@ class MockGoogleStorageBlob(object):
 
         del self._fs[self.bucket.name]['blobs'][self.name]
 
-    # this mocks a future version of this method which is
-    # currently only available in dev. Our code accesses the start and end
-    # keywords through mrjob.fs.gcs._download_as_string(). See
-    # _mock_download_as_string_shim() below.
     def download_as_string(self, client=None, start=None, end=None):
         try:
             data = self._fs[self.bucket.name]['blobs'][self.name]['data']
@@ -213,8 +209,3 @@ class MockGoogleStorageBlob(object):
             pass
 
         self.md5_hash = b64encode(md5(data).digest())
-
-
-# mock mrjob.fs.gcs._download_as_string(), which is a shim
-def _mock_download_as_string_shim(blob, client=None, start=None, end=None):
-    return blob.download_as_string(client=client, start=start, end=end)


### PR DESCRIPTION
Removes shim code backported from the development version `google-cloud-storage` in favor of using `google-cloud-storage` 1.9.0 directly.