### PR TITLE
warn about command-line opts for the wrong runner

### DIFF
--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -26,6 +26,7 @@ from argparse import ArgumentTypeError
 
 from mrjob.conf import combine_dicts
 from mrjob.conf import combine_lists
+from mrjob.options import _RUNNER_OPTS
 from mrjob.options import _add_basic_args
 from mrjob.options import _add_job_args
 from mrjob.options import _add_runner_args
@@ -480,7 +481,8 @@ class MRJobLauncher(object):
         # magic to the runner
         return combine_dicts(
             self._non_option_kwargs(),
-            self._kwargs_from_switches(self._runner_opt_names()),
+            # don't screen out irrelevant opts (see #1898)
+            self._kwargs_from_switches(set(_RUNNER_OPTS)),
             self._job_kwargs(),
         )
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -414,7 +414,6 @@ class MRJobRunner(object):
         results = {}
 
         for k, v in sorted(opts.items()):
-
             # rewrite deprecated aliases
             if k in deprecated_aliases:
                 if v is None:  # don't care
@@ -433,7 +432,7 @@ class MRJobRunner(object):
 
             if k in self.OPT_NAMES:
                 results[k] = None if v is None else self._fix_opt(k, v, source)
-            else:
+            elif v:
                 log.warning('Unexpected option %s (from %s)' % (k, source))
 
         return results

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -29,6 +29,7 @@ from mrjob.conf import combine_envs
 from mrjob.job import MRJob
 from mrjob.job import UsageError
 from mrjob.job import _im_func
+from mrjob.options import _RUNNER_OPTS
 from mrjob.parse import parse_mr_job_stderr
 from mrjob.protocol import BytesValueProtocol
 from mrjob.protocol import JSONProtocol
@@ -1355,7 +1356,7 @@ class RunnerKwargsTestCase(BasicTestCase):
         self.assertEqual(
             option_names,
             # libjars can be set by the job
-            (runner_class.OPT_NAMES -
+            (set(_RUNNER_OPTS) -
              self.CONF_ONLY_OPTIONS)
         )
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1119,6 +1119,13 @@ class UnexpectedOptsWarningTestCase(SandboxedTestCase):
 
         self.log = self.start(patch('mrjob.runner.log'))
 
+    def test_no_warning_by_default(self):
+        job = MRTwoStepJob(['-r', 'local', '--no-conf'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertFalse(self.log.warning.called)
+
     def test_unexpected_opt_from_mrjob_conf(self):
         conf_path = self.makefile('mrjob.custom.conf')
 


### PR DESCRIPTION
Runners now log an "Unexpected option" warning if you use a command-line switch that corresponds to an option it doesn't support. Fixes #1898.

Also added unit tests for this warning.