### PR TITLE
allow input on S3 that's been restored from Glacier

### DIFF
--- a/tests/mock_boto3/case.py
+++ b/tests/mock_boto3/case.py
@@ -86,10 +86,12 @@ class MockBoto3TestCase(SandboxedTestCase):
         self.start(patch.object(time, 'sleep'))
 
     def add_mock_s3_data(self, data,
-                         age=None, location=None, storage_class=None):
+                         age=None, location=None, storage_class=None,
+                         restore=None):
         """Update self.mock_s3_fs with a map from bucket name
         to key name to data."""
-        add_mock_s3_data(self.mock_s3_fs, data, age, location, storage_class)
+        add_mock_s3_data(
+            self.mock_s3_fs, data, age, location, storage_class, restore)
 
     def add_mock_ec2_image(self, image):
         """Add information about a mock EC2 Image (AMI) to be returned by

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5685,7 +5685,7 @@ class CheckInputPathsTestCase(MockBoto3TestCase):
         self.add_mock_s3_data(
             {'walrus': {'data/foo': b'foo\n'}},
             storage_class='GLACIER',
-            restore='ongoing-request="false"')
+            restore='ongoing-request="true"')
 
         job = MRTwoStepJob(['-r', 'emr', 's3://walrus/data/foo'])
 
@@ -5697,7 +5697,7 @@ class CheckInputPathsTestCase(MockBoto3TestCase):
         self.add_mock_s3_data(
             {'walrus': {'data/foo': b'foo\n'}},
             storage_class='GLACIER',
-            restore=('ongoing-request="true",'
+            restore=('ongoing-request="false",'
                      ' expiry-date="Tue, May 23, 3030 00:00:00 GMT'))
 
         job = MRTwoStepJob(['-r', 'emr', 's3://walrus/data/foo'])


### PR DESCRIPTION
This addresses an issue with Pull Request #1904: normally we want to reject input with the `GLACIER` storage class, but not if it's been restored from Glacier. Fixes #1884.