### PR TITLE
upload py_files, Spark cluster mode

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -163,6 +163,14 @@ Options available to hadoop and emr runners
 
     Extra arguments to pass to :command:`spark-submit`.
 
+    .. warning::
+
+       Don't use this to set ``--master``  or ``--deploy-mode``.
+       On the Hadoop runner, you can change these with
+       :mrjob-opt:`spark_master` and :mrjob-opt:`spark_deploy_mode`.
+       Other runners don't allow you to set these because they can only
+       handle the defaults.
+
     .. versionadded:: 0.5.7
 
     .. versionchanged:: 0.6.6
@@ -240,6 +248,18 @@ Options available to hadoop runner only
     .. versionchanged:: 0.5.0
 
        This option used to be named ``hdfs_scratch_dir``.
+
+.. mrjob-opt::
+    :config: spark_deploy_mode
+    :switch: --spark-deploy-mode
+    :type: :ref:`string <data-type-string>`
+    :set: hadoop
+    :default: ``'client'``
+
+    Deploy mode (``client`` or ``cluster``) to pass to the ``--deploy-mode``
+    argument of :command:`spark-submit`.
+
+    .. versionadded:: 0.6.6
 
 .. mrjob-opt::
     :config: spark_master

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -760,9 +760,9 @@ class MRJobBinRunner(MRJobRunner):
 
         # --py-files (Python only)
         if step['type'] in ('spark', 'spark_script'):
-            py_files_arg = ','.join(self._spark_py_files())
-            if py_files_arg:
-                args.extend(['--py-files', py_files_arg])
+            py_file_uris = self._upload_uris(self._py_files())
+            if py_file_uris:
+                args.extend(['--py-files', ','.join(py_file_uris)])
 
         # spark_args option
         args.extend(self._opts['spark_args'])
@@ -815,14 +815,6 @@ class MRJobBinRunner(MRJobRunner):
             cmdenv = dict(PYSPARK_PYTHON=cmd_line(self._python_bin()))
         cmdenv.update(self._opts['cmdenv'])
         return cmdenv
-
-    def _spark_py_files(self):
-        """The list of files to pass to spark-submit with --py-files.
-
-        By default (client mode), Spark only accepts local files, so
-        we pass these as-is.
-        """
-        return self._py_files()
 
 
 # these don't need to be methods

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -716,10 +716,6 @@ class MRJobBinRunner(MRJobRunner):
         """
         return self._opts['spark_submit_bin'] or ['spark-submit']
 
-    def _spark_submit_arg_prefix(self):
-        """Runner-specific args to spark submit (e.g. ['--master', 'yarn'])"""
-        return []
-
     def _spark_submit_args(self, step_num):
         """Build a list of extra args to the spark-submit binary for
         the given spark or spark_script step."""
@@ -730,8 +726,13 @@ class MRJobBinRunner(MRJobRunner):
 
         args = []
 
-        # add runner-specific args
-        args.extend(self._spark_submit_arg_prefix())
+        # add --master
+        if self._spark_master():
+            args.extend(['--master', self._spark_master()])
+
+        # add --deploy-mode
+        if self._spark_deploy_mode():
+            args.extend(['--deploy-mode', self._spark_deploy_mode()])
 
         # add --class (JAR steps)
         if step.get('main_class'):
@@ -770,6 +771,12 @@ class MRJobBinRunner(MRJobRunner):
         args.extend(step['spark_args'])
 
         return args
+
+    def _spark_master(self):
+        return self._opts.get('spark_master') or None
+
+    def _spark_deploy_mode(self):
+        return self._opts.get('spark_deploy_mode') or None
 
     def _spark_upload_args(self):
         return self._upload_args_helper('--files', self._spark_files,

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -32,7 +32,6 @@ from mrjob.conf import combine_local_envs
 from mrjob.py2 import PY2
 from mrjob.py2 import string_types
 from mrjob.runner import MRJobRunner
-from mrjob.setup import parse_legacy_hash_path
 from mrjob.setup import parse_setup_cmd
 from mrjob.step import _is_spark_step_type
 from mrjob.util import cmd_line

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -184,9 +184,6 @@ _MIN_SPARK_AMI_VERSION = '3.8.0'
 # first AMI version with Spark that supports Python 3
 _MIN_SPARK_PY3_AMI_VERSION = '4.0.0'
 
-# always use these args with spark-submit
-_EMR_SPARK_ARGS = ['--master', 'yarn', '--deploy-mode', 'cluster']
-
 # we have to wait this many minutes for logs to transfer to S3 (or wait
 # for the cluster to terminate). Docs say logs are transferred every 5
 # minutes, but I've seen it take longer on the 4.3.0 AMI. Probably it's
@@ -1361,8 +1358,13 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         else:
             return [_3_X_SPARK_SUBMIT]
 
-    def _spark_submit_arg_prefix(self):
-        return _EMR_SPARK_ARGS
+    def _spark_master(self):
+        # hard-coded for EMR
+        return 'yarn'
+
+    def _spark_deploy_mode(self):
+        # hard-coded for EMR; otherwise it can't access S3
+        return 'cluster'
 
     def _spark_jar(self):
         if version_gte(self.get_image_version(), '4'):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1372,15 +1372,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         else:
             return self._script_runner_jar_uri()
 
-    def _spark_py_files(self):
-        """In cluster mode, py_files can be anywhere, so point to their
-        uploaded URIs."""
-        # don't use hash paths with --py-files; see #1375
-        return [
-            self._upload_mgr.uri(path)
-            for path in sorted(self._py_files())
-        ]
-
     def _step_name(self, step_num):
         """Return something like: ``'mr_your_job Step X of Y'``"""
         return '%s: Step %d of %d' % (

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -127,6 +127,7 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
         'hadoop_log_dirs',
         'hadoop_streaming_jar',
         'hadoop_tmp_dir',
+        'spark_deploy_mode',
         'spark_master',
     }
 
@@ -178,6 +179,7 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
             super(HadoopJobRunner, self)._default_opts(),
             dict(
                 hadoop_tmp_dir='tmp/mrjob',
+                spark_deploy_mode='client',
                 spark_master='yarn',
             )
         )
@@ -536,9 +538,6 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
                 self._interpolate_input_and_output(step['args'], step_num))
 
         return args
-
-    def _spark_submit_arg_prefix(self):
-        return ['--master', self._opts['spark_master']]
 
     def _env_for_step(self, step_num):
         step = self._get_step(step_num)

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -372,6 +372,8 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
         to self._upload_mgr."""
         for path in self._working_dir_mgr.paths():
             self._upload_mgr.add(path)
+        for path in self._py_files():
+            self._upload_mgr.add(path)
 
     def _upload_local_files_to_hdfs(self):
         """Copy files managed by self._upload_mgr to HDFS

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -26,8 +26,6 @@ import sys
 
 # don't use relative imports, to allow this script to be invoked as __main__
 from mrjob.cat import decompress
-from mrjob.conf import combine_dicts
-from mrjob.conf import combine_lists
 from mrjob.launch import MRJobLauncher
 from mrjob.launch import _im_func
 from mrjob.launch import _READ_ARGS_FROM_SYS_ARGV

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1121,7 +1121,7 @@ _RUNNER_OPTS = dict(
             (['--spark-args'], dict(
                 action=_AppendArgsAction,
                 help=('One or more arguments to pass to spark-submit'
-                      ' (e.g. --spark-args="--deploy-mode cluster").'),
+                      ' (e.g. --spark-args="--properties-file my.conf").'),
             )),
             (['--spark-arg'], dict(
                 action='append',
@@ -1130,6 +1130,14 @@ _RUNNER_OPTS = dict(
                       ' argument at a time.'),
             )),
         ],
+    ),
+    spark_deploy_mode=dict(
+        switches=[
+            (['--spark-deploy-mode'], dict(
+                help=('--deploy-mode argument to spark-submit (e.g.'
+                      ' "cluster". Default is "client"'),
+            )),
+        ]
     ),
     spark_master=dict(
         switches=[

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1150,8 +1150,21 @@ class MRJobRunner(object):
         for name, path in named_paths:
             if not name:
                 name = self._working_dir_mgr.name(type, path)
-            uri = self._upload_mgr.uri(path)
+
+            if self._upload_mgr:
+                uri = self._upload_mgr.uri(path)
+            else:
+                uri = path
+
             yield '%s#%s' % (uri, name)
+
+    def _upload_uris(self, paths):
+        """If there's an upload manager, convert list of path to list of upload
+        URIs. Otherwise return *paths* as-is"""
+        if self._upload_mgr:
+            return [self._upload_mgr.uri(path) for path in paths]
+        else:
+            return list(paths)
 
     def _write_script(self, lines, path, description):
         """Write text of a setup script, input manifest, etc. to the given

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -32,7 +32,6 @@ import mrjob.step
 from mrjob.compat import translate_jobconf
 from mrjob.compat import translate_jobconf_dict
 from mrjob.compat import translate_jobconf_for_all_versions
-from mrjob.conf import combine_dicts
 from mrjob.conf import combine_jobconfs
 from mrjob.conf import combine_opts
 from mrjob.conf import load_opts_from_mrjob_confs

--- a/mrjob/tools/diagnose.py
+++ b/mrjob/tools/diagnose.py
@@ -45,7 +45,6 @@ from argparse import ArgumentParser
 from logging import getLogger
 
 from mrjob.aws import _boto3_paginate
-from mrjob.emr import _EMR_SPARK_ARGS
 from mrjob.emr import EMRJobRunner
 from mrjob.job import MRJob
 from mrjob.logs.errors import _format_error
@@ -129,9 +128,8 @@ def _infer_step_type(step):
     #
     # and of course we don't know the logging habits of jar steps,
     # so we might as well use streaming's logic
-    for i in range(len(_EMR_SPARK_ARGS)):
-        if list(args[i:i + len(_EMR_SPARK_ARGS)]) == _EMR_SPARK_ARGS:
-            return 'spark'
+    if '--master' in args and '--deploy-mode' in args:
+        return 'spark'
     else:
         return 'streaming'
 

--- a/mrjob/tools/diagnose.py
+++ b/mrjob/tools/diagnose.py
@@ -133,10 +133,6 @@ def _infer_step_type(step):
     else:
         return 'streaming'
 
-    # every spark step on EMR must include these args
-    return any(args[i:i + len(_EMR_SPARK_ARGS)] == _EMR_SPARK_ARGS
-               for i in range(len(_EMR_SPARK_ARGS)))
-
 
 def _make_arg_parser():
     usage = '%(prog)s [opts] [--step-id STEP_ID] CLUSTER_ID'

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -825,14 +825,14 @@ class SetupWrapperScriptContentTestCase(SandboxedTestCase):
             self.assertEqual(out[:2], ['set -e', 'set -v'])
 
 
-class SparkPyFilesTestCase(SandboxedTestCase):
+class PyFilesTestCase(SandboxedTestCase):
 
     def test_default(self):
         job = MRNullSpark(['-r', 'local'])
         job.sandbox()
 
         with job.make_runner() as runner:
-            self.assertEqual(runner._spark_py_files(),
+            self.assertEqual(runner._py_files(),
                              [runner._create_mrjob_zip()])
 
     def test_eggs(self):
@@ -846,7 +846,7 @@ class SparkPyFilesTestCase(SandboxedTestCase):
 
         with job.make_runner() as runner:
             self.assertEqual(
-                runner._spark_py_files(),
+                runner._py_files(),
                 [egg1_path, egg2_path, runner._create_mrjob_zip()]
             )
 
@@ -856,7 +856,7 @@ class SparkPyFilesTestCase(SandboxedTestCase):
         job.sandbox()
 
         with job.make_runner() as runner:
-            self.assertEqual(runner._spark_py_files(),
+            self.assertEqual(runner._py_files(),
                              [])
 
     def test_no_bootstrap_mrjob_in_py_files(self):
@@ -866,7 +866,7 @@ class SparkPyFilesTestCase(SandboxedTestCase):
         with job.make_runner() as runner:
             # this happens in runners that run on a cluster
             runner._BOOTSTRAP_MRJOB_IN_PY_FILES = False
-            self.assertEqual(runner._spark_py_files(),
+            self.assertEqual(runner._py_files(),
                              [])
 
     def test_no_hash_paths(self):
@@ -1503,7 +1503,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         job.sandbox()
 
         with job.make_runner() as runner:
-            runner._spark_py_files = Mock(
+            runner._py_files = Mock(
                 return_value=['<first py_file>', '<second py_file>']
             )
 
@@ -1526,7 +1526,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         job.sandbox()
 
         with job.make_runner() as runner:
-            runner._spark_py_files = Mock(
+            runner._py_files = Mock(
                 return_value=['<first py_file>', '<second py_file>']
             )
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1212,9 +1212,11 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                 self._expected_conf_args(
                     cmdenv=dict(PYSPARK_PYTHON='mypy')))
 
-    def test_spark_submit_arg_prefix(self):
-        self.start(patch('mrjob.bin.MRJobBinRunner._spark_submit_arg_prefix',
-                         return_value=['<arg prefix>']))
+    def test_spark_master_and_deploy_mode(self):
+        self.start(patch('mrjob.bin.MRJobBinRunner._spark_master',
+                         return_value='yoda'))
+        self.start(patch('mrjob.bin.MRJobBinRunner._spark_deploy_mode',
+                         return_value='the-force'))
 
         job = MRNullSpark(['-r', 'local'])
         job.sandbox()
@@ -1222,7 +1224,22 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         with job.make_runner() as runner:
             self.assertEqual(
                 runner._spark_submit_args(0),
-                ['<arg prefix>'] +
+                ['--master', 'yoda', '--deploy-mode', 'the-force'] +
+                self._expected_conf_args(
+                    cmdenv=dict(PYSPARK_PYTHON='mypy')))
+
+    def test_empty_string_spark_master_and_deploy_mode(self):
+        self.start(patch('mrjob.bin.MRJobBinRunner._spark_master',
+                         return_value=''))
+        self.start(patch('mrjob.bin.MRJobBinRunner._spark_deploy_mode',
+                         return_value=''))
+
+        job = MRNullSpark(['-r', 'local'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_submit_args(0),
                 self._expected_conf_args(
                     cmdenv=dict(PYSPARK_PYTHON='mypy')))
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5238,8 +5238,7 @@ class ImageVersionGteTestCase(MockBoto3TestCase):
 
 class SparkMasterAndDeployModeTestCase(MockBoto3TestCase):
 
-    def test_hard_coded(self):
-        # these are hard-coded and always the same
+    def test_default(self):
         mr_job = MRNullSpark(['-r', 'emr'])
         mr_job.sandbox()
 
@@ -5253,9 +5252,12 @@ class SparkMasterAndDeployModeTestCase(MockBoto3TestCase):
                 ['--master', 'yarn', '--deploy-mode', 'cluster']
             )
 
-            # these can't be configured
-            self.assertNotIn('spark_master', runner._opts)
-            self.assertNotIn('spark_deploy_mode', runner._opts)
+    def test_spark_master_and_deploy_mode_are_hard_coded(self):
+        runner = EMRJobRunner()
+
+        # these can't be configured
+        self.assertNotIn('spark_master', runner._opts)
+        self.assertNotIn('spark_deploy_mode', runner._opts)
 
 
 class SSHWorkerHostsTestCase(MockBoto3TestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4963,6 +4963,13 @@ class UsesSparkTestCase(MockBoto3TestCase):
 
 class SparkPyFilesTestCase(MockBoto3TestCase):
 
+    def setUp(self):
+        super(SparkPyFilesTestCase, self).setUp()
+
+        # so we don't need to start a (mock) cluster
+        self.start(patch('mrjob.emr.EMRJobRunner.get_hadoop_version',
+                         return_value='2'))
+
     def test_eggs(self):
         egg1_path = self.makefile('dragon.egg')
         egg2_path = self.makefile('horton.egg')
@@ -4975,15 +4982,20 @@ class SparkPyFilesTestCase(MockBoto3TestCase):
         with job.make_runner() as runner:
             runner._add_job_files_for_upload()
 
+            # we don't use py_files to bootstrap mrjob
+            self.assertEqual(
+                runner._py_files(),
+                [egg1_path, egg2_path]
+            )
+
             # in the cloud, we need to upload py_files to cloud storage
             self.assertIn(egg1_path, runner._upload_mgr.path_to_uri())
             self.assertIn(egg2_path, runner._upload_mgr.path_to_uri())
 
-            self.assertEqual(
-                runner._spark_py_files(),
-                [runner._upload_mgr.uri(egg1_path),
-                 runner._upload_mgr.uri(egg2_path)]
-            )
+            egg_uris = '%s,%s' % (runner._upload_mgr.uri(egg1_path),
+                                  runner._upload_mgr.uri(egg2_path))
+
+            self.assertIn(egg_uris, runner._spark_submit_args(0))
 
 
 class TestClusterSparkSupportWarning(MockBoto3TestCase):

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1226,14 +1226,18 @@ class SparkPyFilesTestCase(MockHadoopTestCase):
             runner._add_job_files_for_upload()
 
             self.assertEqual(
-                runner._spark_py_files(),
+                runner._py_files(),
                 [egg1_path, egg2_path, runner._create_mrjob_zip()]
             )
 
-            # the py_files get uploaded anyway since they appear in
-            # _upload_mgr.
+            # pass the URI of the *uploaded* py_files to Spark
             self.assertIn(egg1_path, runner._upload_mgr.path_to_uri())
             self.assertIn(egg2_path, runner._upload_mgr.path_to_uri())
+
+            egg_uris = ','.join(runner._upload_mgr.uri(path)
+                                for path in runner._py_files())
+
+            self.assertIn(egg_uris, runner._spark_submit_args(0))
 
 
 class SetupLineEncodingTestCase(MockHadoopTestCase):
@@ -1544,10 +1548,7 @@ class SparkMasterAndDeployModeTestCase(MockHadoopTestCase):
         mr_job.sandbox()
 
         with mr_job.make_runner() as runner:
-            # patch this so we don't have to start a (mock) cluster
-            self.start(patch('mrjob.emr.EMRJobRunner.get_hadoop_version',
-                             return_value='2'))
-
+            runner._add_job_files_for_upload()
             self.assertEqual(
                 runner._spark_submit_args(0)[:4],
                 ['--master', 'yarn', '--deploy-mode', 'client']
@@ -1559,10 +1560,7 @@ class SparkMasterAndDeployModeTestCase(MockHadoopTestCase):
         mr_job.sandbox()
 
         with mr_job.make_runner() as runner:
-            # patch this so we don't have to start a (mock) cluster
-            self.start(patch('mrjob.emr.EMRJobRunner.get_hadoop_version',
-                             return_value='2'))
-
+            runner._add_job_files_for_upload()
             self.assertEqual(
                 runner._spark_submit_args(0)[:4],
                 ['--master', 'local', '--deploy-mode', 'client']
@@ -1575,9 +1573,7 @@ class SparkMasterAndDeployModeTestCase(MockHadoopTestCase):
         mr_job.sandbox()
 
         with mr_job.make_runner() as runner:
-            # patch this so we don't have to start a (mock) cluster
-            self.start(patch('mrjob.emr.EMRJobRunner.get_hadoop_version',
-                             return_value='2'))
+            runner._add_job_files_for_upload()
 
             self.assertEqual(
                 runner._spark_submit_args(0)[:4],


### PR DESCRIPTION
The Hadoop runner now uploads `py_files` to HDFS when running on Spark. This is more consistent with the streaming mode and makes it easier to run, say, a `spark-submit` wrapper script that actually SSHs somewhere else and runs the script. Fixes #1852.

Also added a `spark_deploy_mode` option (fixes #1864).

