### PR TITLE
allow output compression in spark harness

### DIFF
--- a/mrjob/spark/mrjob_spark_harness.py
+++ b/mrjob/spark/mrjob_spark_harness.py
@@ -51,7 +51,8 @@ def main(cmd_line_args=None):
         rdd = _run_step(step, step_num, rdd, make_job)
 
     # write the results
-    rdd.saveAsTextFile(args.output_path)
+    rdd.saveAsTextFile(
+        args.output_path, compressionCodecClass=args.compression_codec_class)
 
 
 def _run_step(step, step_num, rdd, make_job):
@@ -134,6 +135,10 @@ def _make_arg_parser():
     parser.add_argument(
         dest='output_path',
         help=('An empty directory to write output to. Can be a path or URI.'))
+
+    parser.add_argument(
+        '--compression-codec-class',
+        help=('Java class path of a codec to use to compress output.'))
 
     return parser
 


### PR DESCRIPTION
Fixes #1943.

This was hand-tested with real jobs. The ability to write automated tests was just recently added to MRJob (see #1361). Added a note to #1948, the ticket for missing Spark harness tests.