### PR TITLE
--spark-args and --hadoop-args switches

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -68,12 +68,16 @@ Options available to hadoop and emr runners
 
 .. mrjob-opt::
     :config: hadoop_extra_args
-    :switch: --hadoop-arg
+    :switch: --hadoop-args
     :type: :ref:`string list <data-type-string-list>`
     :set: all
     :default: ``[]``
 
     Extra arguments to pass to hadoop streaming.
+
+    .. versionchanged:: 0.6.6
+
+       Deprecated the `--hadoop-arg` switch in favor of `--hadoop-args`
 
 .. mrjob-opt::
     :config: hadoop_streaming_jar
@@ -152,7 +156,7 @@ Options available to hadoop and emr runners
 
 .. mrjob-opt::
     :config: spark_args
-    :switch: --spark-arg
+    :switch: --spark-args
     :type: :ref:`string list <data-type-string-list>`
     :set: all
     :default: ``[]``
@@ -160,6 +164,10 @@ Options available to hadoop and emr runners
     Extra arguments to pass to :command:`spark-submit`.
 
     .. versionadded:: 0.5.7
+
+    .. versionchanged:: 0.6.6
+
+       Deprecated the `--spark-arg` switch in favor of `--spark-args`
 
 
 Options available to hadoop runner only

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -680,13 +680,18 @@ _RUNNER_OPTS = dict(
     hadoop_extra_args=dict(
         combiner=combine_lists,
         switches=[
+            (['--hadoop-args'], dict(
+                action=_AppendArgsAction,
+                help=('One or more arguments to pass to the hadoop binary.'
+                      ' (e.g. --hadoop-args="-fs file:///").'),
+            )),
             (['--hadoop-arg'], dict(
                 action='append',
-                help=('Argument of any type to pass to hadoop '
-                      'streaming. Use an equals sign to avoid confusing the'
-                      ' parser (e.g. --hadoop-arg=-verbose).'
-                      ' You can use --hadoop-arg multiple times.'),
+                deprecated=True,
+                help=('Deprecated. Like --hadoop-args, but only takes one'
+                      ' argument at a time.'),
             )),
+
         ],
     ),
     hadoop_log_dirs=dict(

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -607,10 +607,10 @@ _RUNNER_OPTS = dict(
         deprecated=True,
         switches=[
             (['--emr-api-param'], dict(
-                help=('deprecated. Use --extra-cluster-param instead'),
+                help=('Does nothing. Use --extra-cluster-param instead'),
             )),
             (['--no-emr-api-param'], dict(
-                help=('deprecated. Use --extra-cluster-param instead'),
+                help=('Does nothing. Use --extra-cluster-param instead'),
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -34,6 +34,7 @@ from mrjob.conf import combine_lists
 from mrjob.conf import combine_paths
 from mrjob.conf import combine_path_lists
 from mrjob.parse import _parse_port_range_list
+from mrjob.util import shlex_split
 
 log = getLogger(__name__)
 
@@ -149,6 +150,16 @@ class _CommaSeparatedListAction(Action):
         items = [s.strip() for s in value.split(',') if s]
 
         setattr(namespace, self.dest, items)
+
+
+class _AppendArgsAction(Action):
+    """action to parse one or more arguments and append them to a list."""
+    def __call__(self, parser, namespace, value, option_string=None):
+        _default_to(namespace, self.dest, [])
+
+        args = shlex_split(value)
+
+        getattr(namespace, self.dest).extend(args)
 
 
 class _AppendJSONAction(Action):
@@ -285,6 +296,7 @@ _DEPRECATED_NON_RUNNER_OPTS = {'deprecated'}
 #   have the format (['--switch-names', ...], dict(**kwargs)), where kwargs
 #   can be:
 #     action: action to pass to add_argument() (e.g. 'store_true')
+#     deprecated: if True, this switch is deprecated and slated for removal
 #     deprecated_aliases: list of old '--switch-names' slated for removal
 #     help: help string to pass to add_argument()
 #     type: option type for add_argument() to enforce (e.g. float).
@@ -1101,12 +1113,16 @@ _RUNNER_OPTS = dict(
     spark_args=dict(
         combiner=combine_lists,
         switches=[
+            (['--spark-args'], dict(
+                action=_AppendArgsAction,
+                help=('One or more arguments to pass to spark-submit'
+                      ' (e.g. --spark-args="--deploy-mode cluster").'),
+            )),
             (['--spark-arg'], dict(
                 action='append',
-                help=('Argument of any type to pass to spark-submit.'
-                      ' Use an equals sign to avoid confusing the parser'
-                      ' (e.g. --spark-arg=--verbose).'
-                      ' You can use --spark-arg multiple times.'),
+                deprecated=True,
+                help=('Deprecated. Like --spark-args, but only takes one'
+                      ' argument at a time.'),
             )),
         ],
     ),
@@ -1377,15 +1393,18 @@ def _add_runner_args_for_opt(parser, opt_name, include_deprecated=True):
         kwargs = dict(kwargs)
 
         deprecated_aliases = kwargs.pop('deprecated_aliases', None)
+        deprecated = kwargs.pop('deprecated', False)
 
-        kwargs['dest'] = opt_name
+        # add this switch
+        if include_deprecated or not deprecated:
+            kwargs['dest'] = opt_name
 
-        if kwargs.get('action') == 'append':
-            kwargs['default'] = []
-        else:
-            kwargs['default'] = None
+            if kwargs.get('action') == 'append':
+                kwargs['default'] = []
+            else:
+                kwargs['default'] = None
 
-        parser.add_argument(*args, **kwargs)
+            parser.add_argument(*args, **kwargs)
 
         # add a switch for deprecated aliases
         if deprecated_aliases and include_deprecated:

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1355,7 +1355,22 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
 
     def test_option_spark_args(self):
         job = MRNullSpark(['-r', 'local',
-                           '--spark-arg=--name', '--spark-arg', 'Dave'])
+                           '--spark-args=--name Dave'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_submit_args(0), (
+                    self._expected_conf_args(
+                        cmdenv=dict(PYSPARK_PYTHON='mypy')) +
+                    ['--name', 'Dave']
+                )
+            )
+
+    def test_deprecated_spark_arg_switch(self):
+        job = MRNullSpark(['-r', 'local',
+                           '--spark-arg=--name',
+                           '--spark-arg=Dave'])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1386,7 +1401,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         job = MRNullSpark(
             ['-r', 'local',
              '--extra-spark-arg=-v',
-             '--spark-arg=--name', '--spark-arg', 'Dave'])
+             '--spark-args=--name Dave'])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -669,7 +669,7 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
         mr_job = MRTwoStepJob(['-r', 'hadoop', '-v',
                                '--no-conf', '--libjar', 'containsJars.jar',
-                               '--hadoop-arg=-verbose'] + list(args)
+                               '--hadoop-args=-verbose'] + list(args)
                               + ['-', local_input_path, remote_input_path]
                               + ['-D', 'x=y'])
         mr_job.sandbox(stdin=stdin)
@@ -1329,7 +1329,7 @@ class HadoopExtraArgsTestCase(MockHadoopTestCase):
 
     def test_hadoop_extra_args(self):
         # hadoop_extra_args doesn't exist in default runner
-        job = MRWordCount(['-r', self.RUNNER, '--hadoop-arg=-foo'])
+        job = MRWordCount(['-r', self.RUNNER, '--hadoop-args=-foo'])
         with job.make_runner() as runner:
             self.assertEqual(runner._hadoop_args_for_step(0), ['-foo'])
 
@@ -1337,7 +1337,7 @@ class HadoopExtraArgsTestCase(MockHadoopTestCase):
         job = MRWordCount(
             ['-r', self.RUNNER,
              '--cmdenv', 'FOO=bar',
-             '--hadoop-arg=-libjar', '--hadoop-arg', 'qux.jar',
+             '--hadoop-args=-libjar qux.jar',
              '-D', 'baz=qux'])
         job.HADOOP_INPUT_FORMAT = 'FooInputFormat'
         job.HADOOP_OUTPUT_FORMAT = 'BarOutputFormat'
@@ -1348,6 +1348,15 @@ class HadoopExtraArgsTestCase(MockHadoopTestCase):
                 hadoop_args[:4],
                 ['-D', 'baz=qux', '-libjar', 'qux.jar'])
             self.assertEqual(len(hadoop_args), 10)
+
+    def test_deprecated_hadoop_arg_switch(self):
+        job = MRWordCount(['-r', self.RUNNER,
+                           '--hadoop-arg=-libjar',
+                           '--hadoop-arg=qux.jar'])
+        with job.make_runner() as runner:
+            self.assertEqual(runner._hadoop_args_for_step(0),
+                             ['-libjar', 'qux.jar'])
+
 
 
 class LibjarsTestCase(MockHadoopTestCase):


### PR DESCRIPTION
This deprecates the annoying-to-use `--spark-arg` and `--hadoop-arg` switches in favor of `--spark-args` and `--hadoop-args`, which can take a string containing several arguments, separated by spaces. Fixes #1844.