### PR TITLE
document mapper_raw()

### DIFF
--- a/docs/guides/setup-cookbook.rst
+++ b/docs/guides/setup-cookbook.rst
@@ -117,6 +117,8 @@ If you're a :mrjob-opt:`setup` purist, you can also do something like this:
 
 since :command:`true` has no effect and ignores its arguments.
 
+.. _using-a-virtualenv:
+
 Using a virtualenv
 ------------------
 

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -239,18 +239,15 @@ lines containing the string "kitty"::
     if __name__ == '__main__':
         KittyJob().run()
 
-Step commands are run without a shell. But if you'd like to use shell features
-such as pipes, you can use :py:func:`mrjob.util.bash_wrap()` to wrap your
-command in a call to ``bash``.
+Step commands are run without a shell, so if you want to use pipes, etc, you'll
+need to run them in a subshell. For example:
 
-::
-
-    from mrjob.util import bash_wrap
+.. code-block:: python
 
     class DemoJob(MRJob):
 
         def mapper_cmd(self):
-            return bash_wrap("grep 'blah blah' | wc -l")
+            return 'sh -c "grep 'blah' | wc -l"'
 
 .. note::
 
@@ -313,10 +310,10 @@ The output of the job should always be ``0``, since every line that gets to
 :py:func:`test_for_kitty()` is filtered by :command:`grep` to have "kitty" in
 it.
 
-Filter commands are run without a shell. But if you'd like to use shell
-features such as pipes, you can use :py:func:`mrjob.util.bash_wrap()` to wrap
-your command in a call to ``bash``. See :ref:`cmd-filters` for an example of
-:py:func:`mrjob.util.bash_wrap()`.
+
+
+
+
 
 .. _job-protocols:
 

--- a/docs/job.rst
+++ b/docs/job.rst
@@ -28,6 +28,7 @@ One-step jobs
 .. automethod:: MRJob.mapper_pre_filter
 .. automethod:: MRJob.reducer_pre_filter
 .. automethod:: MRJob.combiner_pre_filter
+.. automethod:: MRJob.mapper_raw
 .. automethod:: MRJob.spark
 
 Multi-step jobs


### PR DESCRIPTION
Added mapper_raw() to docs (fixes #1753).

Also removed an obsolete reference to `bash_wrap()`, which no longer exists (fixes #1783).