### PR TITLE
fix booleans in jobconf, simplify jobconf() and libjars()

### DIFF
--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -823,8 +823,9 @@ def _to_java_str(x):
     # e.g. True -> 'true', None -> 'null'. See #323
     if isinstance(x, string_types):
         return x
+    elif x is None:
+        return 'null'
+    elif isinstance(x, boolean):
+        return 'true' if x else 'false'
     else:
-        try:
-            return json.dumps(x)
-        except:
-            return str(x)
+        return str(x)

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -336,8 +336,7 @@ class MRJobBinRunner(MRJobRunner):
         jobconf = self._jobconf_for_step(step_num)
 
         for key, value in sorted(jobconf.items()):
-            if value is not None:
-                args.extend(['-D', '%s=%s' % (key, _to_java_str(value))])
+            args.extend(['-D', '%s=%s' % (key, value)])
 
         return args
 
@@ -724,8 +723,7 @@ class MRJobBinRunner(MRJobRunner):
         jobconf.update(self._jobconf_for_step(step_num))
 
         for key, value in sorted(jobconf.items()):
-            if value is not None:
-                args.extend(['--conf', '%s=%s' % (key, _to_java_str(value))])
+            args.extend(['--conf', '%s=%s' % (key, value)])
 
         # --files and --archives
         args.extend(self._spark_upload_args())
@@ -814,19 +812,3 @@ def _hadoop_escape_arg(arg):
         return arg
     else:
         return "'%s'" % arg.replace("'", r"'\''")
-
-
-def _to_java_str(x):
-    """Convert a value (usually for a configuration property) into its
-    Java string representation, falling back to the Python representation
-    if None is available."""
-    # e.g. True -> 'true', None -> 'null'. See #323
-    if isinstance(x, string_types):
-        return x
-    elif x is None:
-        # Note: currently, None values are blanked out
-        return 'null'
-    elif isinstance(x, bool):
-        return 'true' if x else 'false'
-    else:
-        return str(x)

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -253,7 +253,7 @@ class MRJobBinRunner(MRJobRunner):
         # cmdenv
         for key, value in sorted(self._opts['cmdenv'].items()):
             args.append('-cmdenv')
-            args.append('%s=%s' % (key, _to_java_str(value)))
+            args.append('%s=%s' % (key, value))
 
         # hadoop_input_format
         if step_num == 0:
@@ -824,8 +824,9 @@ def _to_java_str(x):
     if isinstance(x, string_types):
         return x
     elif x is None:
+        # Note: currently, None values are blanked out
         return 'null'
-    elif isinstance(x, boolean):
+    elif isinstance(x, bool):
         return 'true' if x else 'false'
     else:
         return str(x)

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -725,7 +725,7 @@ class MRJobBinRunner(MRJobRunner):
 
         for key, value in sorted(jobconf.items()):
             if value is not None:
-                args.extend(['--conf', '%s=%s' % (key, value)])
+                args.extend(['--conf', '%s=%s' % (key, _to_java_str(value))])
 
         # --files and --archives
         args.extend(self._spark_upload_args())

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -253,7 +253,7 @@ class MRJobBinRunner(MRJobRunner):
         # cmdenv
         for key, value in sorted(self._opts['cmdenv'].items()):
             args.append('-cmdenv')
-            args.append('%s=%s' % (key, value))
+            args.append('%s=%s' % (key, _to_java_str(value)))
 
         # hadoop_input_format
         if step_num == 0:
@@ -337,7 +337,7 @@ class MRJobBinRunner(MRJobRunner):
 
         for key, value in sorted(jobconf.items()):
             if value is not None:
-                args.extend(['-D', '%s=%s' % (key, value)])
+                args.extend(['-D', '%s=%s' % (key, _to_java_str(value))])
 
         return args
 
@@ -814,3 +814,17 @@ def _hadoop_escape_arg(arg):
         return arg
     else:
         return "'%s'" % arg.replace("'", r"'\''")
+
+
+def _to_java_str(x):
+    """Convert a value (usually for a configuration property) into its
+    Java string representation, falling back to the Python representation
+    if None is available."""
+    # e.g. True -> 'true', None -> 'null'. See #323
+    if isinstance(x, string_types):
+        return x
+    else:
+        try:
+            return json.dumps(x)
+        except:
+            return str(x)

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -514,6 +514,15 @@ def _combine_envs_helper(envs, local):
     return result
 
 
+def combine_jobconfs(*jobconfs):
+    """Like combine_dicts(), but non-string values are converted to
+    Java-readable string (e.g. True becomes 'true'). Keys whose
+    value is None are blanked out."""
+    j = combine_dicts(*jobconfs)
+
+    return {k: _to_java_str(v) for k, v in j.items() if v is not None}
+
+
 def combine_paths(*paths):
     """Returns the last value in *paths* that is not ``None``.
     Resolve ``~`` (home dir) and environment variables."""
@@ -570,3 +579,19 @@ def combine_opts(combiners, *opts_list):
         final_opts[key] = combine_func(*values)
 
     return final_opts
+
+
+def _to_java_str(x):
+    """Convert a value (usually for a configuration property) into its
+    Java string representation, falling back to the Python representation
+    if None is available."""
+    # e.g. True -> 'true', None -> 'null'. See #323
+    if isinstance(x, string_types):
+        return x
+    elif x is None:
+        # Note: combine_jobconfs() blanks out keys with None values
+        return 'null'
+    elif isinstance(x, bool):
+        return 'true' if x else 'false'
+    else:
+        return str(x)

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -1252,14 +1252,7 @@ class MRJob(MRJobLauncher):
 
                 return mrjob.conf.combine_dicts(orig_jobconf, custom_jobconf)
         """
-        # combine job and runner jobconf
-        unfiltered_jobconf = combine_dicts(self.JOBCONF, self.options.jobconf)
-
-        # turn booleans into the Java equivalent ("false", not "False")
-        return {
-            k: json.dumps(v) if not isinstance(v, string_types) else v
-            for k, v in unfiltered_jobconf.items() if v is not None
-        }
+        return self.JOBCONF
 
     ### Secondary Sort ###
 

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -1020,12 +1020,8 @@ class MRJob(MRJobLauncher):
     def libjars(self):
         """Optional list of paths of jar files to run our job with using
         Hadoop's ``-libjar`` option. Normally setting :py:attr:`LIBJARS`
-        is sufficient.
-
-        By default, this combines :option:`libjars` options from the command
-        lines with :py:attr:`LIBJARS`, with command line arguments taking
-        precedence. Paths from :py:attr:`LIBJARS` are interpreted as relative
-        to the the directory containing the script (paths from the
+        is sufficient. Paths from :py:attr:`LIBJARS` are interpreted as
+        relative to the the directory containing the script (paths from the
         command-line are relative to the current working directory).
 
         Note that ``~`` and environment variables in paths will always be
@@ -1035,7 +1031,7 @@ class MRJob(MRJobLauncher):
         """
         script_dir = os.path.dirname(self.mr_job_script())
 
-        paths_from_libjars = []
+        paths = []
 
         # libjar paths will eventually be combined with combine_path_lists,
         # which will expand environment variables. We don't want to assume
@@ -1044,11 +1040,11 @@ class MRJob(MRJobLauncher):
         # prematurely.
         for path in self.LIBJARS or []:
             if os.path.isabs(expand_path(path)):
-                paths_from_libjars.append(path)
+                paths.append(path)
             else:
-                paths_from_libjars.append(os.path.join(script_dir, path))
+                paths.append(os.path.join(script_dir, path))
 
-        return combine_lists(paths_from_libjars, self.options.libjars)
+        return paths
 
     ### Partitioning ###
 

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -534,7 +534,8 @@ class MRJobLauncher(object):
         # TODO: this method should take responsibility for combining
         # self.options with method result for jobconf and libjars. See #1453.
         return dict(
-            jobconf=self.jobconf(),
+            jobconf=combine_dicts(
+                self.options.jobconf, self.jobconf()),
             libjars=self.libjars(),
             partitioner=self.partitioner(),
             sort_values=self.sort_values(),

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -532,7 +532,7 @@ class MRJobLauncher(object):
         """Keyword arguments to the runner class that can be specified
         by the job/launcher itself."""
         # TODO: this method should take responsibility for combining
-        # self.options with method result for jobconf and libjars
+        # self.options with method result for jobconf and libjars. See #1453.
         return dict(
             jobconf=self.jobconf(),
             libjars=self.libjars(),

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -536,7 +536,8 @@ class MRJobLauncher(object):
         return dict(
             jobconf=combine_dicts(
                 self.options.jobconf, self.jobconf()),
-            libjars=self.libjars(),
+            libjars=combine_lists(
+                self.options.libjars, self.libjars()),
             partitioner=self.partitioner(),
             sort_values=self.sort_values(),
             upload_archives=combine_lists(

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -473,7 +473,8 @@ class MRJobLauncher(object):
             return LocalMRJobRunner
 
     def _runner_kwargs(self):
-        # TODO: why combine_dicts() and not combine_options()?
+        # just use combine_dicts() and not combine_confs(); leave the
+        # magic to the runner
         return combine_dicts(
             self._non_option_kwargs(),
             self._kwargs_from_switches(self._runner_opt_names()),
@@ -531,15 +532,17 @@ class MRJobLauncher(object):
     def _job_kwargs(self):
         """Keyword arguments to the runner class that can be specified
         by the job/launcher itself."""
-        # TODO: this method should take responsibility for combining
-        # self.options with method result for jobconf and libjars. See #1453.
+        # use the most basic combiners; leave magic like resolving paths
+        # and blanking out jobconf values to the runner
         return dict(
+            # command-line has the final say on jobconf and libjars
             jobconf=combine_dicts(
-                self.options.jobconf, self.jobconf()),
+                self.jobconf(), self.options.jobconf),
             libjars=combine_lists(
-                self.options.libjars, self.libjars()),
+                self.libjars(), self.options.libjars),
             partitioner=self.partitioner(),
             sort_values=self.sort_values(),
+            # TODO: should probably put self.options last below for consistency
             upload_archives=combine_lists(
                 self.options.upload_archives, self.archives()),
             upload_dirs=combine_lists(

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -29,6 +29,7 @@ from logging import getLogger
 from mrjob.conf import combine_cmds
 from mrjob.conf import combine_dicts
 from mrjob.conf import combine_envs
+from mrjob.conf import combine_jobconfs
 from mrjob.conf import combine_lists
 from mrjob.conf import combine_paths
 from mrjob.conf import combine_path_lists
@@ -799,7 +800,7 @@ _RUNNER_OPTS = dict(
         ],
     ),
     jobconf=dict(
-        combiner=combine_dicts,
+        combiner=combine_jobconfs,
         switches=[
             (['-D', '--jobconf'], dict(
                 action=_KeyValueAction,

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -33,6 +33,7 @@ from mrjob.compat import translate_jobconf
 from mrjob.compat import translate_jobconf_dict
 from mrjob.compat import translate_jobconf_for_all_versions
 from mrjob.conf import combine_dicts
+from mrjob.conf import combine_jobconfs
 from mrjob.conf import combine_opts
 from mrjob.conf import load_opts_from_mrjob_confs
 from mrjob.fs.composite import CompositeFilesystem
@@ -1097,9 +1098,9 @@ class MRJobRunner(object):
         # _sort_values_jobconf() isn't relevant to Spark,
         # but it doesn't do any harm either
 
-        jobconf = combine_dicts(self._sort_values_jobconf(),
-                                self._opts['jobconf'],
-                                step.get('jobconf'))
+        jobconf = combine_jobconfs(self._sort_values_jobconf(),
+                                   self._opts['jobconf'],
+                                   step.get('jobconf'))
 
         # if user is using the wrong jobconfs, add in the correct ones
         # and log a warning

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -903,7 +903,7 @@ class SortValuesTestCase(SandboxedTestCase):
             self.assertEqual(runner._jobconf_for_step(0), {
                 'mapred.text.key.partitioner.options': '-k1,1',
                 'mapreduce.partition.keypartitioner.options': '-k1,1',
-                'stream.num.map.output.key.fields': 2,
+                'stream.num.map.output.key.fields': '2',
             })
 
     def test_sort_values_jobconf_hadoop_1(self):
@@ -913,7 +913,7 @@ class SortValuesTestCase(SandboxedTestCase):
         with mr_job.make_runner() as runner:
             self.assertEqual(runner._jobconf_for_step(0), {
                 'mapred.text.key.partitioner.options': '-k1,1',
-                'stream.num.map.output.key.fields': 2,
+                'stream.num.map.output.key.fields': '2',
             })
 
     def test_sort_values_jobconf_hadoop_2(self):
@@ -923,7 +923,7 @@ class SortValuesTestCase(SandboxedTestCase):
         with mr_job.make_runner() as runner:
             self.assertEqual(runner._jobconf_for_step(0), {
                 'mapreduce.partition.keypartitioner.options': '-k1,1',
-                'stream.num.map.output.key.fields': 2,
+                'stream.num.map.output.key.fields': '2',
             })
 
     def test_job_can_override_jobconf(self):
@@ -936,7 +936,7 @@ class SortValuesTestCase(SandboxedTestCase):
                 runner._jobconf_for_step(0), {
                     'mapreduce.partition.keycomparator.options': '-k1 -k2nr',
                     'mapreduce.partition.keypartitioner.options': '-k1,1',
-                    'stream.num.map.output.key.fields': 3,
+                    'stream.num.map.output.key.fields': '3',
                 }
             )
 
@@ -952,7 +952,7 @@ class SortValuesTestCase(SandboxedTestCase):
                     'org.apache.hadoop.mapred.lib.KeyFieldBasedComparator',
                     'mapreduce.partition.keycomparator.options': '-k1 -k2nr',
                     'mapreduce.partition.keypartitioner.options': '-k1,1',
-                    'stream.num.map.output.key.fields': 3,
+                    'stream.num.map.output.key.fields': '3',
                 }
             )
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -936,7 +936,7 @@ class SortValuesTestCase(SandboxedTestCase):
                 runner._jobconf_for_step(0), {
                     'mapreduce.partition.keycomparator.options': '-k1 -k2nr',
                     'mapreduce.partition.keypartitioner.options': '-k1,1',
-                    'stream.num.map.output.key.fields': '3',
+                    'stream.num.map.output.key.fields': 3,
                 }
             )
 
@@ -952,7 +952,7 @@ class SortValuesTestCase(SandboxedTestCase):
                     'org.apache.hadoop.mapred.lib.KeyFieldBasedComparator',
                     'mapreduce.partition.keycomparator.options': '-k1 -k2nr',
                     'mapreduce.partition.keypartitioner.options': '-k1,1',
-                    'stream.num.map.output.key.fields': '3',
+                    'stream.num.map.output.key.fields': 3,
                 }
             )
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1315,6 +1315,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                 self.assertEqual(
                     runner._spark_submit_args(0),
                     self._expected_conf_args(
+                        cmdenv=dict(PYSPARK_PYTHON='mypy'),
                         jobconf=dict(
                             BAX='true',
                             BAZ='false',

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -715,7 +715,7 @@ class MultipleMultipleConfigFilesTestCase(ConfigFilesTestCase):
     BASE_CONFIG_LEFT = {
         'runners': {
             'inline': {
-                'jobconf': dict(from_left=1, from_both=1),
+                'jobconf': dict(from_left='one', from_both='one'),
                 'label': 'i_dont_like_to_be_labelled',
             }
         }
@@ -724,7 +724,7 @@ class MultipleMultipleConfigFilesTestCase(ConfigFilesTestCase):
     BASE_CONFIG_RIGHT = {
         'runners': {
             'inline': {
-                'jobconf': dict(from_right=2, from_both=2),
+                'jobconf': dict(from_right='two', from_both='two'),
                 'owner': 'ownership_is_against_my_principles'
             }
         }
@@ -736,12 +736,15 @@ class MultipleMultipleConfigFilesTestCase(ConfigFilesTestCase):
         opts_both = self.opts_for_conf('both.conf',
                                        dict(include=[path_left, path_right]))
 
-        self.assertEqual(opts_both['jobconf'],
-                         dict(from_left=1, from_both=2, from_right=2))
-        self.assertEqual(opts_both['label'],
-                         'i_dont_like_to_be_labelled')
-        self.assertEqual(opts_both['owner'],
-                         'ownership_is_against_my_principles')
+        self.assertEqual(
+            opts_both['jobconf'],
+            dict(from_left='one', from_both='two', from_right='two'))
+        self.assertEqual(
+            opts_both['label'],
+            'i_dont_like_to_be_labelled')
+        self.assertEqual(
+            opts_both['owner'],
+            'ownership_is_against_my_principles')
 
     def test_multiple_configs_via_runner_args(self):
         path_left = self.save_conf('left.conf', self.BASE_CONFIG_LEFT)
@@ -749,8 +752,9 @@ class MultipleMultipleConfigFilesTestCase(ConfigFilesTestCase):
 
         runner = InlineMRJobRunner(conf_paths=[path_left, path_right])
 
-        self.assertEqual(runner._opts['jobconf'],
-                         dict(from_left=1, from_both=2, from_right=2))
+        self.assertEqual(
+            runner._opts['jobconf'],
+            dict(from_left='one', from_both='two', from_right='two'))
 
 
 @skipIf(mrjob.conf.yaml is None, 'no yaml module')


### PR DESCRIPTION
You can now set `jobconf: mapred.whatever: true` in your conf file, and Hadoop will be passed `-D mapred.whatever=true`, rather than `-D mapred.whatever=True`. Fixes #323. The `jobconf` option now uses custom combiner (`combine_jobconfs()`), so runners can now expect that `self._opts['jobconf']`'s values are all strings.

This also allowed us to remove some fairly flawed code that was trying to do this from `MRJob.jobconf()`. `MRJob.jobconf()` and `MRJob.libjars()` are no longer responsible for handling command line options, leaving that to `MRJobLauncher` instead, fixing #1453.