### PR TITLE
v0.5.x backport of Termination Protected bugfix

### DIFF
--- a/tests/mockboto.py
+++ b/tests/mockboto.py
@@ -1266,6 +1266,13 @@ class MockEmrConnection(object):
                 'TERMINATED', 'TERMINATED_WITH_ERRORS'):
             return
 
+        # termination protected clusters may not be terminated
+        if getattr(cluster, '_TerminationProtected', False):
+            raise boto.exception.EmrResponseError(
+                400, 'Bad Request', body=err_xml(
+                    'Could not shut down one or more job flows since they are'
+                    ' termination protected.'))
+
         # mark cluster as shutting down
         cluster.status.state = 'TERMINATING'
         cluster.status.statechangereason = MockEmrObject(


### PR DESCRIPTION
This backports #1801 for v0.5.x. It does it slightly differently, since I can't find a `TerminationProtected` attribute ever returned by boto. So rather than checking for termination protection ahead of time, we catch the ValidationError and check if it mentions termination protection - it's a bit hacky.