### PR TITLE
add plural switches

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -54,7 +54,7 @@ options related to file uploading.
 
 .. mrjob-opt::
    :config: py_files
-   :switch: --py-file
+   :switch: --py-files
    :type: :ref:`path list <data-type-path-list>`
    :set: all
    :default: ``[]``
@@ -66,9 +66,13 @@ options related to file uploading.
 
    .. versionadded:: 0.5.7
 
+   .. versionchanged:: 0.6.7
+
+      Deprecated :option:`--py-file` in favor of :option:`--py-files`
+
 .. mrjob-opt::
     :config: upload_archives
-    :switch: --archive
+    :switch: --archives
     :type: :ref:`path list <data-type-path-list>`
     :set: all
     :default: ``[]``
@@ -85,9 +89,13 @@ options related to file uploading.
 
        This works with Spark as well.
 
+    .. versionchanged:: 0.6.7
+
+       Deprecated :option:`--archive` in favor of :option:`--archives`
+
 .. mrjob-opt::
     :config: upload_dirs
-    :switch: --dir
+    :switch: --dirs
     :type: :ref:`path list <data-type-path-list>`
     :set: all
     :default: ``[]``
@@ -104,9 +112,14 @@ options related to file uploading.
 
     .. versionadded:: 0.5.8
 
+    .. versionchanged:: 0.6.7
+
+       Deprecated :option:`--dir` in favor of :option:`--dirs`
+
+
 .. mrjob-opt::
     :config: upload_files
-    :switch: --file
+    :switch: --files
     :type: :ref:`path list <data-type-path-list>`
     :set: all
     :default: ``[]``
@@ -130,6 +143,9 @@ options related to file uploading.
 
        This works with Spark as well.
 
+    .. versionchanged:: 0.6.7
+
+       Deprecated :option:`--file` in favor of :option:`--files`
 
 Temp files and cleanup
 ======================

--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -83,7 +83,7 @@ Options available to hadoop and emr runners
 
     .. versionchanged:: 0.6.6
 
-       Deprecated the `--hadoop-arg` switch in favor of `--hadoop-args`
+       Deprecated :option:`--hadoop-arg` in favor of :option:`--hadoop-args`
 
 .. mrjob-opt::
     :config: hadoop_streaming_jar
@@ -115,17 +115,21 @@ Options available to hadoop and emr runners
 
 .. mrjob-opt::
    :config: libjars
-   :switch: --libjar
+   :switch: --libjars
    :type: :ref:`string list <data-type-string-list>`
    :set: all
    :default: ``[]``
 
-   List of paths of JARs to be passed to Hadoop with the ``-libjar`` switch.
+   List of paths of JARs to be passed to Hadoop with the ``-libjars`` switch.
 
    ``~`` and environment variables within paths will be resolved based on the
    local environment.
 
    .. versionadded:: 0.5.3
+
+   .. versionchanged:: 0.6.7
+
+       Deprecated :option:`--libjar` in favor of :option:`--libjars`
 
    .. note::
 
@@ -181,7 +185,7 @@ Options available to hadoop and emr runners
 
     .. versionchanged:: 0.6.6
 
-       Deprecated the `--spark-arg` switch in favor of `--spark-args`
+       Deprecated :option:`--spark-arg` in favor of :option:`--spark-args`
 
 
 Options available to hadoop runner only

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -256,7 +256,7 @@ See also :mrjob-opt:`bootstrap`, :mrjob-opt:`image_id`, and
 
 .. mrjob-opt::
    :config: applications
-   :switch: --application
+   :switch: --application, --applications
    :type: :ref:`string list <data-type-string-list>`
    :set: emr
    :default: ``[]``
@@ -275,6 +275,10 @@ See also :mrjob-opt:`bootstrap`, :mrjob-opt:`image_id`, and
    .. versionchanged:: 0.5.9
 
       This used to be called *emr_applications*.
+
+   .. versionchanged:: 0.6.7
+
+      Added :option:`--applications` switch
 
 .. mrjob-opt::
     :config: bootstrap_actions

--- a/docs/guides/spark.rst
+++ b/docs/guides/spark.rst
@@ -122,9 +122,9 @@ to access files on S3.
 Passing in libraries
 --------------------
 
-Use ``--py-file`` to pass in ``.zip`` or ``.egg`` files full of Python code::
+Use ``--py-files`` to pass in ``.zip`` or ``.egg`` files full of Python code::
 
-  python your_mr_spark_job -r hadoop --py-file lib1.zip --py-file lib2.egg
+  python your_mr_spark_job -r hadoop --py-files lib1.zip,lib2.egg
 
 Or set :mrjob-opt:`py_files` in ``mrjob.conf``.
 

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -1017,7 +1017,7 @@ class MRJob(MRJobLauncher):
     ### Libjars ###
 
     #: Optional list of paths of jar files to run our job with using Hadoop's
-    #: ``-libjar`` option.
+    #: ``-libjars`` option.
     #:
     #: ``~`` and environment variables
     #: in paths be expanded, and relative paths will be interpreted as
@@ -1032,7 +1032,7 @@ class MRJob(MRJobLauncher):
 
     def libjars(self):
         """Optional list of paths of jar files to run our job with using
-        Hadoop's ``-libjar`` option. Normally setting :py:attr:`LIBJARS`
+        Hadoop's ``-libjars`` option. Normally setting :py:attr:`LIBJARS`
         is sufficient. Paths from :py:attr:`LIBJARS` are interpreted as
         relative to the the directory containing the script (paths from the
         command-line are relative to the current working directory).

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -859,7 +859,7 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--libjar'], dict(
                 action='append',
-                help=('Deprecated. Like -libjar, but only takes a'
+                help=('Deprecated. Like --libjars, but only takes a'
                       ' single JAR.'),
             )),
             (['--libjars'], dict(

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -152,6 +152,20 @@ class _CommaSeparatedListAction(Action):
         setattr(namespace, self.dest, items)
 
 
+class _AppendCommaSeparatedItemsAction(Action):
+    """action to parse a comma-separated list and append
+    each of them to an existing list.
+
+    This eliminates whitespace
+    """
+    def __call__(self, parser, namespace, value, option_string=None):
+        _default_to(namespace, self.dest, [])
+
+        items = [s.strip() for s in value.split(',') if s]
+
+        getattr(namespace, self.dest).extend(args)
+
+
 class _AppendArgsAction(Action):
     """action to parse one or more arguments and append them to a list."""
     def __call__(self, parser, namespace, value, option_string=None):
@@ -321,10 +335,17 @@ _RUNNER_OPTS = dict(
         cloud_role='launch',
         combiner=combine_lists,
         switches=[
+            (['--applications'], dict(
+                action=_AppendCommaSeparatedItemsAction,
+                help=('Additional applications to run on 4.x and 5.x'
+                      ' AMIs, separated by commas (e.g.'
+                      ' "Ganglia,Spark")'),
+            )),
             (['--application'], dict(
                 action='append',
-                help=('Additional applications to run on 4.x AMIs (e.g.'
-                      ' Ganglia, Mahout, Spark)'),
+                deprecated=True,
+                help=('Deprecated. Like --applications, but only one'
+                      ' application at a time.'),
             )),
         ],
     ),
@@ -843,11 +864,17 @@ _RUNNER_OPTS = dict(
     libjars=dict(
         combiner=combine_path_lists,
         switches=[
+            (['--libjars'], dict(
+                action=_AppendCommaSeparatedItemsAction,
+                help=('Paths of JARs to pass to Hadoop with -libjars,'
+                      ' separated by commas. On EMR,'
+                      ' these can also be URIs; use file:/// to'
+                      ' reference JARs already on the EMR cluster.')
+            )),
             (['--libjar'], dict(
                 action='append',
-                help=('Path of a JAR to pass to Hadoop with -libjar. On EMR,'
-                      ' this can also be a URI; use file:/// to reference JARs'
-                      ' already on the EMR cluster'),
+                help=('Deprecated. Like -libjar, but only takes a'
+                      ' single JAR.'),
             )),
         ],
     ),
@@ -1012,9 +1039,16 @@ _RUNNER_OPTS = dict(
     py_files=dict(
         combiner=combine_path_lists,
         switches=[
+            (['--py-files'], dict(
+                action=_AppendCommaSeparatedItemsAction,
+                help=('.zip or .egg files to add to PYTHONPATH,'
+                      ' separated by commas'),
+            )),
             (['--py-file'], dict(
                 action='append',
-                help='.zip or .egg file to add to PYTHONPATH'
+                deprecated=True,
+                help=('Deprecated. Like --py-files, but only'
+                      ' takes a single file.')
             )),
         ],
     ),
@@ -1305,31 +1339,51 @@ _RUNNER_OPTS = dict(
     upload_archives=dict(
         combiner=combine_path_lists,
         switches=[
+            (['--archives'], dict(
+                action=_AppendCommaSeparatedItemsAction,
+                help=('Archives to unpack in the working directory of the'
+                      ' script, separated by commas. Use "#" to assign a'
+                      ' different name to each directory (e.g. '
+                      '"foo-libs.zip#lib,bar.tar.gz#bar")'),
+            )),
             (['--archive'], dict(
                 action='append',
-                help=('Unpack archive in the working directory of this script.'
-                      ' You can use --archive multiple times.'),
+                deprecated=True,
+                help='Deprecated. Like --archives, but only takes one file.',
             )),
         ],
     ),
     upload_dirs=dict(
         combiner=combine_path_lists,
         switches=[
+            (['--dirs'], dict(
+                action=_AppendCommaSeparatedItemsAction,
+                help=('Directories to tarball and unpack in the working'
+                      ' directory of the script, separated by commas. Append'
+                      '#<name> to each directory to assign a different name'
+                      ' (e.g. "foo#lib,bar#local-bar")'),
+            )),
             (['--dir'], dict(
                 action='append',
-                help=('Tarball the given directory and unpack the resulting'
-                      ' archive in the working directory of this script.'
-                      ' You can use --dir multiple times'),
+                deprecated=True,
+                help='Deprecated. Like --dirs, but only takes one directory.'
             )),
         ],
     ),
     upload_files=dict(
         combiner=combine_path_lists,
         switches=[
+            (['--files'], dict(
+                action=_AppendCommaSeparatedItemsAction,
+                help=('Files to copy to the working directory of the script,'
+                      ' separated by commas. Use "#"'
+                      ' to assign a different name to each file (e.g. '
+                      '"foo.db#bar.db")'),
+            )),
             (['--file'], dict(
                 action='append',
-                help=('Copy file to the working directory of this script. You'
-                      ' can use --file multiple times.'),
+                deprecated=True,
+                help='Deprecated. Like --files, but only takes one file.'
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -335,13 +335,7 @@ _RUNNER_OPTS = dict(
         cloud_role='launch',
         combiner=combine_lists,
         switches=[
-            (['--application'], dict(
-                action='append',
-                deprecated=True,
-                help=('Deprecated. Like --applications, but only one'
-                      ' application at a time.'),
-            )),
-            (['--applications'], dict(
+            (['--applications', '--application'], dict(
                 action=_AppendCommaSeparatedItemsAction,
                 help=('Additional applications to run on 4.x and 5.x'
                       ' AMIs, separated by commas (e.g.'

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -163,7 +163,7 @@ class _AppendCommaSeparatedItemsAction(Action):
 
         items = [s.strip() for s in value.split(',') if s]
 
-        getattr(namespace, self.dest).extend(args)
+        getattr(namespace, self.dest).extend(items)
 
 
 class _AppendArgsAction(Action):

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -335,17 +335,17 @@ _RUNNER_OPTS = dict(
         cloud_role='launch',
         combiner=combine_lists,
         switches=[
-            (['--applications'], dict(
-                action=_AppendCommaSeparatedItemsAction,
-                help=('Additional applications to run on 4.x and 5.x'
-                      ' AMIs, separated by commas (e.g.'
-                      ' "Ganglia,Spark")'),
-            )),
             (['--application'], dict(
                 action='append',
                 deprecated=True,
                 help=('Deprecated. Like --applications, but only one'
                       ' application at a time.'),
+            )),
+            (['--applications'], dict(
+                action=_AppendCommaSeparatedItemsAction,
+                help=('Additional applications to run on 4.x and 5.x'
+                      ' AMIs, separated by commas (e.g.'
+                      ' "Ganglia,Spark")'),
             )),
         ],
     ),
@@ -704,18 +704,17 @@ _RUNNER_OPTS = dict(
     hadoop_extra_args=dict(
         combiner=combine_lists,
         switches=[
-            (['--hadoop-args'], dict(
-                action=_AppendArgsAction,
-                help=('One or more arguments to pass to the hadoop binary.'
-                      ' (e.g. --hadoop-args="-fs file:///").'),
-            )),
             (['--hadoop-arg'], dict(
                 action='append',
                 deprecated=True,
                 help=('Deprecated. Like --hadoop-args, but only takes one'
                       ' argument at a time.'),
             )),
-
+            (['--hadoop-args'], dict(
+                action=_AppendArgsAction,
+                help=('One or more arguments to pass to the hadoop binary.'
+                      ' (e.g. --hadoop-args="-fs file:///").'),
+            )),
         ],
     ),
     hadoop_log_dirs=dict(
@@ -864,17 +863,17 @@ _RUNNER_OPTS = dict(
     libjars=dict(
         combiner=combine_path_lists,
         switches=[
+            (['--libjar'], dict(
+                action='append',
+                help=('Deprecated. Like -libjar, but only takes a'
+                      ' single JAR.'),
+            )),
             (['--libjars'], dict(
                 action=_AppendCommaSeparatedItemsAction,
                 help=('Paths of JARs to pass to Hadoop with -libjars,'
                       ' separated by commas. On EMR,'
                       ' these can also be URIs; use file:/// to'
                       ' reference JARs already on the EMR cluster.')
-            )),
-            (['--libjar'], dict(
-                action='append',
-                help=('Deprecated. Like -libjar, but only takes a'
-                      ' single JAR.'),
             )),
         ],
     ),
@@ -1039,16 +1038,16 @@ _RUNNER_OPTS = dict(
     py_files=dict(
         combiner=combine_path_lists,
         switches=[
-            (['--py-files'], dict(
-                action=_AppendCommaSeparatedItemsAction,
-                help=('.zip or .egg files to add to PYTHONPATH,'
-                      ' separated by commas'),
-            )),
             (['--py-file'], dict(
                 action='append',
                 deprecated=True,
                 help=('Deprecated. Like --py-files, but only'
                       ' takes a single file.')
+            )),
+            (['--py-files'], dict(
+                action=_AppendCommaSeparatedItemsAction,
+                help=('.zip or .egg files to add to PYTHONPATH,'
+                      ' separated by commas'),
             )),
         ],
     ),
@@ -1160,16 +1159,16 @@ _RUNNER_OPTS = dict(
     spark_args=dict(
         combiner=combine_lists,
         switches=[
-            (['--spark-args'], dict(
-                action=_AppendArgsAction,
-                help=('One or more arguments to pass to spark-submit'
-                      ' (e.g. --spark-args="--properties-file my.conf").'),
-            )),
             (['--spark-arg'], dict(
                 action='append',
                 deprecated=True,
                 help=('Deprecated. Like --spark-args, but only takes one'
                       ' argument at a time.'),
+            )),
+            (['--spark-args'], dict(
+                action=_AppendArgsAction,
+                help=('One or more arguments to pass to spark-submit'
+                      ' (e.g. --spark-args="--properties-file my.conf").'),
             )),
         ],
     ),

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -60,7 +60,7 @@ INPUT = '<input>'
 OUTPUT = '<output>'
 
 #: If this is passed as an argument to :py:class:`JarStep`,
-#: it'll be replaced with generic hadoop args (-D and -libjar)
+#: it'll be replaced with generic hadoop args (-D and -libjars)
 GENERIC_ARGS = '<generic args>'
 
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1467,7 +1467,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
 
         job = MRNullSpark([
             '-r', 'local',
-            '--files', '%s#foo1,%s#foo2' % (foo1_path, foo2_path),
+            '--files', '%s#foo1,%s#bar' % (foo1_path, foo2_path),
             '--archives', baz_path,
             '--dirs', qux_path,
         ])

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1370,6 +1370,8 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                     cmdenv=dict(PYSPARK_PYTHON='mypy')))
 
     def test_deprecated_libjar_switch(self):
+        fake_libjar = self.makefile('fake_lib.jar')
+
         job = MRNullSpark(
             ['-r', 'local', '--libjar', fake_libjar])
         job.sandbox()

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -584,8 +584,8 @@ class SetupTestCase(SandboxedTestCase):
 
     def test_file_upload(self):
         job = MROSWalkJob(['-r', 'local',
-                           '--file', self.foo_sh,
-                           '--file', self.foo_sh + '#bar.sh',
+                           '--files', '%s,%s#bar.sh' % (
+                               self.foo_sh, self.foo_sh)
                            ])
         job.sandbox()
 
@@ -599,8 +599,8 @@ class SetupTestCase(SandboxedTestCase):
 
     def test_archive_upload(self):
         job = MROSWalkJob(['-r', 'local',
-                           '--archive', self.foo_tar_gz,
-                           '--archive', self.foo_tar_gz + '#foo',
+                           '--archives', '%s,%s#foo' % (
+                               self.foo_tar_gz, self.foo_tar_gz)
                            ])
         job.sandbox()
 
@@ -616,8 +616,9 @@ class SetupTestCase(SandboxedTestCase):
 
     def test_dir_upload(self):
         job = MROSWalkJob(['-r', 'local',
-                           '--dir', self.foo_dir,
-                           '--dir', self.foo_dir + '#bar'])
+                           '--dirs', '%s,%s#bar' % (
+                               self.foo_dir, self.foo_dir)
+                           ])
         job.sandbox()
 
         with job.make_runner() as r:
@@ -1466,10 +1467,9 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
 
         job = MRNullSpark([
             '-r', 'local',
-            '--file', foo1_path + '#foo1',
-            '--file', foo2_path + '#bar',
-            '--archive', baz_path,
-            '--dir', qux_path,
+            '--files', '%s#foo1,%s#foo2' % (foo1_path, foo2_path),
+            '--archives', baz_path,
+            '--dirs', qux_path,
         ])
         job.sandbox()
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1349,6 +1349,18 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         fake_libjar = self.makefile('fake_lib.jar')
 
         job = MRNullSpark(
+            ['-r', 'local', '--libjars', fake_libjar])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_submit_args(0),
+                ['--jars', fake_libjar] +
+                self._expected_conf_args(
+                    cmdenv=dict(PYSPARK_PYTHON='mypy')))
+
+    def test_deprecated_libjar_switch(self):
+        job = MRNullSpark(
             ['-r', 'local', '--libjar', fake_libjar])
         job.sandbox()
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -847,7 +847,7 @@ class PyFilesTestCase(SandboxedTestCase):
         egg1_path = self.makefile('dragon.egg')
 
         job = MRNullSpark(['-r', 'local', '--no-bootstrap-mrjob',
-                           '--py-file', egg1_path)])
+                           '--py-file', egg1_path])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -684,7 +684,7 @@ class SetupTestCase(SandboxedTestCase):
     def test_py_file(self):
         job = MROSWalkJob([
             '-r', 'local',
-            '--py-file', self.foo_zip,
+            '--py-files', self.foo_zip,
         ])
         job.sandbox()
 
@@ -834,7 +834,7 @@ class PyFilesTestCase(SandboxedTestCase):
         egg2_path = self.makefile('horton.egg')
 
         job = MRNullSpark(['-r', 'local',
-                           '--py-file', egg1_path, '--py-file', egg2_path])
+                           '--py-files', '%s,%s' % (egg1_path, egg2_path)])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -842,6 +842,16 @@ class PyFilesTestCase(SandboxedTestCase):
                 runner._py_files(),
                 [egg1_path, egg2_path, runner._create_mrjob_zip()]
             )
+
+    def test_deprecated_py_file_switch(self):
+        egg1_path = self.makefile('dragon.egg')
+
+        job = MRNullSpark(['-r', 'local', '--no-bootstrap-mrjob',
+                           '--py-file', egg1_path)])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(runner._py_files(), [egg1_path])
 
     def test_no_bootstrap_mrjob(self):
         job = MRNullSpark(['-r', 'local',
@@ -866,7 +876,7 @@ class PyFilesTestCase(SandboxedTestCase):
         egg_path = self.makefile('horton.egg')
 
         job = MRNullSpark(['-r', 'local',
-                           '--py-file', egg_path + '#mayzie.egg'])
+                           '--py-files', egg_path + '#mayzie.egg'])
         job.sandbox()
 
         self.assertRaises(ValueError, job.make_runner)
@@ -1547,7 +1557,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
             )
 
             # should handle cmdenv and --class
-            # but not set PYSPARK_PYTHON or --py-file
+            # but not set PYSPARK_PYTHON or --py-files
             self.assertEqual(
                 runner._spark_submit_args(0), (
                     ['--class', 'foo.Bar'] +

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4115,8 +4115,7 @@ class EMRApplicationsTestCase(MockBoto3TestCase):
         job = MRTwoStepJob(
             ['-r', 'emr',
              '--image-version', '3.11.0',
-             '--application', 'Hadoop',
-             '--application', 'Mahout'])
+             '--applications', 'Hadoop,Mahout'])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -4124,9 +4123,7 @@ class EMRApplicationsTestCase(MockBoto3TestCase):
 
     def test_explicit_hadoop(self):
         job = MRTwoStepJob(
-            ['-r', 'emr',
-             '--application', 'Hadoop',
-             '--application', 'Mahout'])
+            ['-r', 'emr', '--applications', 'Hadoop,Mahout'])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -4142,8 +4139,7 @@ class EMRApplicationsTestCase(MockBoto3TestCase):
 
     def test_implicit_hadoop(self):
         job = MRTwoStepJob(
-            ['-r', 'emr',
-             '--application', 'Mahout'])
+            ['-r', 'emr', '--application', 'Mahout'])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -4955,8 +4951,7 @@ class UsesSparkTestCase(MockBoto3TestCase):
     def test_spark_and_other_application(self):
         job = MRTwoStepJob(['-r', 'emr',
                             '--image-version', '4.0.0',
-                            '--application', 'Mahout',
-                            '--application', 'Spark'])
+                            '--applications', 'Mahout,Spark'])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4353,9 +4353,9 @@ class WaitForStepsToCompleteTestCase(MockBoto3TestCase):
         with open(fake_jar, 'w'):
             pass
 
-        # --libjar is currently the only way to create the master
+        # --libjars is currently the only way to create the master
         # node setup script
-        runner = self.make_runner('--libjar', fake_jar)
+        runner = self.make_runner('--libjars', fake_jar)
 
         runner._add_master_node_setup_files_for_upload()
         runner._wait_for_steps_to_complete()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5004,7 +5004,7 @@ class SparkPyFilesTestCase(MockBoto3TestCase):
 
         job = MRNullSpark([
             '-r', 'emr',
-            '--py-file', egg1_path, '--py-file', egg2_path])
+            '--py-files', '%s,%s' % (egg1_path, egg2_path)])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -1618,10 +1618,10 @@ class PoolMatchingTestCase(MockBoto3TestCase):
                         EndDateTime='definitely not none')))
         ]
 
-        # --libjar makes this a two-step job, which won't fit
+        # --libjars makes this a two-step job, which won't fit
         self.assertDoesNotJoin(cluster_id, [
             '-r', 'emr', '-v', '--pool-clusters',
-            '--libjar', 's3:///poohs-house/HUNNY.jar'],
+            '--libjars', 's3:///poohs-house/HUNNY.jar'],
             job_class=MRWordCount)
 
     def test_bearly_space_for_master_node_setup(self):
@@ -1643,7 +1643,7 @@ class PoolMatchingTestCase(MockBoto3TestCase):
         # now there's space for two steps
         self.assertJoins(cluster_id, [
             '-r', 'emr', '-v', '--pool-clusters',
-            '--libjar', 's3://poohs-house/HUNNY.jar'],
+            '--libjars', 's3://poohs-house/HUNNY.jar'],
             job_class=MRWordCount)
 
     def test_dont_join_idle_with_pending_steps(self):

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -321,8 +321,7 @@ class PoolMatchingTestCase(MockBoto3TestCase):
         self.assertDoesNotJoin(cluster_id, [
             '-r', 'emr', '-v', '--pool-clusters',
             '--image-version', '4.0.0',
-            '--application', 'Ganglia',
-            '--application', 'Mahout'])
+            '--applications', 'Ganglia,Mahout'])
 
     def test_application_matching_is_case_insensitive(self):
         _, cluster_id = self.make_pooled_cluster(

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -669,7 +669,7 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
 
         mr_job = MRTwoStepJob([
             '-r', 'hadoop', '-v',
-            '--no-conf', '--libjar', 'containsJars.jar',
+            '--no-conf', '--libjars', 'containsJars.jar',
             '--hadoop-args=-verbose'] + list(args) +
             ['-', local_input_path, remote_input_path] +
             ['-D', 'x=y']
@@ -969,14 +969,14 @@ class ArgsForJarStepTestCase(MockHadoopTestCase):
                 ['jar', jar_uri])
 
     def test_no_generic_args_by_default(self):
-        # -D and --libjar are ignored unless you use GENERIC_ARGS. See #1863
+        # -D and --libjars are ignored unless you use GENERIC_ARGS. See #1863
 
         fake_jar = self.makefile('fake.jar')
         fake_libjar = self.makefile('fake_lib.jar')
 
         job = MRJustAJar(
             ['-r', 'hadoop', '--jar', fake_jar,
-             '-D', 'foo=bar', '--libjar', fake_libjar])
+             '-D', 'foo=bar', '--libjars', fake_libjar])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -991,7 +991,7 @@ class ArgsForJarStepTestCase(MockHadoopTestCase):
 
         job = MRJarWithGenericArgs(
             ['-r', 'hadoop', '--jar', fake_jar,
-             '-D', 'foo=bar', '--libjar', fake_libjar])
+             '-D', 'foo=bar', '--libjars', fake_libjar])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1392,7 +1392,7 @@ class LibjarsTestCase(MockHadoopTestCase):
     def test_one_jar(self):
         job = MRWordCount([
             '-r', 'hadoop',
-            '--libjar', '/path/to/a.jar',
+            '--libjars', '/path/to/a.jar',
         ])
         job.sandbox()
 
@@ -1406,8 +1406,8 @@ class LibjarsTestCase(MockHadoopTestCase):
     def test_two_jars(self):
         job = MRWordCount([
             '-r', 'hadoop',
-            '--libjar', '/path/to/a.jar',
-            '--libjar', '/path/to/b.jar',
+            '--libjars', '/path/to/a.jar',
+            '--libjars', '/path/to/b.jar',
         ])
         job.sandbox()
 

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1229,7 +1229,7 @@ class SparkPyFilesTestCase(MockHadoopTestCase):
 
         job = MRNullSpark([
             '-r', 'hadoop',
-            '--py-file', egg1_path, '--py-file', egg2_path])
+            '--py-files', '%s,%s' % (egg1_path, egg2_path)])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1602,7 +1602,7 @@ class WarnAboutSparkArchivesTestCase(MockHadoopTestCase):
 
         job = MRNullSpark(['-r', 'hadoop',
                            '--spark-master', 'local',
-                           '--archive', fake_archive])
+                           '--archives', fake_archive])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1615,7 +1615,7 @@ class WarnAboutSparkArchivesTestCase(MockHadoopTestCase):
 
         job = MRTwoStepJob(['-r', 'hadoop',
                             '--spark-master', 'local',
-                            '--archive', fake_archive])
+                            '--archives', fake_archive])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1628,7 +1628,7 @@ class WarnAboutSparkArchivesTestCase(MockHadoopTestCase):
 
         job = MRNullSpark(['-r', 'hadoop',
                            '--spark-master', 'yarn',
-                           '--archive', fake_archive])
+                           '--archives', fake_archive])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1641,7 +1641,7 @@ class WarnAboutSparkArchivesTestCase(MockHadoopTestCase):
 
         job = MRNullSpark(['-r', 'hadoop',
                            '--spark-master', 'local',
-                           '--file', fake_file])
+                           '--files', fake_file])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1411,7 +1411,7 @@ class UploadAttrsTestCase(SandboxedTestCase):
         class TestJob(MRJob):
             FILES = ['/tmp/foo.db']
 
-        job = TestJob(['--file', 'foo/bar.txt'])
+        job = TestJob(['--files', 'foo/bar.txt'])
 
         self.assertEqual(
             job._runner_kwargs()['upload_files'],
@@ -1520,7 +1520,7 @@ class UploadAttrsTestCase(SandboxedTestCase):
             def files(self):
                 return ['foo/bar.txt']
 
-        job = TestJob(['--file', 'baz.txt'])
+        job = TestJob(['--files', 'baz.txt'])
 
         self.assertEqual(
             job._runner_kwargs()['upload_files'],
@@ -1549,7 +1549,7 @@ class UploadAttrsTestCase(SandboxedTestCase):
         class TestJob(MRJob):
             DIRS = ['/tmp']
 
-        job = TestJob(['--dir', 'foo'])
+        job = TestJob(['--dirs', 'foo'])
 
         self.assertEqual(
             job._runner_kwargs()['upload_dirs'],
@@ -1609,7 +1609,7 @@ class UploadAttrsTestCase(SandboxedTestCase):
             def dirs(self):
                 return ['/tmp']
 
-        job = TestJob(['--dir', 'stuff_dir'])
+        job = TestJob(['--dirs', 'stuff_dir'])
 
         self.assertEqual(
             job._runner_kwargs()['upload_dirs'],
@@ -1634,7 +1634,7 @@ class UploadAttrsTestCase(SandboxedTestCase):
         class TestJob(MRJob):
             ARCHIVES = ['/tmp/dir.tar.gz']
 
-        job = TestJob(['--archive', 'foo.zip'])
+        job = TestJob(['--archives', 'foo.zip'])
 
         self.assertEqual(
             job._runner_kwargs()['upload_archives'],
@@ -1696,7 +1696,7 @@ class UploadAttrsTestCase(SandboxedTestCase):
             def archives(self):
                 return ['/tmp/dir.tar.gz']
 
-        job = TestJob(['--archive', 'stuff.zip'])
+        job = TestJob(['--archives', 'stuff.zip'])
 
         self.assertEqual(
             job._runner_kwargs()['upload_archives'],
@@ -1725,3 +1725,15 @@ class UploadAttrsTestCase(SandboxedTestCase):
             run_job(MRRot13Lib(), b'The quick brown fox'),
             {None: 'Gur dhvpx oebja sbk\n'}
         )
+
+    def test_deprecated_archive_dir_file_switches(self):
+        job = MRJob(['--archive', 'stuff.zip',
+                     '--dir', 'foo',
+                     '--file', 'foo/bar.txt'])
+
+        self.assertEqual(
+            job._runner_kwargs()['upload_archives'], ['stuff.zip'])
+        self.assertEqual(
+            job._runner_kwargs()['upload_dirs'], ['foo'])
+        self.assertEqual(
+            job._runner_kwargs()['upload_files'], ['foo/bar.txt'])

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -681,10 +681,11 @@ class LibjarsTestCase(BasicTestCase):
 
         self.assertEqual(job._runner_kwargs()['libjars'], [])
 
-    def test_libjar_option(self):
-        job = MRJob(['--libjar', 'honey.jar'])
+    def test_libjars_switch(self):
+        job = MRJob(['--libjars', 'honey.jar,dora.jar'])
 
-        self.assertEqual(job._runner_kwargs()['libjars'], ['honey.jar'])
+        self.assertEqual(job._runner_kwargs()['libjars'],
+                         ['honey.jar', 'dora.jar'])
 
     def test_libjars_attr(self):
         with patch.object(MRJob, 'LIBJARS', ['/left/dora.jar']):
@@ -695,7 +696,7 @@ class LibjarsTestCase(BasicTestCase):
 
     def test_libjars_attr_plus_option(self):
         with patch.object(MRJob, 'LIBJARS', ['/left/dora.jar']):
-            job = MRJob(['--libjar', 'honey.jar'])
+            job = MRJob(['--libjars', 'honey.jar'])
 
             self.assertEqual(job._runner_kwargs()['libjars'],
                              ['/left/dora.jar', 'honey.jar'])
@@ -726,7 +727,7 @@ class LibjarsTestCase(BasicTestCase):
 
     def test_cant_override_libjars_on_command_line(self):
         with patch.object(MRJob, 'libjars', return_value=['honey.jar']):
-            job = MRJob(['--libjar', 'cookie.jar'])
+            job = MRJob(['--libjars', 'cookie.jar'])
 
             # ignore switch, don't resolve relative path
             self.assertEqual(job._runner_kwargs()['libjars'],

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -227,7 +227,7 @@ class SimRunnerJobConfTestCase(SandboxedTestCase):
         mr_job = MRTestJobConf(['-r', self.RUNNER,
                                 '--no-bootstrap-mrjob',
                                 '-D=user.defined=something',
-                                '--file', upload_path,
+                                '--files', upload_path,
                                input_gz_path])
 
         mr_job.sandbox()
@@ -349,7 +349,7 @@ class DistributedCachePermissionsTestCase(SandboxedTestCase):
     def test_file_permissions(self):
         data_path = self.makefile('data')
 
-        job = MRFilePermissionsJob(['--file', data_path])
+        job = MRFilePermissionsJob(['--files', data_path])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/tools/emr/test_create_cluster.py
+++ b/tests/tools/emr/test_create_cluster.py
@@ -33,7 +33,7 @@ class ClusterInspectionTestCase(ToolTestCase):
         self.assertEqual(
             _runner_kwargs(), {
                 'additional_emr_info': None,
-                'applications': [],
+                'applications': None,
                 'bootstrap': [],
                 'bootstrap_actions': [],
                 'bootstrap_mrjob': None,


### PR DESCRIPTION
This adds `--applications`, `--archives`, `--dirs`, `--files`, `--libjars`, and `--py-files`, and deprecates their singular equivalents (except for `--application`, which is just an alternate name for `--applications`). Fixes #1882 