### PR TITLE
spark_harness support passthrough arguments

### DIFF
--- a/mrjob/spark/mr_spark_harness.py
+++ b/mrjob/spark/mr_spark_harness.py
@@ -33,14 +33,18 @@ class MRSparkHarness(MRJob):
             help=('Java class path of a codec to use to compress output.'))
 
         self.add_passthru_arg(
-            '--passthru-args',
+            '--job-args',
+            dest='job_args',
             default='',
             help=('The arguments pass to the MRJob. Please quote all passthru '
                   ' args so that they are in the same string')
         )
 
     def spark(self, input_path, output_path):
-        args = [self.options.job_class, input_path, output_path]
+        args = [
+            self.options.job_class,input_path, output_path,
+            '--job-args', self.options.job_args
+        ]
 
         if self.options.compression_codec:
             args.append('--compression-codec')

--- a/mrjob/spark/mr_spark_harness.py
+++ b/mrjob/spark/mr_spark_harness.py
@@ -32,6 +32,13 @@ class MRSparkHarness(MRJob):
             dest='compression_codec',
             help=('Java class path of a codec to use to compress output.'))
 
+        self.add_passthru_arg(
+            '--passthru-args',
+            default='',
+            help=('The arguments pass to the MRJob. Please quote all passthru '
+                  ' args so that they are in the same string')
+        )
+
     def spark(self, input_path, output_path):
         args = [self.options.job_class, input_path, output_path]
 

--- a/mrjob/spark/mrjob_spark_harness.py
+++ b/mrjob/spark/mrjob_spark_harness.py
@@ -14,6 +14,7 @@
 """A Spark script that can run a MRJob without Hadoop."""
 import sys
 from argparse import ArgumentParser
+from argparse import REMAINDER
 from importlib import import_module
 
 
@@ -29,8 +30,7 @@ def main(cmd_line_args=None):
     job_module = import_module(job_module_name)
     job_class = getattr(job_module, job_class_name)
 
-    # eventually will want to set this for passthrough args, etc.
-    job_args = []
+    job_args = args.passthru_args
 
     def make_job(*args):
         j = job_class(job_args + list(args))
@@ -144,6 +144,11 @@ def _make_arg_parser():
         dest='compression_codec',
         help=('Java class path of a codec to use to compress output.'))
 
+    parser.add_argument(
+        'passthru_args',
+        nargs=REMAINDER,
+        help=('the arguments pass to the MRJob')
+    )
     return parser
 
 

--- a/mrjob/spark/mrjob_spark_harness.py
+++ b/mrjob/spark/mrjob_spark_harness.py
@@ -17,6 +17,7 @@ from argparse import ArgumentParser
 from argparse import REMAINDER
 from importlib import import_module
 
+from mrjob.util import shlex_split
 
 def main(cmd_line_args=None):
     if cmd_line_args is None:
@@ -30,7 +31,7 @@ def main(cmd_line_args=None):
     job_module = import_module(job_module_name)
     job_class = getattr(job_module, job_class_name)
 
-    job_args = args.passthru_args
+    job_args = shlex_split(args.passthru_args)
 
     def make_job(*args):
         j = job_class(job_args + list(args))
@@ -145,9 +146,10 @@ def _make_arg_parser():
         help=('Java class path of a codec to use to compress output.'))
 
     parser.add_argument(
-        'passthru_args',
-        nargs=REMAINDER,
-        help=('the arguments pass to the MRJob')
+        '--passthru-args',
+        default='',
+        help=('The arguments pass to the MRJob. Please quote all passthru args'
+              ' so that they are in the same string')
     )
     return parser
 

--- a/mrjob/spark/mrjob_spark_harness.py
+++ b/mrjob/spark/mrjob_spark_harness.py
@@ -14,7 +14,6 @@
 """A Spark script that can run a MRJob without Hadoop."""
 import sys
 from argparse import ArgumentParser
-from argparse import REMAINDER
 from importlib import import_module
 
 from mrjob.util import shlex_split

--- a/mrjob/spark/mrjob_spark_harness.py
+++ b/mrjob/spark/mrjob_spark_harness.py
@@ -30,7 +30,7 @@ def main(cmd_line_args=None):
     job_module = import_module(job_module_name)
     job_class = getattr(job_module, job_class_name)
 
-    job_args = shlex_split(args.passthru_args)
+    job_args = shlex_split(args.job_args)
 
     def make_job(*args):
         j = job_class(job_args + list(args))
@@ -145,7 +145,8 @@ def _make_arg_parser():
         help=('Java class path of a codec to use to compress output.'))
 
     parser.add_argument(
-        '--passthru-args',
+        '--job-args',
+        dest='job_args',
         default='',
         help=('The arguments pass to the MRJob. Please quote all passthru args'
               ' so that they are in the same string')

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -56,8 +56,6 @@ class MRSortAndGroupReversedText(MRSortAndGroup):
 
 class MRPassThruArgTest(MRJob):
 
-    INTERNAL_PROTOCOL = ReversedTextProtocol
-
     def configure_args(self):
         super(MRPassThruArgTest, self).configure_args()
         self.add_passthru_arg('--chars', action='store_true')
@@ -198,7 +196,7 @@ class SparkHarnessOutputComparisonTestCase(
             b'that is the question'])
 
         job = self._harness_job(
-            MRSortAndGroupReversedText, input_bytes=input_bytes,
+            MRPassThruArgTest, input_bytes=input_bytes,
             extra_args=['--lines', '--ignore', 'to'])
 
 # TODO: add back a test of the bare Harness script in local mode (slow)

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -67,8 +67,6 @@ class MRPassThruArgTest(MRJob):
         if self.options.chars:
             for c in value:
                 yield c, 1
-        elif self.options.lines:
-            yield 'line_count', 1
         else:
             for w in value.split(' '):
                 yield w, 1
@@ -107,7 +105,7 @@ class SparkHarnessOutputComparisonTestCase(
             harness_job_args.append('--compression-codec')
             harness_job_args.append(compression_codec)
         if extra_args:
-            harness_job_args.extend(['--passthru-args', ' '.join(extra_args)])
+            harness_job_args.extend(['--job-args', ' '.join(extra_args)])
         harness_job_args.extend(input_paths)
 
         harness_job = MRSparkHarness(harness_job_args)
@@ -195,8 +193,10 @@ class SparkHarnessOutputComparisonTestCase(
             b'not to be',
             b'that is the question'])
 
-        job = self._harness_job(
-            MRPassThruArgTest, input_bytes=input_bytes,
-            extra_args=['--lines', '--ignore', 'to'])
+        self._assert_output_matches(
+            MRPassThruArgTest,
+            input_bytes=input_bytes,
+            extra_args=['--chars', '--ignore', 'to'])
+
 
 # TODO: add back a test of the bare Harness script in local mode (slow)

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -16,6 +16,7 @@ from io import BytesIO
 from os.path import join
 
 from mrjob.examples.mr_word_freq_count import MRWordFreqCount
+from mrjob.job import MRJob
 from mrjob.local import LocalMRJobRunner
 from mrjob.protocol import TextProtocol
 from mrjob.spark import mrjob_spark_harness
@@ -53,6 +54,30 @@ class MRSortAndGroupReversedText(MRSortAndGroup):
     INTERNAL_PROTOCOL = ReversedTextProtocol
 
 
+class MRPassThruArgTest(MRJob):
+
+    INTERNAL_PROTOCOL = ReversedTextProtocol
+
+    def configure_args(self):
+        super(MRPassThruArgTest, self).configure_args()
+        self.add_passthru_arg('--chars', action='store_true')
+        self.add_passthru_arg('--ignore')
+
+    def mapper(self, _, value):
+        if self.options.ignore:
+            value = value.replace(self.options.ignore, '')
+        if self.options.chars:
+            for c in value:
+                yield c, 1
+        elif self.options.lines:
+            yield 'line_count', 1
+        else:
+            for w in value.split(' '):
+                yield w, 1
+
+    def reducer(self, key, values):
+        yield key, sum(values)
+
 
 class SparkHarnessOutputComparisonTestCase(
         SandboxedTestCase, SingleSparkContextTestCase):
@@ -65,23 +90,26 @@ class SparkHarnessOutputComparisonTestCase(
         return path
 
     def _reference_job(self, job_class, input_bytes=b'', input_paths=(),
-                       runner_alias='inline'):
+                       runner_alias='inline', extra_args=[]):
 
         job_args = ['-r', runner_alias] + list(input_paths)
 
-        reference_job = job_class(job_args)
+        reference_job = job_class(job_args + extra_args)
         reference_job.sandbox(stdin=BytesIO(input_bytes))
 
         return reference_job
 
     def _harness_job(self, job_class, input_bytes=b'', input_paths=(),
-                     runner_alias='inline', compression_codec=None):
+                     runner_alias='inline', compression_codec=None,
+                     extra_args=None):
         job_class_path = '%s.%s' % (job_class.__module__, job_class.__name__)
 
         harness_job_args = ['-r', runner_alias, '--job-class', job_class_path]
         if compression_codec:
             harness_job_args.append('--compression-codec')
             harness_job_args.append(compression_codec)
+        if extra_args:
+            harness_job_args.extend(['--passthru-args', ' '.join(extra_args)])
         harness_job_args.extend(input_paths)
 
         harness_job = MRSparkHarness(harness_job_args)
@@ -90,18 +118,22 @@ class SparkHarnessOutputComparisonTestCase(
         return harness_job
 
     def _assert_output_matches(
-            self, job_class, input_bytes=b'', input_paths=()):
+            self, job_class, input_bytes=b'', input_paths=(), extra_args=[]):
 
-        reference_job = self._reference_job(job_class, input_bytes=input_bytes,
-                                            input_paths=input_paths)
+        reference_job = self._reference_job(
+            job_class, input_bytes=input_bytes,
+            input_paths=input_paths,
+            extra_args=extra_args)
 
         with reference_job.make_runner() as runner:
             runner.run()
 
             reference_output = sorted(to_lines(runner.cat_output()))
 
-        harness_job = self._harness_job(job_class, input_bytes=input_bytes,
-                                        input_paths=input_paths)
+        harness_job = self._harness_job(
+            job_class, input_bytes=input_bytes,
+            input_paths=input_paths,
+            extra_args=extra_args)
 
         with harness_job.make_runner() as runner:
             runner.run()
@@ -159,6 +191,14 @@ class SparkHarnessOutputComparisonTestCase(
                 dict(a=['artichoke', 'alligator', 'actuary'],
                      b=['bowling', 'balloon', 'baby']))
 
+    def test_passthru_args(self):
+        input_bytes = b'\n'.join([
+            b'to be or',
+            b'not to be',
+            b'that is the question'])
 
+        job = self._harness_job(
+            MRSortAndGroupReversedText, input_bytes=input_bytes,
+            extra_args=['--lines', '--ignore', 'to'])
 
 # TODO: add back a test of the bare Harness script in local mode (slow)


### PR DESCRIPTION
#1942 

Setting nargs=argparse.REMAINDER which seems to be the easiest way. 
However, the drawback is that the ordering of the passthrough argument would be important. 
'spark_harness_script.py class input output --compression-codec-class compression.class --remaining args --remaining --options'
will have correct compression-codec-class 
but 
'spark_harness_script.py class input output --remaining args --remaining --options --compression-codec-class compression.class'
will have --compression-codec-class compression.class in the passthru_args. 


I am not sure if this is acceptable. Let me know what you think. Thanks! 