### PR TITLE
disable mins_to_end_hour by default

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -295,12 +295,17 @@ Cluster creation and configuration
     :switch: --mins-to-end-of-hour
     :type: :ref:`string <data-type-string>`
     :set: emr
-    :default: 5.0
+    :default: 60.0
 
-    If :mrjob-opt:`max_hours_idle` is set, controls how close to the end of an
-    EC2 billing hour the cluster can automatically terminate itself.
+    Controls how close to the end of an EC2 billing hour the cluster can
+    automatically terminate itself.
 
     .. versionadded:: 0.4.1
+
+    .. versionchanged:: 0.5.12
+
+       Changed from 5.0 to 60.0 (effectively disabling it), since
+       `Amazon no longer bills by the full hour <https://aws.amazon.com/about-aws/whats-new/2017/10/amazon-emr-now-supports-per-second-billing/>`__.
 
 .. mrjob-opt::
     :config: region

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -444,7 +444,7 @@ class EMRRunnerOptionStore(RunnerOptionStore):
             'bootstrap_python': None,
             'check_cluster_every': 30,
             'cleanup_on_failure': ['JOB'],
-            'mins_to_end_of_hour': 5.0,
+            'mins_to_end_of_hour': 60.0,  # disable by default
             'num_core_instances': 0,
             'num_ec2_instances': 1,
             'num_task_instances': 0,

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -3031,7 +3031,7 @@ class MaxHoursIdleTestCase(MockBotoTestCase):
 
         with mr_job.make_runner() as runner:
             runner.make_persistent_cluster()
-            self.assertRanIdleTimeoutScriptWith(runner, ['36', '300'])
+            self.assertRanIdleTimeoutScriptWith(runner, ['36', '3600'])
 
     def test_mins_to_end_of_hour(self):
         mr_job = MRWordCount(['-r', 'emr', '--max-hours-idle', '1',


### PR DESCRIPTION
The `mins_to_end_of_hour` option no longer makes since Amazon stopped billing by the full hour.

This pull request disables `mins_to_end_of_hour` in a minimally invasive way, by setting its default value to 60.