### PR TITLE
add image_id option

### DIFF
--- a/docs/_templates/indexsidebar.html
+++ b/docs/_templates/indexsidebar.html
@@ -13,7 +13,7 @@
     Config options (all runners)</a></li>
   <li><a href="{{ pathto('guides/configs-hadoopy-runners') }}">
     Config options (Hadoop)</a></li>
-  <li><a href="{{ pathto('guides/emr-opts') }}">
+  <li><a href="{{ pathto('guides/cloud-opts') }}">
       Config options (cloud services)</a></li>
   <ul>
     <li><a href="{{ pathto('guides/emr-opts') }}">

--- a/docs/guides/cloud-opts.rst
+++ b/docs/guides/cloud-opts.rst
@@ -223,6 +223,30 @@ Cluster software configuration
 ------------------------------
 
 .. mrjob-opt::
+    :config: image_id
+    :switch: --image-id
+    :type: :ref:`string <data-type-string>`
+    :set: cloud
+    :default: None
+
+    ID of a custom machine image.
+
+    On EMR, this is complimentary with :mrjob-opt:`image_version`; you
+    can install packages and libraries on your custom AMI, but it's up to
+    EMR to install Hadoop, create the ``hadoop`` user, etc.
+    :mrjob-opt:`image_version` may not be less than 5.7.0.
+
+    For more details about how to create a custom AMI that works with EMR, see
+    `Best Practices and Considerations
+    <https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-custom-ami.html#emr-custom-ami-considerations>`_.
+
+    .. note::
+
+       This is not yet implemented in the Dataproc runner.
+
+    .. versionadded:: 0.6.5
+
+.. mrjob-opt::
     :config: image_version
     :switch: --image-version
     :type: :ref:`string <data-type-string>`

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -251,7 +251,8 @@ of instance configuration you use.
 Cluster software configuration
 ------------------------------
 
-See also :mrjob-opt:`image_version` and :mrjob-opt:`bootstrap`.
+See also :mrjob-opt:`bootstrap`, :mrjob-opt:`image_id`, and
+:mrjob-opt:`image_version`.
 
 .. mrjob-opt::
    :config: applications

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -67,6 +67,7 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
         'core_instance_type',
         'extra_cluster_params',
         'hadoop_streaming_jar',
+        'image_id',
         'image_version',
         'instance_type',
         'master_instance_type',

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -254,6 +254,11 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             raise DataprocException(
                 'Dataproc v1 expects core/task instance types to be identical')
 
+        # see #1820
+        if self._opts['image_id']:
+            log.warning('mrjob does not yet support custom machine images'
+                        ' on Dataproc')
+
         # load credentials and project ID
         self._credentials, auth_project_id = google.auth.default(
             scopes=[_FULL_SCOPE])  # needed for $GOOGLE_APPLICATION_CREDENTIALS

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -379,7 +379,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             log.warning("AMIs prior to 2.4.3 probably will not work because"
                         " they don't support Python 2.7. Use a later AMI"
                         " version or mrjob v0.5.11")
-        elif not version_gte(self._opts['image_version'], '5.7.0'):
+        elif not self._image_version_gte('5.7.0'):
             if self._opts['image_id']:
                 log.warning('AMIs prior to 5.7.0 will probably not work'
                             ' with custom machine images')

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -315,7 +315,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'iam_endpoint',
         'iam_instance_profile',
         'iam_service_role',
-        'image_id',
         'instance_fleets',
         'instance_groups',
         'master_instance_bid_price',

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -152,7 +152,7 @@ _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH = os.path.join(
 # for new (since October 10, 2012) accounts (see #1025)
 _DEFAULT_EMR_REGION = 'us-west-2'
 
-# default AMI to use on EMR. This will be updated with each version
+# default AMI to use on EMR. This may be updated with each version
 _DEFAULT_IMAGE_VERSION = '5.8.0'
 
 # first AMI version that we can't run bash -e on (see #1548)
@@ -315,6 +315,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'iam_endpoint',
         'iam_instance_profile',
         'iam_service_role',
+        'image_id',
         'instance_fleets',
         'instance_groups',
         'master_instance_bid_price',
@@ -1151,6 +1152,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             kwargs['ReleaseLabel'] = self._opts['release_label']
         else:
             kwargs['AmiVersion'] = self._opts['image_version']
+
+        if self._opts['image_id']:
+            kwargs['CustomAmiId'] = self._opts['image_id']
 
         # capitalizing Instances because it's just an API parameter
         kwargs['Instances'] = Instances = {}

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -374,12 +374,16 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
         # check AMI version
         if self._opts['image_version'].startswith('1.'):
-            log.warning('1.x AMIs will probably not work because they use'
+            log.warning('1.x AMIs will not work because they use'
                         ' Python 2.5. Use a later AMI version or mrjob v0.4.2')
         elif not version_gte(self._opts['image_version'], '2.4.3'):
             log.warning("AMIs prior to 2.4.3 probably will not work because"
                         " they don't support Python 2.7. Use a later AMI"
                         " version or mrjob v0.5.11")
+        elif not version_gte(self._opts['image_version'], '5.7.0'):
+            if self._opts['image_id']:
+                log.warning('AMIs prior to 5.7.0 will probably not work'
+                            ' with custom machine images')
 
         if self._opts['emr_api_params'] is not None:
             log.warning('emr_api_params is deprecated and does nothing.'

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2289,7 +2289,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         same setup as our own, that is:
 
         - same bootstrap setup (including mrjob version)
-        - have the same AMI version
+        - have the same AMI version and custom AMI ID (if any)
         - install the same applications (if we requested any)
         - same number and type of instances
 
@@ -2398,6 +2398,10 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
                 max_steps = map_version(
                     image_version, _IMAGE_VERSION_TO_MAX_STEPS)
+
+            if self._opts['image_id'] != cluster.get('CustomAmiId'):
+                log.debug('    custom image ID mismatch')
+                return
 
             if self._opts['ebs_root_volume_gb']:
                 if 'EbsRootVolumeSize' not in cluster:

--- a/mrjob/examples/mr_phone_to_url.py
+++ b/mrjob/examples/mr_phone_to_url.py
@@ -33,6 +33,9 @@ Sample command line:
 To find the latest crawl:
 
 ``aws s3 ls s3://commoncrawl/crawl-data/ | grep CC-MAIN``
+
+WET data is often added after a release; usually the second-most recent
+release is a safe bet.
 """
 import re
 from itertools import islice

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -727,11 +727,19 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    image_id=dict(
+        cloud_role='launch',
+        switches=[
+            (['--image-id'], dict(
+                help='ID of custom AWS machine image (AMI) to use',
+            )),
+        ],
+    ),
     image_version=dict(
         cloud_role='launch',
         switches=[
             (['--image-version'], dict(
-                help='EMR/Dataproc machine image to launch clusters with',
+                help='version of EMR/Dataproc machine image to run',
             )),
         ],
     ),

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -321,6 +321,12 @@ class MockEMRClient(object):
                 'Must specify exactly one of the following:'
                 ' release label, AMI version, or Hadoop version.')
 
+        # CustomAmiId
+        if kwargs.get('CustomAmiId'):
+            if not version_gte(running_ami_version, '5.7.0'):
+                raise _error('Custom AMI is not allowed')
+            cluster['CustomAmiId'] = kwargs.pop('CustomAmiId')
+
         # Applications
         hadoop_version = map_version(
             running_ami_version, AMI_HADOOP_VERSION_UPDATES)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -772,11 +772,22 @@ class CustomAmiTestCase(MockBoto3TestCase):
             cluster = runner._describe_cluster()
             self.assertEqual(cluster['CustomAmiId'], 'ami-blanchin')
 
-    def test_ami_must_be_at_least_5_7_0(self):
+    def test_image_version_too_low(self):
         log = self.start(patch('mrjob.emr.log'))
 
+        # must be at least 5.7.0
         with self.make_runner('--image-id', 'ami-blanchin',
                               '--image-version', '5.6.0') as runner:
+            self.assertTrue(log.warning.called)
+
+            self.assertRaises(ClientError, runner.run)
+
+    def test_release_label_too_low(self):
+        log = self.start(patch('mrjob.emr.log'))
+
+        # must be at least 5.7.0
+        with self.make_runner('--image-id', 'ami-blanchin',
+                              '--release-label', 'emr-5.6.0') as runner:
             self.assertTrue(log.warning.called)
 
             self.assertRaises(ClientError, runner.run)

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -254,6 +254,49 @@ class PoolMatchingTestCase(MockBoto3TestCase):
             '--release-label', 'emr-4.0.0',
             '--image-version', '1.0.0'])
 
+    def test_pooling_with_custom_ami(self):
+        _, cluster_id = self.make_pooled_cluster(image_id='ami-blanchin')
+
+        self.assertJoins(cluster_id, [
+            '-r', 'emr', '--pool-clusters',
+            '--image-id', 'ami-blanchin'])
+
+    def test_dont_join_pool_with_wrong_custom_ami(self):
+        _, cluster_id = self.make_pooled_cluster(image_id='ami-blanchin')
+
+        self.assertDoesNotJoin(cluster_id, [
+            '-r', 'emr', '--pool-clusters',
+            '--image-id', 'ami-awake'])
+
+    def test_dont_join_pool_with_non_custom_ami(self):
+        _, cluster_id = self.make_pooled_cluster()
+
+        self.assertDoesNotJoin(cluster_id, [
+            '-r', 'emr', '--pool-clusters',
+            '--image-id', 'ami-blanchin'])
+
+    def test_dont_join_pool_with_custom_ami_if_not_set(self):
+        _, cluster_id = self.make_pooled_cluster(image_id='ami-blanchin')
+
+        self.assertDoesNotJoin(cluster_id, [
+            '-r', 'emr', '--pool-clusters'])
+
+    def test_join_pool_with_matching_custom_ami_and_ami_version(self):
+        _, cluster_id = self.make_pooled_cluster(image_id='ami-blanchin',
+                                                 image_version='5.10.0')
+
+        self.assertJoins(cluster_id, [
+            '-r', 'emr', '--pool-clusters',
+            '--image-id', 'ami-blanchin', '--release-label', 'emr-5.10.0'])
+
+    def test_dont_join_pool_with_right_custom_ami_but_wrong_version(self):
+        _, cluster_id = self.make_pooled_cluster(image_id='ami-blanchin',
+                                                 image_version='5.9.0')
+
+        self.assertDoesNotJoin(cluster_id, [
+            '-r', 'emr', '--pool-clusters',
+            '--image-id', 'ami-blanchin', '--image-version', '5.10.0'])
+
     def test_matching_applications(self):
         _, cluster_id = self.make_pooled_cluster(
             image_version='4.0.0', applications=['Mahout'])

--- a/tests/tools/emr/test_create_cluster.py
+++ b/tests/tools/emr/test_create_cluster.py
@@ -56,6 +56,7 @@ class ClusterInspectionTestCase(ToolTestCase):
                 'iam_endpoint': None,
                 'iam_instance_profile': None,
                 'iam_service_role': None,
+                'image_id': None,
                 'image_version': None,
                 'instance_fleets': None,
                 'instance_groups': None,


### PR DESCRIPTION
This allows launching clusters with custom machine images on EMR (fixes #1805).

Added this as a "cloud runner" option, with the intent of adding Dataproc support later (see #1820). This is something that I imagine would be a standard feature on any Hadoop-as-a-service.