### PR TITLE
add put() to filesystem

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -533,7 +533,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         for path, gcs_uri in self._upload_mgr.path_to_uri().items():
             log.debug('uploading %s -> %s' % (path, gcs_uri))
 
-            self.fs.gcs.put(path, gcs_uri, chunk_size=self._fs_chunk_size())
+            self.fs.put(path, gcs_uri, part_size_mb=self._fs_chunk_size())
 
         self._wait_for_fs_sync()
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -862,19 +862,11 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     def _upload_contents(self, s3_uri, path):
         """Uploads the file at the given path to S3, possibly using
         multipart upload."""
-        s3_key = self.fs.s3._get_s3_key(s3_uri)
-
         # use _HUGE_PART_THRESHOLD to disable multipart uploading
         # (could use put() directly, but that would be another code path)
-        part_size = self._get_upload_part_size() or _HUGE_PART_THRESHOLD
+        part_size_mb = self._get_upload_part_size() or _HUGE_PART_THRESHOLD
 
-        s3_key.upload_file(
-            path,
-            Config=boto3.s3.transfer.TransferConfig(
-                multipart_chunksize=part_size,
-                multipart_threshold=part_size,
-            ),
-        )
+        self.fs.put(path, s3_uri, part_size_mb)
 
     def _get_upload_part_size(self):
         # part size is in MB, as the minimum is 5 MB

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -111,11 +111,12 @@ class Filesystem(object):
         """
         raise NotImplementedError
 
-    def put(self, src, dest):
-        """Upload a file on the local filesystem to *dest* (which should not
-        be a directory).
+    def put(self, src, path):
+        """Upload a file on the local filesystem (*src*) to *path*.
+        *path* should be the path of the new file, not a directory containing
+        it.
 
-        Corresponds roughly to ``hadoop fs -put src dest``.
+        Corresponds roughly to ``hadoop fs -put src path``.
         """
         raise NotImplementedError
 

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -113,12 +113,12 @@ class Filesystem(object):
 
     def put(self, src, path, part_size_mb=None):
         """Upload a file on the local filesystem (*src*) to *path*.
-        *path* should be the path of the new file, not a directory containing
-        it.
+        Like with :py:func:`shutil.copyfile`, *path* should be the full path
+        of the new file, not a directory which should contain it.
 
         You may optionally specify *part_size_mb*, the part size in megabytes
         for multi-part uploading. Filesystems that do not support multi-part
-        uploading may ignore this.
+        uploading will ignore this.
 
         Corresponds roughly to ``hadoop fs -put src path``.
         """

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -111,10 +111,14 @@ class Filesystem(object):
         """
         raise NotImplementedError
 
-    def put(self, src, path):
+    def put(self, src, path, part_size_mb=None):
         """Upload a file on the local filesystem (*src*) to *path*.
         *path* should be the path of the new file, not a directory containing
         it.
+
+        You may optionally specify *part_size_mb*, the part size in megabytes
+        for multi-part uploading. Filesystems that do not support multi-part
+        uploading may ignore this.
 
         Corresponds roughly to ``hadoop fs -put src path``.
         """

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -24,20 +24,23 @@ log = logging.getLogger(__name__)
 
 class Filesystem(object):
     """Some simple filesystem operations that are common across the local
-    filesystem, S3, HDFS, and remote machines via SSH. Different runners
-    provide functionality for different filesystems via their
-    :py:attr:`~mrjob.runner.MRJobRunner.fs` attribute. The ``hadoop`` and
-    ``emr`` runners provide support for multiple protocols using
-    :py:class:`~mrjob.job.composite.CompositeFilesystem`.
+    filesystem, S3, GCS, HDFS, and remote machines via SSH.
 
-    Protocol support:
+    Different runners provide functionality for different filesystems via their
+    :py:attr:`~mrjob.runner.MRJobRunner.fs` attribute. Generally a runner will
+    wrap one or more filesystems with
+    :py:class:`mrjob.fs.composite.CompositeFilesystem`.
 
-    * :py:class:`mrjob.fs.hadoop.HadoopFilesystem`: ``hdfs://``, others
-    * :py:class:`mrjob.fs.local.LocalFilesystem`: ``/``
-    * :py:class:`mrjob.fs.s3.S3Filesystem`: ``s3://bucket/path``,
-      ``s3n://bucket/path``
-    * :py:class:`mrjob.fs.ssh.SSHFilesystem`: ``ssh://hostname/path``
+    Schemes supported:
+
+    * :py:class:`mrjob.fs.gcs.GCSFilesystem`: ``gs://``
+    * :py:class:`mrjob.fs.hadoop.HadoopFilesystem`: ``hdfs://`` and other URIs
+    * :py:class:`mrjob.fs.local.LocalFilesystem`: ``/`` (non-URIs)
+    * :py:class:`mrjob.fs.s3.S3Filesystem`: ``s3://``, ``s3a://``, ``s3n://``,
+    * :py:class:`mrjob.fs.ssh.SSHFilesystem`: ``ssh://``
     """
+    # Note: currently, we're not very consistent about the names of arguments
+    # to these methods in subclasses, which we'll fix in v0.7.0 (see #1979).
 
     def can_handle_path(self, path):
         """Can we handle this path at all?"""

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -111,6 +111,14 @@ class Filesystem(object):
         """
         raise NotImplementedError
 
+    def put(self, src, dest):
+        """Upload a file on the local filesystem to *dest* (which should not
+        be a directory).
+
+        Corresponds roughly to ``hadoop fs -put src dest``.
+        """
+        raise NotImplementedError
+
     def rm(self, path_glob):
         """Recursively delete the given file/directory, if it exists
 

--- a/mrjob/fs/composite.py
+++ b/mrjob/fs/composite.py
@@ -155,8 +155,8 @@ class CompositeFilesystem(Filesystem):
     def join(self, path, *paths):
         return self._handle('join', path, path, *paths)
 
-    def put(self, src, path):
-        return self._handle('put', path, src, path)
+    def put(self, src, path, part_size_mb=None):
+        return self._handle('put', path, src, path, part_size_mb)
 
     def rm(self, path_glob):
         return self._do('rm', path_glob)

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -191,13 +191,24 @@ class GCSFilesystem(Filesystem):
 
         self._blob(dest_uri).upload_from_string(b'')
 
-    def put(self, src_path, dest_uri, chunk_size=None):
-        """Uploads a local file to a specific destination."""
+    def put(self, src_path, dest_uri, part_size_mb=None, chunk_size=None):
+        """Uploads a local file to a specific destination.
+
+        *chunk_size* is a deprecated alias for *part_size_mb* and will
+        be removed in v0.7.0.
+        """
+        # support old name for *part_size_mb*
+        if chunk_size:
+            log.warning('chunk_size is a deprecated alias for part_size_mb'
+                        ' and will be removed in v0.7.0')
+        if part_size_mb is None:
+            part_size_mb = chunk_size
+
         old_blob = self._get_blob(dest_uri)
         if old_blob:
             raise IOError('File already exists: %s' % dest_uri)
 
-        self._blob(dest_uri, chunk_size=chunk_size).upload_from_filename(
+        self._blob(dest_uri, chunk_size=part_size_mb).upload_from_filename(
             src_path)
 
     def get_all_bucket_names(self, prefix=None):

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -313,11 +313,12 @@ class HadoopFilesystem(Filesystem):
         except CalledProcessError:
             raise IOError("Could not check path %s" % path_glob)
 
-    def put(self, src, path):
+    def put(self, src, path, part_size_mb=None):
         # don't inadvertently support cp syntax
         if path.endswith('/'):
             raise ValueError('put() destination may not be a directory')
 
+        # ignore part_size_mb, not supported by `hadoop fs`
         self.invoke_hadoop(['fs', '-put', src, path])
 
     def rm(self, path_glob):

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -313,12 +313,12 @@ class HadoopFilesystem(Filesystem):
         except CalledProcessError:
             raise IOError("Could not check path %s" % path_glob)
 
-    def _put(self, local_path, target):
-        # used by HadoopMRJobRunner._upload_to_hdfs()
+    def put(self, src, path):
+        # don't inadvertently support cp syntax
+        if path.endswith('/'):
+            raise ValueError('put() destination may not be a directory')
 
-        # not exposing this method because it's not part of the general FS
-        # interface. Probably want to add cp() at some point
-        self.invoke_hadoop(['fs', '-put', local_path, target])
+        self.invoke_hadoop(['fs', '-put', src, path])
 
     def rm(self, path_glob):
         if not is_uri(path_glob):

--- a/mrjob/fs/local.py
+++ b/mrjob/fs/local.py
@@ -49,12 +49,16 @@ class LocalFilesystem(Filesystem):
             for chunk in decompress(f, filename):
                 yield chunk
 
+    def exists(self, path_glob):
+        return bool(glob.glob(path_glob))
+
     def mkdir(self, path):
         if not os.path.isdir(path):
             os.makedirs(path)
 
-    def exists(self, path_glob):
-        return bool(glob.glob(path_glob))
+    def put(self, src, path, part_size_mb=None):
+        """Copy a file from *src* to *path*"""
+        shutil.copyfile(src, path)
 
     def rm(self, path_glob):
         for path in glob.glob(path_glob):

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -394,7 +394,7 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
 
     def _upload_to_hdfs(self, path, target):
         log.debug('  %s -> %s' % (path, target))
-        self.fs.hadoop._put(path, target)
+        self.fs.hadoop.put(path, target)
 
     def _dump_stdin_to_local_file(self):
         """Dump sys.stdin to a local file, and return the path to it."""

--- a/tests/fs/test_composite.py
+++ b/tests/fs/test_composite.py
@@ -87,7 +87,16 @@ class CompositeFilesystemTestCase(BasicTestCase):
 
         fs.put('/path/to/file', 's3://walrus/file')
         self.s3_fs.put.assert_called_once_with(
-            '/path/to/file', 's3://walrus/file')
+            '/path/to/file', 's3://walrus/file', None)
+
+    def test_forward_put_with_part_size(self):
+        fs = CompositeFilesystem()
+
+        fs.add_fs('s3', self.s3_fs)
+
+        fs.put('/path/to/file', 's3://walrus/file', part_size_mb=99999)
+        self.s3_fs.put.assert_called_once_with(
+            '/path/to/file', 's3://walrus/file', 99999)
 
     def test_forward_fs_extensions(self):
         fs = CompositeFilesystem()

--- a/tests/fs/test_composite.py
+++ b/tests/fs/test_composite.py
@@ -68,6 +68,27 @@ class CompositeFilesystemTestCase(BasicTestCase):
 
         self.assertRaises(IOError, fs.ls, 's3://walrus/fish')
 
+    def test_forward_join(self):
+        # join() is a special case since it takes multiple arguments
+        fs = CompositeFilesystem()
+
+        fs.add_fs('s3', self.s3_fs)
+
+        self.assertEqual(fs.join('s3://walrus/fish', 'salmon'),
+                         self.s3_fs.join.return_value)
+        self.s3_fs.join.assert_called_once_with(
+            's3://walrus/fish', 'salmon')
+
+    def test_forward_put(self):
+        # put() is a special case since the path that matters comes second
+        fs = CompositeFilesystem()
+
+        fs.add_fs('s3', self.s3_fs)
+
+        fs.put('/path/to/file', 's3://walrus/file')
+        self.s3_fs.put.assert_called_once_with(
+            '/path/to/file', 's3://walrus/file')
+
     def test_forward_fs_extensions(self):
         fs = CompositeFilesystem()
 

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -21,6 +21,7 @@ from mrjob.fs.gcs import _CAT_CHUNK_SIZE
 
 from tests.compress import gzip_compress
 from tests.mock_google import MockGoogleTestCase
+from tests.py2 import patch
 
 
 class CatTestCase(MockGoogleTestCase):
@@ -185,6 +186,23 @@ class GCSFSTestCase(MockGoogleTestCase):
         })
 
         self.assertRaises(IOError, self.fs.md5sum, 'gs://walrus/data/bar')
+
+    def test_put(self):
+        local_path = self.makefile('foo', contents=b'bar')
+        dest = 'gs://bar-files/foo'
+        self.storage_client().bucket('bar-files').create()
+
+        self.fs.put(local_path, dest)
+        self.assertEqual(b''.join(self.fs.cat(dest)), b'bar')
+
+    def test_put_chunk_size(self):
+        local_path = self.makefile('foo', contents=b'bar')
+        dest = 'gs://bar-files/foo'
+        self.storage_client().bucket('bar-files').create()
+
+        with patch.object(GCSFilesystem, '_blob') as blob_meth:
+            self.fs.put(local_path, dest, chunk_size=999)
+            blob_meth.assert_called_once_with(dest, chunk_size=999)
 
     def test_rm(self):
         self.put_gcs_multi({

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -149,11 +149,6 @@ class HadoopFSTestCase(MockSubprocessTestCase):
     def test_du_non_existent(self):
         self.assertEqual(self.fs.du('hdfs:///does-not-exist'), 0)
 
-    def test_mkdir(self):
-        self.fs.mkdir('hdfs:///d/ave')
-        path = os.path.join(get_mock_hdfs_root(self.env), 'd', 'ave')
-        self.assertEqual(os.path.isdir(path), True)
-
     def test_exists_no(self):
         path = 'hdfs:///f'
         self.assertEqual(self.fs.exists(path), False)
@@ -162,6 +157,11 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         self.make_mock_file('f')
         path = 'hdfs:///f'
         self.assertEqual(self.fs.exists(path), True)
+
+    def test_mkdir(self):
+        self.fs.mkdir('hdfs:///d/ave')
+        path = os.path.join(get_mock_hdfs_root(self.env), 'd', 'ave')
+        self.assertEqual(os.path.isdir(path), True)
 
     def test_rm(self):
         path = self.make_mock_file('f')

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -151,8 +151,8 @@ class HadoopFSTestCase(MockSubprocessTestCase):
 
     def test_mkdir(self):
         self.fs.mkdir('hdfs:///d/ave')
-        local_path = os.path.join(get_mock_hdfs_root(self.env), 'd', 'ave')
-        self.assertEqual(os.path.isdir(local_path), True)
+        path = os.path.join(get_mock_hdfs_root(self.env), 'd', 'ave')
+        self.assertEqual(os.path.isdir(path), True)
 
     def test_exists_no(self):
         path = 'hdfs:///f'
@@ -164,16 +164,16 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         self.assertEqual(self.fs.exists(path), True)
 
     def test_rm(self):
-        local_path = self.make_mock_file('f')
-        self.assertEqual(os.path.exists(local_path), True)
+        path = self.make_mock_file('f')
+        self.assertEqual(os.path.exists(path), True)
         self.fs.rm('hdfs:///f')
-        self.assertEqual(os.path.exists(local_path), False)
+        self.assertEqual(os.path.exists(path), False)
 
     def test_rm_recursive(self):
-        local_path = self.make_mock_file('foo/bar')
-        self.assertEqual(os.path.exists(local_path), True)
+        path = self.make_mock_file('foo/bar')
+        self.assertEqual(os.path.exists(path), True)
         self.fs.rm('hdfs:///foo')  # remove containing directory
-        self.assertEqual(os.path.exists(local_path), False)
+        self.assertEqual(os.path.exists(path), False)
 
     def test_rm_nonexistent(self):
         self.fs.rm('hdfs:///baz')

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -193,7 +193,7 @@ class HadoopFSTestCase(MockSubprocessTestCase):
         self.fs.rm('hdfs:///baz')
 
     def test_touchz(self):
-        # mockhadoop doesn't implement this.
+        # mockhadoop doesn't implement this (see #1981)
         pass
 
 

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -160,20 +160,20 @@ class HadoopFSTestCase(MockSubprocessTestCase):
 
     def test_mkdir(self):
         self.fs.mkdir('hdfs:///d/ave')
-        path = os.path.join(get_mock_hdfs_root(self.env), 'd', 'ave')
-        self.assertEqual(os.path.isdir(path), True)
+        local_path = os.path.join(get_mock_hdfs_root(self.env), 'd', 'ave')
+        self.assertEqual(os.path.isdir(local_path), True)
 
     def test_rm(self):
-        path = self.make_mock_file('f')
-        self.assertEqual(os.path.exists(path), True)
+        local_path = self.make_mock_file('f')
+        self.assertEqual(os.path.exists(local_path), True)
         self.fs.rm('hdfs:///f')
-        self.assertEqual(os.path.exists(path), False)
+        self.assertEqual(os.path.exists(local_path), False)
 
     def test_rm_recursive(self):
-        path = self.make_mock_file('foo/bar')
-        self.assertEqual(os.path.exists(path), True)
+        local_path = self.make_mock_file('foo/bar')
+        self.assertEqual(os.path.exists(local_path), True)
         self.fs.rm('hdfs:///foo')  # remove containing directory
-        self.assertEqual(os.path.exists(path), False)
+        self.assertEqual(os.path.exists(local_path), False)
 
     def test_rm_nonexistent(self):
         self.fs.rm('hdfs:///baz')

--- a/tests/fs/test_hadoop.py
+++ b/tests/fs/test_hadoop.py
@@ -160,20 +160,34 @@ class HadoopFSTestCase(MockSubprocessTestCase):
 
     def test_mkdir(self):
         self.fs.mkdir('hdfs:///d/ave')
-        local_path = os.path.join(get_mock_hdfs_root(self.env), 'd', 'ave')
-        self.assertEqual(os.path.isdir(local_path), True)
+        path_in_mock_hdfs = os.path.join(
+            get_mock_hdfs_root(self.env), 'd', 'ave')
+        self.assertEqual(os.path.isdir(path_in_mock_hdfs), True)
+
+    def test_put(self):
+        local_path = self.makefile('foo', contents=b'bar')
+        dest = 'hdfs:///bar'
+
+        self.fs.put(local_path, dest)
+        self.assertEqual(b''.join(self.fs.cat(dest)), b'bar')
+
+    def test_no_put_to_dir(self):
+        local_path = self.makefile('foo', contents=b'bar')
+        dest = 'hdfs:///bar'
+
+        self.assertRaises(ValueError, self.fs.put, local_path, 'hdfs:///')
 
     def test_rm(self):
-        local_path = self.make_mock_file('f')
-        self.assertEqual(os.path.exists(local_path), True)
+        path_in_mock_hdfs = self.make_mock_file('f')
+        self.assertEqual(os.path.exists(path_in_mock_hdfs), True)
         self.fs.rm('hdfs:///f')
-        self.assertEqual(os.path.exists(local_path), False)
+        self.assertEqual(os.path.exists(path_in_mock_hdfs), False)
 
     def test_rm_recursive(self):
-        local_path = self.make_mock_file('foo/bar')
-        self.assertEqual(os.path.exists(local_path), True)
+        path_in_mock_hdfs = self.make_mock_file('foo/bar')
+        self.assertEqual(os.path.exists(path_in_mock_hdfs), True)
         self.fs.rm('hdfs:///foo')  # remove containing directory
-        self.assertEqual(os.path.exists(local_path), False)
+        self.assertEqual(os.path.exists(path_in_mock_hdfs), False)
 
     def test_rm_nonexistent(self):
         self.fs.rm('hdfs:///baz')

--- a/tests/fs/test_local.py
+++ b/tests/fs/test_local.py
@@ -118,6 +118,13 @@ class LocalFSTestCase(SandboxedTestCase):
         path = self.makefile('f', 'contents')
         self.assertEqual(self.fs.exists(path), True)
 
+    def test_put(self):
+        src = self.makefile('f', 'contents')
+        dest = join(self.tmp_dir, 'g')
+
+        self.fs.put(src, dest)
+        self.assertEqual(b''.join(self.fs.cat(dest)), b'contents')
+
     def test_rm_file(self):
         path = self.makefile('f', 'contents')
         self.assertEqual(self.fs.exists(path), True)


### PR DESCRIPTION
Fixes #1977. This implements `put()` in every fs except the SSH filesystem, where we probably won't need it (see #1982).
