### PR TITLE
add experimental MRJob Spark harness

### DIFF
--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -534,11 +534,6 @@ class MRJob(MRJobLauncher):
         :type step_num: int
         :param step_num: which step to run (0-indexed)
 
-        If we encounter a line that can't be decoded by our input protocol,
-        or a tuple that can't be encoded by our output protocol, we'll
-        increment a counter rather than raising an exception. If
-        --strict-protocols is set, then an exception is raised
-
         Called from :py:meth:`run`. You'd probably only want to call this
         directly from automated tests.
         """
@@ -739,9 +734,7 @@ class MRJob(MRJobLauncher):
 
     def _wrap_protocols(self, step_num, step_type):
         """Pick the protocol classes to use for reading and writing
-        for the given step, and wrap them so that bad input and output
-        trigger a counter rather than an exception unless --strict-protocols
-        is set.
+        for the given step.
 
         Returns a tuple of ``(read_lines, write_line)``
 

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -528,10 +528,30 @@ class MRJob(MRJobLauncher):
         for k, v in self.map_pairs(read_lines(), step_num=step_num):
             write_line(k, v)
 
+    def run_reducer(self, step_num=0):
+        """Run the reducer for the given step.
+
+        :type step_num: int
+        :param step_num: which step to run (0-indexed)
+
+        If we encounter a line that can't be decoded by our input protocol,
+        or a tuple that can't be encoded by our output protocol, we'll
+        increment a counter rather than raising an exception. If
+        --strict-protocols is set, then an exception is raised
+
+        Called from :py:meth:`run`. You'd probably only want to call this
+        directly from automated tests.
+        """
+        # pick input and output protocol
+        read_lines, write_line = self._wrap_protocols(step_num, 'reducer')
+
+        for k, v in self.reduce_pairs(read_lines(), step_num=step_num):
+            write_line(k, v)
+
     def map_pairs(self, pairs, step_num=0):
         """Runs :py:meth:`mapper_init`,
         :py:meth:`mapper`/:py:meth:`mapper_raw`, and :py:meth:`mapper_final`
-        for one mapper step.
+        for one map task in one step.
 
         Takes in a sequence of (key, value) pairs as input, and yields
         (key, value) pairs as output.
@@ -564,20 +584,16 @@ class MRJob(MRJobLauncher):
             for k, v in mapper_final() or ():
                 yield k, v
 
-    def run_reducer(self, step_num=0):
-        """Run the reducer for the given step.
+    def reduce_pairs(self, pairs, step_num=0):
+        """Runs :py:meth:`reducer_init`,
+        :py:meth:`reducer`, and :py:meth:`reducer_final`
+        for one reduce task in one step.
 
-        :type step_num: int
-        :param step_num: which step to run (0-indexed)
+        Takes in a sequence of (key, value) pairs as input, and yields
+        (key, value) pairs as output.
 
-        If we encounter a line that can't be decoded by our input protocol,
-        or a tuple that can't be encoded by our output protocol, we'll
-        increment a counter rather than raising an exception. If
-        --strict-protocols is set, then an exception is raised
-
-        Called from :py:meth:`run`. You'd probably only want to call this
-        directly from automated tests.
-        """
+        :py:meth:`run_reducer` is responsible for reading/decoding input
+        and writing/encoding output."""
         step = self._get_step(step_num, MRStep)
 
         reducer = step['reducer']
@@ -586,26 +602,22 @@ class MRJob(MRJobLauncher):
         if reducer is None:
             raise ValueError('No reducer in step %d' % step_num)
 
-        # pick input and output protocol
-        read_lines, write_line = self._wrap_protocols(step_num, 'reducer')
-
         if reducer_init:
-            for out_key, out_value in reducer_init() or ():
-                write_line(out_key, out_value)
+            for k, v in reducer_init() or ():
+                yield k, v
 
         # group all values of the same key together, and pass to the reducer
         #
         # be careful to use generators for everything, to allow for
         # very large groupings of values
-        for key, kv_pairs in itertools.groupby(read_lines(),
-                                               key=lambda k_v: k_v[0]):
-            values = (v for k, v in kv_pairs)
-            for out_key, out_value in reducer(key, values) or ():
-                write_line(out_key, out_value)
+        for key, pairs_for_key in itertools.groupby(pairs, lambda k_v: k_v[0]):
+            values = (value for _, value in pairs_for_key)
+            for k, v in reducer(key, values) or ():
+                yield k, v
 
         if reducer_final:
-            for out_key, out_value in reducer_final() or ():
-                write_line(out_key, out_value)
+            for k, v in reducer_final() or ():
+                yield k, v
 
     def run_combiner(self, step_num=0):
         """Run the combiner for the given step.

--- a/spark/mrjob_spark_harness.py
+++ b/spark/mrjob_spark_harness.py
@@ -1,0 +1,14 @@
+# Copyright 2019 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A Spark script that can run a MRJob without Hadoop."""

--- a/spark/mrjob_spark_harness.py
+++ b/spark/mrjob_spark_harness.py
@@ -35,7 +35,7 @@ def main(cmd_line_args=None):
     job_args = []
 
     def job(*args):
-        j = job_class(job_args + list(*args))
+        j = job_class(job_args + list(args))
         j.sandbox()  # so Spark doesn't try to serialize stdin
         return j
 
@@ -47,7 +47,7 @@ def main(cmd_line_args=None):
     steps = job().steps()
 
     # process steps
-    for step_num, step in steps:
+    for step_num, step in enumerate(steps):
         step_desc = step.description()
         _check_step(step_desc, step_num)
 
@@ -110,25 +110,6 @@ def _check_step(step_desc, step_num):
                     step_num, mrc))
 
 
-
-
-def _check_mapper(mapper_desc, step_num):
-    """Check that the given mapper description doesn't run commands"""
-    if mapper_desc.get('type') != 'script':
-        raise NotImplementedError(
-            "step %d's mapper has unexpected type: %r" % (
-                step_num, mapper_desc.get('type')))
-
-    if mapper_desc.get('pre_filter'):
-        raise NotImplementedError(
-            "step %d's mapper has pre-filter, which is unsupported" % (
-                step_num))
-
-
-
-
-
-
 def _make_arg_parser():
     parser = ArgumentParser()
 
@@ -147,12 +128,6 @@ def _make_arg_parser():
         help=('An empty directory to write output to. Can be a path or URI.'))
 
     return parser
-
-
-
-
-
-
 
 
 if __name__ == '__main__':

--- a/spark/mrjob_spark_harness.py
+++ b/spark/mrjob_spark_harness.py
@@ -57,10 +57,10 @@ def main(cmd_line_args=None):
             mapper_job = job('--mapper', '--step-num=%d' % step_num)
             m_read, m_write = mapper_job.pick_protocols(step_num, 'mapper')
 
-            rdd = rdd.map(lambda line: m_read(line.rstrip(b'\r\n')))
+            rdd = rdd.map(m_read)
             rdd = rdd.mapPartitions(
                 lambda pairs: mapper_job.map_pairs(pairs, step_num=step_num))
-            rdd = rdd.map(lambda k_v: m_write(*k_v) + b'\n')
+            rdd = rdd.map(m_write)
 
         if step_desc.get('reducer'):
             reducer_job = job('--reducer', '--step-num=%d' % step_num)
@@ -69,13 +69,12 @@ def main(cmd_line_args=None):
             # simulate shuffle in Hadoop Streaming
             rdd = rdd.groupBy(lambda line: line.split(b'\t')[0])
             rdd = rdd.flatMap(
-                lambda key_and_lines: (r_read(line.rstrip(b'\r\n'))
-                                       for line in key_and_lines[1]),
+                lambda k_lines: (r_read(line) for line in k_lines[1]),
                 preservesPartitioning=True)
             # run the reducer
             rdd = rdd.mapPartitions(
                 lambda pairs: reducer_job.map_pairs(pairs, step_num=step_num))
-            rdd = rdd.map(lambda k_v: r_write(*k_v) + b'\n')
+            rdd = rdd.map(r_write)
 
     # write the results
     rdd.saveAsTextFile(args.output_path)

--- a/spark/mrjob_spark_harness.py
+++ b/spark/mrjob_spark_harness.py
@@ -48,7 +48,7 @@ def main(cmd_line_args=None):
 
     # process steps
     for step_num, step in enumerate(steps):
-        step_desc = step.description()
+        step_desc = step.description(step_num)
         _check_step(step_desc, step_num)
 
         if step_desc.get('mapper'):

--- a/spark/mrjob_spark_harness.py
+++ b/spark/mrjob_spark_harness.py
@@ -12,3 +12,143 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """A Spark script that can run a MRJob without Hadoop."""
+import sys
+from argparse import ArgumentParser
+from importlib import import_module
+
+from pyspark import SparkContext
+
+
+def main(cmd_line_args=None):
+    if cmd_line_args is None:
+        cmd_line_args = sys.argv[1:]
+
+    parser = _make_arg_parser()
+    args = parser.parse_args(cmd_line_args)
+
+    # get job_class
+    job_module_name, job_class_name = args.job_class.rsplit('.', 1)
+    job_module = import_module(job_module_name)
+    job_class = getattr(job_module, job_class_name)
+
+    # eventually will want to set this for passthrough args, etc.
+    job_args = []
+
+    def job(*args):
+        j = job_class(job_args + list(*args))
+        j.sandbox()  # so Spark doesn't try to serialize stdin
+        return j
+
+    # load initial data
+    sc = SparkContext()
+    rdd = sc.textFile(args.input_path, use_unicode=False)
+
+    # get job steps. don't pass --steps, which is deprecated
+    steps = job().steps()
+
+    # process steps
+    for step_num, step in steps:
+        step_desc = step.description()
+        _check_step(step_desc, step_num)
+
+        if step_desc.get('mapper'):
+            mapper_job = job('--mapper', '--step-num=%d' % step_num)
+            m_read, m_write = mapper_job.pick_protocols(step_num, 'mapper')
+
+            rdd = rdd.map(m_read)
+            rdd = rdd.mapPartitions(mapper_job.map_pairs)
+            rdd = rdd.map(m_write)
+
+        if step_desc.get('reducer'):
+            reducer_job = job('--reducer', '--step-num=%d' % step_num)
+            r_read, r_write = reducer_job.pick_protocols(step_num, 'reducer')
+
+            # simulate shuffle in Hadoop Streaming
+            # TODO: could simulate SORT_VALUES here too
+            rdd = rdd.groupBy(lambda line: line.split(b'\t')[0])
+            rdd = rdd.flatMap(
+                lambda k_lines: (r_read(line) for line in k_lines[1]),
+                preservesPartitioning=True)
+            rdd = rdd.mapPartitions(reducer_job.reduce_pairs)
+            rdd = rdd.map(r_write)
+
+    # write the results
+    rdd.saveAsTextFile(args.output_path)
+
+
+def _check_step(step_desc, step_num):
+    """Check that the given step description is for a MRStep
+    with no input manifest"""
+    if step_desc.get('type') != 'streaming':
+        raise ValueError(
+            'step %d has unexpected type: %r' % (
+                step_num, step_desc.get('type')))
+
+    if step_desc.get('input_manifest'):
+        raise NotImplementedError(
+            'step %d uses an input manifest, which is unsupported')
+
+    for mrc in ('mapper', 'reducer'):
+        # bad combiners won't cause an error because they're optional
+        substep_desc = step_desc.get(mrc)
+        if not substep_desc:
+            continue
+
+        if substep_desc.get('type') != 'script':
+            raise NotImplementedError(
+                "step %d's %s has unexpected type: %r" % (
+                    step_num, mrc, substep_desc.get('type')))
+
+        if substep_desc.get('pre_filter'):
+            raise NotImplementedError(
+                "step %d's %s has pre-filter, which is unsupported" % (
+                    step_num, mrc))
+
+
+
+
+def _check_mapper(mapper_desc, step_num):
+    """Check that the given mapper description doesn't run commands"""
+    if mapper_desc.get('type') != 'script':
+        raise NotImplementedError(
+            "step %d's mapper has unexpected type: %r" % (
+                step_num, mapper_desc.get('type')))
+
+    if mapper_desc.get('pre_filter'):
+        raise NotImplementedError(
+            "step %d's mapper has pre-filter, which is unsupported" % (
+                step_num))
+
+
+
+
+
+
+def _make_arg_parser():
+    parser = ArgumentParser()
+
+    parser.add_argument(
+        dest='job_class',
+        help=('dot-separated module and name of MRJob class. For example:'
+              ' mrjob.examples.mr_wc.MRWordCountUtility'))
+
+    parser.add_argument(
+        dest='input_path',
+        help=('Where to read input from. Can be a path or a URI, or several of'
+              ' these joined by commas'))
+
+    parser.add_argument(
+        dest='output_path',
+        help=('An empty directory to write output to. Can be a path or URI.'))
+
+    return parser
+
+
+
+
+
+
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -875,9 +875,9 @@ class StepNumTestCase(BasicTestCase):
         mr_job = MRJob()
         mr_job.spark = MagicMock()
 
-        self.assertRaises(TypeError, mr_job.run_mapper)
-        self.assertRaises(TypeError, mr_job.run_combiner)
-        self.assertRaises(TypeError, mr_job.run_reducer)
+        self.assertRaises((TypeError, ValueError), mr_job.run_mapper)
+        self.assertRaises((TypeError, ValueError), mr_job.run_combiner)
+        self.assertRaises((TypeError, ValueError), mr_job.run_reducer)
 
 
 class FileOptionsTestCase(SandboxedTestCase):


### PR DESCRIPTION
This change creates a basic harness to run a MRJob in Spark (see #1941) and includes a couple of hooks in `MRJob` which de-couple the mapper/reducer logic from I/O (#1947).

We don't currently have a good way to unit-test the harness, so for now it's "experimental".

Also fixes #1846 (outdated comments about strict protocols).