### PR TITLE
add SparkStep support to inline runner

### DIFF
--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -809,6 +809,7 @@ class MRJobBinRunner(MRJobRunner):
     def _spark_script_args(self, step_num):
         """A list of args to the spark script/jar, used by
         _args_for_spark_step()."""
+        # TODO: this can also return args to the MRJob, which is confusing
         step = self._get_step(step_num)
 
         if step['type'] == 'spark':

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -89,7 +89,7 @@ class LocalMRJobRunner(SimMRJobRunner, MRJobBinRunner):
     }
 
     _STEP_TYPES = (
-        SimMRJobRunner._STEP_TYPES | {'spark', 'spark_jar', 'spark_script'})
+        SimMRJobRunner._STEP_TYPES | {'spark_jar', 'spark_script'})
 
     def __init__(self, **kwargs):
         """Arguments to this constructor may also appear in :file:`mrjob.conf`
@@ -118,12 +118,6 @@ class LocalMRJobRunner(SimMRJobRunner, MRJobBinRunner):
             _invoke_task_in_subprocess,
             task_type, step_num, task_num,
             args, num_steps)
-
-    def _run_step(self, step, step_num):
-        if _is_spark_step_type(step['type']):
-            self._run_step_on_spark(step, step_num)
-        else:
-            super(LocalMRJobRunner, self)._run_step(step, step_num)
 
     # TODO: this is similar to _run_job_in_hadoop() (hadoop.py), and is
     # probably useful to other runners with minor modifications

--- a/mrjob/local.py
+++ b/mrjob/local.py
@@ -46,7 +46,6 @@ from mrjob.py2 import to_unicode
 from mrjob.sim import SimMRJobRunner
 from mrjob.sim import _sort_lines_in_memory
 from mrjob.step import StepFailedException
-from mrjob.step import _is_spark_step_type
 from mrjob.util import cmd_line
 
 log = logging.getLogger(__name__)

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -1,7 +1,7 @@
 # Copyright 2009-2012 Yelp and Contributors
 # Copyright 2013 David Marin
-# Copyright 2015-2017 Yelp
-# Copyright 2018 Yelp
+# Copyright 2015-2018 Yelp
+# Copyright 2019 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,12 @@ from contextlib import contextmanager
 from tempfile import mkdtemp
 from shutil import rmtree
 from unittest import TestCase
+from unittest import skipIf
+
+try:
+    import pyspark
+except ImportError:
+    pyspark = None
 
 import mrjob
 from mrjob import runner
@@ -172,6 +178,30 @@ class SandboxedTestCase(EmptyMrjobConfTestCase):
         """
         os.environ['PYTHONPATH'] = (
             mrjob_pythonpath() + ':' + os.environ.get('PYTHONPATH', ''))
+
+
+@skipIf(pyspark is None, 'no pyspark module')
+class SingleSparkContextTestCase(TestCase):
+    """Only create a single SparkContext, to speed things up and prevent
+    errors from attempting to instantiate multiple contexts."""
+
+    @classmethod
+    def setUpClass(cls):
+        super(SingleSparkContextTestCase, cls).setUpClass()
+
+        from pyspark import SparkContext
+        cls.spark_context = SparkContext()
+
+        try:
+            cls.spark_context.setLogLevel('FATAL')
+        except:
+            # tearDownClass() won't be called if there's an exception
+            cls.spark_context.stop()
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.spark_context.stop()
 
 
 def mrjob_pythonpath():

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -21,26 +21,39 @@
 import gzip
 import os
 import os.path
+import sys
 from os.path import exists
 from os.path import join
 from io import BytesIO
+from unittest import TestCase
+from unittest import skipIf
 
 from warcio.warcwriter import WARCWriter
 
+try:
+    import pyspark
+except ImportError:
+    pyspark = None
+
 from mrjob.examples.mr_phone_to_url import MRPhoneToURL
+from mrjob.examples.mr_spark_wordcount import MRSparkWordcount
+from mrjob.examples.mr_spark_wordcount_script import MRSparkScriptWordcount
+from mrjob.examples.mr_sparkaboom import MRSparKaboom
 from mrjob.inline import InlineMRJobRunner
 from mrjob.job import MRJob
+from mrjob.util import safeeval
+from mrjob.util import to_lines
 
 from tests.examples.test_mr_phone_to_url import write_conversion_record
+from tests.job import run_job
 from tests.mr_cmd_job import MRCmdJob
 from tests.mr_filter_job import MRFilterJob
-from tests.mr_null_spark import MRNullSpark
 from tests.mr_test_cmdenv import MRTestCmdenv
 from tests.mr_two_step_job import MRTwoStepJob
+from tests.py2 import patch
 from tests.sandbox import EmptyMrjobConfTestCase
 from tests.sandbox import SandboxedTestCase
-from tests.job import run_job
-from tests.py2 import patch
+from tests.sandbox import SingleSparkContextTestCase
 from tests.test_sim import MRIncrementerJob
 
 
@@ -241,9 +254,46 @@ class UnsupportedStepsTestCase(SandboxedTestCase):
 
         self.assertRaises(NotImplementedError, job.make_runner)
 
-    def test_no_spark_steps(self):
+    def test_no_spark_script_steps(self):
         # just a sanity check; _STEP_TYPES is tested in a lot of ways
-        job = MRNullSpark(['-r', 'inline'])
+        job = MRSparkScriptWordcount(['-r', 'inline'])
         job.sandbox()
 
         self.assertRaises(NotImplementedError, job.make_runner)
+
+
+@skipIf(pyspark is None, 'no pyspark module')
+class InlineRunnerSparkTestCase(SandboxedTestCase, SingleSparkContextTestCase):
+
+    def setUp(self):
+        super(InlineRunnerSparkTestCase, self).setUp()
+
+        self.start(patch('pyspark.SparkContext',
+                         return_value=self.spark_context))
+
+    def test_spark_mrjob(self):
+        text = b'one fish\ntwo fish\nred fish\nblue fish\n'
+
+        job = MRSparkWordcount(['-r', 'inline'])
+        job.sandbox(stdin=BytesIO(text))
+
+        counts = {}
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            for line in to_lines(runner.cat_output()):
+                k, v = safeeval(line)
+                counts[k] = v
+
+        self.assertEqual(counts, dict(
+            blue=1, fish=4, one=1, red=1, two=1))
+
+    def test_spark_job_failure(self):
+        job = MRSparKaboom(['-r', 'inline'])
+        job.sandbox(stdin=BytesIO(b'line\n'))
+
+        from py4j.protocol import Py4JJavaError
+
+        with job.make_runner() as runner:
+            self.assertRaises(Py4JJavaError, runner.run)


### PR DESCRIPTION
The inline runner can now run `SparkSteps` inline, which allows us to write reasonably fast Spark unit tests. Fixes #1965.

This change also sets up a fake "working directory", much like we do when simulating Hadoop, so that it's possible to fully test the Spark harness quickly.