### PR TITLE
handle "Not a valid JAR" error message

### DIFF
--- a/mrjob/examples/mr_jar_step_example.py
+++ b/mrjob/examples/mr_jar_step_example.py
@@ -1,5 +1,6 @@
 # Copyright 2013 David Marin
 # Copyright 2016 Yelp
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/logs/test_step.py
+++ b/tests/logs/test_step.py
@@ -98,6 +98,21 @@ PARSED_PRE_YARN_STEP_LOG_LINES = dict(
     progress=dict(map=100, message=' map 100%  reduce 100%', reduce=100),
 )
 
+NOT_A_VALID_JAR_LOG_LINES = [
+    'Not a valid JAR: /home/hadoop/hadoop-examples.jar',
+]
+
+PARSED_NOT_A_VALID_JAR_LOG_LINES = dict(
+    errors=[
+        dict(
+            hadoop_error=dict(
+                message='Not a valid JAR: /home/hadoop/hadoop-examples.jar',
+                start_line=0,
+                num_lines=1,
+            ),
+        ),
+    ],
+)
 
 class ParseStepSyslogTestCase(TestCase):
 
@@ -113,6 +128,12 @@ class ParseStepSyslogTestCase(TestCase):
         self.assertEqual(
             _parse_step_syslog(PRE_YARN_STEP_LOG_LINES),
             PARSED_PRE_YARN_STEP_LOG_LINES)
+
+    def test_not_a_valid_jar(self):
+        self.assertEqual(
+            _parse_step_syslog(NOT_A_VALID_JAR_LOG_LINES),
+            PARSED_NOT_A_VALID_JAR_LOG_LINES,
+        )
 
 
 class InterpretHadoopJarCommandStderrTestCase(TestCase):


### PR DESCRIPTION
mrjob now gives a clear error message when you specify an invalid jar on Dataproc or your own Hadoop cluster.

(EMR fails in the controller on an invalid JAR path, so a different strategy is needed. See #1786.)