### PR TITLE
Minor correction for Hadoop documentation URLs.

### DIFF
--- a/docs/guides/runners.rst
+++ b/docs/guides/runners.rst
@@ -72,7 +72,7 @@ See :py:mod:`mrjob.examples` for more examples.
 Running on your own Hadoop cluster
 ----------------------------------
 
-* Set up a hadoop cluster (see http://hadoop.apache.org/common/docs/current/)
+* Set up a hadoop cluster (see http://hadoop.apache.org/docs/current/)
 * Run your job with ``-r hadoop``::
 
     python your_mr_job_sub_class.py -r hadoop < input > output

--- a/mrjob/compat.py
+++ b/mrjob/compat.py
@@ -24,7 +24,7 @@ from mrjob.py2 import string_types
 
 # lists alternative names for jobconf variables
 # full listing thanks to translation table in
-# http://hadoop.apache.org/common/docs/current/hadoop-project-dist/hadoop-common/DeprecatedProperties.html # noqa
+# http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/DeprecatedProperties.html # noqa
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
The existing links were returning a 404, corrected them.