### PR TITLE
Deprecate interpreter options

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -42,7 +42,8 @@ options related to file uploading.
     :default: (automatic)
 
     Should we automatically zip up the mrjob library and install it when we run
-    job? By default, we do unless :mrjob-opt:`interpreter` is set.
+    job? By default, we do unless :mrjob-opt:`interpreter` (deprecated)
+    is set.
 
     Set this to ``False`` if you've already installed ``mrjob`` on your
     Hadoop cluster or install it by some other method.
@@ -278,6 +279,10 @@ Job execution context
     :set: all
     :default: ``None``
 
+    .. deprecated:: 0.6.7
+
+       support for non-Python jobs is being phased out.
+
     Non-Python command to launch your script with (e.g. ``'ruby'``).
     This will also be used to query the script about steps unless you set
     :mrjob-opt:`steps_interpreter`.
@@ -305,12 +310,9 @@ Job execution context
 
     This option also affects which Python binary is used for file locking in
     :mrjob-opt:`setup` scripts, so it might be useful to set even if you're
-    using a non-Python :mrjob-opt:`interpreter`. It's also used by
-    :py:class:`~mrjob.emr.EMRJobRunner` to compile mrjob after bootstrapping it
-    (see :mrjob-opt:`bootstrap_mrjob`).
-
-    Unlike :mrjob-opt:`interpreter`, this does not affect the binary used to
-    query the job about its steps (use :mrjob-opt:`steps_python_bin`).
+    using a non-Python :mrjob-opt:`interpreter` (deprecated). It's also
+    used by :py:class:`~mrjob.emr.EMRJobRunner` to compile mrjob after
+    bootstrapping it (see :mrjob-opt:`bootstrap_mrjob`).
 
 .. mrjob-opt::
     :config: setup
@@ -388,6 +390,10 @@ Job execution context
     :type: :ref:`command <data-type-command>`
     :set: all
     :default: current Python interpreter
+
+    .. deprecated:: 0.6.7
+
+       support for non-Python jobs is being phased out.
 
     Alternate (non-Python) command to use to query the job about
     its steps. Usually it's good enough to set :mrjob-opt:`interpreter`.

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -814,6 +814,7 @@ _RUNNER_OPTS = dict(
     ),
     interpreter=dict(
         combiner=combine_cmds,
+        deprecated=True,
         switches=[
             (['--interpreter'], dict(
                 help='Non-python command to run your script, e.g. "ruby".',
@@ -1212,6 +1213,7 @@ _RUNNER_OPTS = dict(
     ),
     steps_interpreter=dict(
         combiner=combine_cmds,
+        deprecated=True,
         switches=[
             (['--steps-interpreter'], dict(
                 help=("Non-Python command to use to query the job about its"


### PR DESCRIPTION
This deprecates the `interpreter` and `steps_intepreter` options which are rarely (never?) used. Fixes #1850.