### PR TITLE
add mrjob spark-submit subcommand

### DIFF
--- a/docs/guides/cmd.rst
+++ b/docs/guides/cmd.rst
@@ -53,6 +53,13 @@ s3-tmpwatch
 
     .. automodule:: mrjob.tools.emr.s3_tmpwatch
 
+.. _spark-submit:
+
+spark-submit
+^^^^^^^^^^^^
+
+    .. automodule:: mrjob.tools.spark_submit
+
 terminate-cluster
 ^^^^^^^^^^^^^^^^^
 

--- a/mrjob/cmd.py
+++ b/mrjob/cmd.py
@@ -111,6 +111,12 @@ def _s3_tmpwatch(args):
     main(args)
 
 
+@_command('spark-submit', 'Submit Spark jobs')
+def _spark_submit(args):
+    from mrjob.tools.spark_submit import main
+    main(args)
+
+
 @_command('terminate-idle-clusters', 'Terminate idle EMR clusters')
 def _terminate_idle_clusters(args):
     from mrjob.tools.emr.terminate_idle_clusters import main

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -121,7 +121,6 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
     alias = 'hadoop'
 
     OPT_NAMES = MRJobBinRunner.OPT_NAMES | {
-        'bootstrap_spark',
         'hadoop_bin',
         'hadoop_extra_args',
         'hadoop_log_dirs',

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -33,6 +33,7 @@ from mrjob.options import _optparse_kwargs_to_argparse
 from mrjob.options import _parse_raw_args
 from mrjob.options import _print_help_for_runner
 from mrjob.options import _print_basic_help
+from mrjob.runner import _runner_class
 from mrjob.setup import parse_legacy_hash_path
 from mrjob.step import StepFailedException
 from mrjob.util import log_to_null
@@ -464,26 +465,15 @@ class MRJobLauncher(object):
 
         Defaults to ``'local'`` and disallows use of inline runner.
         """
-        if self.options.runner == 'dataproc':
-            from mrjob.dataproc import DataprocJobRunner
-            return DataprocJobRunner
-
-        elif self.options.runner == 'emr':
-            from mrjob.emr import EMRJobRunner
-            return EMRJobRunner
-
-        elif self.options.runner == 'hadoop':
-            from mrjob.hadoop import HadoopJobRunner
-            return HadoopJobRunner
+        if not self.options.runner:
+            return LocalMRJobRunner
 
         elif self.options.runner == 'inline':
-            raise ValueError("inline is not supported in the multi-lingual"
-                             " launcher.")
+             raise ValueError(
+                 "inline is not supported in the multi-lingual"
+                 " launcher.")
 
-        else:
-            # run locally by default
-            from mrjob.local import LocalMRJobRunner
-            return LocalMRJobRunner
+        return _runner_class(self.options.runner)
 
     def _runner_kwargs(self):
         # just use combine_dicts() and not combine_confs(); leave the

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -840,9 +840,8 @@ _RUNNER_OPTS = dict(
         switches=[
             (['-D', '--jobconf'], dict(
                 action=_KeyValueAction,
-                help=('-D arg to pass through to hadoop streaming; should'
-                      ' take the form KEY=VALUE. You can use -D'
-                      ' multiple times.'),
+                help=('passed through to hadoop streaming as -D and to Spark'
+                      ' as --conf. Should take the form KEY=VALUE'),
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -539,8 +539,8 @@ _RUNNER_OPTS = dict(
             (['--cmdenv'], dict(
                 action=_KeyValueAction,
                 help=('Set an environment variable for your job inside Hadoop '
-                      'streaming. Must take the form KEY=VALUE. You can use'
-                      ' --cmdenv multiple times.'),
+                      'streaming/Spark. Must take the form KEY=VALUE.'
+                      ' You can use --cmdenv multiple times.'),
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1178,7 +1178,7 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--spark-master'], dict(
                 help=('--master argument to spark-submit (e.g. '
-                      'spark://host:port, local. Default is yarn'),
+                      'spark://host:port, local). Default is "yarn"'),
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1049,9 +1049,8 @@ _RUNNER_OPTS = dict(
         combiner=combine_cmds,
         switches=[
             (['--python-bin'], dict(
-                help=('Alternate python command for Python mappers/reducers.'
-                      ' You can include arguments, e.g. --python-bin "python'
-                      ' -v"'),
+                help=('Alternate python command. You can include arguments,'
+                      ' e.g. --python-bin "python -v"'),
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -25,6 +25,7 @@ from argparse import Action
 from argparse import ArgumentParser
 from argparse import SUPPRESS
 from logging import getLogger
+from os import devnull
 
 from mrjob.conf import combine_cmds
 from mrjob.conf import combine_dicts

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -45,6 +45,7 @@ from mrjob.py2 import string_types
 from mrjob.setup import WorkingDirManager
 from mrjob.setup import name_uniquely
 from mrjob.setup import parse_legacy_hash_path
+from mrjob.step import OUTPUT
 from mrjob.step import STEP_TYPES
 from mrjob.step import _is_spark_step_type
 from mrjob.util import to_lines
@@ -510,7 +511,11 @@ class MRJobRunner(object):
         self._run()
         self._ran_job = True
 
-        log.info('job output is in %s' % self._output_dir)
+        last_step = self._get_steps()[-1]
+
+        # only print this message if the last step uses our output dir
+        if 'args' not in last_step or OUTPUT in last_step['args']:
+            log.info('job output is in %s' % self._output_dir)
 
     def cat_output(self):
         """Stream the jobs output, as a stream of ``bytes``. If there are

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1220,3 +1220,32 @@ def _blank_out_conflicting_opts(opt_list, opt_names, conflicting_opts=None):
             blank_out = True
 
     return opt_list
+
+
+
+
+def _runner_class(alias):
+    """Get the runner subclass corresponding to the given alias
+    (importing code only as needed)."""
+    if alias == 'dataproc':
+        from mrjob.dataproc import DataprocJobRunner
+        return DataprocJobRunner
+
+    elif alias == 'emr':
+        from mrjob.emr import EMRJobRunner
+        return EMRJobRunner
+
+    elif alias == 'hadoop':
+        from mrjob.hadoop import HadoopJobRunner
+        return HadoopJobRunner
+
+    elif alias == 'inline':
+        from mrjob.inline import InlineMRJobRunner
+        return InlineMRJobRunner
+
+    elif alias == 'local':
+        from mrjob.local import LocalMRJobRunner
+        return LocalMRJobRunner
+
+    else:
+        raise ValueError('bad runner alias: %s' % alias)

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -492,7 +492,7 @@ class MRJobRunner(object):
         :py:class:`~mrjob.inline.InlineMRJobRunner`, where we raise the
         actual exception that caused the step to fail).
         """
-        if not self._script_path:
+        if not (self._script_path or self._steps):
             raise AssertionError('No script to run!')
 
         if self._ran_job:
@@ -1220,8 +1220,6 @@ def _blank_out_conflicting_opts(opt_list, opt_names, conflicting_opts=None):
             blank_out = True
 
     return opt_list
-
-
 
 
 def _runner_class(alias):

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -235,7 +235,7 @@ class MRStep(object):
     def render_reducer(self):
         return self._render_substep('reducer_cmd', 'reducer_pre_filter')
 
-    def description(self, step_num):
+    def description(self, step_num=0):
         """Returns a dictionary representation of this step:
 
         .. code-block:: js
@@ -378,7 +378,7 @@ class _Step(object):
         else:
             return None
 
-    def description(self, other):
+    def description(self, step_num=0):
         """Return a dictionary representation of this step. See
         :ref:`steps-format` for examples."""
         result = dict(

--- a/mrjob/tools/spark-submit-notes.txt
+++ b/mrjob/tools/spark-submit-notes.txt
@@ -13,13 +13,11 @@ opts that are just aliases for mrjob opts:
 --jars (libjars)
 --conf (jobconf)
 
-opts where mrjob should have switches in plural form anyhow:
+opts than can be used as-is
 
 --py-files (py_files)
 --files (upload_files)
 --archives (upload_archives)
-
-(should also add --libjars, like --jars above)
 
 opts that can be passed through directly to Spark
 

--- a/mrjob/tools/spark-submit-notes.txt
+++ b/mrjob/tools/spark-submit-notes.txt
@@ -1,0 +1,74 @@
+Usage: mrjob spark-submit [options] <app jar | python file> app arguments
+
+(no R file support)
+
+opts that go into the job definition:
+
+--class (main_class)
+
+opts that are just aliases for mrjob opts:
+
+--master (spark_master)
+--deploy-mode (spark_deploy_mode)
+--jars (libjars)
+--conf (jobconf)
+
+opts where mrjob should have switches in plural form anyhow:
+
+--py-files (py_files)
+--files (upload_files)
+--archives (upload_archives)
+
+(should also add --libjars, like --jars above)
+
+opts that can be passed through directly to Spark
+
+--name
+--packages
+--exclude-packages
+--repositories
+--driver-memory
+--driver-java-options
+--driver-library-path
+--driver-class-path
+--executor-memory
+--proxy-user
+--driver-cores
+--supervise
+--total-executor-cores
+--executor-cores
+--queue
+--num-executors
+--principal
+--keytab
+
+
+opts involving files, should see if we can pass them through
+
+--properties-file
+
+
+pass through to spark?
+
+--verbose  (possibly depending on runner)
+
+
+not relevant to submitting
+--version
+--kill
+--status
+
+
+all mrjob options basically make sense except check_input_paths
+
+for now, setting input_paths to os.devnull and setting check_input_paths to
+False would be enough
+
+
+
+
+
+Other notes:
+
+why doesn't cluster_id have cloud_role='launch'?
+same for cluster_properties?

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -346,7 +346,8 @@ def _make_arg_parser():
     _add_deprecated_arg(parser)
 
     # add runner opts
-    _add_runner_args(parser)
+    runner_opt_names = set(_RUNNER_OPTS) - set(_HARD_CODED_OPTS)
+    _add_runner_args(parser, opt_names=runner_opt_names)
 
     # add spark-specific opts (without colliding with runner opts)
     for opt_name, switch in _SPARK_SUBMIT_SWITCHES.items():

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -335,9 +335,9 @@ def _add_spark_submit_arg(parser, opt_name):
 
 
 def _make_arg_parser():
-    # this parser is never used for help messages, so ordering,
-    # usage, etc. don't matter
-    parser = ArgumentParser(add_help=False)
+    # this parser is never used for help messages, but
+    # will show usage on error
+    parser = ArgumentParser(usage=_USAGE, add_help=False)
 
     # add positional arguments
     parser.add_argument(dest='script_or_jar', nargs='?')

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import os
 import sys
 from argparse import ArgumentParser
+from argparse import SUPPRESS
 from logging import getLogger
 
 from mrjob.conf import combine_lists
@@ -35,7 +36,7 @@ log = getLogger(__name__)
 _USAGE = ('%(prog)s spark-submit [-r <runner>] [options]'
           ' <python file | app jar> [app arguments]')
 
-_DESCRIPTION = 'Submit a spark job using mrjob runners'
+_DESCRIPTION = 'Submit a spark job locally or in the cloud'
 
 _BASIC_HELP_EPILOG = (
     'To see help for a specific runner, use --help -r <runner name>')
@@ -57,9 +58,16 @@ _SPARK_RUNNERS = ('emr', 'hadoop')
 _DEFAULT_RUNNER = 'hadoop'
 
 
+# our mostly similar version of spark-submit's args, arranged in to groups
+# for the --help message. Differences:
+#
+# spark_master (--master) is in its own "Hadoop runner only" group
+# added upload_dirs (--dirs) which is similar to --archive
+#
+# --runner and other basic options are patched into the first ("None")
+# argument group in _make_basic_help_parser(), below
 _SPARK_SUBMIT_ARG_GROUPS = [
     (None, [
-        'spark_master',
         'spark_deploy_mode',
         'main_class',
         'name',
@@ -78,6 +86,9 @@ _SPARK_SUBMIT_ARG_GROUPS = [
         'executor_memory',
         'proxy_user',
     ]),
+    ('Hadoop runner only', [
+        'spark_master',
+    ]),
     ('Cluster deploy mode only', [
         'driver_cores',
     ]),
@@ -95,10 +106,74 @@ _SPARK_SUBMIT_ARG_GROUPS = [
         'queue_name',
         'num_executors',
         'upload_archives',
+        'upload_dirs',
         'principal',
         'keytab',
     ]),
 ]
+
+# lightly modified versions of help messages from spark-submit
+_SPARK_SUBMIT_ARG_HELP = dict(
+    driver_class_path=('Extra class path entries to pass to the driver. Note'
+                       ' that jars added with --jars are automatically'
+                       ' included in the classpath.'),
+    driver_cores='Number of cores used by the driver (Default: 1).',
+    driver_java_options='Extra Java options to pass to the driver.',
+    driver_library_path='Extra library path entries to pass to the driver.',
+    driver_memory='Memory for driver (e.g. 1000M, 2G) (Default: 1024M).',
+    exclude_packages=('Comma-separated list of groupId:artifactId, to exclude'
+                      ' while resolving the dependencies provided in'
+                      ' --packages to avoid dependency conflicts.'),
+    executor_cores=('Number of cores per executor. (Default: 1 in YARN mode,'
+                    ' or all available cores on the worker in standalone'
+                    ' mode)'),
+    executor_memory='Memory per executor (e.g. 1000M, 2G) (Default: 1G).',
+    jobconf='Arbitrary Spark configuration property.',
+    keytab=('The full path to the file that contains the keytab for the'
+            ' principal specified above. This keytab will be copied to'
+            ' the node running the Application Master via the Secure'
+            ' Distributed Cache, for renewing the login tickets and the'
+            ' delegation tokens periodically.'),
+    libjars=('Comma-separated list of jars to include on the driver'
+             'and executor classpaths.'),
+    main_class="Your application's main class (for Java / Scala apps).",
+    name='The name of your application.',
+    num_executors=('Number of executors to launch (Default: 2).'
+                   ' If dynamic allocation is enabled, the initial number of'
+                   ' executors will be at least NUM.'),
+    packages=('Comma-separated list of maven coordinates of jars to include'
+              ' on the driver and executor classpaths. Will search the local'
+              ' maven repo, then maven central and any additional remote'
+              ' repositories given by --repositories. The format for the'
+              ' coordinates should be groupId:artifactId:version.'),
+    principal=('Principal to be used to login to KDC, while running on'
+               'secure HDFS.'),
+    properties_file=('Path to a file from which to load extra properties. If'
+                     ' not specified, this will look for'
+                     ' conf/spark-defaults.conf.'),
+    proxy_user=('User to impersonate when submitting the application.'
+                ' This argument does not work with --principal / --keytab.'),
+    py_files=('Comma-separated list of .zip, .egg, or .py files to place'
+              'on the PYTHONPATH for Python apps.'),
+    queue_name='The YARN queue to submit to (Default: "default").',
+    repositories=('Comma-separated list of additional remote repositories to'
+                  ' search for the maven coordinates given with --packages.'),
+    spark_deploy_mode=('Whether to launch the driver program locally'
+                       ' ("client") or on one of the worker machines inside'
+                       ' the cluster ("cluster") (Default: client).'),
+    spark_master=('spark://host:port, mesos://host:port, yarn,'
+                  'k8s://https://host:port, or local (Default: yarn).'),
+    supervise='If given, restarts the driver on failure.',
+    total_executor_cores='Total cores for all executors.',
+    upload_archives=('Comma-separated list of archives to be extracted into'
+                     ' the working directory of each executor.'),
+    upload_dirs=('Comma-separated list of directors to be archived and then'
+                 ' extracted into the working directory of each executor.'),
+    upload_files=('Comma-separated list of files to be placed in the working'
+                  ' directory of each executor. File paths of these files'
+                  ' in executors can be accessed via'
+                  ' SparkFiles.get(fileName).'),
+)
 
 _SPARK_SUBMIT_OPT_NAMES = {
     opt_name for _, opt_names in _SPARK_SUBMIT_ARG_GROUPS
@@ -132,7 +207,13 @@ _SPARK_SUBMIT_SWITCHES = dict(
     supervise='--supervise',
     total_executor_cores='--total-executor-cores',
     upload_archives='--archives',
+    upload_dirs='--dirs',
     upload_files='--files',
+)
+
+# things that are different about specific spark submit args
+_SPARK_SUBMIT_ARG_KWARGS = dict(
+    supervise=dict(action='store_true'),
 )
 
 # not a runner opt or one that's passed straight through to spark
@@ -142,8 +223,6 @@ _STEP_OPT_NAMES = {'main_class'}
 _SPARK_ARG_OPT_NAMES = (
     set(_SPARK_SUBMIT_SWITCHES) - set(_RUNNER_OPTS) - _STEP_OPT_NAMES)
 
-
-
 _SWITCH_ALIASES = {
     '--master': '--spark-master',
     '--deploy-mode': '--spark-deploy-mode',
@@ -151,10 +230,7 @@ _SWITCH_ALIASES = {
     '--conf': '--jobconf',
 }
 
-
 # these options don't make any sense with Spark scripts
-
-# TODO: suppress this in --help
 _HARD_CODED_OPTS = dict(
     check_input_paths=False,
     output_dir=None,
@@ -165,17 +241,17 @@ def main(cl_args=None):
     parser = _make_arg_parser()
     options = parser.parse_args(cl_args)
 
+    runner_alias = options.runner or _DEFAULT_RUNNER
+    runner_class = _runner_class(runner_alias)
+
     if options.help or not options.script_or_jar:
-        _print_help(options)
+        _print_help(options, runner_class)
         sys.exit(0)
 
     MRJob.set_up_logging(
         quiet=options.quiet,
         verbose=options.verbose,
     )
-
-    runner_alias = options.runner or _DEFAULT_RUNNER
-    runner_class = _runner_class(runner_alias)
 
     kwargs = _get_runner_opt_kwargs(options, runner_class)
     kwargs['input_paths'] = [os.devnull]
@@ -252,6 +328,9 @@ def _add_spark_submit_arg(parser, opt_name):
             if opt_alias in opt_strings:
                 kwargs.update(opt_kwargs)
 
+    kwargs['help'] = _SPARK_SUBMIT_ARG_HELP[opt_name]
+    kwargs.update(_SPARK_SUBMIT_ARG_KWARGS.get(opt_name) or {})
+
     parser.add_argument(opt_string, **kwargs)
 
 
@@ -302,56 +381,59 @@ def _add_deprecated_arg(parser):
         help='include help for deprecated options')
 
 
-def _print_help(options):
-    if options.runner:
-        _print_help_for_runner(options.runner, options.deprecated)
+def _print_help(options, runner_class):
+    if options.help and options.runner:
+        # if user specifies -r without -h, show basic help
+        _print_help_for_runner(runner_class, options.deprecated)
     else:
         _print_basic_help(options.deprecated)
 
 
-def _print_help_for_runner(runner_alias, include_deprecated=False):
-    # TODO: finish this
-    print('<help for %s runner>' % runner_alias)
+def _print_help_for_runner(runner_class, include_deprecated=False):
+    help_parser = ArgumentParser(usage=SUPPRESS, add_help=False)
+
+    opt_names = runner_class.OPT_NAMES - set(_HARD_CODED_OPTS)
+    _add_runner_args(help_parser, opt_names,
+                     include_deprecated=include_deprecated)
+
+    help_parser.print_help()
 
 
 def _print_basic_help(include_deprecated=False):
-    _make_basic_help_arg_parser(include_deprecated).print_help()
+    _make_basic_help_parser(include_deprecated).print_help()
 
     if not include_deprecated:
         print()
         print(_DEPRECATED_OPT_HELP)
 
 
-def _make_basic_help_arg_parser(include_deprecated=False):
+def _make_basic_help_parser(include_deprecated=False):
     """Make an arg parser that's used only for printing basic help.
 
     This prints help very similar to spark-submit itself. Runner args
     are not included unless they are also spark-submit args (e.g. --py-files)
     """
-    parser = ArgumentParser(usage=_USAGE, description=_DESCRIPTION,
-                            epilog=_BASIC_HELP_EPILOG, add_help=False)
+    help_parser = ArgumentParser(usage=_USAGE, description=_DESCRIPTION,
+                                 epilog=_BASIC_HELP_EPILOG, add_help=False)
 
-    _add_runner_alias_arg(parser)
+    _add_runner_alias_arg(help_parser)
 
     for group_desc, opt_names in _SPARK_SUBMIT_ARG_GROUPS:
         if group_desc is None:
-            parser_or_group = parser
+            parser_or_group = help_parser
         else:
-            parser_or_group = parser.add_argument_group(group_desc)
+            parser_or_group = help_parser.add_argument_group(group_desc)
 
         for opt_name in opt_names:
             _add_spark_submit_arg(parser_or_group, opt_name)
 
         if group_desc is None:
-            _add_basic_args(parser)
-            _add_help_arg(parser)
+            _add_basic_args(help_parser)
+            _add_help_arg(help_parser)
             if include_deprecated:
-                _add_deprecated_arg(parser)
+                _add_deprecated_arg(help_parser)
 
-
-            # TODO: add --deprecated and --help
-
-    return parser
+    return help_parser
 
 
 

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -11,7 +11,118 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Submit a spark job using mrjob runners."""
+"""A drop-in replacement for :command:`spark-submit` that can use mrjob's
+runners. For example, you can submit your spark job to EMR just by adding
+``-r emr``.
+
+This also adds a couple of mrjob features that are not standard with
+:command:`spark-submit`: ``--cmdenv`` and ``--dirs``.
+
+Usage::
+
+    mrjob spark-submit [-r <runner>] [options] <python file | app jar>
+    [app arguments]
+
+Options::
+
+  -r {emr,hadoop}, --runner {emr,hadoop}
+                        Where to run the job (default: "hadoop")
+  --deploy-mode SPARK_DEPLOY_MODE
+                        Whether to launch the driver program locally
+                        ("client") or on one of the worker machines inside the
+                        cluster ("cluster") (Default: client).
+  --class MAIN_CLASS    Your application's main class (for Java / Scala apps).
+  --name NAME           The name of your application.
+  --jars LIBJARS        Comma-separated list of jars to include on the
+                        driverand executor classpaths.
+  --packages PACKAGES   Comma-separated list of maven coordinates of jars to
+                        include on the driver and executor classpaths. Will
+                        search the local maven repo, then maven central and
+                        any additional remote repositories given by
+                        --repositories. The format for the coordinates should
+                        be groupId:artifactId:version.
+  --exclude-packages EXCLUDE_PACKAGES
+                        Comma-separated list of groupId:artifactId, to exclude
+                        while resolving the dependencies provided in
+                        --packages to avoid dependency conflicts.
+  --repositories REPOSITORIES
+                        Comma-separated list of additional remote repositories
+                        to search for the maven coordinates given with
+                        --packages.
+  --py-files PY_FILES   Comma-separated list of .zip, .egg, or .py files to
+                        placeon the PYTHONPATH for Python apps.
+  --files UPLOAD_FILES  Comma-separated list of files to be placed in the
+                        working directory of each executor. File paths of
+                        these files in executors can be accessed via
+                        SparkFiles.get(fileName).
+  --cmdenv CMDENV       Arbitrary environment variable to set inside Spark, in
+                        the format NAME=VALUE.
+  --conf JOBCONF        Arbitrary Spark configuration property, in the format
+                        PROP=VALUE.
+  --properties-file PROPERTIES_FILE
+                        Path to a file from which to load extra properties. If
+                        not specified, this will look for conf/spark-
+                        defaults.conf.
+  --driver-memory DRIVER_MEMORY
+                        Memory for driver (e.g. 1000M, 2G) (Default: 1024M).
+  --driver-java-options DRIVER_JAVA_OPTIONS
+                        Extra Java options to pass to the driver.
+  --driver-library-path DRIVER_LIBRARY_PATH
+                        Extra library path entries to pass to the driver.
+  --driver-class-path DRIVER_CLASS_PATH
+                        Extra class path entries to pass to the driver. Note
+                        that jars added with --jars are automatically included
+                        in the classpath.
+  --executor-memory EXECUTOR_MEMORY
+                        Memory per executor (e.g. 1000M, 2G) (Default: 1G).
+  --proxy-user PROXY_USER
+                        User to impersonate when submitting the application.
+                        This argument does not work with --principal /
+                        --keytab.
+  -c CONF_PATHS, --conf-path CONF_PATHS
+                        Path to alternate mrjob.conf file to read from
+  --no-conf             Don't load mrjob.conf even if it's available
+  -q, --quiet           Don't print anything to stderr
+  -v, --verbose         print more messages to stderr
+  -h, --help            show this message and exit
+  --master SPARK_MASTER
+                        spark://host:port, mesos://host:port,
+                        yarn,k8s://https://host:port, or local (Default:
+                        yarn).
+  --driver-cores DRIVER_CORES
+                        Number of cores used by the driver (Default: 1).
+  --supervise           If given, restarts the driver on failure.
+  --total-executor-cores TOTAL_EXECUTOR_CORES
+                        Total cores for all executors.
+  --executor-cores EXECUTOR_CORES
+                        Number of cores per executor. (Default: 1 in YARN
+                        mode, or all available cores on the worker in
+                        standalone mode)
+  --queue QUEUE_NAME    The YARN queue to submit to (Default: "default").
+  --num-executors NUM_EXECUTORS
+                        Number of executors to launch (Default: 2). If dynamic
+                        allocation is enabled, the initial number of executors
+                        will be at least NUM.
+  --archives UPLOAD_ARCHIVES
+                        Comma-separated list of archives to be extracted into
+                        the working directory of each executor.
+  --dirs UPLOAD_DIRS    Comma-separated list of directors to be archived and
+                        then extracted into the working directory of each
+                        executor.
+  --principal PRINCIPAL
+                        Principal to be used to login to KDC, while running
+                        onsecure HDFS.
+  --keytab KEYTAB       The full path to the file that contains the keytab for
+                        the principal specified above. This keytab will be
+                        copied to the node running the Application Master via
+                        the Secure Distributed Cache, for renewing the login
+                        tickets and the delegation tokens periodically.
+
+This also supports the same runner-specific switches as
+:py:class:`~mrjob.job.MRJob`\s (e.g. ``--hadoop-bin``, ``--region``).
+
+.. versionadded:: 0.6.7
+"""
 from __future__ import print_function
 
 import os
@@ -36,7 +147,7 @@ log = getLogger(__name__)
 _USAGE = ('%(prog)s spark-submit [-r <runner>] [options]'
           ' <python file | app jar> [app arguments]')
 
-_DESCRIPTION = 'Submit a spark job locally or in the cloud'
+_DESCRIPTION = 'Submit a spark job to Hadoop or the cloud'
 
 _BASIC_HELP_EPILOG = (
     'To see help for a specific runner, use --help -r <runner name>')

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -270,8 +270,10 @@ def main(cl_args=None):
 
     runner = runner_class(**kwargs)
 
-    runner.run()
-
+    try:
+        runner.run()
+    finally:
+        runner.cleanup()
 
 def _get_runner_opt_kwargs(options, runner_class):
     """Extract the options for the given runner class from *options*."""

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -239,6 +239,7 @@ _SWITCH_ALIASES = {
 _HARD_CODED_OPTS = dict(
     check_input_paths=False,
     output_dir=None,
+    setup=None,  # currently does nothing on Spark
 )
 
 

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -77,6 +77,7 @@ _SPARK_SUBMIT_ARG_GROUPS = [
         'repositories',
         'py_files',
         'upload_files',
+        'cmdenv',
         'jobconf',
         'properties_file',
         'driver_memory',
@@ -114,6 +115,8 @@ _SPARK_SUBMIT_ARG_GROUPS = [
 
 # lightly modified versions of help messages from spark-submit
 _SPARK_SUBMIT_ARG_HELP = dict(
+    cmdenv=('Arbitrary environment variable to set inside Spark, in the'
+            ' format NAME=VALUE.'),
     driver_class_path=('Extra class path entries to pass to the driver. Note'
                        ' that jars added with --jars are automatically'
                        ' included in the classpath.'),
@@ -128,7 +131,8 @@ _SPARK_SUBMIT_ARG_HELP = dict(
                     ' or all available cores on the worker in standalone'
                     ' mode)'),
     executor_memory='Memory per executor (e.g. 1000M, 2G) (Default: 1G).',
-    jobconf='Arbitrary Spark configuration property.',
+    jobconf=('Arbitrary Spark configuration property, in the format'
+             ' PROP=VALUE.'),
     keytab=('The full path to the file that contains the keytab for the'
             ' principal specified above. This keytab will be copied to'
             ' the node running the Application Master via the Secure'
@@ -181,6 +185,7 @@ _SPARK_SUBMIT_OPT_NAMES = {
 }
 
 _SPARK_SUBMIT_SWITCHES = dict(
+    cmdenv='--cmdenv',
     driver_class_path='--driver-class-path',
     driver_cores='--driver-cores',
     driver_java_options='--driver-java-options',

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -240,6 +240,7 @@ _HARD_CODED_OPTS = dict(
     check_input_paths=False,
     output_dir=None,
     setup=None,  # currently does nothing on Spark
+    task_python_bin=None,  # without setup, same as python_bin
 )
 
 

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -40,7 +40,7 @@ _DESCRIPTION = 'Submit a spark job using mrjob runners'
 # display in default help message
 
 # the only runners that support spark scripts/jars
-_SPARK_RUNNERS = ('dataproc', 'emr', 'hadoop')
+_SPARK_RUNNERS = ('emr', 'hadoop')
 
 # the default spark runner to use
 _DEFAULT_RUNNER = 'hadoop'
@@ -252,6 +252,8 @@ def _make_arg_parser():
     #_add_help_arg(parser)
 
     # add runner opts
+
+    # TODO: just add all runner opts, don't display the irrelevant ones
     runner_opt_names = (
         set(_RUNNER_OPTS) - set(_HARD_CODED_OPTS) - _IRRELEVANT_OPT_NAMES)
     _add_runner_args(parser, runner_opt_names)

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -396,7 +396,7 @@ def _print_help_for_runner(runner_class, include_deprecated=False):
     help_parser = ArgumentParser(usage=SUPPRESS, add_help=False)
 
     arg_group = help_parser.add_argument_group(
-        'optional switches for %s runner' % runner_class.alias)
+        'optional arguments for %s runner' % runner_class.alias)
 
     # don't include hard-coded opts or opts in basic help
     opt_names = runner_class.OPT_NAMES - set(_HARD_CODED_OPTS)

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -391,9 +391,22 @@ def _print_help(options, runner_class):
 def _print_help_for_runner(runner_class, include_deprecated=False):
     help_parser = ArgumentParser(usage=SUPPRESS, add_help=False)
 
+    # don't include hard-coded opts or opts in basic help
     opt_names = runner_class.OPT_NAMES - set(_HARD_CODED_OPTS)
+
+    # don't include switches already in basic help
+    suppress_switches = set(_SPARK_SUBMIT_SWITCHES.values())
+
+    # simplify description of aliases of switches in basic help
+    customize_switches = {
+        v: dict(help='Alias for %s' % k)
+        for k, v in _SWITCH_ALIASES.items()
+    }
+
     _add_runner_args(help_parser, opt_names,
-                     include_deprecated=include_deprecated)
+                     include_deprecated=include_deprecated,
+                     customize_switches=customize_switches,
+                     suppress_switches=suppress_switches)
 
     help_parser.print_help()
 

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -1,0 +1,46 @@
+# Copyright 2018 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Submit a spark job using mrjob runners."""
+
+_USAGE = ('%(prog)s spark-submit [-r <runner>] [options]'
+          ' <python file | app jar> [app arguments]')
+
+
+# opts, mrjob or otherwise, used by the spark-submit utility
+_SPARK_SUBMIT_OPTS = [
+    ('spark_master', dict(
+        help=('Hadoop runner only: spark://host:port, mesos://host:port, yarn,'
+              ' k8s://https://host:port, or local. Defaults to yarn')
+        switch_aliases={'--spark-master': '--master'}
+    )),
+
+
+
+]
+
+
+
+_CORE_OPTS = {
+
+
+}
+
+
+# map from a mrjob switch to the Spark equivalent
+_SPARK_SUBMIT_SWITCHES = {
+    '--jobconf': '--conf',
+    '--libjars': '--jars',
+    '--spark-deploy-mode': '--deploy-mode',
+    '--spark-master': '--master',
+}

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -12,22 +12,112 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Submit a spark job using mrjob runners."""
+from argparse import ArgumentParser
+
+from mrjob.job import MRJob
+from mrjob.options import _RUNNER_OPTS
+from mrjob.options import _add_basic_args
+from mrjob.runner import _runner_class
 
 _USAGE = ('%(prog)s spark-submit [-r <runner>] [options]'
           ' <python file | app jar> [app arguments]')
 
+_DESCRIPTION = 'Submit a spark job using mrjob runners'
 
-# opts, mrjob or otherwise, used by the spark-submit utility
-_SPARK_SUBMIT_OPTS = [
-    ('spark_master', dict(
-        help=('Hadoop runner only: spark://host:port, mesos://host:port, yarn,'
-              ' k8s://https://host:port, or local. Defaults to yarn')
-        switch_aliases={'--spark-master': '--master'}
-    )),
+# for spark-submit args, just need switches and help message
+# (which can be patched into runner opts with same dest name)
 
+# then add runner opts (other than check_input_paths) but don't
+# display in default help message
 
 
+
+_SPARK_SUBMIT_ARG_GROUPS = [
+    (None, [
+        'spark_master',
+        'spark_deploy_mode',
+        'main_class',
+        'name',
+        'libjars',
+        'packages',
+        'exclude_packages',
+        'repositories',
+        'py_files',
+        'upload_files',
+        'jobconf',
+        'properties_file',
+        'driver_memory',
+        'driver_java_options',
+        'driver_library_path',
+        'driver_class_path',
+        'executor_memory',
+        'proxy_user',
+    ]),
+    ('Cluster deploy mode only', [
+        'driver_cores',
+    ]),
+    ('Spark standalone or Mesos with cluster deploy mode only', [
+        'supervise',
+        # --kill and --status aren't for launching jobs
+    ]),
+    ('Spark standalone and Mesos only', [
+        'total_executor_cores',
+    ]),
+    ('Spark standalone and YARN only', [
+        'executor_cores',
+    ]),
+    ('YARN-only', [
+        'queue_name',
+        'num_executors',
+        'upload_archives',
+        'principal',
+        'keytab',
+    ]),
 ]
+
+_SPARK_SUBMIT_OPT_NAMES = {
+    opt_name for _, opt_names in _SPARK_SUBMIT_ARG_GROUPS
+    for opt_name in opt_names
+}
+
+
+_SPARK_SUBMIT_SWITCHES = dict(
+    driver_class_path='--driver-class-path',
+    driver_cores='--driver-cores',
+    driver_java_options='--driver-java-options',
+    driver_library_path='--driver-library-path',
+    driver_memory='--driver-memory',
+    exclude_packages='--exclude-packages',
+    executor_cores='--executor-cores',
+    executor_memory='--executor-memory',
+    jobconf='--conf',
+    keytab='--keytab',
+    libjars='--jars',
+    main_class='--class',
+    name='--name',
+    num_executors='--num-executors',
+    packages='--packages',
+    principal='--principal',
+    properties_file='--properties-file',
+    proxy_user='--proxy-user',
+    py_files='--py-files',
+    queue_name='--queue',
+    repositories='--repositories',
+    spark_deploy_mode='--deploy-mode',
+    spark_master='--master',
+    supervise='--supervise',
+    total_executor_cores='--total-executor-cores',
+    upload_archives='--archives',
+    upload_files='--files',
+)
+
+
+_SWITCH_ALIASES = {
+    '--master': '--spark-master',
+    '--deploy-mode': '--spark-deploy-mode',
+    '--jars': '--libjars',
+    '--conf': '--jobconf',
+}
 
 
 
@@ -37,10 +127,66 @@ _CORE_OPTS = {
 }
 
 
-# map from a mrjob switch to the Spark equivalent
-_SPARK_SUBMIT_SWITCHES = {
-    '--jobconf': '--conf',
-    '--libjars': '--jars',
-    '--spark-deploy-mode': '--deploy-mode',
-    '--spark-master': '--master',
-}
+def main(cl_args=None):
+    parser = _make_arg_parser()
+    options = parser.parse_args(cl_args)
+
+    print(options)
+
+    MRJob.set_up_logging(
+        quiet=options.quiet,
+        verbose=options.verbose,
+    )
+
+    runner_class = _runner_class(options.runner)
+    runner_kwargs = _get_runner_kwargs(options)
+
+    runner = runner_class(**runner_kwargs)
+
+    runner.run()
+
+
+def _add_spark_submit_arg(opt_name, parser_or_group):
+    opt_string = _SPARK_SUBMIT_SWITCHES[opt_name]
+
+    kwargs = dict(dest=opt_name)
+
+    # if opt_name is a mrjob opt, parse args like a MRJob would
+    if opt_name in _RUNNER_OPTS:
+        opt_alias = _SWITCH_ALIASES.get(opt_string, opt_string)
+
+        for opt_strings, opt_kwargs in _RUNNER_OPTS[opt_name]['switches']:
+            if opt_alias in opt_strings:
+                kwargs.update(opt_kwargs)
+
+    parser_or_group.add_argument(opt_string, **kwargs)
+
+
+def _make_arg_parser():
+    parser = ArgumentParser(usage=_USAGE, description=_DESCRIPTION)
+
+    parser.add_argument(
+        '-r', '--runner', dest='runner', default='hadoop',
+        choices=('hadoop', 'emr', 'dataproc'),
+        help=('Where to run the job (default: %(default)s")'))
+
+    for group_desc, opt_names in _SPARK_SUBMIT_ARG_GROUPS:
+        if group_desc is None:
+            parser_or_group = parser
+        else:
+            parser_or_group = parser.add_argument_group(group_desc)
+
+        for opt_name in opt_names:
+            _add_spark_submit_arg(opt_name, parser_or_group)
+
+        if group_desc is None:
+            _add_basic_args(parser)
+            # TODO: add --deprecated and --help
+
+    return parser
+
+
+
+
+if __name__ == '__main__':
+    main()

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -392,6 +392,9 @@ def _print_help(options, runner_class):
 def _print_help_for_runner(runner_class, include_deprecated=False):
     help_parser = ArgumentParser(usage=SUPPRESS, add_help=False)
 
+    arg_group = help_parser.add_argument_group(
+        'optional switches for %s runner' % runner_class.alias)
+
     # don't include hard-coded opts or opts in basic help
     opt_names = runner_class.OPT_NAMES - set(_HARD_CODED_OPTS)
 
@@ -404,7 +407,7 @@ def _print_help_for_runner(runner_class, include_deprecated=False):
         for k, v in _SWITCH_ALIASES.items()
     }
 
-    _add_runner_args(help_parser, opt_names,
+    _add_runner_args(arg_group, opt_names,
                      include_deprecated=include_deprecated,
                      customize_switches=customize_switches,
                      suppress_switches=suppress_switches)

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -146,7 +146,8 @@ _SWITCH_ALIASES = {
 
 # TODO: suppress this in --help
 _HARD_CODED_OPTS = dict(
-    check_input_paths=False
+    check_input_paths=False,
+    output_dir=None,
 )
 
 

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 from mrjob import cmd
 from mrjob import launch
+from mrjob.tools import diagnose
+from mrjob.tools import spark_submit
 from mrjob.tools.emr import audit_usage
 from mrjob.tools.emr import create_cluster
 from mrjob.tools.emr import report_long_jobs
@@ -54,6 +56,9 @@ class CommandTestCase(BasicTestCase):
     def test_audit_usage(self):
         self._test_main_call(audit_usage, 'audit-emr-usage')
 
+    def test_diagnose(self):
+        self._test_main_call(diagnose, 'diagnose')
+
     def test_create_cluster(self):
         self._test_main_call(create_cluster, 'create-cluster')
 
@@ -62,6 +67,9 @@ class CommandTestCase(BasicTestCase):
 
     def test_s3_tmpwatch(self):
         self._test_main_call(s3_tmpwatch, 's3-tmpwatch')
+
+    def test_spark_submit(self):
+        self._test_main_call(spark_submit, 'spark-submit')
 
     def test_terminate_idle_clusters(self):
         self._test_main_call(terminate_idle_clusters,

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1226,7 +1226,7 @@ class PrintHelpTestCase(SandboxedTestCase):
 
         output = self.stdout.getvalue()
         # basic option
-        self.assertIn('--conf', output)
+        self.assertIn('--conf-path', output)
 
         # not basic options
         self.assertNotIn('--step-num', output)
@@ -1242,7 +1242,7 @@ class PrintHelpTestCase(SandboxedTestCase):
 
         output = self.stdout.getvalue()
         # basic option
-        self.assertIn('--conf', output)
+        self.assertIn('--conf-path', output)
 
         # not basic options
         self.assertNotIn('--step-num', output)
@@ -1261,7 +1261,7 @@ class PrintHelpTestCase(SandboxedTestCase):
         self.assertIn('--s3-endpoint', output)
 
         # not runner options
-        self.assertNotIn('--conf', output)
+        self.assertNotIn('--conf-path', output)
         self.assertNotIn('--step-num', output)
 
         # a runner option, but not for EMR
@@ -1279,7 +1279,7 @@ class PrintHelpTestCase(SandboxedTestCase):
         self.assertIn('--s3-endpoint', output)
 
         # not runner options
-        self.assertNotIn('--conf', output)
+        self.assertNotIn('--conf-path', output)
         self.assertNotIn('--step-num', output)
 
         # a runner option, but not for EMR
@@ -1297,7 +1297,7 @@ class PrintHelpTestCase(SandboxedTestCase):
         self.assertIn('--step-num', output)
 
         # not step options
-        self.assertNotIn('--conf', output)
+        self.assertNotIn('--conf-path', output)
         self.assertNotIn('--s3-endpoint', output)
 
     def test_passthrough_options(self):

--- a/tests/tools/test_spark_submit.py
+++ b/tests/tools/test_spark_submit.py
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test the spark-submit script."""
+from __future__ import print_function
+
 from mrjob.runner import _runner_class
 from mrjob.tools.spark_submit import main as spark_submit_main
 
 from tests.py2 import Mock
 from tests.py2 import patch
 from tests.sandbox import SandboxedTestCase
+
+
+class MockSystemExit(Exception):
+    pass
 
 
 class SparkSubmitToolTestCase(SandboxedTestCase):
@@ -42,10 +48,16 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
 
         self.runner_log = self.start(patch('mrjob.runner.log'))
 
+        # don't actually want to exit after printing help
+        self.exit = self.start(patch('sys.exit', side_effect=MockSystemExit))
+
+        # also probably better not to print
+        self.print = self.start(patch('mrjob.tools.spark_submit.print'))
+
     def get_runner_kwargs(self):
         return self.runner_class.call_args_list[-1][1]
 
-    def test_basic_end_to_end(self):
+    def test_basic(self):
         spark_submit_main(['foo.py', 'arg1', 'arg2'])
 
         self.assertEqual(self.runner_class.alias, 'hadoop')
@@ -58,6 +70,21 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
         self.assertEqual(kwargs['steps'], [
             dict(
                 args=['arg1', 'arg2'],
+                jobconf={},
+                script='foo.py',
+                spark_args=[],
+                type='spark_script',
+            )
+        ])
+
+    def test_no_args_okay(self):
+        spark_submit_main(['foo.py'])
+
+        kwargs = self.get_runner_kwargs()
+
+        self.assertEqual(kwargs['steps'], [
+            dict(
+                args=[],
                 jobconf={},
                 script='foo.py',
                 spark_args=[],
@@ -87,8 +114,8 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
         ])
 
     def test_jar_main_class(self):
-        spark_submit_main(['dora.jar', '--class', 'Backpack',
-                           'arg1', 'arg2', 'arg3'])
+        spark_submit_main(['--class', 'Backpack',
+                           'dora.jar', 'arg1', 'arg2', 'arg3'])
 
         kwargs = self.get_runner_kwargs()
 
@@ -102,3 +129,89 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
                 type='spark_jar',
             )
         ])
+
+    def test_allow_py3_extension(self):
+        spark_submit_main(['foo.py3', 'arg1', 'arg2'])
+
+        kwargs = self.get_runner_kwargs()
+
+        self.assertEqual(kwargs['steps'], [
+            dict(
+                args=['arg1', 'arg2'],
+                jobconf={},
+                script='foo.py3',
+                spark_args=[],
+                type='spark_script',
+            )
+        ])
+
+    def test_not_py_or_jar(self):
+        self.assertRaises(ValueError, spark_submit_main,
+                          ['whoo.sh', 'arg1'])
+
+    def test_pass_through_to_step_spark_args(self):
+        spark_submit_main(['--class', 'Backpack',
+                           '--name', 'Backpack',
+                           '--num-executors', '3',
+                           '--conf', 'foo=BAR',
+                           '--name', 'Mochila',
+                           'dora.jar', 'arg1'])
+
+        # --class becomes part of step
+        # --conf is an alias for a mrjob opt, goes to runner
+        # other args end up in spark-args as-is
+        kwargs = self.get_runner_kwargs()
+
+        self.assertEqual(kwargs['steps'], [
+            dict(
+                args=['arg1'],
+                jar='dora.jar',
+                jobconf={},
+                main_class='Backpack',
+                spark_args=[
+                    '--name', 'Backpack',
+                    '--num-executors', '3',
+                    '--name', 'Mochila',
+                ],
+                type='spark_jar',
+            )
+        ])
+
+        self.assertEqual(kwargs['jobconf'], dict(foo='BAR'))
+
+    # test help
+
+    def test_basic_help(self):
+        with patch('mrjob.tools.spark_submit._print_basic_help') as pbh:
+            self.assertRaises(MockSystemExit, spark_submit_main, ['-h'])
+
+            self.exit.assert_called_once_with(0)
+            pbh.assert_called_once_with(include_deprecated=False)
+
+    def test_help_runner(self):
+        with patch('mrjob.tools.spark_submit._print_help_for_runner') as phfr:
+            self.assertRaises(MockSystemExit, spark_submit_main,
+                              ['-h', '-r', 'emr'])
+
+            self.exit.assert_called_once_with(0)
+            phfr.assert_called_once_with(self.runner_class,
+                                         include_deprecated=False)
+
+    def test_no_script_prints_basic_help(self):
+        with patch('mrjob.tools.spark_submit._print_basic_help') as pbh:
+            self.assertRaises(MockSystemExit, spark_submit_main, [])
+
+            self.exit.assert_called_once_with(0)
+            pbh.assert_called_once_with(include_deprecated=False)
+
+    def test_no_script_prints_basic_help_even_with_runner(self):
+        # to get runner help, you have to do --help --runner ...
+        with patch('mrjob.tools.spark_submit._print_basic_help') as pbh:
+            self.assertRaises(MockSystemExit, spark_submit_main,
+                              ['-r', 'emr'])
+
+            self.exit.assert_called_once_with(0)
+            pbh.assert_called_once_with(include_deprecated=False)
+
+
+# add end-to-end test on EMR

--- a/tests/tools/test_spark_submit.py
+++ b/tests/tools/test_spark_submit.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test the spark-submit script."""
+from mrjob.runner import _runner_class
+from mrjob.tools.spark_submit import main as spark_submit_main
+
+from tests.py2 import Mock
+from tests.sandbox import SandboxedTestCase
+
+
+def SparkSubmitToolTestCase(SandboxedTestCase):
+
+    def setUp(self):
+        super(SparkSubmitToolTestCase, self).setUp()
+
+        self.mock_runner = Mock()
+
+        def _mock_runner_class(runner_alias):
+            rc = _runner_class(runner_alias)
+            self.mock_runner.OPT_NAMES = set(rc.OPT_NAMES)
+            return self.mock_runner
+
+        self.start(patch('mrjob.tools.spark_submit._runner_class',
+                         mock_runner_class))
+
+        self.runner_log = self.start(patch('mrjob.runner.log'))
+
+    def mock_runner_kwargs(self):
+        return self.mock_runner.call_args_list[-1][1]

--- a/tests/tools/test_spark_submit.py
+++ b/tests/tools/test_spark_submit.py
@@ -229,12 +229,15 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
         self.assertEqual(kwargs['check_input_paths'], False)
         self.assertEqual(kwargs['input_paths'], [os.devnull])
         self.assertEqual(kwargs['output_dir'], None)
+        self.assertEqual(kwargs['setup'], None)
 
     def test_no_switches_for_hard_coded_kwargs(self):
         self.assertRaises(MockSystemExit, spark_submit_main,
                           ['--check-input-paths', 'foo.py', 'arg1'])
         self.assertRaises(MockSystemExit, spark_submit_main,
-                          ['--output-dir', 'foo.py', 'arg1'])
+                          ['--output-dir', 'out', 'foo.py', 'arg1'])
+        self.assertRaises(MockSystemExit, spark_submit_main,
+                          ['--setup', 'true', 'foo.py', 'arg1'])
 
     def test_help_arg(self):
         with patch('mrjob.tools.spark_submit._print_basic_help') as pbh:

--- a/tests/tools/test_spark_submit.py
+++ b/tests/tools/test_spark_submit.py
@@ -42,9 +42,6 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
 
         self.runner_log = self.start(patch('mrjob.runner.log'))
 
-    def get_runner(self):
-        return self.runner_class.return_value
-
     def get_runner_kwargs(self):
         return self.runner_class.call_args_list[-1][1]
 
@@ -65,5 +62,43 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
                 script='foo.py',
                 spark_args=[],
                 type='spark_script',
+            )
+        ])
+
+    def test_jar_step(self):
+        spark_submit_main(['dora.jar', 'arg1', 'arg2', 'arg3'])
+
+        self.assertEqual(self.runner_class.alias, 'hadoop')
+
+        self.assertTrue(self.runner_class.called)
+        self.assertTrue(self.runner_class.return_value.run.called)
+
+        kwargs = self.get_runner_kwargs()
+
+        self.assertEqual(kwargs['steps'], [
+            dict(
+                args=['arg1', 'arg2', 'arg3'],
+                jar='dora.jar',
+                jobconf={},
+                main_class=None,
+                spark_args=[],
+                type='spark_jar',
+            )
+        ])
+
+    def test_jar_main_class(self):
+        spark_submit_main(['dora.jar', '--class', 'Backpack',
+                           'arg1', 'arg2', 'arg3'])
+
+        kwargs = self.get_runner_kwargs()
+
+        self.assertEqual(kwargs['steps'], [
+            dict(
+                args=['arg1', 'arg2', 'arg3'],
+                jar='dora.jar',
+                jobconf={},
+                main_class='Backpack',
+                spark_args=[],
+                type='spark_jar',
             )
         ])

--- a/tests/tools/test_spark_submit.py
+++ b/tests/tools/test_spark_submit.py
@@ -76,8 +76,9 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
         def _mock_print(s=''):
             self.printout += s + '\n'
 
+        # print() isn't considered part of the module in Python 3.4
         self.start(patch('mrjob.tools.spark_submit.print',
-                         _mock_print))
+                         _mock_print, create=True))
 
     def get_runner_kwargs(self):
         return self.runner_class.call_args_list[-1][1]

--- a/tests/tools/test_spark_submit.py
+++ b/tests/tools/test_spark_submit.py
@@ -230,6 +230,7 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
         self.assertEqual(kwargs['input_paths'], [os.devnull])
         self.assertEqual(kwargs['output_dir'], None)
         self.assertEqual(kwargs['setup'], None)
+        self.assertEqual(kwargs['task_python_bin'], None)
 
     def test_no_switches_for_hard_coded_kwargs(self):
         self.assertRaises(MockSystemExit, spark_submit_main,
@@ -238,6 +239,8 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
                           ['--output-dir', 'out', 'foo.py', 'arg1'])
         self.assertRaises(MockSystemExit, spark_submit_main,
                           ['--setup', 'true', 'foo.py', 'arg1'])
+        self.assertRaises(MockSystemExit, spark_submit_main,
+                          ['--task-python-bin', 'pypy', 'foo.py', 'arg1'])
 
     def test_help_arg(self):
         with patch('mrjob.tools.spark_submit._print_basic_help') as pbh:


### PR DESCRIPTION
This creates a drop-in replacement for `spark-submit` that's capable of launching Spark jobs on EMR. Fixes #1382.

Also removed an extraneous option from the Hadoop runner (see #1899).