### PR TITLE
Spark harness can run a range of steps

### DIFF
--- a/mrjob/spark/mr_spark_harness.py
+++ b/mrjob/spark/mr_spark_harness.py
@@ -14,7 +14,13 @@
 """A wrapper for mrjob_spark_harness.py, so we can test the harness with
 the inline runner."""
 from mrjob.job import MRJob
+from mrjob.options import _parse_raw_args
+from mrjob.spark.mrjob_spark_harness import _PASSTHRU_OPTIONS
 from mrjob.spark.mrjob_spark_harness import main as harness_main
+
+
+_PASSTHRU_OPTION_STRINGS = {
+    arg for args, kwargs in _PASSTHRU_OPTIONS for arg in args}
 
 
 class MRSparkHarness(MRJob):
@@ -22,35 +28,29 @@ class MRSparkHarness(MRJob):
     def configure_args(self):
         super(MRSparkHarness, self).configure_args()
 
+        # this is a positional argument in the spark harness
         self.add_passthru_arg(
             '--job-class', dest='job_class', type=str,
             help='dot-separated module and class name of MRJob',
             default='mrjob.job.MRJob')
 
-        self.add_passthru_arg(
-            '--compression-codec',
-            dest='compression_codec',
-            help=('Java class path of a codec to use to compress output.'))
-
-        self.add_passthru_arg(
-            '--job-args',
-            dest='job_args',
-            default='',
-            help=('The arguments pass to the MRJob. Please quote all passthru '
-                  ' args so that they are in the same string')
-        )
+        for args, kwargs in _PASSTHRU_OPTIONS:
+            self.add_passthru_arg(*args, **kwargs)
 
     def spark(self, input_path, output_path):
-        args = [
+        harness_args = [
             self.options.job_class,input_path, output_path,
-            '--job-args', self.options.job_args
         ]
 
-        if self.options.compression_codec:
-            args.append('--compression-codec')
-            args.append(self.options.compression_codec)
+        # find arguments to pass through to the Spark harness
+        raw_args = _parse_raw_args(self.arg_parser, self._cl_args)
 
-        harness_main(args)
+        for dest, option_string, args in raw_args:
+            if option_string in _PASSTHRU_OPTION_STRINGS:
+                harness_args.append(option_string)
+                harness_args.extend(args)
+
+        harness_main(harness_args)
 
 
 if __name__ == '__main__':

--- a/mrjob/spark/mrjob_spark_harness.py
+++ b/mrjob/spark/mrjob_spark_harness.py
@@ -28,16 +28,16 @@ _PASSTHRU_OPTIONS = [
         help=('The arguments pass to the MRJob. Please quote all passthru args'
               ' so that they are in the same string'),
     )),
-    (['--start'], dict(
+    (['--start-step'], dict(
         default=None,
-        dest='start',
+        dest='start_step',
         type=int,
         help=("Don't run steps before the step with this (0-indexed) step"
               " number. Use with --end to define a range of steps to run")
     )),
-    (['--end'], dict(
+    (['--end-step'], dict(
         default=None,
-        dest='end',
+        dest='end_step',
         type=int,
         help=("Don't run the step with this (0-indexed) step number, or steps"
               " after it. Use with --start to define a range of steps to run")
@@ -81,7 +81,9 @@ def main(cmd_line_args=None):
     steps = make_job().steps()
 
     # process steps
-    for step_num, step in list(enumerate(steps))[args.start:args.end]:
+    steps_to_run = list(enumerate(steps))[args.start_step:args.end_step]
+
+    for step_num, step in steps_to_run:
         rdd = _run_step(step, step_num, rdd, make_job)
 
     # write the results

--- a/mrjob/spark/mrjob_spark_harness.py
+++ b/mrjob/spark/mrjob_spark_harness.py
@@ -22,16 +22,30 @@ from mrjob.util import shlex_split
 #
 # these are tuples of (args, kwargs) for ArgumentParser.add_argument()
 _PASSTHRU_OPTIONS = [
-    (['--compression-codec'], dict(
-        default=None,
-        dest='compression_codec',
-        help=('Java class path of a codec to use to compress output.'),
-    )),
     (['--job-args'], dict(
         default=None,
         dest='job_args',
         help=('The arguments pass to the MRJob. Please quote all passthru args'
               ' so that they are in the same string'),
+    )),
+    (['--start'], dict(
+        default=None,
+        dest='start',
+        type=int,
+        help=("Don't run steps before the step with this (0-indexed) step"
+              " number. Use with --end to define a range of steps to run")
+    )),
+    (['--end'], dict(
+        default=None,
+        dest='end',
+        type=int,
+        help=("Don't run the step with this (0-indexed) step number, or steps"
+              " after it. Use with --start to define a range of steps to run")
+    )),
+    (['--compression-codec'], dict(
+        default=None,
+        dest='compression_codec',
+        help=('Java class path of a codec to use to compress output.'),
     )),
 ]
 
@@ -67,7 +81,7 @@ def main(cmd_line_args=None):
     steps = make_job().steps()
 
     # process steps
-    for step_num, step in enumerate(steps):
+    for step_num, step in list(enumerate(steps))[args.start:args.end]:
         rdd = _run_step(step, step_num, rdd, make_job)
 
     # write the results

--- a/tests/mr_doubler.py
+++ b/tests/mr_doubler.py
@@ -1,0 +1,36 @@
+# Copyright 2019 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mrjob.job import MRJob
+from mrjob.protocol import JSONProtocol
+from mrjob.step import MRStep
+
+
+class MRDoubler(MRJob):
+    """Double the value *n* times."""
+    INPUT_PROTOCOL = JSONProtocol
+
+    def configure_args(self):
+        super(MRDoubler, self).configure_args()
+
+        self.add_passthru_arg('-n', dest='n', type=int, default=1)
+
+    def mapper(self, key, value):
+        yield key, value * 2
+
+    def steps(self):
+        return [MRStep(mapper=self.mapper)] * self.options.n
+
+
+if __name__ == '__main__':
+    MRDoubler.run()

--- a/tests/mr_streaming_and_spark.py
+++ b/tests/mr_streaming_and_spark.py
@@ -22,8 +22,8 @@ from mrjob.step import SparkStep
 
 class MRStreamingAndSpark(MRJob):
 
-    def mapper(self):
-        return
+    def mapper(self, key, value):
+        yield key, value
 
     def spark(self):
         pass

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -23,6 +23,7 @@ from mrjob.spark import mrjob_spark_harness
 from mrjob.spark.mr_spark_harness import MRSparkHarness
 from mrjob.step import INPUT
 from mrjob.step import OUTPUT
+from mrjob.util import cmd_line
 from mrjob.util import to_lines
 
 from tests.mr_streaming_and_spark import MRStreamingAndSpark
@@ -106,7 +107,7 @@ class SparkHarnessOutputComparisonTestCase(
             harness_job_args.append('--compression-codec')
             harness_job_args.append(compression_codec)
         if job_args:
-            harness_job_args.extend(['--job-args', ' '.join(job_args)])
+            harness_job_args.extend(['--job-args', cmd_line(job_args)])
         if start_step:
             harness_job_args.extend(['--start-step', str(start_step)])
         if end_step:

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -87,26 +87,26 @@ class SparkHarnessOutputComparisonTestCase(
         return path
 
     def _reference_job(self, job_class, input_bytes=b'', input_paths=(),
-                       runner_alias='inline', extra_args=[]):
+                       runner_alias='inline', job_args=[]):
 
-        job_args = ['-r', runner_alias] + list(input_paths)
+        args = ['-r', runner_alias] + list(job_args) + list(input_paths)
 
-        reference_job = job_class(job_args + extra_args)
+        reference_job = job_class(args)
         reference_job.sandbox(stdin=BytesIO(input_bytes))
 
         return reference_job
 
     def _harness_job(self, job_class, input_bytes=b'', input_paths=(),
                      runner_alias='inline', compression_codec=None,
-                     extra_args=None, start_step=None, end_step=None):
+                     job_args=None, start_step=None, end_step=None):
         job_class_path = '%s.%s' % (job_class.__module__, job_class.__name__)
 
         harness_job_args = ['-r', runner_alias, '--job-class', job_class_path]
         if compression_codec:
             harness_job_args.append('--compression-codec')
             harness_job_args.append(compression_codec)
-        if extra_args:
-            harness_job_args.extend(['--job-args', ' '.join(extra_args)])
+        if job_args:
+            harness_job_args.extend(['--job-args', ' '.join(job_args)])
         if start_step:
             harness_job_args.extend(['--start-step', str(start_step)])
         if end_step:
@@ -120,12 +120,12 @@ class SparkHarnessOutputComparisonTestCase(
         return harness_job
 
     def _assert_output_matches(
-            self, job_class, input_bytes=b'', input_paths=(), extra_args=[]):
+            self, job_class, input_bytes=b'', input_paths=(), job_args=[]):
 
         reference_job = self._reference_job(
             job_class, input_bytes=input_bytes,
             input_paths=input_paths,
-            extra_args=extra_args)
+            job_args=job_args)
 
         with reference_job.make_runner() as runner:
             runner.run()
@@ -135,7 +135,7 @@ class SparkHarnessOutputComparisonTestCase(
         harness_job = self._harness_job(
             job_class, input_bytes=input_bytes,
             input_paths=input_paths,
-            extra_args=extra_args)
+            job_args=job_args)
 
         with harness_job.make_runner() as runner:
             runner.run()
@@ -217,7 +217,7 @@ class SparkHarnessOutputComparisonTestCase(
         self._assert_output_matches(
             MRPassThruArgTest,
             input_bytes=input_bytes,
-            extra_args=['--chars', '--ignore', 'to'])
+            job_args=['--chars', '--ignore', 'to'])
 
 
 # TODO: add back a test of the bare Harness script in local mode (slow)


### PR DESCRIPTION
Added `--start-step` and `--end-step` arguments to the Spark harness, so it can deal gracefully with jobs with mixed step types. Fixes #1950.

Also simplified the code in `MRSparkHarness` that passes arguments straight through to the Spark harness, so we don't have to keep switches in sync in three different places.