### PR TITLE
clean up logic for runners with no mrjob script

### DIFF
--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -99,9 +99,6 @@ class MRJobBinRunner(MRJobRunner):
         )
 
     def _load_steps(self):
-        if not self._script_path:
-            return []
-
         args = (self._executable(True) + ['--steps'] +
                 self._mr_job_extra_args(local=True))
         log.debug('> %s' % cmd_line(args))

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -1086,7 +1086,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     def _store_cluster_info(self):
         """Set self._image_version and self._hadoop_version."""
         if not self._cluster_id:
-            raise AssertionError('cluster has not yet been created')
+            raise ValueError('cluster has not yet been created')
 
         cluster = self._get_cluster(self._cluster_id)
         self._image_version = (

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1367,7 +1367,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         elif _is_spark_step_type(step['type']):
             method = self._spark_step_hadoop_jar_step
         else:
-            raise AssertionError('Bad step type: %r' % (step['type'],))
+            raise ValueError('Bad step type: %r' % (step['type'],))
 
         hadoop_jar_step = method(step_num)
 
@@ -2341,7 +2341,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
     def make_persistent_cluster(self):
         if (self._cluster_id):
-            raise AssertionError(
+            raise ValueError(
                 'This runner is already associated with cluster ID %s' %
                 (self._cluster_id))
 
@@ -2771,7 +2771,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         """Describe our cluster, and cache image_version, hadoop_version,
         and master_public_dns"""
         if not self._cluster_id:
-            raise AssertionError('cluster has not yet been created')
+            raise ValueError('cluster has not yet been created')
 
         cache = self._cluster_to_cache[self._cluster_id]
 
@@ -2799,7 +2799,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         """List master instance for our cluster, and cache
         master_private_ip."""
         if not self._cluster_id:
-            raise AssertionError('cluster has not yet been created')
+            raise ValueError('cluster has not yet been created')
 
         cache = self._cluster_to_cache[self._cluster_id]
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -500,7 +500,7 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
         elif _is_spark_step_type(step['type']):
             return self._args_for_spark_step(step_num)
         else:
-            raise AssertionError('Bad step type: %r' % (step['type'],))
+            raise ValueError('Bad step type: %r' % (step['type'],))
 
     def _args_for_streaming_step(self, step_num):
         hadoop_streaming_jar = self.get_hadoop_streaming_jar()

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -497,9 +497,6 @@ class MRJobRunner(object):
         :py:class:`~mrjob.inline.InlineMRJobRunner`, where we raise the
         actual exception that caused the step to fail).
         """
-        if not (self._script_path or self._steps):
-            raise AssertionError('No script to run!')
-
         if self._ran_job:
             raise AssertionError('Job already ran!')
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -798,7 +798,7 @@ class MRJobRunner(object):
         """
         if self._steps is None:
             log.warning(
-                'querying jobs for steps is deprecated and '
+                'querying jobs for steps is deprecated and'
                 ' will go away in v0.7.0')
             steps = self._load_steps()
             self._check_steps(steps)

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -329,7 +329,11 @@ class MRJobRunner(object):
 
         # check and store *steps*
         self._steps = None
-        if steps is not None:
+        if steps is None:
+            if not mr_job_script:
+                self._steps = []
+            # otherwise we'll load steps on-the-fly, see _load_steps()
+        else:
             self._check_steps(steps)
             self._steps = copy.deepcopy(steps)
 
@@ -811,6 +815,8 @@ class MRJobRunner(object):
         there are mappers and reducers for each step.
 
         Returns output as described in :ref:`steps-format`.
+
+        If this is called, you can assume self._script_path is set.
         """
         raise NotImplementedError
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -498,7 +498,7 @@ class MRJobRunner(object):
         actual exception that caused the step to fail).
         """
         if self._ran_job:
-            raise AssertionError('Job already ran!')
+            raise ValueError('Job already ran!')
 
         if self._num_steps() == 0:
             raise ValueError('Job has no steps!')
@@ -529,7 +529,7 @@ class MRJobRunner(object):
         """
         output_dir = self.get_output_dir()
         if output_dir is None:
-            raise AssertionError('Run the job before streaming output')
+            raise ValueError('Run the job before streaming output')
 
         if self._closed is True:
             log.warning(

--- a/tests/mock_boto3/emr.py
+++ b/tests/mock_boto3/emr.py
@@ -1638,7 +1638,7 @@ class MockEMRClient(object):
                     add_mock_s3_data(self.mock_s3_fs, {
                         bucket_name: {key_name + 'part-%05d' % i: part}})
             elif (cluster_id, step_num) in self.mock_emr_output:
-                raise AssertionError(
+                raise ValueError(
                     "can't use output for cluster ID %s, step %d "
                     "(it doesn't output to S3)" %
                     (cluster_id, step_num))

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -82,8 +82,12 @@ class InlineMRJobRunnerEndToEndTestCase(SandboxedTestCase):
                          [(1, 'qux'), (2, 'bar'), (2, 'foo'), (5, None)])
 
     def test_missing_input(self):
-        runner = InlineMRJobRunner(input_paths=['/some/bogus/file/path'])
-        self.assertRaises(Exception, runner._run)
+        mr_job = MRTwoStepJob(['-r', 'inline', '/some/bogus/file/path'])
+        mr_job.sandbox()
+
+        with mr_job.make_runner() as runner:
+            assert isinstance(runner, InlineMRJobRunner)
+            self.assertRaises(IOError, runner.run)
 
 
 class InlineMRJobRunnerCmdenvTest(EmptyMrjobConfTestCase):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -19,6 +19,7 @@ import os
 import os.path
 import tarfile
 import tempfile
+from io import BytesIO
 from time import sleep
 from unittest import skipIf
 
@@ -28,13 +29,19 @@ from mrjob.conf import dump_mrjob_conf
 from mrjob.emr import EMRJobRunner
 from mrjob.examples.mr_phone_to_url import MRPhoneToURL
 from mrjob.inline import InlineMRJobRunner
+from mrjob.local import LocalMRJobRunner
 from mrjob.job import MRJob
 from mrjob.step import MRStep
 from mrjob.tools.emr.audit_usage import _JOB_KEY_RE
 from mrjob.util import to_lines
 
 from tests.mock_boto3 import MockBoto3TestCase
+from tests.mr_cmd_job import MRCmdJob
 from tests.mr_counting_job import MRCountingJob
+from tests.mr_just_a_jar import MRJustAJar
+from tests.mr_null_spark import MRNullSpark
+from tests.mr_spark_jar import MRSparkJar
+from tests.mr_spark_script import MRSparkScript
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
 from tests.py2 import patch
@@ -968,7 +975,7 @@ class MRCatsJob(MRJob):
         return [MRStep(mapper_cmd='cat')] * self.options.num_cats
 
 
-class PassStepsToRunnerTestCase(BasicTestCase):
+class PassStepsToRunnerTestCase(MockBoto3TestCase):
 
     def setUp(self):
         super(PassStepsToRunnerTestCase, self).setUp()
@@ -1028,3 +1035,54 @@ class PassStepsToRunnerTestCase(BasicTestCase):
         self.assertRaises(ValueError, runner.run)
 
         self.assertFalse(self.log.warning.called)
+
+    def test_classic_streaming_step_without_mr_job_script(self):
+        # classic MRJob mappers and reducers require a MRJob script
+        steps = MRWordCount()._steps_desc()
+
+        self.assertRaises(ValueError,
+                          LocalMRJobRunner,
+                          steps=steps, stdin=BytesIO(b'one\ntwo\n'))
+
+    def test_command_streaming_step_without_mr_job_script(self):
+        # you don't need a script to run commands
+        steps = MRCmdJob(['--mapper-cmd', 'cat'])._steps_desc()
+
+        runner = LocalMRJobRunner(steps=steps, stdin=BytesIO(b'dog\n'))
+
+        runner.run()
+        runner.cleanup()
+
+    def test_jar_step_without_mr_job_script(self):
+        jar_path = self.makefile('dora.jar')
+        steps = MRJustAJar(['--jar', jar_path])._steps_desc()
+
+        runner = EMRJobRunner(steps=steps, stdin=BytesIO(b'backpack'))
+
+        runner.run()
+        runner.cleanup()
+
+    def test_spark_step_without_mr_job_script(self):
+        steps = MRNullSpark()._steps_desc()
+
+        # need to be able to call the script's spark() method
+        self.assertRaises(ValueError,
+                          EMRJobRunner, steps=steps, stdin=BytesIO())
+
+    def test_spark_jar_step_without_mr_job_script(self):
+        spark_jar_path = self.makefile('fireflies.jar')
+        steps = MRSparkJar(['--jar', spark_jar_path])._steps_desc()
+
+        runner = EMRJobRunner(steps=steps, stdin=BytesIO())
+
+        runner.run()
+        runner.cleanup()
+
+    def test_spark_script_step_without_mr_job_script(self):
+        spark_script_path = self.makefile('a_spark_script.py')
+        steps = MRSparkScript(['--script', spark_script_path])._steps_desc()
+
+        runner = EMRJobRunner(steps=steps, stdin=BytesIO())
+
+        runner.run()
+        runner.cleanup()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1018,3 +1018,13 @@ class PassStepsToRunnerTestCase(BasicTestCase):
             self.assertEqual(runner._steps, [])
 
             self.assertRaises(ValueError, runner.run)
+
+    def test_no_script_and_no_steps(self):
+        runner = InlineMRJobRunner()
+
+        self.assertEqual(runner._script_path, None)
+        self.assertEqual(runner._steps, [])
+
+        self.assertRaises(AssertionError, runner.run)
+
+        self.assertFalse(self.log.warning.called)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1025,6 +1025,6 @@ class PassStepsToRunnerTestCase(BasicTestCase):
         self.assertEqual(runner._script_path, None)
         self.assertEqual(runner._steps, [])
 
-        self.assertRaises(AssertionError, runner.run)
+        self.assertRaises(ValueError, runner.run)
 
         self.assertFalse(self.log.warning.called)


### PR DESCRIPTION
This fixes a warning that happened (#1911) when we initialized a runner without setting `mr_job_script`, even when we didn't intend to run it.

Updated `_check_steps()` to ensure that if we initialize a runner with no `mr_job_script`, only steps that don't require a MRJob script are allowed.

Finally, raise ValueErrors rather than AssertionErrors (fixes #1877).