### PR TITLE
idle self-termination improvements

### DIFF
--- a/mrjob/bootstrap/terminate_idle_cluster_emr.sh
+++ b/mrjob/bootstrap/terminate_idle_cluster_emr.sh
@@ -98,7 +98,7 @@ do
             if expr $SECS_IDLE '>' $MAX_SECS_IDLE > /dev/null
             then
                 sudo shutdown -h now
-                exit
+                # continue looping in case something went wrong (see #1819)
             fi
         fi
     fi

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -224,7 +224,7 @@ class _PooledClusterSelfTerminatedException(Exception):
 # mildly flexible regex to detect cluster self-termination. Termination of
 # non-master nodes won't shut down the cluster, so don't need to match that.
 _CLUSTER_SELF_TERMINATED_RE = re.compile(
-    '^.*The master node was terminated.*$', re.I)
+    '^.*(node|instances) .* terminated.*$', re.I)
 
 
 def _make_lock_uri(cloud_tmp_dir, cluster_id, step_num):

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -1563,9 +1563,17 @@ class MockEMRClient(object):
         # simulate self-termination
         if cluster_id in self.mock_emr_self_termination:
             cluster['Status']['State'] = 'TERMINATING'
+
+            if (len(cluster.get('_InstanceFleets') or ()) == 1 or
+                    len(cluster.get('_InstanceGroups') or ()) == 1):
+                # single master node
+                message = 'All instances in the job flow are terminated'
+            else:
+                message = 'The master node was terminated'
+
             cluster['Status']['StateChangeReason'] = dict(
                 Code='INSTANCE_FAILURE',
-                Message='The master node was terminated. ',  # sic
+                Message=message,
             )
 
             for step in cluster['_Steps']:

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -2010,6 +2010,25 @@ class PoolingRecoveryTestCase(MockBoto3TestCase):
             self.assertNotEqual(runner.get_cluster_id(), cluster_id)
             self.assertEqual(self.num_steps(runner.get_cluster_id()), 2)
 
+    def test_launch_new_multi_node_cluster_after_self_termination(self):
+        # the error message is different when a multi-node cluster
+        # self-terminates
+        cluster_id = self.make_pooled_cluster(num_core_instances=1)
+        self.mock_emr_self_termination.add(cluster_id)
+
+        job = MRTwoStepJob(['-r', 'emr', '--num-core-instances', '1'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            # tried to add steps to pooled cluster, had to try again
+            self.assertEqual(self.num_steps(cluster_id), 2)
+
+            self.assertNotEqual(runner.get_cluster_id(), cluster_id)
+            self.assertEqual(self.num_steps(runner.get_cluster_id()), 2)
+
+
     def test_restart_ssh_tunnel_on_launch(self):
         # regression test for #1549
         ssh_tunnel_cluster_ids = []


### PR DESCRIPTION
Updated the master bootstrap script to continue after issuing a `shutdown -h now`. There were apparently some cases where shutdown was issued and nothing happened; hopefully even if the box doesn't shut down the first time the script asks, it'll shut down on the second or third try. Fixes #1819.

As part of diagnosing this issue, updated the idle self-termination script on EMR so that it logs what it's doing to `/var/log/bootstrap-actions/mrjob-idle-termination.log`. This seems like it could only be useful, so leaving it in.

Also updated mock_boto3 to better match the error messages we get when a cluster self-terminates, and in the process found and fixed a bug (#1822) affecting single-node clusters.