### PR TITLE
Spark setup scripts on YARN

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -384,7 +384,9 @@ Job execution context
 
     Name/path of alternate shell binary to use for :mrjob-opt:`setup` and
     :mrjob-opt:`bootstrap`. Needs to be backwards compatible with
-    Bourne Shell (e.g. ``'sh'``, ``'bash'``, ``'zsh'``).
+    Bourne Shell (e.g. :command:`bash`, :command:`zsh`). If you want
+    to add arguments, use an absolute path (:command:`/bin/bash -x`, not
+    :command:`bash -x`).
 
     This is also used to wrap mappers, reducers, etc. that require piping
     one command into another (see e.g.

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -384,9 +384,12 @@ Job execution context
 
     Name/path of alternate shell binary to use for :mrjob-opt:`setup` and
     :mrjob-opt:`bootstrap`. Needs to be backwards compatible with
-    Bourne Shell (e.g. :command:`bash`, :command:`zsh`). If you want
-    to add arguments, use an absolute path (:command:`/bin/bash -x`, not
-    :command:`bash -x`).
+    Bourne Shell (e.g. :command:`bash`, :command:`zsh`).
+
+    If you want to add an argument, use an absolute path
+    (:command:`/bin/bash -x`, not :command:`bash -x`). Please do not pass
+    multiple args to your shell binary (this plays poorly with Linux
+    shebang syntax).
 
     This is also used to wrap mappers, reducers, etc. that require piping
     one command into another (see e.g.

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -426,11 +426,7 @@ class MRJobBinRunner(MRJobRunner):
         """
         setup = self._setup
 
-        # add py_files
-        for py_file in self._py_files():
-            path_dict = {'type': 'file', 'name': None, 'path': py_file}
-            self._working_dir_mgr.add(**path_dict)
-            setup = [['export PYTHONPATH=', path_dict, ':$PYTHONPATH']] + setup
+        setup = self._py_files_setup() + setup
 
         if setup and not self._setup_wrapper_script_path:
 
@@ -452,6 +448,18 @@ class MRJobBinRunner(MRJobRunner):
 
             self._manifest_setup_script_path = path
             self._working_dir_mgr.add('file', self._manifest_setup_script_path)
+
+    def _py_files_setup(self):
+        """A list of additional setup commands to emulate Spark's
+        --py-files option on Hadoop Streaming."""
+        result = []
+
+        for py_file in self._py_files():
+            path_dict = {'type': 'file', 'name': None, 'path': py_file}
+            self._working_dir_mgr.add(**path_dict)
+            result.append(['export PYTHONPATH=', path_dict, ':$PYTHONPATH'])
+
+        return result
 
     def _create_mrjob_zip(self):
         """Make a zip of the mrjob library, without .pyc or .pyo files,

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -453,8 +453,8 @@ class MRJobBinRunner(MRJobRunner):
         if not self._setup:
             return False  # nothing to do
 
-        # setup scripts definitely don't work with local mode (see #1376)
-        if (self._spark_master() or '').startswith('local'):
+        # for now, we only support setup scripts on YARN (see #1376)
+        if self._spark_master() != 'yarn':
             return False
 
         return True

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -117,7 +117,10 @@ class MRJobBinRunner(MRJobRunner):
             # make this a hard requirement in v0.7.0?
             if len(opt_value) > 1 and not os.path.isabs(opt_value[0]):
                 log.warning('sh_bin (from %s) should use an absolute path'
-                            ' if you want it to take arguments')
+                            ' if you want it to take arguments' % source)
+            elif len(opt_value) > 2:
+                log.warning('sh_bin (from %s) should not take more than one'
+                            ' argument' % source)
 
         return opt_value
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -28,6 +28,7 @@ from subprocess import PIPE
 
 import mrjob.step
 from mrjob.compat import translate_jobconf
+from mrjob.conf import combine_cmds
 from mrjob.conf import combine_dicts
 from mrjob.conf import combine_local_envs
 from mrjob.py2 import PY2
@@ -111,14 +112,16 @@ class MRJobBinRunner(MRJobRunner):
             opt_key, opt_value, source)
 
         if opt_key == 'sh_bin':
-            if len(opt_value) == 0:
-                raise ValueError('sh_bin (from %s) may not be empty!' % source)
+            # opt_value is usually a string, combiner makes it a list of args
+            sh_bin = combine_cmds(opt_value)
 
-            # make this a hard requirement in v0.7.0?
-            if len(opt_value) > 1 and not os.path.isabs(opt_value[0]):
+            if len(sh_bin) == 0:
+                raise ValueError('sh_bin (from %s) may not be empty!' % source)
+            # make these hard requirements in v0.7.0?
+            elif len(sh_bin) > 1 and not os.path.isabs(sh_bin[0]):
                 log.warning('sh_bin (from %s) should use an absolute path'
                             ' if you want it to take arguments' % source)
-            elif len(opt_value) > 2:
+            elif len(sh_bin) > 2:
                 log.warning('sh_bin (from %s) should not take more than one'
                             ' argument' % source)
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -859,16 +859,17 @@ class MRJobBinRunner(MRJobRunner):
         return self._opts.get('spark_deploy_mode') or None
 
     def _spark_upload_args(self):
-        # TODO: will need a solution for Spark installations without --archives
+        # if using a setup script, upload all files to working dir
         if self._spark_python_wrapper_path:
             return self._upload_args_helper('--files', None,
                                             '--archives', None)
         else:
+            # otherwise, just pass through --files and --archives
             return self._upload_args_helper('--files', self._spark_files,
                                             '--archives', self._spark_archives)
 
     def _spark_script_path(self, step_num):
-        """The path of the spark script or har, used by
+        """The path of the spark script or JAR, used by
         _args_for_spark_step()."""
         step = self._get_step(step_num)
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -438,7 +438,8 @@ class MRJobBinRunner(MRJobRunner):
 
                 self._manifest_setup_script_path = self._write_setup_script(
                     streaming_setup, 'manifest-setup.sh',
-                    'manifest setup wrapper script')
+                    'manifest setup wrapper script',
+                    manifest=True)
 
         if (self._uses_spark_setup_script() and not
                 self._spark_python_wrapper_path):

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -573,9 +573,13 @@ class MRJobBinRunner(MRJobRunner):
             if os.path.isabs(sh_bin[0]):
                 shebang_bin = sh_bin
             else:
-                # Linux only allows one argument to shebangs
-                # (warning already issued by :py:meth:`_fix_opt`
-                shebang_bin = ['/usr/bin/env', sh_bin[0]]
+                shebang_bin = ['/usr/bin/env'] + list(sh_bin)
+
+            if len(shebang_bin) > 2:
+                # Linux limits shebang to one binary and one arg
+                shebang_bin = shebang_bin[:2]
+                log.warning('Limiting shebang to two arguments:'
+                            '#!%s' % cmd_line(shebang_bin))
 
             lines.append('#!%s' % cmd_line(shebang_bin))
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -243,10 +243,8 @@ class MRJobRunner(object):
         # set of dir_archives that have actually been created
         self._dir_archives_created = set()
 
-        # track (name, path) of files and archives to upload to spark.
-        # these are a subset of those in self._working_dir_mgr
-        #
-        # TODO: these might go away now that Spark does setup scripts too
+        # track (name, path) of files and archives to upload to spark
+        # if not using a setup script.
         self._spark_files = []
         self._spark_archives = []
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -48,6 +48,7 @@ from mrjob.setup import parse_legacy_hash_path
 from mrjob.step import OUTPUT
 from mrjob.step import STEP_TYPES
 from mrjob.step import _is_spark_step_type
+from mrjob.step import _is_pyspark_step_type
 from mrjob.util import to_lines
 
 
@@ -845,8 +846,21 @@ class MRJobRunner(object):
         return bool(self._get_step(0).get('input_manifest'))
 
     def _has_spark_steps(self):
-        """Are any of our steps Spark steps (either spark or spark_script)"""
+        """Are any of our steps Spark steps? (e.g. spark, spark_jar,
+        spark_script)
+
+        Generally used to determine if we need to install Spark on a cluster.
+        """
         return any(_is_spark_step_type(step['type'])
+                   for step in self._get_steps())
+
+    def _has_pyspark_steps(self):
+        """Do any of our steps involve running Python on Spark?
+        Includes spark and spark_script types, but not spark_jar.
+
+        Generally used to tell if we need a Spark setup script.
+        """
+        return any(_is_pyspark_step_type(step['type'])
                    for step in self._get_steps())
 
     def _args_for_task(self, step_num, mrc):

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -845,6 +845,11 @@ class MRJobRunner(object):
         """Does the first step take an input manifest?"""
         return bool(self._get_step(0).get('input_manifest'))
 
+    def _has_streaming_steps(self):
+        """Are any of our steps Hadoop Streaming steps?"""
+        return any(step['type'] == 'streaming'
+                   for step in self._get_steps())
+
     def _has_spark_steps(self):
         """Are any of our steps Spark steps? (e.g. spark, spark_jar,
         spark_script)

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -244,6 +244,8 @@ class MRJobRunner(object):
 
         # track (name, path) of files and archives to upload to spark.
         # these are a subset of those in self._working_dir_mgr
+        #
+        # TODO: these might go away now that Spark does setup scripts too
         self._spark_files = []
         self._spark_archives = []
 

--- a/mrjob/step.py
+++ b/mrjob/step.py
@@ -496,3 +496,8 @@ class SparkScriptStep(_Step):
 def _is_spark_step_type(step_type):
     """Does the given step type indicate that it uses Spark?"""
     return step_type.split('_')[0] == 'spark'
+
+
+def _is_pyspark_step_type(step_type):
+    """Does the given step type indicate that it uses Spark and Python?"""
+    return step_type in ('spark', 'spark_script')

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -350,8 +350,6 @@ _SWITCH_ALIASES = {
 _HARD_CODED_OPTS = dict(
     check_input_paths=False,
     output_dir=None,
-    setup=None,  # currently does nothing on Spark
-    task_python_bin=None,  # without setup, same as python_bin
 )
 
 

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -215,10 +215,11 @@ _SPARK_SUBMIT_ARG_GROUPS = [
         'executor_cores',
     ]),
     ('YARN-only', [
-        'queue_name',
-        'num_executors',
+        'setup',
         'upload_archives',
         'upload_dirs',
+        'queue_name',
+        'num_executors',
         'principal',
         'keytab',
     ]),
@@ -273,6 +274,12 @@ _SPARK_SUBMIT_ARG_HELP = dict(
     queue_name='The YARN queue to submit to (Default: "default").',
     repositories=('Comma-separated list of additional remote repositories to'
                   ' search for the maven coordinates given with --packages.'),
+    setup=('A command to run before each Spark executor in the'
+           ' shell ("touch foo"). In cluster mode, runs before the Spark'
+           ' driver as well. You may interpolate files'
+           ' available via URL or on your local filesystem using'
+           ' Hadoop Distributed Cache syntax (". setup.sh#"). To'
+           ' interpolate archives, use #/: "cd foo.tar.gz#/; make.'),
     spark_deploy_mode=('Whether to launch the driver program locally'
                        ' ("client") or on one of the worker machines inside'
                        ' the cluster ("cluster") (Default: client).'),
@@ -318,6 +325,7 @@ _SPARK_SUBMIT_SWITCHES = dict(
     py_files='--py-files',
     queue_name='--queue',
     repositories='--repositories',
+    setup='--setup',
     spark_deploy_mode='--deploy-mode',
     spark_master='--master',
     supervise='--supervise',

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -179,7 +179,6 @@ _DEFAULT_RUNNER = 'hadoop'
 # argument group in _make_basic_help_parser(), below
 _SPARK_SUBMIT_ARG_GROUPS = [
     (None, [
-        'spark_deploy_mode',
         'main_class',
         'name',
         'libjars',
@@ -200,6 +199,7 @@ _SPARK_SUBMIT_ARG_GROUPS = [
     ]),
     ('Hadoop runner only', [
         'spark_master',
+        'spark_deploy_mode',
     ]),
     ('Cluster deploy mode only', [
         'driver_cores',

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1291,6 +1291,22 @@ class SparkSubmitArgsTestCase(AllowSparkOnLocalRunnerTestCase):
                 self._expected_conf_args(
                     cmdenv=dict(PYSPARK_PYTHON='ourpy')))
 
+    def test_spark_cmdenv_method(self):
+        # test that _spark_submit_args() uses _spark_cmdenv(),
+        # so we can just test _spark_cmdenv() in other test cases
+        hard_coded_env = dict(FOO='bar')
+
+        self.start(patch('mrjob.local.LocalMRJobRunner._spark_cmdenv',
+                         return_value=hard_coded_env, create=True))
+
+        job = MRNullSpark(['-r', 'local'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_submit_args(0),
+                self._expected_conf_args(cmdenv=hard_coded_env))
+
     def test_jobconf(self):
         job = MRNullSpark(['-r', 'local',
                            '-D', 'spark.executor.memory=10g'])

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1888,3 +1888,34 @@ class SparkPythonSetupWrapperTestCase(MockHadoopTestCase):
 
         self.assertIsNone(self._get_python_wrapper_content(
             MRJustAJar, ['--jar', jar_path, '--setup', 'true']))
+
+
+class ShBinValidationTestCase(SandboxedTestCase):
+
+    def setUp(self):
+        super(ShBinValidationTestCase, self).setUp()
+
+        self.log = self.start(patch('mrjob.bin.log'))
+
+    def test_empty_sh_bin(self):
+        self.assertRaises(ValueError, MRJobBinRunner, sh_bin=[])
+
+    def test_absolute_sh_bin(self):
+        runner = MRJobBinRunner(sh_bin=['/bin/zsh'])
+
+        self.assertFalse(self.log.warning.called)
+
+    def test_absolute_sh_bin_with_args(self):
+        runner = MRJobBinRunner(sh_bin=['/bin/zsh', '-v'])
+
+        self.assertFalse(self.log.warning.called)
+
+    def test_relative_sh_bin(self):
+        runner = MRJobBinRunner(sh_bin=['zsh'])
+
+        self.assertFalse(self.log.warning.called)
+
+    def test_relative_sh_bin_with_args(self):
+        runner = MRJobBinRunner(sh_bin=['zsh', '-v'])
+
+        self.assertTrue(self.log.warning.called)

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1905,17 +1905,22 @@ class ShBinValidationTestCase(SandboxedTestCase):
 
         self.assertFalse(self.log.warning.called)
 
-    def test_absolute_sh_bin_with_args(self):
+    def test_absolute_sh_bin_with_one_arg(self):
         runner = MRJobBinRunner(sh_bin=['/bin/zsh', '-v'])
 
         self.assertFalse(self.log.warning.called)
+
+    def test_absolute_sh_bin_with_two_args(self):
+        runner = MRJobBinRunner(sh_bin=['/bin/zsh', '-v', '-x'])
+
+        self.assertTrue(self.log.warning.called)
 
     def test_relative_sh_bin(self):
         runner = MRJobBinRunner(sh_bin=['zsh'])
 
         self.assertFalse(self.log.warning.called)
 
-    def test_relative_sh_bin_with_args(self):
+    def test_relative_sh_bin_with_one_arg(self):
         runner = MRJobBinRunner(sh_bin=['zsh', '-v'])
 
         self.assertTrue(self.log.warning.called)

--- a/tests/tools/test_spark_submit.py
+++ b/tests/tools/test_spark_submit.py
@@ -258,18 +258,12 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
         self.assertEqual(kwargs['check_input_paths'], False)
         self.assertEqual(kwargs['input_paths'], [os.devnull])
         self.assertEqual(kwargs['output_dir'], None)
-        self.assertEqual(kwargs['setup'], None)
-        self.assertEqual(kwargs['task_python_bin'], None)
 
     def test_no_switches_for_hard_coded_kwargs(self):
         self.assertRaises(MockSystemExit, spark_submit_main,
                           ['--check-input-paths', 'foo.py', 'arg1'])
         self.assertRaises(MockSystemExit, spark_submit_main,
                           ['--output-dir', 'out', 'foo.py', 'arg1'])
-        self.assertRaises(MockSystemExit, spark_submit_main,
-                          ['--setup', 'true', 'foo.py', 'arg1'])
-        self.assertRaises(MockSystemExit, spark_submit_main,
-                          ['--task-python-bin', 'pypy', 'foo.py', 'arg1'])
 
     def _assert_prints_basic_help(self, args, include_deprecated=False):
         self.assertRaises(MockSystemExit, spark_submit_main, args)


### PR DESCRIPTION
This makes `--setup` work when running Spark on YARN by wrapping the Python binary. Fixes #1376.
