### PR TITLE
fix deprecated escape sequences in regexes and docstrings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,17 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
   - "3.8-dev"
   - "nightly"
 matrix:
   allow_failures:
     - python: "3.8-dev"
     - python: "nightly"
+  include:
+    - python: '3.7'
+      dist: xenial
+    - python: '3.8-dev'
+      dist: xenial
   fast_finish: true
 install:
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,14 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.8-dev"
-  - "nightly"
 matrix:
-  allow_failures:
-    - python: "3.8-dev"
-    - python: "nightly"
   include:
     - python: '3.7'
       dist: xenial
+  allow_failures:
     - python: '3.8-dev'
       dist: xenial
+    - python: "nightly"
   fast_finish: true
 install:
   - "pip install ."

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -711,7 +711,7 @@ class MRJobBinRunner(MRJobRunner):
             lines.append('    *.%s)' % ext)
             lines.append('      %s $INPUT_PATH' % cmd)
             lines.append("      INPUT_PATH="
-                         "$(echo $INPUT_PATH | sed -e 's/\.%s$//')" % ext)
+                         r"$(echo $INPUT_PATH | sed -e 's/\.%s$//')" % ext)
             lines.append('      ;;')
         lines.append('  esac')
         lines.append('} 1>&2')

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -116,7 +116,7 @@ _CONTAINER_EXIT_RE = re.compile(
     r'Exit code from container (?P<container_id>\w+)'
     r' is ?: (?P<returncode>\d+)')
 
-_TRACEBACK_EXCEPTION_RE = re.compile('\w+: .*$')
+_TRACEBACK_EXCEPTION_RE = re.compile(r'\w+: .*$')
 
 _STDERR_LOG4J_WARNING = re.compile(
     r'.*(No appenders could be found for logger'
@@ -170,7 +170,7 @@ def _wait_for(msg, sleep_secs):
 
 
 def _cleanse_gcp_job_id(job_id):
-    return re.sub('[^a-zA-Z0-9_\-]', '-', job_id)
+    return re.sub(r'[^a-zA-Z0-9_\-]', '-', job_id)
 
 
 def _check_and_fix_fs_dir(gcs_uri):

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -80,14 +80,14 @@ _FALLBACK_HADOOP_YARN_LOG_DIRS = [
 ]
 
 # start of Counters printed by Hadoop
-_HADOOP_COUNTERS_START_RE = re.compile(b'^Counters: (?P<amount>\d+)\s*$')
+_HADOOP_COUNTERS_START_RE = re.compile(br'^Counters: (?P<amount>\d+)\s*$')
 
 # header for a group of counters
-_HADOOP_COUNTER_GROUP_RE = re.compile(b'^(?P<indent>\s+)(?P<group>.*)$')
+_HADOOP_COUNTER_GROUP_RE = re.compile(br'^(?P<indent>\s+)(?P<group>.*)$')
 
 # line for a counter
 _HADOOP_COUNTER_RE = re.compile(
-    b'^(?P<indent>\s+)(?P<counter>.*)=(?P<amount>\d+)\s*$')
+    br'^(?P<indent>\s+)(?P<counter>.*)=(?P<amount>\d+)\s*$')
 
 # the one thing Hadoop streaming prints to stderr not in log format
 _HADOOP_NON_LOG_LINE_RE = re.compile(r'^Streaming Command Failed!')

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -37,7 +37,7 @@ class InlineMRJobRunner(SimMRJobRunner):
     This is the default way to run jobs (we assume you'll spend some time
     debugging your job before you're ready to run it on EMR or Hadoop).
 
-    Unlike other runners, ``InlineMRJobRunner``\ 's ``run()`` method
+    Unlike other runners, ``InlineMRJobRunner``\\'s ``run()`` method
     raises the actual exception that caused a step to fail (rather than
     :py:class:`~mrjob.step.StepFailedException`).
 

--- a/mrjob/logs/history.py
+++ b/mrjob/logs/history.py
@@ -334,7 +334,7 @@ def _parse_pre_yarn_history_log(lines):
 
 
 def _parse_pre_yarn_history_records(lines):
-    """Yield records from the given sequence of lines. For example,
+    r"""Yield records from the given sequence of lines. For example,
     a line like this:
 
     Task TASKID="task_201512311928_0001_m_000003" \

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 ### URI PARSING ###
 
 def is_uri(uri):
-    """Return True if *uri* is a URI and contains ``://``
+    r"""Return True if *uri* is a URI and contains ``://``
     (we only care about URIs that can describe files)
 
     .. versionchanged:: 0.5.7

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -24,8 +24,8 @@ that all non-byte strings be unicode. But that doesn't really make sense for
 Python 2, where str (bytes) and unicode can be used interchangeably.
 
 So really our string datatypes fall into two categories, bytes, and
-"strings", which means either ``unicode``\s or ASCII ``str``\s in
-Python 2, and ``str``\s (i.e. unicode) in Python 3.
+"strings", which means either ``unicode``\\s or ASCII ``str``\\s in
+Python 2, and ``str``\\s (i.e. unicode) in Python 3.
 
 These things should always be bytes:
 

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -129,7 +129,7 @@ def _runner_kwargs(options):
 
 
 def _clusters_to_stats(clusters, now=None):
-    """Aggregate statistics for several clusters into a dictionary.
+    r"""Aggregate statistics for several clusters into a dictionary.
 
     :param clusters: a sequence of dicts with the keys ``bootstrap_actions``,
                      ``cluster``, ``steps``.
@@ -354,7 +354,7 @@ def _cluster_to_basic_summary(cluster, now=None):
 
 
 def _cluster_to_usage_data(cluster, basic_summary=None, now=None):
-    """Break billing/usage information for a cluster down by job.
+    r"""Break billing/usage information for a cluster down by job.
 
     :param cluster: a :py:mod:`boto3` cluster data structure
     :param basic_summary: a basic summary of the cluster, returned by

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -119,7 +119,7 @@ Options::
                         tickets and the delegation tokens periodically.
 
 This also supports the same runner-specific switches as
-:py:class:`~mrjob.job.MRJob`\s (e.g. ``--hadoop-bin``, ``--region``).
+:py:class:`~mrjob.job.MRJob`\\s (e.g. ``--hadoop-bin``, ``--region``).
 
 .. versionadded:: 0.6.7
 """


### PR DESCRIPTION
This fixes some warnings that came up in Python 3.7. Fixes #1920.

This also updates the Travis CI config to run unit tests on a non-dev version of Python 3.7.