### PR TITLE
don't print "usage: usage: " in help message

### DIFF
--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -79,7 +79,7 @@ class MRJob(MRJobLauncher):
 
     @classmethod
     def _usage(cls):
-        return "usage: %(prog)s [options] [input files]"
+        return "%(prog)s [options] [input files]"
 
     ### Defining one-step streaming jobs ###
 

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -149,7 +149,7 @@ class MRJobLauncher(object):
     @classmethod
     def _usage(cls):
         """Command line usage string for this class"""
-        return ("usage: mrjob run [script path|executable path|--help]"
+        return ("mrjob run [script path|executable path|--help]"
                 " [options] [input files]")
 
     def _print_help(self, options):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1316,6 +1316,17 @@ class PrintHelpTestCase(SandboxedTestCase):
         output = self.stdout.getvalue()
         self.assertIn('--reducer-cmd-2', output)
 
+    def test_dont_print_usage_usage(self):
+        # regression test for #1866
+        MRCmdJob(['--help'])
+        self.exit.assert_called_once_with(0)
+
+        output = self.stdout.getvalue()
+        first_line = output.split('\n')[0]
+
+        self.assertTrue(first_line.startswith('usage: '))
+        self.assertNotIn('usage', first_line[len('usage: '):])
+
 
 class RunnerKwargsTestCase(TestCase):
     # ensure that switches exist for every option passed to runners


### PR DESCRIPTION
Unlike `optparse`, `argparse` prepends `usage: ` to your usage string automatically. Fixes #1866 