### PR TITLE
bootstrap mrjob in py_files, not setup

### DIFF
--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -785,7 +785,7 @@ class MRJobBinRunner(MRJobRunner):
     def _spark_py_files(self):
         """The list of files to pass to spark-submit with --py-files.
 
-        By default (cluster mode), Spark only accepts local files, so
+        By default (client mode), Spark only accepts local files, so
         we pass these as-is.
         """
         py_files = []

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -84,7 +84,7 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
     }
 
     # so far, every service provides the ability to run bootstrap scripts
-    _BOOTSTRAP_MRJOB_IN_SETUP = False
+    _BOOTSTRAP_MRJOB_IN_PY_FILES = False
 
     def __init__(self, **kwargs):
         super(HadoopInTheCloudJobRunner, self).__init__(**kwargs)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -793,7 +793,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         for path in self._working_dir_mgr.paths():
             self._upload_mgr.add(path)
 
-        for path in self._opts['py_files']:
+        for path in self._py_files():
             self._upload_mgr.add(path)
 
         if self._opts['hadoop_streaming_jar']:
@@ -1376,7 +1376,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         # don't use hash paths with --py-files; see #1375
         return [
             self._upload_mgr.uri(path)
-            for path in sorted(self._opts['py_files'])
+            for path in sorted(self._py_files())
         ]
 
     def _step_name(self, step_num):

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -836,13 +836,13 @@ class SparkPyFilesTestCase(SandboxedTestCase):
             self.assertEqual(runner._spark_py_files(),
                              [])
 
-    def test_no_bootstrap_mrjob_in_setup(self):
+    def test_no_bootstrap_mrjob_in_py_files(self):
         job = MRNullSpark(['-r', 'local'])
         job.sandbox()
 
         with job.make_runner() as runner:
             # this happens in runners that run on a cluster
-            runner._BOOTSTRAP_MRJOB_IN_SETUP = False
+            runner._BOOTSTRAP_MRJOB_IN_PY_FILES = False
             self.assertEqual(runner._spark_py_files(),
                              [])
 

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1222,6 +1222,7 @@ class SparkPyFilesTestCase(MockHadoopTestCase):
         job.sandbox()
 
         with job.make_runner() as runner:
+            runner._create_setup_wrapper_scripts()
             runner._add_job_files_for_upload()
 
             self.assertEqual(
@@ -1230,7 +1231,7 @@ class SparkPyFilesTestCase(MockHadoopTestCase):
             )
 
             # the py_files get uploaded anyway since they appear in
-            # _upload_dir_mgr.
+            # _upload_mgr.
             self.assertIn(egg1_path, runner._upload_mgr.path_to_uri())
             self.assertIn(egg2_path, runner._upload_mgr.path_to_uri())
 


### PR DESCRIPTION
This treats bootstrapping mrjob the same way in Hadoop Streaming as it does in Spark, by creating a .zip file of mrjob, and adding it to py_files (fixes #1842).

This undoes a decision to patch `py_files` into `setup`, instead explicitly handling them as part of setup wrapper creation.