### PR TITLE
Bug Fix: Recursively merge extra_cluster_params dict

### DIFF
--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -410,8 +410,16 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
     def _add_extra_cluster_params(self, params):
         """Return a dict with the *extra_cluster_params* opt patched into
         *params*, and ``None`` values removed."""
+        def recursive_dict_merge(base, new_dict):
+           """Merged new_dict into base recursively at each value"""
+           for key in new_dict:
+                if key in base and isinstance(base[key], dict) and isinstance(new_dict[key], dict):
+                   recursive_dict_merge(base[key], new_dict[key])
+                else:
+                   base[key] = new_dict[key]
+
         params = params.copy()
-        params.update(self._opts['extra_cluster_params'])
+        recursive_dict_merge(params, self._opts['extra_cluster_params'])
         params = {k: v for k, v in params.items() if v is not None}
 
         return params


### PR DESCRIPTION
The function `_cluster_kwargs` builds a dict of options to submit to AWS
for cluster creation. The last operation the function performs is a dict update
with any custom parameters the user adds. Since this update is not recursive,
if the user sets a nested option that mrjob specifies, then user will override
everything in that nested option. Therefore we must perform a recursive
update. For example, the following will only end up setting the master security
group and not the ec2 key pair nor subnet:

```
    ec2_key_pair: key_name
    subnet: subnet-foo

    extra_cluster_params:
      Instances.EmrManagedMasterSecurityGroup: sg-bar
```
