### PR TITLE
Fixed usage in mrjob subcommand help messages

### DIFF
--- a/mrjob/tools/diagnose.py
+++ b/mrjob/tools/diagnose.py
@@ -136,7 +136,7 @@ def _infer_step_type(step):
 
 
 def _make_arg_parser():
-    usage = '%(prog)s [opts] [--step-id STEP_ID] CLUSTER_ID'
+    usage = '%(prog)s diagnose [opts] [--step-id STEP_ID] CLUSTER_ID'
     description = (
         'Get probable cause of failure for step on CLUSTER_ID.'
         ' By default we look at the last failed step')

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -100,7 +100,7 @@ def main(args=None):
 
 
 def _make_arg_parser():
-    usage = '%(prog)s [options]'
+    usage = '%(prog)s audit-emr-usage [options]'
     description = 'Print a giant report on EMR usage.'
 
     arg_parser = ArgumentParser(usage=usage, description=description)

--- a/mrjob/tools/emr/create_cluster.py
+++ b/mrjob/tools/emr/create_cluster.py
@@ -234,9 +234,7 @@ def _make_arg_parser():
     usage = '%(prog)s create-cluster [options]'
     description = (
         'Create a persistent EMR cluster to run jobs in, and print its ID to'
-        ' stdout. WARNING: Do not run'
-        ' this without mrjob terminate-idle-clusters in your'
-        ' crontab; clusters left idle can quickly become expensive!')
+        ' stdout.')
     arg_parser = ArgumentParser(usage=usage, description=description)
 
     _add_basic_args(arg_parser)

--- a/mrjob/tools/emr/create_cluster.py
+++ b/mrjob/tools/emr/create_cluster.py
@@ -231,7 +231,7 @@ def _runner_kwargs(cl_args=None):
 
 
 def _make_arg_parser():
-    usage = '%(prog)s [options]'
+    usage = '%(prog)s create-cluster [options]'
     description = (
         'Create a persistent EMR cluster to run jobs in, and print its ID to'
         ' stdout. WARNING: Do not run'

--- a/mrjob/tools/emr/mrboss.py
+++ b/mrjob/tools/emr/mrboss.py
@@ -61,7 +61,7 @@ from mrjob.util import shlex_split
 
 
 def main(cl_args=None):
-    usage = 'usage: %(prog)s CLUSTER_ID [options] "command string"'
+    usage = 'usage: %(prog)s boss CLUSTER_ID [options] "command string"'
     description = ('Run a command on the master and all worker nodes of an EMR'
                    ' cluster. Store stdout/stderr for results in OUTPUT_DIR.')
 

--- a/mrjob/tools/emr/report_long_jobs.py
+++ b/mrjob/tools/emr/report_long_jobs.py
@@ -243,7 +243,7 @@ def _format_timedelta(time):
 
 
 def _make_arg_parser():
-    usage = '%(prog)s [options]'
+    usage = '%(prog)s report-long-jobs [options]'
     description = ('Report jobs running for more than a certain number of'
                    ' hours (by default, %.1f). This can help catch buggy jobs'
                    ' and Hadoop/EMR operational issues.' % DEFAULT_MIN_HOURS)

--- a/mrjob/tools/emr/s3_tmpwatch.py
+++ b/mrjob/tools/emr/s3_tmpwatch.py
@@ -115,11 +115,12 @@ def _process_time(time):
 
 
 def _make_arg_parser():
+    usage = '%(prog)s s3-tmpwatch [options] TIME_UNTOUCHED URI [URI ...]'
     description = (
         'Delete all files at one or more URIs that are older than a'
         ' specified time.')
 
-    arg_parser = ArgumentParser(description=description)
+    arg_parser = ArgumentParser(usage=usage, description=description)
 
     arg_parser.add_argument(
         '-t', '--test', dest='test', default=False,
@@ -131,7 +132,7 @@ def _make_arg_parser():
         help='The time threshold for removing'
         ' files. A number with an optional'
         ' single-character suffix specifying the units: m for minutes, h for'
-        ' hours, d for days.  If no suffix is specified, time is in hours.')
+        ' hours, d for days. If no suffix is specified, time is in hours.')
 
     arg_parser.add_argument(
         dest='uris', nargs='+',

--- a/mrjob/tools/emr/terminate_cluster.py
+++ b/mrjob/tools/emr/terminate_cluster.py
@@ -18,7 +18,7 @@
 
 Usage::
 
-    mrjob terminate-cluster [options] j-CLUSTERID
+    mrjob terminate-cluster [options] CLUSTER_ID
 
 Terminate an existing EMR cluster.
 
@@ -72,9 +72,10 @@ def main(cl_args=None):
 
 
 def _make_arg_parser():
+    usage = '%(prog)s terminate-cluster [options] CLUSTER_ID'
     description = 'Terminate an existing EMR cluster.'
 
-    arg_parser = ArgumentParser(description=description)
+    arg_parser = ArgumentParser(usage=usage, description=description)
 
     arg_parser.add_argument(
         '-t', '--test', dest='test', default=False,

--- a/mrjob/tools/emr/terminate_idle_clusters.py
+++ b/mrjob/tools/emr/terminate_idle_clusters.py
@@ -348,7 +348,7 @@ def _terminate_and_notify(runner, cluster_id, cluster_name, num_steps,
 
 
 def _make_arg_parser():
-    usage = '%(prog)s [options]'
+    usage = '%(prog)s terminate-idle-clusters [options]'
     description = ('Terminate idle EMR clusters that meet the criteria'
                    ' passed in on the command line (or, by default,'
                    ' clusters that have been idle for one hour).')


### PR DESCRIPTION
Added the subcommand name to the `--help` message for subcommands to the mrjob binary. Fixes #1885.