### PR TITLE
rework google_account_scopes

### DIFF
--- a/docs/guides/dataproc-opts.rst
+++ b/docs/guides/dataproc-opts.rst
@@ -111,25 +111,14 @@ Cluster creation and configuration
 
 .. mrjob-opt::
    :config: service_account_scopes
-   :switch: --service-account-scope
+   :switch: --service-account-scopes
    :set: dataproc
    :default: (automatic)
 
-   Service account scopes to use when creating a cluster. By default,
-   Dataproc uses these scopes::
+   Optional service account scopes to pass to the API when creating a cluster.
 
-     https://www.googleapis.com/auth/bigquery
-     https://www.googleapis.com/auth/bigtable.admin.table
-     https://www.googleapis.com/auth/bigtable.data
-     https://www.googleapis.com/auth/cloud-platform
-     https://www.googleapis.com/auth/cloud.useraccounts.readonly
-     https://www.googleapis.com/auth/devstorage.full_control
-     https://www.googleapis.com/auth/devstorage.read_write
-     https://www.googleapis.com/auth/logging.write
-
-   ``--service-account-scope`` can only be used to add additional scopes.
-   If you wish to exclude some of these scopes, you can use ``!clear`` in
-   your config file (see :ref:`clearing-configs`).
+   Generally it's suggested that you instead create a
+   :mrjob-opt:`service_account` with the scopes you want.
 
    .. versionadded:: 0.6.3
 

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -48,6 +48,7 @@ from mrjob.logs.mixin import LogInterpretationMixin
 from mrjob.logs.task import _parse_task_stderr
 from mrjob.logs.task import _parse_task_syslog_records
 from mrjob.logs.step import _interpret_new_dataproc_step_stderr
+from mrjob.parse import is_uri
 from mrjob.py2 import PY2
 from mrjob.py2 import string_types
 from mrjob.py2 import to_unicode
@@ -73,19 +74,6 @@ _DEFAULT_IMAGE_VERSION = '1.0'
 _DEFAULT_CHECK_CLUSTER_EVERY = 10.0
 _DEFAULT_CLOUD_FS_SYNC_SECS = 5.0
 _DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS = 90
-
-# https://cloud.google.com/dataproc/reference/rest/v1/projects.regions.clusters#GceClusterConfig  # noqa
-# NOTE - added cloud-platform so we can invoke gcloud commands from the cluster master (used for auto termination script)  # noqa
-_DEFAULT_GCE_SERVICE_ACCOUNT_SCOPES = [
-    'https://www.googleapis.com/auth/cloud.useraccounts.readonly',
-    'https://www.googleapis.com/auth/devstorage.read_write',
-    'https://www.googleapis.com/auth/logging.write',
-    'https://www.googleapis.com/auth/bigquery',
-    'https://www.googleapis.com/auth/bigtable.admin.table',
-    'https://www.googleapis.com/auth/bigtable.data',
-    'https://www.googleapis.com/auth/devstorage.full_control',
-    'https://www.googleapis.com/auth/cloud-platform',
-]
 
 # job state matcher enum
 # use this to only find active jobs. (2 for NON_ACTIVE, but we don't use that)
@@ -127,7 +115,6 @@ _SSH_TUNNEL_CONFIG = dict(
     port=8088,
 )
 
-
 # used to match log entries that tell us if a container exited
 _CONTAINER_EXECUTOR_CLASS_NAME = (
     'org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor')
@@ -143,6 +130,9 @@ _STDERR_LOG4J_WARNING = re.compile(
     r'.*(No appenders could be found for logger'
     r'|Please initialize the log4j system'
     r'|See http://logging.apache.org/log4j)')
+
+# this is equivalent to full permission
+_FULL_SCOPE = 'https://www.googleapis.com/auth/cloud-platform'
 
 # convert enum values to strings (e.g. 'RUNNING')
 
@@ -271,7 +261,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
         # load credentials and project ID
         self._credentials, auth_project_id = google.auth.default(
-            scopes=_DEFAULT_GCE_SERVICE_ACCOUNT_SCOPES)
+            scopes=[_FULL_SCOPE]) # needed for $GOOGLE_APPLICATION_CREDENTIALS
 
         self._project_id = self._opts['project_id'] or auth_project_id
 
@@ -281,6 +271,12 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 ' set $GOOGLE_CLOUD_PROJECT')
 
         self._fix_zone_and_region_opts()
+
+        if self._opts['service_account_scopes']:
+            self._opts['service_account_scopes'] = [
+                _fully_qualify_scope_uri(s)
+                for s in self._opts['service_account_scopes']
+            ]
 
         # cluster_id can be None here
         self._cluster_id = self._opts['cluster_id']
@@ -356,8 +352,6 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 master_instance_type=_DEFAULT_INSTANCE_TYPE,
                 num_core_instances=_DATAPROC_MIN_WORKERS,
                 num_task_instances=0,
-                service_account_scopes=list(
-                    _DEFAULT_GCE_SERVICE_ACCOUNT_SCOPES),
                 sh_bin=['/bin/sh', '-ex'],
             )
         )
@@ -1158,6 +1152,10 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             gce_cluster_config['service_account'] = (
                 self._opts['service_account'])
 
+        if self._opts['service_account_scopes']:
+            gce_cluster_config['service_account_scopes'] = (
+                self._opts['service_account_scopes'])
+
         if self._opts['zone']:
             gce_cluster_config['zone_uri'] = _gcp_zone_uri(
                 project=self._project_id, zone=self._opts['zone'])
@@ -1443,3 +1441,10 @@ def _values_to_text(d):
         result[k] = v
 
     return result
+
+
+def _fully_qualify_scope_uri(uri):
+    if is_uri(uri):
+        return uri
+    else:
+        return 'https://www.googleapis.com/auth/%s' % uri

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -138,15 +138,15 @@ class _CleanupAction(Action):
         setattr(namespace, self.dest, result)
 
 
-class _SubnetsAction(Action):
+class _CommaSeparatedListAction(Action):
     """action to parse a comma-separated list of subnets.
 
     This eliminates whitespace
     """
     def __call__(self, parser, namespace, value, option_string=None):
-        subnets = [s.strip() for s in value.split(',') if s]
+        items = [s.strip() for s in value.split(',') if s]
 
-        setattr(namespace, self.dest, subnets)
+        setattr(namespace, self.dest, items)
 
 
 class _AppendJSONAction(Action):
@@ -1016,10 +1016,12 @@ _RUNNER_OPTS = dict(
         cloud_role='launch',
         combiner=combine_lists,
         switches=[
-            (['--service-account-scope'], dict(
-                action='append',
-                help=('Additional service account scope to use when creating'
-                      ' a Dataproc cluster.'),
+            (['--service-account-scopes'], dict(
+                action=_CommaSeparatedListAction,
+                help=("A comma-separated list of service account scopes"
+                      " on Dataproc, used to limit your cluster's access."
+                      " For each scope, you can specify the"
+                      " full URI or just the name (e.g. 'logging.write')"),
             )),
         ],
     ),
@@ -1157,7 +1159,7 @@ _RUNNER_OPTS = dict(
                       ' subnetwork to launch cluster in.'),
             )),
             (['--subnets'], dict(
-                action=_SubnetsAction,
+                action=_CommaSeparatedListAction,
                 help=('Like --subnet, but with a comma-separated list, to'
                       ' specify multiple subnets in conjunction with'
                       ' --instance-fleets (EMR only)'),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1014,7 +1014,6 @@ _RUNNER_OPTS = dict(
     ),
     service_account_scopes=dict(
         cloud_role='launch',
-        combiner=combine_lists,
         switches=[
             (['--service-account-scopes'], dict(
                 action=_CommaSeparatedListAction,

--- a/tests/mock_google/dataproc.py
+++ b/tests/mock_google/dataproc.py
@@ -26,8 +26,6 @@ from mrjob._vendor.dataproc_v1beta2.types import DiskConfig
 from mrjob._vendor.dataproc_v1beta2.types import Job
 from mrjob._vendor.dataproc_v1beta2.types import JobStatus
 
-from mrjob.dataproc import _DEFAULT_SCOPES
-from mrjob.dataproc import _MANDATORY_SCOPES
 from mrjob.dataproc import _STATE_MATCHER_ACTIVE
 from mrjob.dataproc import _cluster_state_name
 from mrjob.dataproc import _job_state_name

--- a/tests/mock_google/dataproc.py
+++ b/tests/mock_google/dataproc.py
@@ -26,6 +26,8 @@ from mrjob._vendor.dataproc_v1beta2.types import DiskConfig
 from mrjob._vendor.dataproc_v1beta2.types import Job
 from mrjob._vendor.dataproc_v1beta2.types import JobStatus
 
+from mrjob.dataproc import _DEFAULT_SCOPES
+from mrjob.dataproc import _MANDATORY_SCOPES
 from mrjob.dataproc import _STATE_MATCHER_ACTIVE
 from mrjob.dataproc import _cluster_state_name
 from mrjob.dataproc import _job_state_name
@@ -33,8 +35,6 @@ from mrjob.dataproc import _zone_to_region
 from mrjob.parse import is_uri
 from mrjob.util import random_identifier
 
-# default boot disk size set by the API
-_DEFAULT_DISK_SIZE_GB = 500
 
 # account scopes that are included whether you ask for them or not
 # for more info, see:
@@ -52,6 +52,9 @@ _DEFAULT_SCOPES = {
     'https://www.googleapis.com/auth/bigtable.data',
     'https://www.googleapis.com/auth/devstorage.full_control',
 }
+
+# default boot disk size set by the API
+_DEFAULT_DISK_SIZE_GB = 500
 
 # actual properties taken from Dataproc
 _DEFAULT_CLUSTER_PROPERTIES = {

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -35,7 +35,6 @@ from mrjob.dataproc import DataprocJobRunner
 from mrjob.dataproc import _CONTAINER_EXECUTOR_CLASS_NAME
 from mrjob.dataproc import _DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS
 from mrjob.dataproc import _DEFAULT_GCE_REGION
-from mrjob.dataproc import _DEFAULT_GCE_SERVICE_ACCOUNT_SCOPES
 from mrjob.dataproc import _DEFAULT_IMAGE_VERSION
 from mrjob.dataproc import _HADOOP_STREAMING_JAR_URI
 from mrjob.dataproc import _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH
@@ -46,6 +45,7 @@ from mrjob.examples.mr_boom import MRBoom
 from mrjob.fs.gcs import GCSFilesystem
 from mrjob.fs.gcs import parse_gcs_uri
 from mrjob.logs.errors import _pick_error
+from mrjob.parse import is_uri
 from mrjob.py2 import PY2
 from mrjob.py2 import StringIO
 from mrjob.step import StepFailedException
@@ -54,6 +54,8 @@ from mrjob.util import log_to_stream
 from mrjob.util import save_current_environment
 
 from tests.mock_google import MockGoogleTestCase
+from tests.mock_google.dataproc import _DEFAULT_SCOPES
+from tests.mock_google.dataproc import _MANDATORY_SCOPES
 from tests.mock_google.storage import MockGoogleStorageBlob
 from tests.mr_hadoop_format_job import MRHadoopFormatJob
 from tests.mr_jar_and_streaming import MRJarAndStreaming
@@ -459,8 +461,18 @@ class GCEClusterConfigTestCase(MockGoogleTestCase):
         gcc = self._get_gce_cluster_config()
 
         self.assertFalse(gcc.service_account)
-        self.assertEqual(set(gcc.service_account_scopes),
-                         set(_DEFAULT_GCE_SERVICE_ACCOUNT_SCOPES))
+        self.assertEqual(
+            set(gcc.service_account_scopes),
+            _MANDATORY_SCOPES | _DEFAULT_SCOPES
+        )
+
+    def test_blank_means_default(self):
+        gcc = self._get_gce_cluster_config('--service-account-scopes', '')
+
+        self.assertEqual(
+            set(gcc.service_account_scopes),
+            _MANDATORY_SCOPES | _DEFAULT_SCOPES
+        )
 
     def test_service_account(self):
         account = '12345678901-compute@developer.gserviceaccount.com'
@@ -475,29 +487,25 @@ class GCEClusterConfigTestCase(MockGoogleTestCase):
         scope2 = 'https://www.googleapis.com/auth/scope2'
 
         gcc = self._get_gce_cluster_config(
-            '--service-account-scope', scope1,
-            '--service-account-scope', scope2)
+            '--service-account-scopes', '%s,%s' % (scope1, scope2))
 
-        self.assertGreater(
+        self.assertEqual(
             set(gcc.service_account_scopes),
-            set(_DEFAULT_GCE_SERVICE_ACCOUNT_SCOPES))
-        self.assertIn(scope1, set(gcc.service_account_scopes))
-        self.assertIn(scope2, set(gcc.service_account_scopes))
+            _MANDATORY_SCOPES | {scope1, scope2})
 
-    def test_clear_service_account_scopes(self):
-        # it's possible to use less service accounts than the default,
-        # just not very wise
-        conf_path = self.makefile(
-            'mrjob.conf',
-            b'runners:\n  dataproc:\n    service_account_scopes: !clear')
+    def test_set_scope_by_name(self):
+        scope_name = 'test.name'
+        scope_uri = 'https://www.googleapis.com/auth/test.name'
 
-        self.mrjob_conf_patcher.stop()
-        gcc = self._get_gce_cluster_config('-c', conf_path)
-        self.mrjob_conf_patcher.start()
+        gcc = self._get_gce_cluster_config(
+            '--service-account-scopes', scope_name)
 
-        self.assertLess(
+        self.assertEqual(
             set(gcc.service_account_scopes),
-            set(_DEFAULT_GCE_SERVICE_ACCOUNT_SCOPES))
+            _MANDATORY_SCOPES | {scope_uri})
+
+
+
 
 
 class ClusterPropertiesTestCase(MockGoogleTestCase):


### PR DESCRIPTION
Now that we're using the built-in idle timeout feature on Dataproc, we don't really need to worry about what scopes the user is using.

This change removes the default value for `service_account_scopes`, instead just letting the API use its own default. It also removes the append semantics for configuring this option, since the main point is to limit the scope of an existing account.
