### PR TITLE
min backoff for EMR client

### DIFF
--- a/docs/guides/cloud-opts.rst
+++ b/docs/guides/cloud-opts.rst
@@ -407,7 +407,10 @@ Monitoring your job
 
     How often to check on the status of your job, in seconds.
 
-    (Higher on EMR to keep the API from throttling you.)
+    .. versionchanged:: 0.6.5
+
+       When the EMR client encounters a transient error, it will wait at
+       least this many seconds before trying again.
 
     .. versionchanged:: 0.5.4
 

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -362,21 +362,7 @@ See also :mrjob-opt:`bootstrap`, :mrjob-opt:`image_id`, and
 Monitoring your job
 -------------------
 
-See also :mrjob-opt:`ssh_tunnel`.
-
-.. mrjob-opt::
-    :config: check_cluster_every
-    :switch: --check-cluster-every
-    :type: :ref:`string <data-type-string>`
-    :set: emr
-    :default: 30
-
-    How often to check on the status of EMR jobs in seconds. If you set this
-    too low, AWS will throttle you.
-
-    .. versionchanged:: 0.5.4
-
-       This used to be called *check_emr_status_every*
+See also :mrjob-opt:`check_cluster_every`, :mrjob-opt:`ssh_tunnel`.
 
 .. mrjob-opt::
     :config: enable_emr_debugging

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2630,7 +2630,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             region_name=self._opts['region'],
         )
 
-        return _wrap_aws_client(raw_emr_client)
+        # #1799: don't retry faster than EMR checks the API
+        return _wrap_aws_client(raw_emr_client,
+                                min_backoff=self._opts['check_cluster_every'])
 
     def _describe_cluster(self):
         emr_client = self.make_emr_client()

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -117,12 +117,16 @@ def _is_retriable_client_error(ex):
         return False
 
 
-def _wrap_aws_client(raw_client):
+def _wrap_aws_client(raw_client, min_backoff=None):
     """Wrap a given boto3 Client object so that it can retry when
     throttled."""
+    backoff=_AWS_BACKOFF
+    if min_backoff:
+        backoff = max(min_backoff, backoff)
+
     return RetryWrapper(raw_client,
                         retry_if=_is_retriable_client_error,
-                        backoff=_AWS_BACKOFF,
+                        backoff=backoff,
                         multiplier=_AWS_BACKOFF_MULTIPLIER,
                         max_tries=_AWS_MAX_TRIES)
 

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -54,10 +54,10 @@ log = logging.getLogger(__name__)
 
 _CHUNK_SIZE = 8192
 
-# if EMR throttles us, how long to wait (in seconds) before trying again?
-_EMR_BACKOFF = 20
-_EMR_BACKOFF_MULTIPLIER = 1.5
-_EMR_MAX_TRIES = 20  # this takes about a day before we run out of tries
+# if AWS throttles us, how long to wait (in seconds) before trying again?
+_AWS_BACKOFF = 20
+_AWS_BACKOFF_MULTIPLIER = 1.5
+_AWS_MAX_TRIES = 20  # this takes about a day before we run out of tries
 
 
 def _client_error_code(ex):
@@ -122,9 +122,9 @@ def _wrap_aws_client(raw_client):
     throttled."""
     return RetryWrapper(raw_client,
                         retry_if=_is_retriable_client_error,
-                        backoff=_EMR_BACKOFF,
-                        multiplier=_EMR_BACKOFF_MULTIPLIER,
-                        max_tries=_EMR_MAX_TRIES)
+                        backoff=_AWS_BACKOFF,
+                        multiplier=_AWS_BACKOFF_MULTIPLIER,
+                        max_tries=_AWS_MAX_TRIES)
 
 
 class S3Filesystem(Filesystem):

--- a/mrjob/retry.py
+++ b/mrjob/retry.py
@@ -21,6 +21,11 @@ import time
 log = logging.getLogger(__name__)
 
 
+_DEFAULT_BACKOFF = 15
+_DEFAULT_MULTIPLIER = 1.5
+_DEFAULT_MAX_TRIES = 10
+
+
 class RetryWrapper(object):
     """Handle transient errors, with configurable backoff.
 
@@ -32,8 +37,10 @@ class RetryWrapper(object):
     """
     # TODO: this doesn't correctly handle object properties or wrapping
     # functions.
-    def __init__(self, wrapped, retry_if, backoff=15, multiplier=1.5,
-                 max_tries=10):
+    def __init__(self, wrapped, retry_if,
+                 backoff=_DEFAULT_BACKOFF,
+                 multiplier=_DEFAULT_MULTIPLIER,
+                 max_tries=_DEFAULT_MAX_TRIES):
         """
         Wrap the given object
 

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -21,7 +21,7 @@ from botocore.exceptions import ClientError
 
 from mrjob.fs.s3 import S3Filesystem
 from mrjob.fs.s3 import _wrap_aws_client
-from mrjob.fs.s3 import _EMR_MAX_TRIES
+from mrjob.fs.s3 import _AWS_MAX_TRIES
 
 from tests.compress import gzip_compress
 from tests.mock_boto3 import MockBoto3TestCase
@@ -515,7 +515,7 @@ class WrapAWSClientTestCase(MockBoto3TestCase):
         self.assertTrue(self.log.info.called)
 
     def test_eventually_give_up(self):
-        for _ in range(_EMR_MAX_TRIES + 1):
+        for _ in range(_AWS_MAX_TRIES + 1):
             self.add_transient_error(socket.error(110, 'Connection timed out'))
 
         self.assertRaises(socket.error, self.wrapped_client.list_buckets)

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -54,7 +54,8 @@ EMPTY_MRJOB_CONF = {'runners': {
 
 def mrjob_conf_patcher(substitute_conf=EMPTY_MRJOB_CONF):
     def mock_load_opts_from_mrjob_confs(runner_alias, conf_paths=None):
-        return [(None, substitute_conf['runners'][runner_alias])]
+        return [(None,
+                 substitute_conf.get('runners', {}).get(runner_alias, {}))]
 
     return patch.object(runner, 'load_opts_from_mrjob_confs',
                         mock_load_opts_from_mrjob_confs)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -24,6 +24,7 @@ import json
 import os
 import os.path
 import posixpath
+import socket
 import sys
 import time
 from io import BytesIO
@@ -5566,3 +5567,42 @@ class EMRInputManifestTestCase(InlineInputManifestTestCase, MockBoto3TestCase):
 
         # verify that the input manfiest was used
         self.assertIn('input-manifest.txt', first_step_cmd)
+
+
+class EMRClientBackoffTest(MockBoto3TestCase):
+    """Test backoff behavior of EMR client on transient errors."""
+    # this tests #1799
+
+    # don't set check_cluster_every to 0; we mock out time.sleep() instead
+    MRJOB_CONF_CONTENTS = {}
+
+    def setUp(self):
+        super(EMRClientBackoffTest, self).setUp()
+
+        # don't actually wait between retries
+        self.sleep = self.start(patch('time.sleep'))
+
+        # make list_clusters give one transient error before returning
+        self.list_clusters = self.start(patch(
+            'tests.mock_boto3.emr.MockEMRClient.list_clusters',
+            side_effect=[
+                socket.error(104, 'Connection reset by peer'),
+                dict(Clusters=[])
+            ]))
+
+    def _test_backoff(self, expected_backoff, **runner_kwargs):
+        runner = EMRJobRunner(**runner_kwargs)
+        emr_client = runner.make_emr_client()
+
+        self.assertEqual(emr_client.list_clusters()['Clusters'], [])
+        self.sleep.assert_called_with(expected_backoff)
+
+    def test_default_backoff(self):
+        self._test_backoff(30)  # default value of check_cluster_every
+
+    def test_large_check_cluster_every(self):
+        self._test_backoff(1000, check_cluster_every=1000)
+
+    def test_small_check_cluster_every(self):
+        # minimum backoff is always 20
+        self._test_backoff(20, check_cluster_every=1)


### PR DESCRIPTION
When the EMR client encounters a transient error, it will now back off at least at long as `check_cluster_every`. Fixes #1799.