### PR TITLE
Add new parameter emr_backoff

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -311,6 +311,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'ec2_key_pair_file',
         'emr_action_on_failure',
         'emr_api_params',
+        'emr_backoff',
         'emr_configurations',
         'emr_endpoint',
         'enable_emr_debugging',
@@ -449,6 +450,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 check_cluster_every=30,
                 cleanup_on_failure=['JOB'],
                 cloud_fs_sync_secs=5.0,
+                emr_backoff=20,
                 image_version=_DEFAULT_IMAGE_VERSION,
                 num_core_instances=0,
                 num_task_instances=0,
@@ -2680,7 +2682,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
         # #1799: don't retry faster than EMR checks the API
         return _wrap_aws_client(raw_emr_client,
-                                min_backoff=self._opts['check_cluster_every'])
+                                min_backoff=self._opts['emr_backoff'])
 
     def _describe_cluster(self):
         emr_client = self.make_emr_client()

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -117,12 +117,12 @@ def _is_retriable_client_error(ex):
         return False
 
 
-def _wrap_aws_client(raw_client, min_backoff=None):
+def _wrap_aws_client(raw_client, min_backoff=_AWS_BACKOFF):
     """Wrap a given boto3 Client object so that it can retry when
     throttled."""
     return RetryWrapper(raw_client,
                         retry_if=_is_retriable_client_error,
-                        backoff=max(_AWS_BACKOFF, min_backoff or 0),
+                        backoff=min_backoff,
                         multiplier=_AWS_BACKOFF_MULTIPLIER,
                         max_tries=_AWS_MAX_TRIES)
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -655,6 +655,17 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    emr_backoff=dict(
+        switches=[
+            (['--emr-backoff'], dict(
+                help=('Number of seconds to wait after an EMR throttling'
+                      ' error. This wait-time exponentiates each occurrence by'
+                      ' 1.5x until we hit 20 occurrences (e.g. emr_backoff=5'
+                      ' will wait up to 5*1.5^20/60/60 ~= 4.5 hours).'),
+                type=float,
+            )),
+        ],
+    ),
     enable_emr_debugging=dict(
         cloud_role='launch',
         switches=[

--- a/mrjob/retry.py
+++ b/mrjob/retry.py
@@ -92,8 +92,9 @@ class RetryWrapper(object):
                     if (self.__retry_if(ex) and
                         (tries < self.__max_tries - 1 or
                          not self.__max_tries)):
-                        log.info('Got retriable error: %r' % ex)
-                        log.info('Backing off for %.1f seconds' % backoff)
+                        log.debug('Got retriable error: %r' % ex)
+                        log.info('After retriable error backing off for'
+                                 ' %.1f seconds' % backoff)
                         time.sleep(backoff)
                         tries += 1
                         backoff *= self.__multiplier

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -475,6 +475,7 @@ class VisibleToAllUsersTestCase(MockBoto3TestCase):
 
     def test_force_to_bool(self):
         VISIBLE_MRJOB_CONF = {'runners': {'emr': {
+            'emr_backoff': 0.01,  # must be non-zero
             'check_cluster_every': 0.00,
             'cloud_fs_sync_secs': 0.00,
             'visible_to_all_users': 1,  # should be True
@@ -788,6 +789,7 @@ class CustomAmiTestCase(MockBoto3TestCase):
 class AvailabilityZoneTestCase(MockBoto3TestCase):
 
     MRJOB_CONF_CONTENTS = {'runners': {'emr': {
+        'emr_backoff': 0.01,  # must be non-zero
         'check_cluster_every': 0.00,
         'cloud_fs_sync_secs': 0.00,
         'zone': 'PUPPYLAND',
@@ -2491,6 +2493,7 @@ class StreamingJarAndStepArgPrefixTestCase(MockBoto3TestCase):
 class JarStepTestCase(MockBoto3TestCase):
 
     MRJOB_CONF_CONTENTS = {'runners': {'emr': {
+        'emr_backoff': 0.01,  # must be non-zero
         'check_cluster_every': 0.00,
         'cloud_fs_sync_secs': 0.00,
     }}}
@@ -3308,6 +3311,7 @@ class EMRTagsTestCase(MockBoto3TestCase):
 
     def test_command_line_overrides_config(self):
         TAGS_MRJOB_CONF = {'runners': {'emr': {
+            'emr_backoff': 0.01,  # must be non-zero
             'check_cluster_every': 0.00,
             'cloud_fs_sync_secs': 0.00,
             'tags': {
@@ -5748,11 +5752,7 @@ class EMRClientBackoffTest(MockBoto3TestCase):
         self.sleep.assert_called_with(expected_backoff)
 
     def test_default_backoff(self):
-        self._test_backoff(30)  # default value of check_cluster_every
+        self._test_backoff(20)  # default value of emr_backoff
 
-    def test_large_check_cluster_every(self):
-        self._test_backoff(1000, check_cluster_every=1000)
-
-    def test_small_check_cluster_every(self):
-        # minimum backoff is always 20
-        self._test_backoff(20, check_cluster_every=1)
+    def test_large_emr_backoff(self):
+        self._test_backoff(1000, emr_backoff=1000)


### PR DESCRIPTION
This parameter is used instead of `check_cluster_every` during EMR throttling retries.

Previously, when throttled, any EMR api call would backoff for `check_cluster_every*1.5^{retry count}` seconds. Consider the default of 30; after 10 retries the next attempt would be in approximately 30 minutes. This backoff is too long for certain use-cases. As such we add functionality to adjust the throttling initial backoff. Therefore, if this is set to 5, after 10 retries the next attempt would be in only 5 minutes. In the current code we can only adjust `check_cluster_every`. This is insufficient as this also affects termination/step completion polling. Therefore we add `emr_backoff`.