### PR TITLE
fix idle-timeout script on 2.x AMIs

### DIFF
--- a/mrjob/bootstrap/terminate_idle_cluster_emr.sh
+++ b/mrjob/bootstrap/terminate_idle_cluster_emr.sh
@@ -58,7 +58,7 @@ if [ -z "$GRACE_PERIOD_SECS" ]; then GRACE_PERIOD_SECS=600; fi
 LOG_PATH=$3
 if [ -z "$LOG_PATH" ]
 then
-    LOG_PATH=/var/log/bootstrap-actions/mrjob-idle-termination.log
+    LOG_PATH=/mnt/var/log/bootstrap-actions/mrjob-idle-termination.log
 fi
 
 # exit if this isn't the master node


### PR DESCRIPTION
Use `/mnt/var/log/...` because `/var/log` doesn't exist on 2.x AMIs.

Hand-tested this on 2.x, 3.x, 4.x, and 5.x AMIs, all correctly shut themselves down.

I don't see much point in unit-testing this because it's a static script.