### PR TITLE
catch SSL timeouts

### DIFF
--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -96,6 +96,7 @@ def _get_bucket_region(client, bucket_name):
 def _is_retriable_client_error(ex):
     """Is the exception from a boto3 client retriable?"""
     if isinstance(ex, botocore.exceptions.ClientError):
+        # these rarely get through in boto3
         code = _client_error_code(ex)
         # "Throttl" catches "Throttled" and "Throttling"
         if any(c in code for c in ('Throttl', 'RequestExpired', 'Timeout')):

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -106,7 +106,8 @@ def _is_retriable_client_error(ex):
     # in Python 2.7, SSLError is a subclass of socket.error, so catch
     # SSLError first
     elif isinstance(ex, SSLError):
-        # catch ssl.SSLError: ('The read operation timed out',). See #1827
+        # catch ssl.SSLError: ('The read operation timed out',). See #1827.
+        # also catches 'The write operation timed out'
         return any(isinstance(arg, str) and 'timed out' in arg
                    for arg in ex.args)
     elif isinstance(ex, socket.error):

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -458,6 +458,9 @@ class WrapAWSClientTestCase(MockBoto3TestCase):
     def test_ssl_read_op_timed_out_error(self):
         self.assert_retry(SSLError('The read operation timed out'))
 
+    def test_ssl_write_op_timed_out_error(self):
+        self.assert_retry(SSLError('The write operation timed out'))
+
     def test_other_ssl_error(self):
         self.assert_no_retry(SSLError('certificate verify failed'))
 


### PR DESCRIPTION
This adds certain SSLErrors to the list of exceptions that we catch (fixes #1827).

Also added automated tests for `_wrap_aws_client()`.