### PR TITLE
Check if input paths are in Glacier

### DIFF
--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1016,15 +1016,21 @@ class MRJobRunner(object):
             return
 
         for path in self._input_paths:
-            if path == '-':
-                    continue  # STDIN always exists
+            self._check_input_path(path)
 
-            if not self.fs.can_handle_path(path):
-                continue  # e.g. non-S3 URIs on EMR
+    def _check_input_path(self, path):
+        """Raise :py:class:`IOError` if the given input does not exist or
+        is otherwise invalid. Override this to provide custom check
+        behavior."""
+        if path == '-':
+            return  # STDIN always exists
 
-            if not self.fs.exists(path):
-                raise IOError(
-                    'Input path %s does not exist!' % (path,))
+        if not self.fs.can_handle_path(path):
+            return  # no way to check (e.g. non-S3 URIs on EMR)
+
+        if not self.fs.exists(path):
+            raise IOError(
+                'Input path %s does not exist!' % (path,))
 
     def _add_input_files_for_upload(self):
         """If there is an upload manager, add input files to it."""

--- a/tests/mock_boto3/case.py
+++ b/tests/mock_boto3/case.py
@@ -85,10 +85,11 @@ class MockBoto3TestCase(SandboxedTestCase):
 
         self.start(patch.object(time, 'sleep'))
 
-    def add_mock_s3_data(self, data, age=None, location=None):
+    def add_mock_s3_data(self, data,
+                         age=None, location=None, storage_class=None):
         """Update self.mock_s3_fs with a map from bucket name
         to key name to data."""
-        add_mock_s3_data(self.mock_s3_fs, data, age, location)
+        add_mock_s3_data(self.mock_s3_fs, data, age, location, storage_class)
 
     def add_mock_ec2_image(self, image):
         """Add information about a mock EC2 Image (AMI) to be returned by

--- a/tests/mock_boto3/s3.py
+++ b/tests/mock_boto3/s3.py
@@ -18,12 +18,10 @@ from datetime import datetime
 from datetime import timedelta
 
 from botocore.exceptions import ClientError
-from botocore.exceptions import ParamValidationError
 from boto3.exceptions import S3UploadFailedError
 
 from mrjob.aws import _DEFAULT_AWS_REGION
 from mrjob.aws import _boto3_now
-from mrjob.py2 import string_types
 
 from .util import MockClientMeta
 
@@ -223,41 +221,6 @@ class MockS3Object(object):
         self.key = key
 
         self.meta = MockClientMeta(client=client)
-
-    def copy_from(self, CopySource, StorageClass=None):
-        # very limited emulation of copy_from, to allow archiving
-        # in Glacier
-
-        # CopySource may be a string or a dict
-        if isinstance(CopySource, string_types):
-            bucket, key = CopySource.split('/', 1)
-            CopySource = dict(Bucket=bucket, Key=key)
-
-        # validate CopySource
-        if not (isinstance(CopySource, dict) and
-                set(CopySource) >= {'Bucket', 'Key'}):
-            # this isn't the exact error message
-            raise ParamValidationError(
-                report='CopySource must include Bucket and Key')
-
-        # look up the source key
-        mock_source_bucket = self.meta.client.mock_s3_fs.get(
-            CopySource['Bucket'])
-        if not mock_source_bucket:
-            raise _no_such_bucket_error(CopySource['Bucket'], 'CopyObject')
-
-        mock_source_key = mock_source_bucket['keys'].get(CopySource('Key'))
-        if not mock_source_key:
-            raise _no_such_key_error(CopySource['Key'], 'CopyObject')
-
-        new_mock_key = dict(mock_source_key)
-        new_mock_key['time_modified'] = _boto3_now()
-        new_mock_key['storage_class'] = StorageClass
-
-        mock_bucket_keys = self._mock_bucket_keys('CopyObject')
-        mock_bucket_keys[self.key] = new_mock_key
-
-        return {}
 
     def delete(self):
         mock_keys = self._mock_bucket_keys('DeleteObject')

--- a/tests/mock_boto3/s3.py
+++ b/tests/mock_boto3/s3.py
@@ -232,13 +232,19 @@ class MockS3Object(object):
         self.e_tag = '"%s"' % m.hexdigest()
         self.last_modified = mtime
         self.size = len(key_data)
+        self.storage_class = None
 
-        return dict(
+        result = dict(
             Body=MockStreamingBody(key_data),
             ContentLength=self.size,
             ETag=self.e_tag,
             LastModified=self.last_modified,
         )
+
+        if self.storage_class is not None:
+            result['StorageClass'] = self.storage_class
+
+        return result
 
     def put(self, Body):
         if not isinstance(Body, bytes):

--- a/tests/mock_boto3/s3.py
+++ b/tests/mock_boto3/s3.py
@@ -93,11 +93,13 @@ class MockS3Client(object):
         return dict(Buckets=buckets)
 
 
-def add_mock_s3_data(mock_s3_fs, data, age=None, location=None):
+def add_mock_s3_data(mock_s3_fs, data,
+                     age=None, location=None, storage_class=None):
     """Update *mock_s3_fs* with a map from bucket name to key name to data.
 
     :param age: a timedelta
     :param location string: the bucket's location constraint (a region name)
+    :param storage_class string: storage class for all data added
     """
     age = age or timedelta(0)
     time_modified = _boto3_now() - age
@@ -110,8 +112,13 @@ def add_mock_s3_data(mock_s3_fs, data, age=None, location=None):
         for key_name, key_data in key_name_to_bytes.items():
             if not isinstance(key_data, bytes):
                 raise TypeError('mock s3 data must be bytes')
-            bucket['keys'][key_name] = dict(
+
+            mock_key = dict(
                 body=key_data, time_modified=time_modified)
+            if storage_class:
+                mock_key['storage_class'] = storage_class
+
+            bucket['keys'][key_name] = mock_key
 
         if location is not None:
             bucket['location'] = location

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5662,6 +5662,25 @@ class CheckInputPathsTestCase(MockBoto3TestCase):
         with job.make_runner() as runner:
             self.assertRaises(StopIteration, runner.run)
 
+    def test_existing_s3_dir(self):
+        self.add_mock_s3_data({'walrus': {'data/one': b'one\n',
+                                          'data/two': b'two\n'}})
+
+        job = MRTwoStepJob(['-r', 'emr', 's3://walrus/data/'])
+
+        with job.make_runner() as runner:
+            self.assertRaises(StopIteration, runner.run)
+
+    def test_s3_path_in_glacier(self):
+        self.add_mock_s3_data({'walrus': {'data/one': b'one\n'}})
+        self.add_mock_s3_data({'walrus': {'data/two': b'two\n'}},
+                              storage_class='GLACIER')
+
+        job = MRTwoStepJob(['-r', 'emr', 's3://walrus/data/'])
+
+        with job.make_runner() as runner:
+            self.assertRaises(IOError, runner.run)
+
     def test_nonexistent_s3_path(self):
         job = MRTwoStepJob(['-r', 'emr', 's3://walrus/data/foo'])
 


### PR DESCRIPTION
Input path check now fails if any input "files" on S3 are archived in Glacier, as EMR is unable to read them and will fail with a rather cryptic Java error. Fixes #1887.