### PR TITLE
Drop python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.6-dev"
-# - "nightly"
+  - "3.7-dev"
+  - "nightly"
 matrix:
   allow-failures:
-    - python: "3.5-dev"
+    - python: "3.7-dev"
     - python: "nightly"
   fast_finish: true
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "2.7"
   - "pypy"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -17,7 +16,6 @@ install:
   - "pip install ."
   - "pip install ujson warcio"
   - "pip install rapidjson || true"
-  - "if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.2.0; fi"
 # command to run tests
 script: python -m unittest discover -v
 sudo: false

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v0.6.4, 2018-??-?? -- ???
+ * drop support for Python 3.3
+
 v0.6.3, 2018-05-31 -- Dataproc parity
  * jobs:
    * use mapper_raw() to read entire file, in any format (#754)

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ mrjob: the Python MapReduce library
 
 .. image:: https://github.com/Yelp/mrjob/raw/master/docs/logos/logo_medium.png
 
-mrjob is a Python 2.7/3.3+ package that helps you write and run Hadoop
+mrjob is a Python 2.7/3.4+ package that helps you write and run Hadoop
 Streaming jobs.
 
 `Stable version (v0.6.3) documentation <http://mrjob.readthedocs.org/en/stable/>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 mrjob
 =====
 
-**mrjob lets you write MapReduce jobs in Python 2.7/3.3+ and run them on
+**mrjob lets you write MapReduce jobs in Python 2.7/3.4+ and run them on
 several platforms.** You can:
 
 * Write multi-step MapReduce jobs in pure Python

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,6 @@ try:
         setuptools_kwargs['extras_require']['rapidjson'] = ['rapidjson']
         setuptools_kwargs['tests_require'].append('rapidjson')
 
-    # mock is included in Python 3.3 as unittest.mock
-    if sys.version_info < (3, 3):
-        setuptools_kwargs['tests_require'].append('mock')
-
     # grpc requires enum, which is a builtin starting in Python 3.4
     if sys.version_info >= (3, 0) and sys.version_info < (3, 4):
         setuptools_kwargs['install_requires'].append('enum34')
@@ -75,7 +71,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Python 3.3 reached end of life last September, and stopped working on Travis CI within the last week. This makes it official that mrjob no longer supports Python 3.3.