### PR TITLE
bump default AMI to 5.16.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v0.6.5, 2018-09-?? -- AMI pooling
+ * EMR idle termination script logs its output to mrjob-idle-termination.log
+
 v0.6.4, 2018-07-31 -- FILES, DIRS, ARCHIVES
  * drop support for Python 3.3
  * unvendored google-cloud-dataproc, version 0.2.0+ required (#1796)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -153,7 +153,7 @@ _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH = os.path.join(
 _DEFAULT_EMR_REGION = 'us-west-2'
 
 # default AMI to use on EMR. This may be updated with each version
-_DEFAULT_IMAGE_VERSION = '5.8.0'
+_DEFAULT_IMAGE_VERSION = '5.16.0'
 
 # first AMI version that we can't run bash -e on (see #1548)
 _BAD_BASH_IMAGE_VERSION = '5.2.0'

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -71,6 +71,8 @@ AMI_HADOOP_VERSION_UPDATES = {
     '4.8.2': '2.7.3',
     '5.0.0': '2.7.2',
     '5.0.3': '2.7.3',
+    '5.12.0': '2.8.3',
+    '5.16.0': '2.8.4',
 }
 
 # does the AMI have a limit on the *total* number of steps?

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -699,7 +699,7 @@ class AMIAndHadoopVersionTestCase(MockBoto3TestCase):
             runner.run()
             self.assertEqual(runner.get_image_version(),
                              _DEFAULT_IMAGE_VERSION)
-            self.assertEqual(runner.get_hadoop_version(), '2.7.3')
+            self.assertEqual(runner.get_hadoop_version(), '2.8.4')
 
     def test_ami_version_1_0_no_longer_supported(self):
         with self.make_runner('--image-version', '1.0') as runner:
@@ -753,7 +753,7 @@ class AMIAndHadoopVersionTestCase(MockBoto3TestCase):
                 runner.run()
                 self.assertEqual(runner.get_image_version(),
                                  _DEFAULT_IMAGE_VERSION)
-                self.assertEqual(runner.get_hadoop_version(), '2.7.3')
+                self.assertEqual(runner.get_hadoop_version(), '2.8.4')
 
 
 class CustomAmiTestCase(MockBoto3TestCase):


### PR DESCRIPTION
Fixes #1818.