### PR TITLE
-D as synonym for --jobconf

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -48,7 +48,7 @@ and ``inline`` runners to some degree.
 
 .. mrjob-opt::
     :config: jobconf
-    :switch: --jobconf
+    :switch: -D, --jobconf
     :type: :ref:`dict <data-type-plain-dict>`
     :set: all
     :default: ``{}``
@@ -57,6 +57,10 @@ and ``inline`` runners to some degree.
     property name to value.  Equivalent to passing ``['-D',
     'KEY1=VALUE1', '-D', 'KEY2=VALUE2', ...]`` to
     :mrjob-opt:`hadoop_extra_args`
+
+    .. versionchanged:: 0.6.6
+
+       added the ``-D`` switch on the command line, to match Hadoop.
 
 
 Options available to hadoop and emr runners

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -801,10 +801,10 @@ _RUNNER_OPTS = dict(
     jobconf=dict(
         combiner=combine_dicts,
         switches=[
-            (['--jobconf'], dict(
+            (['-D', '--jobconf'], dict(
                 action=_KeyValueAction,
                 help=('-D arg to pass through to hadoop streaming; should'
-                      ' take the form KEY=VALUE. You can use --jobconf'
+                      ' take the form KEY=VALUE. You can use -D'
                       ' multiple times.'),
             )),
         ],

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -207,9 +207,9 @@ class HadoopArgsForStepTestCase(EmptyMrjobConfTestCase):
 
     def test_jobconf(self):
         job = MRWordCount(['-r', 'local',
-                           '--jobconf', 'FOO=bar',
-                           '--jobconf', 'BAZ=qux',
-                           '--jobconf', 'BAX=Arnold'])
+                           '-D', 'FOO=bar',
+                           '-D', 'BAZ=qux',
+                           '-D', 'BAX=Arnold'])
 
         with job.make_runner() as runner:
             self.assertEqual(runner._hadoop_args_for_step(0),
@@ -231,7 +231,7 @@ class HadoopArgsForStepTestCase(EmptyMrjobConfTestCase):
     def test_configuration_translation(self):
         job = MRWordCount(
             ['-r', 'local',
-             '--jobconf', 'mapred.jobtracker.maxtasks.per.job=1'])
+             '-D', 'mapred.jobtracker.maxtasks.per.job=1'])
 
         with job.make_runner() as runner:
             with no_handlers_for_logger('mrjob.runner'):
@@ -937,7 +937,7 @@ class SortValuesTestCase(SandboxedTestCase):
         mr_job = MRSortValues([
             '-r', 'local',
             '--hadoop-version', '2.0.0',
-            '--jobconf', 'stream.num.map.output.key.fields=3',
+            '-D', 'stream.num.map.output.key.fields=3',
         ])
         mr_job.sandbox()
 
@@ -1226,7 +1226,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
 
     def test_jobconf(self):
         job = MRNullSpark(['-r', 'local',
-                           '--jobconf', 'spark.executor.memory=10g'])
+                           '-D', 'spark.executor.memory=10g'])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1257,8 +1257,8 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         job = MRNullSpark(
             ['-r', 'local',
              '--cmdenv', 'FOO=bar',
-             '--jobconf', 'spark.executorEnv.FOO=baz',
-             '--jobconf', 'spark.yarn.appMasterEnv.PYSPARK_PYTHON=ourpy'])
+             '-D', 'spark.executorEnv.FOO=baz',
+             '-D', 'spark.yarn.appMasterEnv.PYSPARK_PYTHON=ourpy'])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1440,7 +1440,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         job = MRSparkJar(['-r', 'local',
                           '--jar-main-class', 'foo.Bar',
                           '--cmdenv', 'BAZ=qux',
-                          '--jobconf', 'QUX=baz'])
+                          '-D', 'QUX=baz'])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -163,7 +163,7 @@ class DataprocJobRunnerEndToEndTestCase(MockGoogleTestCase):
 
         mr_job = MRHadoopFormatJob(['-r', 'dataproc', '-v',
                                     '-', local_input_path, remote_input_path,
-                                    '--jobconf', 'x=y'])
+                                    '-D', 'x=y'])
         mr_job.sandbox(stdin=stdin)
 
         results = []

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -188,7 +188,7 @@ class EMRJobRunnerEndToEndTestCase(MockBoto3TestCase):
 
         mr_job = MRHadoopFormatJob(['-r', 'emr', '-v',
                                     '-', local_input_path, remote_input_path,
-                                    '--jobconf', 'x=y'])
+                                    '-D', 'x=y'])
         mr_job.sandbox(stdin=stdin)
 
         local_tmp_dir = None

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -671,7 +671,7 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
                                '--no-conf', '--libjar', 'containsJars.jar',
                                '--hadoop-arg=-verbose'] + list(args)
                               + ['-', local_input_path, remote_input_path]
-                              + ['--jobconf', 'x=y'])
+                              + ['-D', 'x=y'])
         mr_job.sandbox(stdin=stdin)
 
         local_tmp_dir = None
@@ -984,7 +984,7 @@ class ArgsForJarStepTestCase(MockHadoopTestCase):
         fake_jar = self.makefile('fake.jar')
 
         job = MRJustAJar(
-            ['-r', 'hadoop', '--jobconf', 'foo=bar', '--jar', fake_jar])
+            ['-r', 'hadoop', '-D', 'foo=bar', '--jar', fake_jar])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1337,7 +1337,7 @@ class HadoopExtraArgsTestCase(MockHadoopTestCase):
             ['-r', self.RUNNER,
              '--cmdenv', 'FOO=bar',
              '--hadoop-arg=-libjar', '--hadoop-arg', 'qux.jar',
-             '--jobconf', 'baz=qux'])
+             '-D', 'baz=qux'])
         job.HADOOP_INPUT_FORMAT = 'FooInputFormat'
         job.HADOOP_OUTPUT_FORMAT = 'BarOutputFormat'
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -624,9 +624,9 @@ class JobConfTestCase(TestCase):
 
     def test_cmd_line_options(self):
         mr_job = MRJob([
-            '--jobconf', 'mapred.foo=bar',
-            '--jobconf', 'mapred.foo=baz',
-            '--jobconf', 'mapred.qux=quux',
+            '-D', 'mapred.foo=bar',
+            '-D', 'mapred.foo=baz',
+            '-D', 'mapred.qux=quux',
         ])
 
         self.assertEqual(mr_job._runner_kwargs()['jobconf'],
@@ -647,9 +647,9 @@ class JobConfTestCase(TestCase):
 
     def test_jobconf_attr_and_cmd_line_options(self):
         mr_job = self.MRJobConfJob([
-            '--jobconf', 'mapred.foo=bar',
-            '--jobconf', 'mapred.foo=baz',
-            '--jobconf', 'mapred.qux=quux',
+            '-D', 'mapred.foo=bar',
+            '-D', 'mapred.foo=baz',
+            '-D', 'mapred.qux=quux',
         ])
 
         self.assertEqual(mr_job._runner_kwargs()['jobconf'],
@@ -665,11 +665,11 @@ class JobConfTestCase(TestCase):
 
     def test_redefined_jobconf_method_overrides_cmd_line(self):
         mr_job = self.MRJobConfMethodJob([
-            '--jobconf', 'mapred.foo=bar',
-            '--jobconf', 'mapred.baz=foo',
+            '-D', 'mapred.foo=bar',
+            '-D', 'mapred.baz=foo',
         ])
 
-        # --jobconf is ignored because that's the way we defined jobconf()
+        # -D is ignored because that's the way we defined jobconf()
         self.assertEqual(mr_job._runner_kwargs()['jobconf'],
                          {'mapred.baz': 'bar'})
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -626,7 +626,8 @@ class JobConfTestCase(TestCase):
         mr_job = MRJob([
             '-D', 'mapred.foo=bar',
             '-D', 'mapred.foo=baz',
-            '-D', 'mapred.qux=quux',
+            # --jobconf is the long name for -D
+            '--jobconf', 'mapred.qux=quux',
         ])
 
         self.assertEqual(mr_job._runner_kwargs()['jobconf'],

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -172,8 +172,8 @@ class TestsToPort:
         input_gz.close()
 
         mr_job = MRTwoStepJob(['-r', 'local',
-                               '--jobconf=mapred.map.tasks=2',
-                               '--jobconf=mapred.reduce.tasks=2',
+                               '-D=mapred.map.tasks=2',
+                               '-D=mapred.reduce.tasks=2',
                                '-', input_path, input_gz_path])
         mr_job.sandbox(stdin=stdin)
 

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -225,7 +225,7 @@ class SimRunnerJobConfTestCase(SandboxedTestCase):
         self.add_mrjob_to_pythonpath()
         mr_job = MRTestJobConf(['-r', self.RUNNER,
                                 '--no-bootstrap-mrjob',
-                                '--jobconf=user.defined=something',
+                                '-D=user.defined=something',
                                 '--file', upload_path,
                                input_gz_path])
 
@@ -291,7 +291,7 @@ class SimRunnerJobConfTestCase(SandboxedTestCase):
 
     def test_per_step_jobconf(self):
         mr_job = MRTestPerStepJobConf([
-            '-r', self.RUNNER, '--jobconf', 'user.defined=something'])
+            '-r', self.RUNNER, '-D', 'user.defined=something'])
         mr_job.sandbox()
 
         results = {}


### PR DESCRIPTION
Hadoop has worked this way for ages, and mrjob should match. Fixes #1839.