### PR TITLE
don't automatically add generic args to JarSteps

### DIFF
--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -627,6 +627,13 @@ for that step. For example::
                 )
             ]
 
+.. versionchanged:: 0.6.6
+
+   mrjob no longer passes hadoop generic args (`-D` and `-libjars`) to
+   ``JarStep``\s. If you want them, add :py:data:`mrjob.step.GENERIC_ARGS`
+   to your ``JarStep``\'s *args*, and mrjob will automatically interpolate
+   them.
+
 :py:class:`~mrjob.step.JarStep` has no concept of :ref:`job-protocols`. If your
 jar reads input from a :py:class:`~mrjob.step.MRStep`, or writes input
 read by another :py:class:`~mrjob.step.MRStep`, it is up to those

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -367,6 +367,36 @@ class MRJobBinRunner(MRJobRunner):
         """
         return self._opts['libjars']
 
+    def _interpolate_step_args(self, args, step_num):
+        """Replace :py:data:`~mrjob.step.INPUT` and
+        :py:data:`~mrjob.step.OUTPUT` in arguments to a jar or Spark
+        step.
+
+        Also replaces `~mrjob.step.GENERIC_ARGS` with
+        :py:meth:`_hadoop_generic_args_for_step`. This only
+        makes sense for jar steps; Spark should raise an error
+        if `~mrjob.step.GENERIC_ARGS` is encountered.
+        """
+        result = []
+
+        for arg in args:
+            if arg == mrjob.step.GENERIC_ARGS:
+                result.extend(
+                    self._hadoop_generic_args_for_step(step_num))
+
+            elif arg == mrjob.step.INPUT:
+                result.append(
+                    ','.join(self._step_input_uris(step_num)))
+
+            elif arg == mrjob.step.OUTPUT:
+                result.append(
+                    self._step_output_uri(step_num))
+
+            else:
+                result.append(arg)
+
+        return result
+
     ### setup scripts ###
 
     def _py_files(self):
@@ -704,10 +734,14 @@ class MRJobBinRunner(MRJobRunner):
             )
         elif step['type'] in ('spark_jar', 'spark_script'):
             args = step['args']
+
+            if mrjob.step.GENERIC_ARGS in args:
+                raise ValueError(
+                    'GENERIC_ARGS is not allowed in spark steps')
         else:
             raise TypeError('Bad step type: %r' % step['type'])
 
-        return self._interpolate_input_and_output(args, step_num)
+        return self._interpolate_step_args(args, step_num)
 
     def get_spark_submit_bin(self):
         """The spark-submit command, as a list of args. Re-define

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -644,8 +644,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         hadoop_job = {}
 
         hadoop_job['args'] = (
-            self._hadoop_generic_args_for_step(step_num) +
-            self._interpolate_input_and_output(step['args'], step_num))
+            self._interpolate_step_args(step['args'], step_num))
 
         jar_uri = self._upload_mgr.uri(step['jar'])
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1357,9 +1357,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         jar = self._upload_uri_or_remote_path(step['jar'])
 
         args = (
-            # -libjars, -D comes before jar-specific args
-            self._hadoop_generic_args_for_step(step_num) +
-            self._interpolate_input_and_output(step['args'], step_num))
+            self._interpolate_step_args(step['args'], step_num))
 
         hadoop_jar_step = dict(Jar=jar, Args=args)
 

--- a/mrjob/examples/mr_jar_step_example.py
+++ b/mrjob/examples/mr_jar_step_example.py
@@ -25,6 +25,7 @@ import logging
 
 from mrjob.job import MRJob
 from mrjob.protocol import RawProtocol
+from mrjob.step import GENERIC_ARGS
 from mrjob.step import INPUT
 from mrjob.step import JarStep
 from mrjob.step import MRStep
@@ -66,13 +67,13 @@ class MRJarStepExample(MRJob):
         if self.options.use_main_class:
             jar_step = JarStep(
                 jar=jar,
-                args=[INPUT, OUTPUT],
+                args=[GENERIC_ARGS, INPUT, OUTPUT],
                 main_class=_WORDCOUNT_MAIN_CLASS,
             )
         else:
             jar_step = JarStep(
                 jar=jar,
-                args=['wordcount', INPUT, OUTPUT],
+                args=['wordcount', GENERIC_ARGS, INPUT, OUTPUT],
             )
 
         return [

--- a/mrjob/examples/mr_jar_step_example.py
+++ b/mrjob/examples/mr_jar_step_example.py
@@ -21,6 +21,8 @@ This example works out-of-the box on EMR and Google Cloud Dataproc.
 This also only works on a single input path/directory, due to limitations
 of the example jar.
 """
+import logging
+
 from mrjob.job import MRJob
 from mrjob.protocol import RawProtocol
 from mrjob.step import INPUT
@@ -29,12 +31,14 @@ from mrjob.step import MRStep
 from mrjob.step import OUTPUT
 
 # use the file:// trick to access a jar hosted on the cloud
-_RUNNER_TO_EXAMPLES_JAR = dict(
-    dataproc='file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar',
-    emr='file:///home/hadoop/hadoop-examples.jar',
-)
+_EXAMPLES_JAR_URI = (
+    'file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar')
+
+_EMR_HADOOP_PRE_4_X_JAR_URI = (
+    'file:///home/hadoop/hadoop-examples.jar')
 
 _WORDCOUNT_MAIN_CLASS = 'org.apache.hadoop.examples.WordCount'
+
 
 class MRJarStepExample(MRJob):
     """A contrived example that runs wordcount from the hadoop example
@@ -47,10 +51,17 @@ class MRJarStepExample(MRJob):
             '--use-main-class', dest='use_main_class',
             default=False, action='store_true')
 
-        self.pass_arg_through('--runner')
+        self.add_passthru_arg(
+            '--examples-jar', dest='examples_jar',
+            default=_EXAMPLES_JAR_URI,
+            help=('URI of Hadoop example jar. Usually the default'
+                  ' is fine, but on EMR, you should use '
+                  ' file:///home/hadoop/hadoop-examples.jar'
+                  ' with 3.x AMIs and earlier')
+        )
 
     def steps(self):
-        jar = _RUNNER_TO_EXAMPLES_JAR[self.options.runner]
+        jar = self.options.examples_jar
 
         if self.options.use_main_class:
             jar_step = JarStep(

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -518,9 +518,6 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
 
         args.extend(self.get_hadoop_bin())
 
-        # -libjars, -D
-        args.extend(self._hadoop_generic_args_for_step(step_num))
-
         # special case for consistency with EMR runner.
         #
         # This might look less like duplicated code if we ever
@@ -537,7 +534,7 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
 
         if step.get('args'):
             args.extend(
-                self._interpolate_input_and_output(step['args'], step_num))
+                self._interpolate_step_args(step['args'], step_num))
 
         return args
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1051,25 +1051,6 @@ class MRJobRunner(object):
         else:
             return self._intermediate_output_uri(step_num)
 
-    def _interpolate_input_and_output(self, args, step_num):
-        """Replace :py:data:`~mrjob.step.INPUT` and
-        :py:data:`~mrjob.step.OUTPUT` in arguments to a jar or Spark
-        step.
-
-        If there are multiple input paths (i.e. on the first step), they'll
-        be joined with a comma.
-        """
-
-        def interpolate(arg):
-            if arg == mrjob.step.INPUT:
-                return ','.join(self._step_input_uris(step_num))
-            elif arg == mrjob.step.OUTPUT:
-                return self._step_output_uri(step_num)
-            else:
-                return arg
-
-        return [interpolate(arg) for arg in args]
-
     def _jobconf_for_step(self, step_num):
         """Get the jobconf dictionary, optionally including step-specific
         jobconf info.

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -54,10 +54,15 @@ _SPARK_SCRIPT_STEP_KWARGS = ['args', 'script', 'spark_args']
 #: (if there are multiple paths, they'll be joined with commas)
 INPUT = '<input>'
 
-#: If this is passed as passed as an argument to :py:class:`JarStep` or
+#: If this is passed as an argument to :py:class:`JarStep` or
 #: py:class:`SparkScriptStep`, it'll be replaced
 #: with the step's output path
 OUTPUT = '<output>'
+
+#: If this is passed as an argument to :py:class:`JarStep`,
+#: it'll be replaced with generic hadoop args (-D and -libjar)
+GENERIC_ARGS = '<generic args>'
+
 
 log = logging.getLogger(__name__)
 

--- a/tests/mr_jar_with_generic_args.py
+++ b/tests/mr_jar_with_generic_args.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright 2009-2013 Yelp and Contributors
+# Copyright 2017 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Job that runs a single jar, specified on the command line."""
+
+from mrjob.job import MRJob
+from mrjob.step import GENERIC_ARGS
+from mrjob.step import JarStep
+
+class MRJarWithGenericArgs(MRJob):
+
+    def configure_args(self):
+        super(MRJarWithGenericArgs, self).configure_args()
+
+        self.add_passthru_arg('--jar')
+        self.add_passthru_arg('--main-class', default=None)
+
+    def steps(self):
+        return [JarStep(
+            args=['before', GENERIC_ARGS, 'after'],
+            jar=self.options.jar,
+            main_class=self.options.main_class)]
+
+
+if __name__ == '__main__':
+    MRJarWithGenericArgs.run()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -66,6 +66,7 @@ from tests.mockssh import mock_ssh_dir
 from tests.mockssh import mock_ssh_file
 from tests.mr_hadoop_format_job import MRHadoopFormatJob
 from tests.mr_jar_and_streaming import MRJarAndStreaming
+from tests.mr_jar_with_generic_args import MRJarWithGenericArgs
 from tests.mr_just_a_jar import MRJustAJar
 from tests.mr_null_spark import MRNullSpark
 from tests.mr_no_mapper import MRNoMapper
@@ -2523,7 +2524,7 @@ class JarStepTestCase(MockBoto3TestCase):
         with open(fake_libjar, 'w'):
             pass
 
-        job = MRJustAJar(
+        job = MRJarWithGenericArgs(
             ['-r', 'emr', '--jar', fake_jar, '--libjar', fake_libjar])
         job.sandbox()
 
@@ -2549,7 +2550,9 @@ class JarStepTestCase(MockBoto3TestCase):
             working_dir = runner._master_node_setup_working_dir()
 
             self.assertEqual(step_args,
-                             ['-libjars', working_dir + '/libfake.jar'])
+                             ['before',
+                              '-libjars', working_dir + '/libfake.jar',
+                              'after'])
 
     def test_jar_on_s3(self):
         self.add_mock_s3_data({'dubliners': {'whiskeyinthe.jar': b''}})


### PR DESCRIPTION
It turns out that many Hadoop JARs either don't handle generic args (e.g. `-D`, `-libjars`) or don't handle them as the first arguments after `jar`. See #1863 (which this fixes).

After this change, you'll need to explicitly use `mrjob.step.GENERIC_ARGS` to interpolate `-D` and `-libjars` into `JarStep`s. See `mrjob/examples/mr_jar_step_example.py` for an example of how to use `GENERIC_ARGS`.