### PR TITLE
Dataproc service account opts

### DIFF
--- a/docs/guides/dataproc-opts.rst
+++ b/docs/guides/dataproc-opts.rst
@@ -122,6 +122,41 @@ Cluster creation and configuration
    .. versionadded:: 0.6.3
 
 .. mrjob-opt::
+   :config: service_account
+   :switch: --service-account
+   :set: dataproc
+   :default: ``None``
+
+   Optional service account to use when creating a cluster. For more
+   information see `Service Accounts <https://cloud.google.com/compute/docs/access/service-accounts#custom_service_accounts>`__.
+
+   .. versionadded:: 0.6.3
+
+.. mrjob-opt::
+   :config: service_account_scopes
+   :switch: --service-account-scope
+   :set: dataproc
+   :default: (automatic)
+
+   Service account scopes to use when creating a cluster. By default,
+   Dataproc uses these scopes::
+
+     https://www.googleapis.com/auth/bigquery
+     https://www.googleapis.com/auth/bigtable.admin.table
+     https://www.googleapis.com/auth/bigtable.data
+     https://www.googleapis.com/auth/cloud-platform
+     https://www.googleapis.com/auth/cloud.useraccounts.readonly
+     https://www.googleapis.com/auth/devstorage.full_control
+     https://www.googleapis.com/auth/devstorage.read_write
+     https://www.googleapis.com/auth/logging.write
+
+   ``--service-account-scope`` can only be used to add additional scopes.
+   If you wish to exclude some of these scopes, you can use ``!clear`` in
+   your config file (see :ref:`clearing-configs`).
+
+   .. versionadded:: 0.6.3
+
+.. mrjob-opt::
    :config: task_instance_config
    :switch: --task-instance-config
    :set: dataproc

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -230,6 +230,8 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'gcloud_bin',
         'master_instance_config',
         'project_id',
+        'service_account',
+        'service_account_scopes',
         'task_instance_config',
     }
 
@@ -348,6 +350,8 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 master_instance_type=_DEFAULT_INSTANCE_TYPE,
                 num_core_instances=_DATAPROC_MIN_WORKERS,
                 num_task_instances=0,
+                service_account_scopes=list(
+                    _DEFAULT_GCE_SERVICE_ACCOUNT_SCOPES),
                 sh_bin=['/bin/sh', '-ex'],
             )
         )
@@ -1144,9 +1148,13 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             self._opts['max_mins_idle'] * 60))
 
         gce_cluster_config = dict(
-            service_account_scopes=_DEFAULT_GCE_SERVICE_ACCOUNT_SCOPES,
-            metadata=cluster_metadata
+            metadata=cluster_metadata,
+            service_account_scopes=self._opts['service_account_scopes'],
         )
+
+        if self._opts['service_account']:
+            gce_cluster_config['service_account'] = (
+                self._opts['service_account'])
 
         if self._opts['zone']:
             gce_cluster_config['zone_uri'] = _gcp_zone_uri(

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -976,6 +976,28 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    service_account=dict(
+        cloud_role='launch',
+        switches=[
+            (['--service-account'], dict(
+                help=('Service account to use when creating a Dataproc'
+                      ' cluster. Usually takes the form'
+                      ' [account_id]@[project_id].iam.gserviceaccount.com.'
+                      ' Set to "" to use the default.'),
+            )),
+        ],
+    ),
+    service_account_scopes=dict(
+        cloud_role='launch',
+        combiner=combine_lists,
+        switches=[
+            (['--service-account-scope'], dict(
+                action='append',
+                help=('Additional service account scope to use when creating'
+                      ' a Dataproc cluster.'),
+            )),
+        ],
+    ),
     setup=dict(
         combiner=combine_lists,
         switches=[

--- a/tests/mock_google/dataproc.py
+++ b/tests/mock_google/dataproc.py
@@ -124,11 +124,6 @@ class MockGoogleDataprocClusterClient(MockGoogleDataprocClient):
         if not cluster.cluster_name:
             raise InvalidArgument('Cluster name is required')
 
-        # TODO: could better mock behavior of service_account_scopes,
-        # including default values, and sorting, though this doesn't affect
-        # existing tests. See:
-        # https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#GceClusterConfig
-
         # add in default disk config
         for x in ('master', 'worker', 'secondary_worker'):
             field = x + '_config'
@@ -150,7 +145,6 @@ class MockGoogleDataprocClusterClient(MockGoogleDataprocClient):
         scopes.update(_MANDATORY_SCOPES)
 
         gce_config.service_account_scopes[:] = sorted(scopes)
-
 
         # initialize cluster status
         cluster.status.state = _cluster_state_value('CREATING')

--- a/tests/mock_google/dataproc.py
+++ b/tests/mock_google/dataproc.py
@@ -107,6 +107,11 @@ class MockGoogleDataprocClusterClient(MockGoogleDataprocClient):
         if not cluster.cluster_name:
             raise InvalidArgument('Cluster name is required')
 
+        # TODO: could better mock behavior of service_account_scopes,
+        # including default values, and sorting, though this doesn't affect
+        # existing tests. See:
+        # https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#GceClusterConfig
+
         # add in default disk config
         for x in ('master', 'worker', 'secondary_worker'):
             field = x + '_config'

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -98,9 +98,10 @@ class EmptyMrjobConfTestCase(PatcherTestCase):
         add_null_handler_to_root_logger()
 
         if self.MRJOB_CONF_CONTENTS is not None:
-            patcher = mrjob_conf_patcher(self.MRJOB_CONF_CONTENTS)
-            patcher.start()
-            self.addCleanup(patcher.stop)
+            self.mrjob_conf_patcher = mrjob_conf_patcher(
+                self.MRJOB_CONF_CONTENTS)
+            self.mrjob_conf_patcher.start()
+            self.addCleanup(self.mrjob_conf_patcher.stop)
 
 
 class SandboxedTestCase(EmptyMrjobConfTestCase):


### PR DESCRIPTION
This adds the ``service_account`` and ``service_account_scopes`` opts to the Dataproc runner. Fixes #1682.