### PR TITLE
pass file:/// URIs to Spark for input and output

### DIFF
--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -20,7 +20,6 @@ process. Useful for debugging."""
 import logging
 import os
 import sys
-from os.path import abspath
 
 from mrjob.job import MRJob
 from mrjob.runner import _fix_env
@@ -195,8 +194,7 @@ class InlineMRJobRunner(SimMRJobRunner):
                 '--step-num=%d' % step_num,
                 '--spark',
             ] + self._mr_job_extra_args() + [
-                ','.join(abspath(path)
-                         for path in self._step_input_uris(step_num)),
+                ','.join(self._step_input_uris(step_num)),
                 self._step_output_uri(step_num),
             ]
         )

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -1,8 +1,8 @@
 # Copyright 2009-2012 Yelp
 # Copyright 2013 Steve Johnson and David Marin
 # Copyright 2014 Yelp and Contributors
-# Copyright 2015-2017 Yelp
-# Copyright 2018 Yelp
+# Copyright 2015-2018 Yelp
+# Copyright 2019 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,9 +20,12 @@ import logging
 import re
 from functools import wraps
 from io import BytesIO
+from os.path import abspath
 
 from mrjob.py2 import ParseResult
+from mrjob.py2 import pathname2url
 from mrjob.py2 import to_unicode
+from mrjob.py2 import urljoin
 from mrjob.py2 import urlparse as urlparse_buggy
 
 log = logging.getLogger(__name__)
@@ -66,6 +69,15 @@ def parse_s3_uri(uri):
         raise ValueError('Invalid S3 URI: %s' % uri)
 
     return components.netloc, components.path[1:]
+
+
+def to_uri(path_or_uri):
+    """If *path_or_uri* is not a URI already, convert it to a ``file:///`
+    URI."""
+    if is_uri(path_or_uri):
+        return path_or_uri
+    else:
+        return urljoin('file:', pathname2url(abspath(path_or_uri)))
 
 
 @wraps(urlparse_buggy)

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -141,10 +141,14 @@ xrange  # quiet, pyflakes
 # in most cases you should use ``mrjob.parse.urlparse()``
 if PY2:
     from urlparse import ParseResult
+    from urllib import pathname2url
+    from urlparse import urljoin
     from urllib2 import urlopen
     from urlparse import urlparse
 else:
     from urllib.parse import ParseResult
+    from urllib.request import pathname2url
+    from urllib.parse import urljoin
     from urllib.request import urlopen
     from urllib.parse import urlparse
 ParseResult

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -40,6 +40,7 @@ from mrjob.options import _combiners
 from mrjob.options import _deprecated_aliases
 from mrjob.options import CLEANUP_CHOICES
 from mrjob.parse import is_uri
+from mrjob.parse import to_uri
 from mrjob.py2 import PY2
 from mrjob.py2 import string_types
 from mrjob.setup import WorkingDirManager
@@ -1087,9 +1088,9 @@ class MRJobRunner(object):
         """A URI for intermediate output for the given step number."""
         join = os.path.join if local else posixpath.join
 
-        return join(
+        return to_uri(join(
             self._step_output_dir or self._default_step_output_dir(),
-            '%04d' % step_num)
+            '%04d' % step_num))
 
     def _default_step_output_dir(self):
         """Where to put output for steps other than the last one,
@@ -1105,7 +1106,8 @@ class MRJobRunner(object):
         except the first step, this list will have a single item (a
         directory)."""
         if step_num == 0:
-            return [self._upload_mgr.uri(path) if self._upload_mgr else path
+            return [self._upload_mgr.uri(path) if self._upload_mgr
+                    else to_uri(path)
                     for path in self._get_input_paths()]
         else:
             return [self._intermediate_output_uri(step_num - 1)]
@@ -1115,7 +1117,7 @@ class MRJobRunner(object):
         intermediate dir (see :py:meth:`intermediate_output_uri`) or
         ``self._output_dir`` for the final step."""
         if step_num == len(self._get_steps()) - 1:
-            return self._output_dir
+            return to_uri(self._output_dir)
         else:
             return self._intermediate_output_uri(step_num)
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1084,13 +1084,13 @@ class MRJobRunner(object):
             for path in self._get_input_paths():
                 self._upload_mgr.add(path)
 
-    def _intermediate_output_uri(self, step_num, local=False):
-        """A URI for intermediate output for the given step number."""
+    def _intermediate_output_dir(self, step_num, local=False):
+        """A directory for intermediate output for the given step number."""
         join = os.path.join if local else posixpath.join
 
-        return to_uri(join(
+        return join(
             self._step_output_dir or self._default_step_output_dir(),
-            '%04d' % step_num))
+            '%04d' % step_num)
 
     def _default_step_output_dir(self):
         """Where to put output for steps other than the last one,
@@ -1110,7 +1110,7 @@ class MRJobRunner(object):
                     else to_uri(path)
                     for path in self._get_input_paths()]
         else:
-            return [self._intermediate_output_uri(step_num - 1)]
+            return [to_uri(self._intermediate_output_dir(step_num - 1))]
 
     def _step_output_uri(self, step_num):
         """URI to use as output for the given step. This is either an
@@ -1119,7 +1119,7 @@ class MRJobRunner(object):
         if step_num == len(self._get_steps()) - 1:
             return to_uri(self._output_dir)
         else:
-            return self._intermediate_output_uri(step_num)
+            return to_uri(self._intermediate_output_uri(step_num))
 
     def _jobconf_for_step(self, step_num):
         """Get the jobconf dictionary, optionally including step-specific

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1119,7 +1119,7 @@ class MRJobRunner(object):
         if step_num == len(self._get_steps()) - 1:
             return to_uri(self._output_dir)
         else:
-            return to_uri(self._intermediate_output_uri(step_num))
+            return to_uri(self._intermediate_output_dir(step_num))
 
     def _jobconf_for_step(self, step_num):
         """Get the jobconf dictionary, optionally including step-specific

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -593,7 +593,7 @@ class SimMRJobRunner(MRJobRunner):
         if step_num == self._num_steps() - 1:
             return self._output_dir
         else:
-            return self._intermediate_output_uri(step_num, local=True)
+            return self._intermediate_output_dir(step_num, local=True)
 
     def _default_step_output_dir(self):
         return join(self._get_local_tmp_dir(), 'step-output')


### PR DESCRIPTION
Apparently, some Spark installations treat input and output paths as local paths, and others treat them as HDFS paths (even when running in the local master). We now use `file:///` URIs instead of unqualified paths. Fixes #1985.