### PR TITLE
catch bad steps on runner initialization

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -226,6 +226,9 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'task_instance_config',
     }
 
+    # no Spark support yet (see #1765)
+    _STEP_TYPES = {'jar', 'streaming'}
+
     def __init__(self, **kwargs):
         """:py:class:`~mrjob.dataproc.DataprocJobRunner` takes the same
         arguments as

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -340,6 +340,10 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'visible_to_all_users',
     }
 
+    # supports everything (so far)
+    _STEP_TYPES = {
+        'jar', 'spark', 'spark_jar', 'spark_script', 'streaming'}
+
     # everything that controls instances number, type, or price
     _INSTANCE_OPT_NAMES = {
         name for name in OPT_NAMES

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -130,6 +130,10 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
         'spark_master',
     }
 
+    # supports everything (so far)
+    _STEP_TYPES = {
+        'jar', 'spark', 'spark_jar', 'spark_script', 'streaming'}
+
     def __init__(self, **kwargs):
         """:py:class:`~mrjob.hadoop.HadoopJobRunner` takes the same arguments
         as :py:class:`~mrjob.runner.MRJobRunner`, plus some additional options

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -84,11 +84,12 @@ class InlineMRJobRunner(SimMRJobRunner):
         for step_num, step in enumerate(steps):
             if step['type'] == 'streaming':
                 for mrc in ('mapper', 'combiner', 'reducer'):
-                    if step.get(mrc) and step[mrc].get('type') == 'command':
-                        raise ValueError(
-                            "step %d's %s runs a command, but inline runner"
-                            " does not support subprocesses (try -r local)" % (
-                                step_num, mrc))
+                    if step.get(mrc):
+                        if 'command' in step[mrc] or 'pre_filter' in step[mrc]:
+                            raise NotImplementedError(
+                                "step %d's %s runs a command, but inline"
+                                " runner does not support subprocesses (try"
+                                " -r local)" % (step_num, mrc))
 
     def _invoke_task_func(self, task_type, step_num, task_num):
         """Just run tasks in the same process."""

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -77,6 +77,19 @@ class InlineMRJobRunner(SimMRJobRunner):
         if self._opts['setup']:
             log.warning("inline runner can't run setup commands")
 
+    def _check_steps(self, steps):
+        """Don't try to run steps that include commands."""
+        super(InlineMRJobRunner, self)._check_steps(steps)
+
+        for step_num, step in enumerate(steps):
+            if step['type'] == 'streaming':
+                for mrc in ('mapper', 'combiner', 'reducer'):
+                    if step.get(mrc) and step[mrc].get('type') == 'command':
+                        raise ValueError(
+                            "step %d's %s runs a command, but inline runner"
+                            " does not support subprocesses (try -r local)" % (
+                                step_num, mrc))
+
     def _invoke_task_func(self, task_type, step_num, task_num):
         """Just run tasks in the same process."""
         manifest = (step_num == 0 and task_type == 'mapper' and

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -819,8 +819,10 @@ class MRJobRunner(object):
         raise NotImplementedError
 
     def _check_steps(self, steps):
-        """Raise an exception if there's something wrong with the step
-        definition."""
+        """Look at the step definition (*steps*). If it is not supported by
+        the runner, raise :py:class:`NotImplementedError`. If it is not
+        supported by mrjob, raise :py:class:`ValueError`.
+        """
         if not self._STEP_TYPES:
             # use __class__.__name__ because only MRJobRunner would
             # trigger this

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -81,9 +81,7 @@ class MRJobRunner(object):
     # command lines to run substeps (including Spark) are handled by
     # mrjob.bin.MRJobBinRunner
 
-    #: alias for this runner; used for picking section of
-    #: :py:mod:`mrjob.conf` to load one of ``'local'``, ``'emr'``,
-    #: or ``'hadoop'``
+    #: alias for this runner, used on the command line with ``-r``
     alias = None
 
     # libjars is only here because the job can set it; might want to
@@ -106,6 +104,9 @@ class MRJobRunner(object):
         'upload_dirs',
         'upload_files'
     }
+
+    # re-define this as a set of step types supported by your runner
+    STEP_TYPES = None
 
     # if this is true, when bootstrap_mrjob is true, create a mrjob.zip
     # and patch it into the *py_files* option
@@ -820,11 +821,18 @@ class MRJobRunner(object):
     def _check_steps(self, steps):
         """Raise an exception if there's something wrong with the step
         definition."""
+        if not self._STEP_TYPES:
+            # use __class__.__name__ because only MRJobRunner would
+            # trigger this
+            raise NotImplementedError(
+                '%s cannot run steps!' % self.__class__.__name__)
+
         for step_num, step in enumerate(steps):
-            if step['type'] not in STEP_TYPES:
-                raise ValueError(
-                    'step %d has unexpected step type %r' % (
-                        step_num, step['type']))
+            if step['type'] not in self._STEP_TYPES:
+                raise NotImplementedError(
+                    'step %d has type %r, but %s runner only supports:'
+                    ' %s' % (step_num, step['type'], self.alias,
+                             ', '.join(sorted(self._STEP_TYPES))))
 
             if step.get('input_manifest') and step_num != 0:
                 raise ValueError(

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -106,7 +106,7 @@ class MRJobRunner(object):
     }
 
     # re-define this as a set of step types supported by your runner
-    STEP_TYPES = None
+    _STEP_TYPES = None
 
     # if this is true, when bootstrap_mrjob is true, create a mrjob.zip
     # and patch it into the *py_files* option
@@ -830,10 +830,10 @@ class MRJobRunner(object):
                 '%s cannot run steps!' % self.__class__.__name__)
 
         for step_num, step in enumerate(steps):
-            if step['type'] not in self._STEP_TYPES:
+            if step.get('type') not in self._STEP_TYPES:
                 raise NotImplementedError(
                     'step %d has type %r, but %s runner only supports:'
-                    ' %s' % (step_num, step['type'], self.alias,
+                    ' %s' % (step_num, step.get('type'), self.alias,
                              ', '.join(sorted(self._STEP_TYPES))))
 
             if step.get('input_manifest') and step_num != 0:

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -67,6 +67,8 @@ class SimMRJobRunner(MRJobRunner):
         'num_cores'
     }
 
+    _STEP_TYPES = {'streaming'}
+
     def __init__(self, **kwargs):
         super(SimMRJobRunner, self).__init__(**kwargs)
 

--- a/tests/mockhadoop.py
+++ b/tests/mockhadoop.py
@@ -50,6 +50,34 @@ from mrjob.hadoop import _HADOOP_STREAMING_JAR_RE
 from mrjob.parse import urlparse
 from mrjob.util import shlex_split
 
+from tests.sandbox import SandboxedTestCase
+
+
+class MockHadoopTestCase(SandboxedTestCase):
+
+    def setUp(self):
+        super(MockHadoopTestCase, self).setUp()
+        # setup fake hadoop home
+        hadoop_home = self.makedirs('mock_hadoop_home')
+        os.environ['HADOOP_HOME'] = hadoop_home
+        os.environ['MOCK_HADOOP_VERSION'] = "1.2.0"
+        os.environ['MOCK_HADOOP_TMP'] = self.makedirs('mock_hadoop_tmp')
+
+        # make fake hadoop binary
+        os.mkdir(os.path.join(hadoop_home, 'bin'))
+        self.hadoop_bin = os.path.join(hadoop_home, 'bin', 'hadoop')
+        create_mock_hadoop_script(self.hadoop_bin)
+
+        # make fake streaming jar
+        os.makedirs(os.path.join(hadoop_home, 'contrib', 'streaming'))
+        streaming_jar_path = os.path.join(
+            hadoop_home, 'contrib', 'streaming', 'hadoop-0.X.Y-streaming.jar')
+        open(streaming_jar_path, 'w').close()
+
+        # make sure the fake hadoop binaries can find mrjob
+        self.add_mrjob_to_pythonpath()
+
+
 # layout of $MOCK_HADOOP_TMP:
 #   cmd.log: single file containing one line per invocation of mock hadoop
 #     binary, with lines containing space-separated args passed

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -25,12 +25,14 @@ from zipfile import ZipFile
 from zipfile import ZIP_DEFLATED
 
 from mrjob.bin import MRJobBinRunner
+from mrjob.hadoop import HadoopJobRunner
 from mrjob.local import LocalMRJobRunner
 from mrjob.py2 import PY2
 from mrjob.step import GENERIC_ARGS
 from mrjob.step import INPUT
 from mrjob.step import OUTPUT
 
+from tests.mockhadoop import MockHadoopTestCase
 from tests.mr_cmd_job import MRCmdJob
 from tests.mr_filter_job import MRFilterJob
 from tests.mr_no_mapper import MRNoMapper
@@ -59,14 +61,14 @@ else:
     PYTHON_BIN = 'python3'
 
 
-class ArgsForSparkStepTestCase(SandboxedTestCase):
+class ArgsForSparkStepTestCase(MockHadoopTestCase):
     # just test the structure of _args_for_spark_step()
 
     def setUp(self):
         super(ArgsForSparkStepTestCase, self).setUp()
 
         self.mock_get_spark_submit_bin = self.start(patch(
-            'mrjob.bin.MRJobBinRunner.get_spark_submit_bin',
+            'mrjob.hadoop.HadoopJobRunner.get_spark_submit_bin',
             return_value=['<spark-submit bin>']))
 
         self.mock_spark_submit_args = self.start(patch(
@@ -82,7 +84,8 @@ class ArgsForSparkStepTestCase(SandboxedTestCase):
             return_value=['<spark script args>']))
 
     def _test_step(self, step_num):
-        job = MRNullSpark(['-r', 'local'])
+        # use Hadoop because it supports spark steps and local runner doesn't
+        job = MRNullSpark(['-r', 'hadoop'])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -56,6 +56,8 @@ from tests.mr_hadoop_format_job import MRHadoopFormatJob
 from tests.mr_jar_and_streaming import MRJarAndStreaming
 from tests.mr_just_a_jar import MRJustAJar
 from tests.mr_no_mapper import MRNoMapper
+from tests.mr_null_spark import MRNullSpark
+from tests.mr_spark_script import MRSparkScript
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
 from tests.py2 import call
@@ -2354,3 +2356,21 @@ class NetworkAndSubnetworkTestCase(MockGoogleTestCase):
             'https://www.googleapis.com/compute/v1/projects/%s'
             '/us-west1/subnetworks/test' % project_id)
         self.assertFalse(gce_config.network_uri)
+
+
+class UnsupportedStepsTestCase(MockGoogleTestCase):
+
+    def test_no_spark_steps(self):
+        # just a sanity check; _STEP_TYPES is tested in a lot of ways
+        job = MRNullSpark(['-r', 'dataproc'])
+        job.sandbox()
+
+        self.assertRaises(NotImplementedError, job.make_runner)
+
+    def test_no_jar_steps(self):
+        spark_script_path = self.makefile('chispa.py')
+
+        job = MRSparkScript(['-r', 'dataproc', '--script', spark_script_path])
+        job.sandbox()
+
+        self.assertRaises(NotImplementedError, job.make_runner)

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -33,9 +33,9 @@ from mrjob.util import which
 
 from tests.mockhadoop import add_mock_hadoop_counters
 from tests.mockhadoop import add_mock_hadoop_output
-from tests.mockhadoop import create_mock_hadoop_script
 from tests.mockhadoop import get_mock_hadoop_cmd_args
 from tests.mockhadoop import get_mock_hdfs_root
+from tests.mockhadoop import MockHadoopTestCase
 from tests.mr_jar_and_streaming import MRJarAndStreaming
 from tests.mr_jar_with_generic_args import MRJarWithGenericArgs
 from tests.mr_just_a_jar import MRJustAJar
@@ -60,31 +60,6 @@ try:
     pty
 except ImportError:
     pty = Mock()
-
-
-class MockHadoopTestCase(SandboxedTestCase):
-
-    def setUp(self):
-        super(MockHadoopTestCase, self).setUp()
-        # setup fake hadoop home
-        hadoop_home = self.makedirs('mock_hadoop_home')
-        os.environ['HADOOP_HOME'] = hadoop_home
-        os.environ['MOCK_HADOOP_VERSION'] = "1.2.0"
-        os.environ['MOCK_HADOOP_TMP'] = self.makedirs('mock_hadoop_tmp')
-
-        # make fake hadoop binary
-        os.mkdir(os.path.join(hadoop_home, 'bin'))
-        self.hadoop_bin = os.path.join(hadoop_home, 'bin', 'hadoop')
-        create_mock_hadoop_script(self.hadoop_bin)
-
-        # make fake streaming jar
-        os.makedirs(os.path.join(hadoop_home, 'contrib', 'streaming'))
-        streaming_jar_path = os.path.join(
-            hadoop_home, 'contrib', 'streaming', 'hadoop-0.X.Y-streaming.jar')
-        open(streaming_jar_path, 'w').close()
-
-        # make sure the fake hadoop binaries can find mrjob
-        self.add_mrjob_to_pythonpath()
 
 
 class TestFullyQualifyHDFSPath(BasicTestCase):

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -32,6 +32,9 @@ from mrjob.inline import InlineMRJobRunner
 from mrjob.job import MRJob
 
 from tests.examples.test_mr_phone_to_url import write_conversion_record
+from tests.mr_cmd_job import MRCmdJob
+from tests.mr_filter_job import MRFilterJob
+from tests.mr_null_spark import MRNullSpark
 from tests.mr_test_cmdenv import MRTestCmdenv
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.sandbox import EmptyMrjobConfTestCase
@@ -222,3 +225,25 @@ class WhileReadingFromTestCase(SandboxedTestCase):
 
     def test_input_manifest(self):
         self._test_reading_from(MRManifestNope, expect_input_path=True)
+
+
+class UnsupportedStepsTestCase(SandboxedTestCase):
+
+    def test_no_command_steps(self):
+        job = MRCmdJob(['-r', 'inline', '--mapper-cmd', 'cat'])
+        job.sandbox()
+
+        self.assertRaises(NotImplementedError, job.make_runner)
+
+    def test_no_pre_filters(self):
+        job = MRFilterJob(['-r', 'inline', '--mapper-filter', 'grep foo'])
+        job.sandbox()
+
+        self.assertRaises(NotImplementedError, job.make_runner)
+
+    def test_no_spark_jobs(self):
+        # just a sanity check; _STEP_TYPES is tested in a lot of ways
+        job = MRNullSpark(['-r', 'inline'])
+        job.sandbox()
+
+        self.assertRaises(NotImplementedError, job.make_runner)

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -241,7 +241,7 @@ class UnsupportedStepsTestCase(SandboxedTestCase):
 
         self.assertRaises(NotImplementedError, job.make_runner)
 
-    def test_no_spark_jobs(self):
+    def test_no_spark_steps(self):
         # just a sanity check; _STEP_TYPES is tested in a lot of ways
         job = MRNullSpark(['-r', 'inline'])
         job.sandbox()

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -48,6 +48,8 @@ from tests.mr_exit_42_job import MRExit42Job
 from tests.mr_filter_job import MRFilterJob
 from tests.mr_group import MRGroup
 from tests.mr_job_where_are_you import MRJobWhereAreYou
+from tests.mr_just_a_jar import MRJustAJar
+from tests.mr_null_spark import MRNullSpark
 from tests.mr_sort_and_group import MRSortAndGroup
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
@@ -1024,3 +1026,21 @@ class LocalInputManifestTestCase(InlineInputManifestTestCase):
             self.EXPECTED_OUTPUT)
 
         self.assertTrue(exists(touched_path))
+
+
+class UnsupportedStepsTestCase(SandboxedTestCase):
+
+    def test_no_spark_steps(self):
+        # just a sanity check; _STEP_TYPES is tested in a lot of ways
+        job = MRNullSpark(['-r', 'local'])
+        job.sandbox()
+
+        self.assertRaises(NotImplementedError, job.make_runner)
+
+    def test_no_jar_steps(self):
+        jar_path = self.makefile('dora.jar')
+
+        job = MRJustAJar(['-r', 'local', '--jar', jar_path])
+        job.sandbox()
+
+        self.assertRaises(NotImplementedError, job.make_runner)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -975,7 +975,7 @@ class MRCatsJob(MRJob):
         return [MRStep(mapper_cmd='cat')] * self.options.num_cats
 
 
-class PassStepsToRunnerTestCase(MockBoto3TestCase):
+class PassStepsToRunnerTestCase(BasicTestCase):
 
     def setUp(self):
         super(PassStepsToRunnerTestCase, self).setUp()
@@ -1035,6 +1035,9 @@ class PassStepsToRunnerTestCase(MockBoto3TestCase):
         self.assertRaises(ValueError, runner.run)
 
         self.assertFalse(self.log.warning.called)
+
+
+class TestStepsWithoutMRJobScript(MockBoto3TestCase):
 
     def test_classic_streaming_step_without_mr_job_script(self):
         # classic MRJob mappers and reducers require a MRJob script

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -31,6 +31,7 @@ from mrjob.examples.mr_phone_to_url import MRPhoneToURL
 from mrjob.inline import InlineMRJobRunner
 from mrjob.local import LocalMRJobRunner
 from mrjob.job import MRJob
+from mrjob.runner import MRJobRunner
 from mrjob.step import MRStep
 from mrjob.tools.emr.audit_usage import _JOB_KEY_RE
 from mrjob.util import to_lines
@@ -1089,3 +1090,21 @@ class TestStepsWithoutMRJobScript(MockBoto3TestCase):
 
         runner.run()
         runner.cleanup()
+
+
+class UnsupportedStepsTestCase(MockBoto3TestCase):
+
+    def test_base_classes_cant_have_steps(self):
+        steps = MRTwoStepJob()._steps_desc()
+
+        self.assertRaises(NotImplementedError, MRJobRunner, steps=steps)
+
+    def test_unknown_step_type(self):
+        steps = [dict(type='cameloop')]  # great name for your ML startup?
+
+        self.assertRaises(NotImplementedError, EMRJobRunner, steps=steps)
+
+    def test_malformed_step(self):
+        steps = [dict(foo='bar')]
+
+        self.assertRaises(NotImplementedError, EMRJobRunner, steps=steps)


### PR DESCRIPTION
Made `_check_steps()` much more robust. This keeps sim runners from pretending to run non-streaming step types (#1915), keeps the inline runner from trying and failing to run commands (#1878), and makes the Dataproc runner fail fast if passed Spark steps.

`_check_steps()` now raises `NotImplementedError` if it encounters steps unsupported by a particular runner, and `ValueError` if it encounters steps that don't make sense on any runner.