### PR TITLE
add --local-tmp-dir switch

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -179,15 +179,20 @@ Temp files and cleanup
 
 .. mrjob-opt::
     :config: local_tmp_dir
+    :switch: --local-tmp-dir
     :type: :ref:`path <data-type-path>`
     :set: all
     :default: value of :py:func:`tempfile.gettempdir`
 
     Alternate local temp directory.
 
-    There isn't a command-line switch for this option; just set
-    :envvar:`TMPDIR` or any other environment variable respected by
-    :py:func:`tempfile.gettempdir`.
+    ``--local-tmp-dir ''`` tells mrjob to ignore the config file
+    and use the default temp directory
+    (:py:func:`tempfile.gettempdir`)
+
+    .. versionchanged:: 0.6.6
+
+       Added `--local-tmp-dir` switch.
 
     .. versionchanged:: 0.5.0
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -849,7 +849,11 @@ _RUNNER_OPTS = dict(
     ),
     local_tmp_dir=dict(
         combiner=combine_paths,
-        # no switches, use $TMPDIR etc.
+        switches=[
+            (['--local-tmp-dir'], dict(
+                help='temp directory on local filesystem',
+            )),
+        ],
     ),
     master_instance_bid_price=dict(
         cloud_role='launch',

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -341,7 +341,6 @@ class MRJobRunner(object):
             check_input_paths=True,
             cleanup=['ALL'],
             cleanup_on_failure=['NONE'],
-            local_tmp_dir=tempfile.gettempdir(),
             owner=owner,
         )
 
@@ -725,7 +724,10 @@ class MRJobRunner(object):
         """Create a tmp directory on the local filesystem that will be
         cleaned up by self.cleanup()"""
         if not self._local_tmp_dir:
-            path = os.path.join(self._opts['local_tmp_dir'], self._job_key)
+            tmp_dir = (self._opts['local_tmp_dir'] or
+                       tempfile.gettempdir())
+
+            path = os.path.join(tmp_dir, self._job_key)
             log.info('Creating temp directory %s' % path)
             if os.path.isdir(path):
                 shutil.rmtree(path)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1350,7 +1350,6 @@ class RunnerKwargsTestCase(BasicTestCase):
         'aws_access_key_id',
         'aws_secret_access_key',
         'aws_session_token',
-        'local_tmp_dir',
     ])
 
     def _test_runner_kwargs(self, runner_alias):


### PR DESCRIPTION
Adds a `--local-tmp-dir` switch, which can be used to override the config file (including to just use the default temp dir, if set to empty string). Fixes #1870.