### PR TITLE
job pushes steps to runner

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -404,6 +404,11 @@ Job execution context
     :set: all
     :default: (current Python interpreter)
 
+    .. deprecated:: 0.6.7
+
+       In most cases, runners no longer query jobs for steps, so this
+       does nothing.
+
     Name/path of alternate python binary to use to query the job about its
     steps. Rarely needed. If not set, we use ``sys.executable`` (the current
     Python interpreter).

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -359,7 +359,10 @@ class MRJob(MRJobLauncher):
 
         kwargs.update(updates)
 
-        return [MRStep(**kwargs)]
+        if kwargs:
+            return [MRStep(**kwargs)]
+        else:
+            return []
 
     def increment_counter(self, group, counter, amount=1):
         """Increment a counter in Hadoop streaming by printing to stderr.

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -860,7 +860,7 @@ class MRJob(MRJobLauncher):
         """
         super(MRJob, self).configure_args()
 
-        _add_step_args(self.arg_parser)
+        _add_step_args(self.arg_parser, include_deprecated=True)
 
     def is_task(self):
         """True if this is a mapper, combiner, reducer, or Spark script.
@@ -876,7 +876,7 @@ class MRJob(MRJobLauncher):
     def _print_help(self, options):
         """Implement --help --steps"""
         if options.show_steps:
-            _print_help_for_steps()
+            _print_help_for_steps(include_deprecated=self.options.deprecated)
         else:
             super(MRJob, self)._print_help(options)
 

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -488,6 +488,9 @@ class MRJob(MRJobLauncher):
         if self._runner_class().alias == 'inline':
             kwargs = dict(mrjob_cls=self.__class__, **kwargs)
 
+        # pass steps to runner (see #1845)
+        kwargs = dict(steps=self._steps_desc(), **kwargs)
+
         return kwargs
 
     def _get_step(self, step_num, expected_type):

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -17,6 +17,7 @@ for more information."""
 
 # don't add imports here that aren't part of the standard Python library,
 # since MRJobs need to run in Amazon's generic EMR environment
+import codecs
 import inspect
 import itertools
 import json
@@ -434,9 +435,15 @@ class MRJob(MRJobLauncher):
         mr_job.execute()
 
     def execute(self):
-        # MRJob does Hadoop Streaming stuff, or defers to Launcher (superclass)
-        # if not otherwise instructed
+        # MRJob does Hadoop Streaming stuff, or defers to its superclass
+        # (MRJobLauncher) if not otherwise instructed
         if self.options.show_steps:
+            log_stream = codecs.getwriter('utf_8')(self.stderr)
+
+            self.set_up_logging(quiet=self.options.quiet,
+                                verbose=self.options.verbose,
+                                stream=log_stream)
+
             self.show_steps()
 
         elif self.options.run_mapper:
@@ -656,6 +663,8 @@ class MRJob(MRJobLauncher):
         Called from :py:meth:`run`. You'd probably only want to call this
         directly from automated tests.
         """
+        log.warning('--steps is deprecated and going away in v0.7.0')
+
         # json only uses strings, but self.stdout only accepts bytes
         steps_json = json.dumps(self._steps_desc())
         if not isinstance(steps_json, bytes):

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1218,6 +1218,7 @@ _RUNNER_OPTS = dict(
     ),
     steps_python_bin=dict(
         combiner=combine_cmds,
+        deprecated=True,
         switches=[
             (['--steps-python-bin'], dict(
                 help=('Name/path of alternate python command to use to'

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -278,6 +278,9 @@ _STEP_OPTS = dict(
     ),
 )
 
+# don't show these unless someone types --help --steps --deprecated
+_DEPRECATED_STEP_OPTS = {'show_steps'}
+
 # don't show these unless someone types --help --deprecated
 _DEPRECATED_NON_RUNNER_OPTS = {'deprecated'}
 
@@ -1504,9 +1507,11 @@ def _add_job_args(parser, include_deprecated=True):
         help='show this message and exit')
 
 
-def _add_step_args(parser):
+def _add_step_args(parser, include_deprecated=False):
     """Add switches that determine what part of the job a MRJob runs."""
     for dest, (args, kwargs) in _STEP_OPTS.items():
+        if dest in _DEPRECATED_STEP_OPTS and not include_deprecated:
+            continue
         kwargs = dict(dest=dest, **kwargs)
         parser.add_argument(*args, **kwargs)
 
@@ -1522,10 +1527,10 @@ def _print_help_for_runner(opt_names, include_deprecated=False):
     help_parser.print_help()
 
 
-def _print_help_for_steps():
+def _print_help_for_steps(include_deprecated=False):
     help_parser = ArgumentParser(usage=SUPPRESS, add_help=False)
 
-    _add_step_args(help_parser)
+    _add_step_args(help_parser, include_deprecated=include_deprecated)
 
     help_parser.print_help()
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -499,7 +499,7 @@ class MRJobRunner(object):
             raise AssertionError('Job already ran!')
 
         if self._num_steps() == 0:
-            raise AssertionError('Job has no steps!')
+            raise ValueError('Job has no steps!')
 
         self._create_dir_archives()
         # TODO: no point in checking input paths if we're going to

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -493,10 +493,13 @@ class MRJobRunner(object):
         actual exception that caused the step to fail).
         """
         if not self._script_path:
-            raise AssertionError("No script to run!")
+            raise AssertionError('No script to run!')
 
         if self._ran_job:
-            raise AssertionError("Job already ran!")
+            raise AssertionError('Job already ran!')
+
+        if self._num_steps() == 0:
+            raise AssertionError('Job has no steps!')
 
         self._create_dir_archives()
         # TODO: no point in checking input paths if we're going to

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -195,7 +195,7 @@ class MRJobRunner(object):
         :param steps: a list of descriptions of steps to run (see
                       :py:meth:`mrjob.steps.MRStep.description`,
                       :py:meth:`mrjob.steps.JarStep.description`, etc.
-                       for format).
+                      for format).
         :type step_output_dir: str
         :param step_output_dir: An empty/non-existent directory where Hadoop
                                 should put output from all steps other than

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1333,6 +1333,7 @@ class RunnerKwargsTestCase(BasicTestCase):
         'partitioner',
         'sort_values',
         'stdin',
+        'steps',
         'step_output_dir',
     ])
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -904,8 +904,7 @@ class InputManifestTestCase(SandboxedTestCase):
     def test_only_first_step_can_use_mapper_raw(self):
         job = MRPhoneToURLToPhoneToURL('')
 
-        with job.make_runner() as runner:
-            self.assertRaises(ValueError, runner._get_steps)
+        self.assertRaises(ValueError, job.make_runner)
 
 
 class LocalTmpDirTestCase(SandboxedTestCase):


### PR DESCRIPTION
For historical reasons involving supporting non-Python languages, `MRJob`s don't directly report their step definition to the runner, instead relying on the runner to invoke your `MRJob` script with `--steps`. Fixes #1845.

Deprecated `steps_python_bin` as well (fixes #1851).

This change makes it so `MRJob` passes *steps* to `MRJobRunner`'s constructor. The code to support loading steps by invoking the script still exists, but is deprecated and should go away in the next major version.

If you have a `MRJob` script that doesn't actually run tasks (it's just a definition of JARs, command steps, etc.), you can get away without using passthru options and instead just using `self.arg_parser.add_argument()`. I didn't make a note of this in the documentation because it's kind of an edge case, but there are tests for it.
