### PR TITLE
argument parser fixes

### DIFF
--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -22,7 +22,7 @@ import sys
 import time
 from io import BytesIO
 from argparse import ArgumentParser
-from argparse import ArgumentError
+from argparse import ArgumentTypeError
 
 from mrjob.conf import combine_dicts
 from mrjob.conf import combine_lists
@@ -329,11 +329,11 @@ class MRJobLauncher(object):
         hash table, try out the :py:mod:`sqlite3dbm` module.
         """
         if kwargs.get('type') not in (None, 'string'):
-            raise ArgumentError(
+            raise ArgumentTypeError(
                 'file options must take strings')
 
         if kwargs.get('action') not in (None, 'append', 'store'):
-            raise ArgumentError(
+            raise ArgumentTypeError(
                 "file options must use the actions 'store' or 'append'")
 
         pass_opt = self.arg_parser.add_argument(*args, **kwargs)

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -328,7 +328,7 @@ class MRJobLauncher(object):
         Hadoop). Use SQLite databases instead. If all you need is an on-disk
         hash table, try out the :py:mod:`sqlite3dbm` module.
         """
-        if kwargs.get('type') not in (None, 'string'):
+        if kwargs.get('type') not in (None, str):
             raise ArgumentTypeError(
                 'file options must take strings')
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -77,6 +77,7 @@ _OPTPARSE_TYPES = dict(
     float=float,
     int=int,
     long=int,
+    str=str,  # undocumented alias for 'string', see #1857
     string=str,
 )
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -88,6 +88,9 @@ class MRDeprecatedCustomJobLauncher(MRJobLauncher):
             '--pill-type', '-T', type='choice', choices=(['red', 'blue']),
             default='blue')
 
+        # test 'str' alias for 'string' type (see #1857)
+        self.add_passthrough_option('--word', '-w', type='str', default=None)
+
         self.pass_through_option('--runner')
 
         self.add_file_option('--accordian-file', dest='accordian_files',
@@ -451,13 +454,14 @@ class DeprecatedOptionHooksTestCase(SandboxedTestCase):
 
     def test_add_passthrough_option(self):
         mr_job = MRDeprecatedCustomJobLauncher(
-            args=['', '-F', '6', '-T', 'red'])
+            args=['', '-F', '6', '-T', 'red', '--word', 'bird'])
 
         self.assertEqual(mr_job.options.foo_size, 6)
         self.assertEqual(mr_job.options.pill_type, 'red')
+        self.assertEqual(mr_job.options.word, 'bird')
 
         self.assertEqual(mr_job._non_option_kwargs()['extra_args'],
-                         ['-F', '6', '-T', 'red'])
+                         ['-F', '6', '-T', 'red', '--word', 'bird'])
 
     def test_add_file_option(self):
         mr_job = MRDeprecatedCustomJobLauncher(

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -95,6 +95,9 @@ class MRDeprecatedCustomJobLauncher(MRJobLauncher):
         self.add_file_option('--accordian-file', dest='accordian_files',
                              action='append', default=[])
 
+        # regression test for #1858
+        self.add_file_option('--foo-db', dest='foo_db', type='string')
+
     def load_options(self, args):
         super(MRDeprecatedCustomJobLauncher, self).load_options(args)
 
@@ -479,17 +482,24 @@ class DeprecatedOptionHooksTestCase(SandboxedTestCase):
         mr_job = MRDeprecatedCustomJobLauncher(
             args=['',
                   '--accordian-file', 'WeirdAl.mp3',
-                  '--accordian-file', '/home/dave/JohnLinnell.ogg'])
+                  '--accordian-file', '/home/dave/JohnLinnell.ogg',
+                  '--foo-db', '/var/foo.db',
+                  ])
 
         self.assertEqual(
             mr_job.options.accordian_files, [
                 'WeirdAl.mp3', '/home/dave/JohnLinnell.ogg'])
+
+        self.assertEqual(
+            mrjob.options.foo_db, '/var/foo.db')
 
         self.assertEqual(mr_job._non_option_kwargs()['extra_args'], [
             '--accordian-file', dict(
                 path='WeirdAl.mp3', name=None, type='file'),
             '--accordian-file', dict(
                 path='/home/dave/JohnLinnell.ogg', name=None, type='file'),
+            '--foo-db', dict(
+                path='/var/foo.db', name=None, type='file'),
         ])
 
     def test_pass_through_option_method(self):

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -356,7 +356,7 @@ class CommandLineArgsTestCase(TestCase):
             def configure_args(self):
                 super(MRGoodFileArgTypeLauncher, self).configure_args()
                 self.add_file_arg(
-                    '--bibliophile', dest='bibliophiles', type='str')
+                    '--bibliophile', dest='bibliophiles', type=str)
 
         mr_job = MRGoodFileArgTypeLauncher(
             args=['', '--bibliophile', '/var/bookworm'])
@@ -491,7 +491,7 @@ class DeprecatedOptionHooksTestCase(SandboxedTestCase):
                 'WeirdAl.mp3', '/home/dave/JohnLinnell.ogg'])
 
         self.assertEqual(
-            mrjob.options.foo_db, '/var/foo.db')
+            mr_job.options.foo_db, '/var/foo.db')
 
         self.assertEqual(mr_job._non_option_kwargs()['extra_args'], [
             '--accordian-file', dict(

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -74,7 +74,6 @@ class MRCustomJobLauncher(MRJobLauncher):
         self.add_file_arg('--accordian-file', dest='accordian_files',
                           action='append', default=[])
 
-
 # used to test old options() hooks
 class MRDeprecatedCustomJobLauncher(MRJobLauncher):
 
@@ -347,6 +346,19 @@ class CommandLineArgsTestCase(TestCase):
             '--accordian-file', dict(
                 path='/home/dave/JohnLinnell.ogg', name=None, type='file')
         ])
+
+    def test_str_type_with_file_arg(self):
+        # regression test for #1858
+        class MRGoodFileArgTypeLauncher(MRJobLauncher):
+            def configure_args(self):
+                super(MRGoodFileArgTypeLauncher, self).configure_args()
+                self.add_file_arg(
+                    '--bibliophile', dest='bibliophiles', type='str')
+
+        mr_job = MRGoodFileArgTypeLauncher(
+            args=['', '--bibliophile', '/var/bookworm'])
+
+        self.assertEqual(mr_job.options.bibliophiles, '/var/bookworm')
 
     def test_no_conf_overrides(self):
         mr_job = MRCustomJobLauncher(args=['', '-c', 'blah.conf', '--no-conf'])


### PR DESCRIPTION
`add_file_arg()` now correctly accepts `type=str` (it had some old code from `add_file_option()` that incorrectly expected `'string'`). Fixes #1858.

`add_passthrough_option()` and related optparse emulation code now handles the undocumented type `'str'`, which is an alias for `'string'`. Fixes #1857.