### PR TITLE
Dataproc network and subnet opts

### DIFF
--- a/docs/guides/dataproc-opts.rst
+++ b/docs/guides/dataproc-opts.rst
@@ -75,49 +75,26 @@ Cluster creation and configuration
         https://cloud.google.com/dataproc/dataproc-versions
 
 .. mrjob-opt::
-   :config: core_instance_config
-   :switch: --core-instance-config
+   :config: network
+   :switch: --network
+   :type: :ref:`string <data-type-string>`
    :set: dataproc
    :default: ``None``
 
-   A dictionary of additional parameters to pass as ``config.worker_config``
-   when creating the cluster. Follows the format of
-   `InstanceGroupConfig <https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#InstanceGroupConfig>`__ except that it uses
-   `snake_case` instead of `camel_case`.
-
-   For example, to specify 100GB of disk space on core instances, add this to
-   your config file:
-
-   .. code-block:: yaml
-
-       runners:
-         dataproc:
-           core_instance_config:
-             disk_config:
-               boot_disk_size_gb: 100
-
-   To set this option on the command line, pass in JSON:
-
-   .. code-block:: sh
-
-       --core-instance-config '{"disk_config": {"boot_disk_size_gb": 100}}'
-
-   This option *can* be used to set number of core instances
-   (``num_instances``) or instance type (``machine_type_uri``), but usually
-   you'll want to use :mrjob-opt:`num_core_instances` and
-   :mrjob-opt:`core_instance_type` along with this option.
+   Name or URI on network to launch cluster in on Dataproc. Cannot be used
+   with :mrjob-opt:`subnet`.
 
    .. versionadded:: 0.6.3
 
 .. mrjob-opt::
-   :config: master_instance_config
-   :switch: --master-instance-config
+   :config: subnet
+   :switch: --subnet
+   :type: :ref:`string <data-type-string>`
    :set: dataproc
    :default: ``None``
 
-   A dictionary of additional parameters to pass as ``config.master_config``
-   when creating the cluster. See :mrjob-opt:`core_instance_config` for
-   more details.
+   Name or URI on subnetwork to launch cluster in on Dataproc. Cannot be used
+   with :mrjob-opt:`network`.
 
    .. versionadded:: 0.6.3
 
@@ -153,32 +130,6 @@ Cluster creation and configuration
    ``--service-account-scope`` can only be used to add additional scopes.
    If you wish to exclude some of these scopes, you can use ``!clear`` in
    your config file (see :ref:`clearing-configs`).
-
-   .. versionadded:: 0.6.3
-
-.. mrjob-opt::
-   :config: task_instance_config
-   :switch: --task-instance-config
-   :set: dataproc
-   :default: ``None``
-
-   A dictionary of additional parameters to pass as
-   ``config.secondary_worker_config``
-   when creating the cluster. See :mrjob-opt:`task_instance_config` for
-   more details.
-
-   To make task instances preemptible, add this to your config file:
-
-   .. code-block:: yaml
-
-       runners:
-         dataproc:
-           task_instance_config:
-             is_preemptible: true
-
-   Note that this config won't be applied unless you specify at least one
-   task instance (either through :mrjob-opt:`num_task_instances` or
-   by passing ``num_instances`` to this option).
 
    .. versionadded:: 0.6.3
 
@@ -322,6 +273,82 @@ Number and type of instances
     HDFS. If you use this, you must set :mrjob-opt:`num_core_instances`; Dataproc does not allow you to
     run task instances without core instances (because there's nowhere to host
     HDFS).
+
+
+.. mrjob-opt::
+   :config: core_instance_config
+   :switch: --core-instance-config
+   :set: dataproc
+   :default: ``None``
+
+   A dictionary of additional parameters to pass as ``config.worker_config``
+   when creating the cluster. Follows the format of
+   `InstanceGroupConfig <https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#InstanceGroupConfig>`__ except that it uses
+   `snake_case` instead of `camel_case`.
+
+   For example, to specify 100GB of disk space on core instances, add this to
+   your config file:
+
+   .. code-block:: yaml
+
+       runners:
+         dataproc:
+           core_instance_config:
+             disk_config:
+               boot_disk_size_gb: 100
+
+   To set this option on the command line, pass in JSON:
+
+   .. code-block:: sh
+
+       --core-instance-config '{"disk_config": {"boot_disk_size_gb": 100}}'
+
+   This option *can* be used to set number of core instances
+   (``num_instances``) or instance type (``machine_type_uri``), but usually
+   you'll want to use :mrjob-opt:`num_core_instances` and
+   :mrjob-opt:`core_instance_type` along with this option.
+
+   .. versionadded:: 0.6.3
+
+.. mrjob-opt::
+   :config: master_instance_config
+   :switch: --master-instance-config
+   :set: dataproc
+   :default: ``None``
+
+   A dictionary of additional parameters to pass as ``config.master_config``
+   when creating the cluster. See :mrjob-opt:`core_instance_config` for
+   more details.
+
+   .. versionadded:: 0.6.3
+
+
+.. mrjob-opt::
+   :config: task_instance_config
+   :switch: --task-instance-config
+   :set: dataproc
+   :default: ``None``
+
+   A dictionary of additional parameters to pass as
+   ``config.secondary_worker_config``
+   when creating the cluster. See :mrjob-opt:`task_instance_config` for
+   more details.
+
+   To make task instances preemptible, add this to your config file:
+
+   .. code-block:: yaml
+
+       runners:
+         dataproc:
+           task_instance_config:
+             is_preemptible: true
+
+   Note that this config won't be applied unless you specify at least one
+   task instance (either through :mrjob-opt:`num_task_instances` or
+   by passing ``num_instances`` to this option).
+
+   .. versionadded:: 0.6.3
+
 
 FS paths and options
 --------------------

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -365,8 +365,8 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     def _combine_opts(self, opt_list):
         """Blank out conflicts between *network*/*subnet* and
         *region*/*zone*."""
-        opt_list = _blank_out_conflicting_opts(opt_list, 'region', 'zone')
-        opt_list = _blank_out_conflicting_opts(opt_list, 'network', 'subnet')
+        opt_list = _blank_out_conflicting_opts(opt_list, ['region', 'zone'])
+        opt_list = _blank_out_conflicting_opts(opt_list, ['network', 'subnet'])
 
         # now combine opts, with region/zone blanked out
         return super(DataprocJobRunner, self)._combine_opts(opt_list)

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -232,9 +232,11 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'core_instance_config',
         'gcloud_bin',
         'master_instance_config',
+        'network',
         'project_id',
         'service_account',
         'service_account_scopes',
+        'subnet',
         'task_instance_config',
     }
 
@@ -1154,6 +1156,12 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             metadata=cluster_metadata,
             service_account_scopes=self._opts['service_account_scopes'],
         )
+
+        if self._opts['network']:
+            gce_cluster_config['network_uri'] = self._opts['network']
+
+        if self._opts['subnet']:
+            gce_cluster_config['subnetwork_uri'] = self._opts['subnet']
 
         if self._opts['service_account']:
             gce_cluster_config['service_account'] = (

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -872,7 +872,7 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--network'], dict(
                 help=('URI of Google Compute Engine network to launch cluster'
-                      ' in.'),
+                      " in. Can't be used with --subnet."),
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -867,6 +867,15 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    network=dict(
+        cloud_role='launch',
+        switches=[
+            (['--network'], dict(
+                help=('URI of Google Compute Engine network to launch cluster'
+                      ' in.'),
+            )),
+        ],
+    ),
     num_core_instances=dict(
         cloud_role='launch',
         switches=[
@@ -1142,9 +1151,8 @@ _RUNNER_OPTS = dict(
         cloud_role='launch',
         switches=[
             (['--subnet'], dict(
-                help=('ID of Amazon VPC subnet to launch cluster in. If not'
-                      ' set or empty string, cluster is launched in the normal'
-                      ' AWS cloud.'),
+                help=('ID of Amazon VPC subnet/URI of Google Compute Engine'
+                      ' subnetwork to launch cluster in.'),
             )),
             (['--subnets'], dict(
                 action=_SubnetsAction,

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1156,9 +1156,9 @@ _RUNNER_OPTS = dict(
             )),
             (['--subnets'], dict(
                 action=_SubnetsAction,
-                help=('Like --subnets, but with a comma-separated list, to'
+                help=('Like --subnet, but with a comma-separated list, to'
                       ' specify multiple subnets in conjunction with'
-                      ' --instance-fleets'),
+                      ' --instance-fleets (EMR only)'),
             )),
         ],
     ),

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1207,3 +1207,26 @@ def _fix_env(env):
             return s
 
     return dict((_to_str(k), _to_str(v)) for k, v in env.items())
+
+
+def _blank_out_conflicting_opts(opt_list, *opt_names):
+    """Utility for :py:meth:`MRJobRunner._combine_opts()`: if multiple
+    configs specify conflicting opts, blank them out in all but the
+    last config (so, for example, the command line beats the config file).
+
+    This returns a copy of *opt_list*
+    """
+    # copy opt_list so we can modify it
+    opt_list = [dict(opts) for opts in opt_list]
+
+    # blank out region/zone before the last config where they are set
+    blank_out = False
+    for opts in reversed(opt_list):
+        if blank_out:
+            for opt_name in opt_names:
+                opts[opt_name] = None
+        elif any(opts.get(opt_name) is not None
+                 for opt_name in opt_names):
+            blank_out = True
+
+    return opt_list

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1209,13 +1209,15 @@ def _fix_env(env):
     return dict((_to_str(k), _to_str(v)) for k, v in env.items())
 
 
-def _blank_out_conflicting_opts(opt_list, *opt_names):
+def _blank_out_conflicting_opts(opt_list, opt_names, conflicting_opts=None):
     """Utility for :py:meth:`MRJobRunner._combine_opts()`: if multiple
     configs specify conflicting opts, blank them out in all but the
     last config (so, for example, the command line beats the config file).
 
     This returns a copy of *opt_list*
     """
+    conflicting_opts = set(conflicting_opts or ()) | set(opt_names)
+
     # copy opt_list so we can modify it
     opt_list = [dict(opts) for opts in opt_list]
 
@@ -1226,7 +1228,7 @@ def _blank_out_conflicting_opts(opt_list, *opt_names):
             for opt_name in opt_names:
                 opts[opt_name] = None
         elif any(opts.get(opt_name) is not None
-                 for opt_name in opt_names):
+                 for opt_name in conflicting_opts):
             blank_out = True
 
     return opt_list

--- a/tests/mock_google/dataproc.py
+++ b/tests/mock_google/dataproc.py
@@ -201,10 +201,10 @@ class MockGoogleDataprocClusterClient(MockGoogleDataprocClient):
 
         if gce_config.network_uri:
             gce_config.network_uri = _fully_qualify_network_uri(
-                gce_config.network_uri, project_id, 'global')
+                gce_config.network_uri, project_id)
 
         if gce_config.subnetwork_uri:
-            gce_config.subnetwork_uri = _fully_qualify_network_uri(
+            gce_config.subnetwork_uri = _fully_qualify_subnetwork_uri(
                 gce_config.subnetwork_uri, project_id, region)
 
         # add in default cluster properties
@@ -383,11 +383,21 @@ def _job_path(project_id, region, job_id):
     return 'projects/%s/regions/%s/jobs/%s'
 
 
-def _fully_qualify_network_uri(uri, project_id, region):
+def _fully_qualify_network_uri(uri, project_id):
     if '/' not in uri:  # just a name
-        uri = 'projects/%s/regions/%s/%s' % (project_id, region, uri)
+        uri = 'projects/%s/global/networks/%s' % (project_id, uri)
 
     if not is_uri(uri):
-        uri = 'https://www.googleapis.com/compute/v1/%s' % uri
+        uri = 'https://www.googleapis.com/compute/v1/' + uri
+
+    return uri
+
+
+def _fully_qualify_subnetwork_uri(uri, project_id, region):
+    if '/' not in uri:  # just a name
+        uri = 'projects/%s/%s/subnetworks/%s' % (project_id, region, uri)
+
+    if not is_uri(uri):
+        uri = 'https://www.googleapis.com/compute/v1/' + uri
 
     return uri

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -23,6 +23,7 @@ from io import BytesIO
 from subprocess import PIPE
 from unittest import TestCase
 
+from google.api_core.exceptions import InvalidArgument
 from google.api_core.exceptions import NotFound
 from google.api_core.exceptions import RequestRangeNotSatisfiable
 
@@ -2215,3 +2216,90 @@ class HadoopStreamingJarTestCase(MockGoogleTestCase):
             '--hadoop-streaming-jar', jar_uri)
 
         self.assertEqual(job.hadoop_job.main_jar_file_uri, jar_uri)
+
+
+class NetworkAndSubnetworkTestCase(MockGoogleTestCase):
+
+    def _get_project_id_and_gce_config(self, *args):
+        job = MRWordCount(['-r', 'dataproc'] + list(args))
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._launch()
+            cluster = runner._get_cluster(
+                runner._cluster_id)
+            return cluster.project_id, cluster.config.gce_cluster_config
+
+
+    def test_default(self):
+        project_id, gce_config = self._get_project_id_and_gce_config()
+
+        self.assertEqual(
+            gce_config.network_uri,
+            'https://www.googleapis.com/compute/v1/projects/%s'
+            '/global/networks/default' % project_id)
+        self.assertFalse(gce_config.subnetwork_uri)
+
+    def test_network_name(self):
+        project_id, gce_config = self._get_project_id_and_gce_config(
+            '--network', 'test')
+
+        self.assertEqual(
+            gce_config.network_uri,
+            'https://www.googleapis.com/compute/v1/projects/%s'
+            '/global/networks/test' % project_id)
+        self.assertFalse(gce_config.subnetwork_uri)
+
+    def test_network_path(self):
+        project_id, gce_config = self._get_project_id_and_gce_config(
+            '--network', 'projects/manhattan/global/networks/secret')
+
+        self.assertEqual(
+            gce_config.network_uri,
+            'https://www.googleapis.com/compute/v1'
+            '/projects/manhattan/global/networks/secret')
+        self.assertFalse(gce_config.subnetwork_uri)
+
+    def test_network_uri(self):
+        project_id, gce_config = self._get_project_id_and_gce_config(
+            '--network', 'https://www.cnn.com/')
+
+        self.assertEqual(
+            gce_config.network_uri, 'https://www.cnn.com/')
+        self.assertFalse(gce_config.subnetwork_uri)
+
+    def test_subnetwork_name(self):
+        project_id, gce_config = self._get_project_id_and_gce_config(
+            '--subnet', 'test')
+
+        self.assertEqual(
+            gce_config.subnetwork_uri,
+            'https://www.googleapis.com/compute/v1/projects/%s'
+            '/us-west1/subnetworks/test' % project_id)
+        self.assertFalse(gce_config.network_uri)
+
+    def test_subnetwork_path(self):
+        project_id, gce_config = self._get_project_id_and_gce_config(
+            '--subnet', 'projects/manhattan/los-alamos/networks/lanl')
+
+        self.assertEqual(
+            gce_config.subnetwork_uri,
+            'https://www.googleapis.com/compute/v1'
+            '/projects/manhattan/los-alamos/networks/lanl')
+        self.assertFalse(gce_config.network_uri)
+
+    def test_subnetwork_uri(self):
+        project_id, gce_config = self._get_project_id_and_gce_config(
+            '--subnet', 'https://www.cnn.com/specials/videos/hln')
+
+        self.assertEqual(
+            gce_config.subnetwork_uri,
+            'https://www.cnn.com/specials/videos/hln')
+        self.assertFalse(gce_config.network_uri)
+
+    def test_network_and_subnet_conflict(self):
+        self.assertRaises(
+            InvalidArgument,
+            self._get_project_id_and_gce_config,
+            '--network', 'default',
+            '--subnet', 'default')

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -2303,3 +2303,35 @@ class NetworkAndSubnetworkTestCase(MockGoogleTestCase):
             self._get_project_id_and_gce_config,
             '--network', 'default',
             '--subnet', 'default')
+
+    def test_network_on_cmd_line_overrides_subnet_in_config(self):
+        conf_path = self.makefile(
+            'mrjob.conf',
+            b'runners:\n  dataproc:\n    subnet: default')
+
+        self.mrjob_conf_patcher.stop()
+        project_id, gce_config = self._get_project_id_and_gce_config(
+            '-c', conf_path, '--network', 'test')
+        self.mrjob_conf_patcher.start()
+
+        self.assertEqual(
+            gce_config.network_uri,
+            'https://www.googleapis.com/compute/v1/projects/%s'
+            '/global/networks/test' % project_id)
+        self.assertFalse(gce_config.subnetwork_uri)
+
+    def test_subnet_on_cmd_line_overrides_network_in_config(self):
+        conf_path = self.makefile(
+            'mrjob.conf',
+            b'runners:\n  dataproc:\n    network: default')
+
+        self.mrjob_conf_patcher.stop()
+        project_id, gce_config = self._get_project_id_and_gce_config(
+            '-c', conf_path, '--subnet', 'test')
+        self.mrjob_conf_patcher.start()
+
+        self.assertEqual(
+            gce_config.subnetwork_uri,
+            'https://www.googleapis.com/compute/v1/projects/%s'
+            '/us-west1/subnetworks/test' % project_id)
+        self.assertFalse(gce_config.network_uri)


### PR DESCRIPTION
Added `network` and `subnet` opts to Dataproc. Fixes #1683.