### PR TITLE
default sh_bin to /bin/sh -ex in all runners

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -380,7 +380,7 @@ Job execution context
     :switch: --sh-bin
     :type: :ref:`command <data-type-command>`
     :set: all
-    :default: :command:`sh -ex` (with exceptions below)
+    :default: :command:`/bin/sh -ex`
 
     Name/path of alternate shell binary to use for :mrjob-opt:`setup` and
     :mrjob-opt:`bootstrap`. Needs to be backwards compatible with
@@ -390,15 +390,17 @@ Job execution context
     one command into another (see e.g.
     :py:meth:`~mrjob.job.MRJob.mapper_pre_filter`).
 
-    On Dataproc and EMR, this defaults to :command:`/bin/sh -ex`.
-
     .. versionchanged:: 0.5.9
 
-       Starting with EMR AMI 5.2.0, :command:`sh -e` is broken, so we
+       Starting with EMR AMI 5.2.0, :command:`/bin/sh -e` is broken, so we
        emulate the :command:`-e` switch by using :command:`/bin/sh -x` as our
        shell, and prepending :command:`set -e` to any shell script generated
        by mrjob. :command:`set -e` is not prepended if you
        set *sh_bin* yourself; you could add it with :mrjob-opt:`setup`.
+
+    .. versionchanged:: 0.6.7
+
+       Used to be :command:`sh -ex` on local and Hadoop runners
 
 .. mrjob-opt::
     :config: steps_interpreter

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -94,7 +94,7 @@ class MRJobBinRunner(MRJobRunner):
             super(MRJobBinRunner, self)._default_opts(),
             dict(
                 read_logs=True,
-                sh_bin=['sh', '-ex'],
+                sh_bin=['/bin/sh', '-ex'],
             )
         )
 

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -355,7 +355,6 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 master_instance_type=_DEFAULT_INSTANCE_TYPE,
                 num_core_instances=_DATAPROC_MIN_WORKERS,
                 num_task_instances=0,
-                sh_bin=['/bin/sh', '-ex'],
             )
         )
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -462,7 +462,7 @@ class RenderSubstepTestCase(SandboxedTestCase):
             # note that local mode uses sys.executable, not python/python3
             self.assertEqual(
                 runner._render_substep(0, 'mapper'),
-                'sh -ex setup-wrapper.sh %s mr_two_step_job.py'
+                '/bin/sh -ex setup-wrapper.sh %s mr_two_step_job.py'
                 ' --step-num=0 --mapper' % sys.executable
             )
 
@@ -513,7 +513,7 @@ class RenderSubstepTestCase(SandboxedTestCase):
         with job.make_runner() as runner:
             self.assertEqual(
                 runner._render_substep(0, mrc),
-                "sh -ex -c 'cat |"
+                "/bin/sh -ex -c 'cat |"
                 " %s mr_filter_job.py --step-num=0 --%s"
                 " --%s-filter cat'" %
                 (sys.executable, mrc, mrc))
@@ -554,7 +554,7 @@ class RenderSubstepTestCase(SandboxedTestCase):
         with job.make_runner() as runner:
             self.assertEqual(
                 runner._render_substep(0, 'mapper'),
-                "sh -ex -c 'set -v;"
+                "/bin/sh -ex -c 'set -v;"
                 " cat | %s mr_filter_job.py --step-num=0 --mapper"
                 " --mapper-filter cat'" % sys.executable)
 

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -880,13 +880,13 @@ class StreamingArgsTestCase(EmptyMrjobConfTestCase):
             self.runner._args_for_streaming_step(0),
             (self.BASIC_HADOOP_ARGS + self.BASIC_JOB_ARGS + [
              '-mapper',
-             "sh -ex -c 'grep anything | " + PYTHON_BIN +
+             "/bin/sh -ex -c 'grep anything | " + PYTHON_BIN +
              " my_job.py --step-num=0 --mapper'",
              '-combiner',
-             "sh -ex -c 'grep nothing | " + PYTHON_BIN +
+             "/bin/sh -ex -c 'grep nothing | " + PYTHON_BIN +
              " my_job.py --step-num=0 --combiner'",
              '-reducer',
-             "sh -ex -c 'grep something | " + PYTHON_BIN +
+             "/bin/sh -ex -c 'grep something | " + PYTHON_BIN +
              " my_job.py --step-num=0 --reducer'"]))
 
     def test_pre_filter_escaping(self):
@@ -907,7 +907,7 @@ class StreamingArgsTestCase(EmptyMrjobConfTestCase):
              ['-D', 'mapreduce.job.reduces=0'] +
              self.BASIC_JOB_ARGS + [
                  '-mapper',
-                 "sh -ex -c 'bash -c '\\''grep"
+                 "/bin/sh -ex -c 'bash -c '\\''grep"
                  " '\\''\\'\\'''\\''anything'\\''\\'\\'''\\'''\\'' | " +
                  PYTHON_BIN +
                  " my_job.py --step-num=0 --mapper'"]))


### PR DESCRIPTION
For local and Hadoop runners it was just `sh -ex`, which is tricky to use in a shebang (see #1376). Fixes #1924.

`/bin/sh` is considered compatible across platforms, so this change shouldn't break anything.