### PR TITLE
spark harness preserves partitioning

### DIFF
--- a/mrjob/spark/mrjob_spark_harness.py
+++ b/mrjob/spark/mrjob_spark_harness.py
@@ -249,7 +249,7 @@ def _shuffle_and_sort(rdd, sort_values=False):
     return rdd
 
 
-def _run_reducer(reducer_job, rdd, sort_values=False):
+def _run_reducer(reducer_job, rdd):
     """Run our job's combiner, and group lines with the same key together.
 
     :param reducer_job: an instance of our job, instantiated to be the mapper

--- a/mrjob/spark/mrjob_spark_harness.py
+++ b/mrjob/spark/mrjob_spark_harness.py
@@ -96,82 +96,163 @@ def _run_step(step, step_num, rdd, make_job):
     step_desc = step.description(step_num)
     _check_step(step_desc, step_num)
 
-    # creating a separate job instances to ensure that initialization
-    # happens correctly (e.g. mapper_job.is_task() should be True).
-    # probably doesn't actually matter that we pass --step-num
+    # create a separate job instance for each substep. This contains
+    # *step_num* (in ``job.options.step_num``) and ensures that
+    # ``job.is_task()`` is set to true
     mapper_job, reducer_job, combiner_job = (
         make_job('--%s' % mrc, '--step-num=%d' % step_num)
         if step_desc.get(mrc) else None
         for mrc in ('mapper', 'reducer', 'combiner')
     )
 
-    if mapper_job is not None:
-        m_read, m_write = mapper_job.pick_protocols(step_num, 'mapper')
+    # is SORT_VALUES enabled?
+    sort_values = reducer_job.sort_values() if reducer_job else False
 
-        # run the mapper
-        rdd = rdd.map(m_read)
-        rdd = rdd.mapPartitions(
-            lambda pairs: mapper_job.map_pairs(pairs, step_num))
-        rdd = rdd.map(lambda k_v: m_write(*k_v))
+    if mapper_job:
+        rdd = _run_mapper(mapper_job, rdd)
 
-    if combiner_job is not None:
-        c_read, c_write = combiner_job.pick_protocols(step_num, 'combiner')
+    if combiner_job:
+        # _run_combiner() includes shuffle-and-sort
+        rdd = _run_combiner(combiner_job, rdd, sort_values=sort_values)
+    elif reducer_job:
+        rdd = _shuffle_and_sort(rdd, sort_values=sort_values)
 
-        # run the combiner
-        rdd = rdd.map(c_read)
-
-        # Most combiners should return a single value per key to shrink the
-        # mapper output. If the combiner does not seem to be doing this, fall
-        # back to recreating the mapper output since Hadoop combiners are
-        # optional anyway and we do not want to run the same values through the
-        # combiner multiple times.
-        def combiner_helper(pairs1, pairs2):
-            if len(pairs1) == len(pairs2) == 1:
-                return list(
-                    combiner_job.combine_pairs(pairs1 + pairs2, step_num),
-                )
-            else:
-                pairs1.extend(pairs2)
-                return pairs1
-
-        # combine_pairs takes a list of key-value pairs; restructuring the
-        # data so that we can provide that
-        rdd = rdd.map(lambda k_v: (k_v[0], k_v))
-
-        # a shuffle is unneccesary in this case since combineByKey returns an
-        # RDD grouped by key.
-        rdd = rdd.combineByKey(
-            createCombiner=lambda k_v: [k_v],
-            mergeValue=lambda k_v_list, k_v: combiner_helper(k_v_list, [k_v]),
-            mergeCombiners=combiner_helper,
-        )
-        rdd = rdd.mapValues(
-            lambda pairs: [c_write(*pair) for pair in pairs])
-        rdd = _flatten_and_maybe_sort_keys(
-            rdd,
-            should_sort=(
-                reducer_job.sort_values() if reducer_job is not None else False
-            ))
-    elif reducer_job is not None and combiner_job is None:
-        # simulate shuffle in Hadoop Streaming
-        rdd = rdd.groupBy(lambda line: line.split(b'\t')[0])
-        rdd = _flatten_and_maybe_sort_keys(
-            rdd, should_sort=reducer_job.sort_values())
-
-    if reducer_job is not None:
-        r_read, r_write = reducer_job.pick_protocols(step_num, 'reducer')
-
-        # run the reducer
-        rdd = rdd.map(r_read)
-        rdd = rdd.mapPartitions(
-            lambda pairs: reducer_job.reduce_pairs(pairs, step_num))
-        rdd = rdd.map(lambda k_v: r_write(*k_v))
+    if reducer_job:
+        rdd = _run_reducer(reducer_job, rdd)
 
     return rdd
 
 
-def _flatten_and_maybe_sort_keys(rdd, should_sort):
-    if should_sort:
+def _run_mapper(mapper_job, rdd):
+    """Run our job's mapper.
+
+    :param mapper_job: an instance of our job, instantiated to be the mapper
+                       for the step we wish to run
+    :param rdd: an RDD containing lines representing encoded key-value pairs
+    :return: an RDD containing lines representing encoded key-value pairs
+    """
+    step_num = mapper_job.options.step_num
+
+    m_read, m_write = mapper_job.pick_protocols(step_num, 'mapper')
+
+    # run the mapper
+    rdd = rdd.map(m_read)
+    rdd = rdd.mapPartitions(
+        lambda pairs: mapper_job.map_pairs(pairs, step_num))
+    rdd = rdd.map(lambda k_v: m_write(*k_v))
+
+    return rdd
+
+
+def _run_combiner(combiner_job, rdd, sort_values=False):
+    """Run our job's combiner, and group lines with the same key together.
+
+    :param combiner_job: an instance of our job, instantiated to be the mapper
+                         for the step we wish to run
+    :param rdd: an RDD containing lines representing encoded key-value pairs
+    :sort_values: if true, ensure all lines corresponding to a given key
+                  are sorted (by their encoded value)
+    :return: an RDD containing "reducer ready" lines representing encoded
+             key-value pairs, that is, where all lines with the same key are
+             adjacent and in the same partition
+    """
+    step_num = combiner_job.options.step_num
+
+    c_read, c_write = combiner_job.pick_protocols(step_num, 'combiner')
+
+    # run the combiner
+    rdd = rdd.map(c_read)
+
+    # The common case for MRJob combiners is to yield a single key-value pair
+    # (for example ``(key, sum(values))``. If the combiner does something
+    # else, just build a list of values so we don't end up running multiple
+    # values through the MRJob's combiner multiple times.
+    def combiner_helper(pairs1, pairs2):
+        if len(pairs1) == len(pairs2) == 1:
+            return list(
+                combiner_job.combine_pairs(pairs1 + pairs2, step_num),
+            )
+        else:
+            pairs1.extend(pairs2)
+            return pairs1
+
+    # Spark's combineByKey() only looks at values, but MRJob combiners
+    # expect to know the key as well. So include the key in our "values"
+    rdd = rdd.map(lambda k_v: (k_v[0], k_v))
+
+    # :py:meth:`pyspark.RDD.combineByKey()`, where the magic happens.
+    #
+    # Our "values" are key-value pairs, and our "combined values" are lists of
+    # key-value pairs (single-item lists in the common case).
+    #
+    # note that unlike Hadoop combiners, combineByKey() sees *all* the
+    # key-value pairs, essentially doing a shuffle-and-sort for free.
+    rdd = rdd.combineByKey(
+        createCombiner=lambda k_v: [k_v],
+        mergeValue=lambda k_v_list, k_v: combiner_helper(k_v_list, [k_v]),
+        mergeCombiners=combiner_helper,
+    )
+    # encode our lists of key-value pairs back into lists of lines
+    rdd = rdd.mapValues(
+        lambda pairs: [c_write(*pair) for pair in pairs])
+    # throw away the key and just get lists of lines
+    rdd = _discard_key_and_flatten_values(rdd, sort_values=sort_values)
+
+    return rdd
+
+
+def _shuffle_and_sort(rdd, sort_values=False):
+    """Simulate Hadoop's shuffle-and-sort step, so that data will be in the
+    format the reducer expects.
+
+    :param rdd: an RDD containing lines representing encoded key-value pairs,
+                where the encoded key comes first and is followed by a TAB
+                character (the encoded key may not contain TAB).
+    :sort_values: if true, ensure all lines corresponding to a given key
+                  are sorted (by their encoded value)
+    :return: an RDD containing "reducer ready" lines representing encoded
+             key-value pairs, that is, where all lines with the same key are
+             adjacent and in the same partition
+    """
+    rdd = rdd.groupBy(lambda line: line.split(b'\t')[0])
+    rdd = _discard_key_and_flatten_values(rdd, sort_values=sort_values)
+
+    return rdd
+
+
+def _run_reducer(reducer_job, rdd, sort_values=False):
+    """Run our job's combiner, and group lines with the same key together.
+
+    :param reducer_job: an instance of our job, instantiated to be the mapper
+                        for the step we wish to run
+    :param rdd: an RDD containing "reducer ready" lines representing encoded
+                key-value pairs, that is, where all lines with the same key are
+                adjacent and in the same partition
+    :return: an RDD containing encoded key-value pairs
+    """
+    step_num = reducer_job.options.step_num
+
+    r_read, r_write = reducer_job.pick_protocols(step_num, 'reducer')
+
+    # run the reducer
+    rdd = rdd.map(r_read)
+    rdd = rdd.mapPartitions(
+        lambda pairs: reducer_job.reduce_pairs(pairs, step_num))
+    rdd = rdd.map(lambda k_v: r_write(*k_v))
+
+    return rdd
+
+
+def _discard_key_and_flatten_values(rdd, sort_values=False):
+    """Helper function for :py:func:`_run_combiner` and
+    :py:func:`_shuffle_and_sort`.
+
+    Given an RDD containing (key, [line1, line2, ...]), discard *key*
+    and return an RDD containing line1, line2, ...
+
+    If *sort_values* is true, sort each list of lines before flattening it.
+    """
+    if sort_values:
         return rdd.flatMap(lambda key_and_lines: sorted(key_and_lines[1]))
     else:
         return rdd.flatMap(lambda key_and_lines: key_and_lines[1])

--- a/tests/mr_word_freq_count_with_combiner_cmd.py
+++ b/tests/mr_word_freq_count_with_combiner_cmd.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MRWordFreqCount, with a trivial combiner command.
+
+Used to ensure that Spark runner can skip combiners that run commands.
+"""
+from mrjob.examples.mr_word_freq_count import MRWordFreqCount
+from mrjob.job import MRJob
+
+
+class MRWordFreqCountWithCombinerCmd(MRWordFreqCount):
+
+    combiner = MRJob.combiner  # un-set combiner()
+
+    def combiner_cmd(self):
+        return 'cat'
+
+
+if __name__ == '__main__':
+    MRWordFreqCountWithCombinerCmd.run()

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -413,6 +413,9 @@ class PreservesPartitioningTestCase(SandboxedTestCase):
         after_combineByKey = False
         for name, args, kwargs in rdd.method_calls:
             if after_combineByKey:
+                if '.' in name:
+                    continue  # Python 3.4/3.5 tracks groupBy.assert_called()
+
                 # mapValues() doesn't have to use preservesPartitioning
                 # because it's just encoding the list of all values for a key
                 if name == 'mapValues':
@@ -449,6 +452,11 @@ class PreservesPartitioningTestCase(SandboxedTestCase):
         after_groupBy = False
         for name, args, kwargs in rdd.method_calls:
             if after_groupBy:
+                if '.' in name:
+                    continue  # Python 3.4/3.5 tracks groupBy.assert_called()
+
+                if not kwargs.get('preservesPartitioning'):
+                    import pdb; pdb.set_trace()
                 self.assertEqual(kwargs.get('preservesPartitioning'), True)
             elif name == 'groupBy':
                 after_groupBy = True

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -22,6 +22,9 @@ from mrjob.local import LocalMRJobRunner
 from mrjob.protocol import TextProtocol
 from mrjob.spark import mrjob_spark_harness
 from mrjob.spark.mr_spark_harness import MRSparkHarness
+from mrjob.spark.mrjob_spark_harness import _run_combiner
+from mrjob.spark.mrjob_spark_harness import _run_reducer
+from mrjob.spark.mrjob_spark_harness import _shuffle_and_sort
 from mrjob.step import INPUT
 from mrjob.step import OUTPUT
 from mrjob.util import cmd_line
@@ -33,6 +36,8 @@ from tests.mr_sort_and_group import MRSortAndGroup
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_freq_count_with_combiner_cmd import \
      MRWordFreqCountWithCombinerCmd
+from tests.py2 import Mock
+from tests.py2 import call
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import SingleSparkContextTestCase
 
@@ -357,3 +362,114 @@ class SparkHarnessOutputComparisonTestCase(
 
         self._assert_output_matches(
             MRWordFreqCountWithCombinerCmd, input_bytes=input_bytes)
+
+
+class PreservesPartitioningTestCase(SandboxedTestCase):
+
+    # ensure that Spark doesn't repartition values once they're grouped
+    # by key.
+    #
+    # unfortunately, it's hard to "catch" Spark re-partitioning (espeically
+    # since our code doesn't give it a good reason to re-partition), so we
+    # instead use mocks and check that the RDD was called with
+    # preservesPartitioning=True when necessary
+
+    def mock_rdd(self):
+        """Make a mock RDD that returns itself."""
+        method_names = [
+            'combineByKey',
+            'flatMap',
+            'groupBy',
+            'map',
+            'mapPartitions',
+            'mapValues',
+        ]
+
+        rdd = Mock(spec=method_names)
+
+        for name in method_names:
+            getattr(rdd, name).return_value = rdd
+
+        return rdd
+
+    def test_run_combiner_with_sort_values(self):
+        self._test_run_combiner(sort_values=True)
+
+    def test_run_combiner_without_sort_values(self):
+        self._test_run_combiner(sort_values=False)
+
+    def _test_run_combiner(self, sort_values):
+        rdd = self.mock_rdd()
+
+        combiner_job = Mock()
+        combiner_job.pick_protocols.return_value = (Mock(), Mock())
+
+        final_rdd = _run_combiner(combiner_job, rdd)
+        self.assertEqual(final_rdd, rdd)  # mock RDD's methods return it
+
+        # check that we always preserve partitioning after combineByKey()
+        rdd.combineByKey.assert_called()
+
+        after_combineByKey = False
+        for name, args, kwargs in rdd.method_calls:
+            if after_combineByKey:
+                # mapValues() doesn't have to use preservesPartitioning
+                # because it's just encoding the list of all values for a key
+                if name == 'mapValues':
+                    # check that mapValues() is mapping a list to a list
+                    # of the same size
+                    f = args[0]
+                    f_of_values = f([('k', 'v1'), ('k', 'v2')])
+                    self.assertEqual(type(f_of_values), list)
+                    self.assertEqual(len(f_of_values), 2)
+                    self.assertRaises(TypeError, 123)
+                else:
+                    self.assertEqual(kwargs.get('preservesPartitioning'), True)
+            elif name == 'combineByKey':
+                after_combineByKey = True
+
+        # sanity-check that we found the call to combineByKey()
+        self.assertTrue(after_combineByKey)
+
+    def test_shuffle_and_sort_with_sort_values(self):
+        self._test_shuffle_and_sort(sort_values=True)
+
+    def test_shuffle_and_sort_without_sort_values(self):
+        self._test_shuffle_and_sort(sort_values=False)
+
+    def _test_shuffle_and_sort(self, sort_values):
+        rdd = self.mock_rdd()
+
+        final_rdd = _shuffle_and_sort(rdd)
+        self.assertEqual(final_rdd, rdd)  # mock RDD's methods return it
+
+        # check that we always preserve partitioning after groupBy()
+        rdd.groupBy.assert_called()
+
+        after_groupBy = False
+        for name, args, kwargs in rdd.method_calls:
+            if after_groupBy:
+                self.assertEqual(kwargs.get('preservesPartitioning'), True)
+            elif name == 'groupBy':
+                after_groupBy = True
+
+        # sanity-check that we found the call to groupBy()
+        self.assertTrue(after_groupBy)
+
+    def test_run_reducer(self):
+        rdd = self.mock_rdd()
+
+        reducer_job = Mock()
+        reducer_job.pick_protocols.return_value = (Mock(), Mock())
+
+        final_rdd = _run_reducer(reducer_job, rdd)
+        self.assertEqual(final_rdd, rdd)  # mock RDD's methods return it
+
+        # check that we preserve partitions until mapPartitions() is called
+        rdd.mapPartitions.assert_called()
+
+        for name, args, kwargs in rdd.method_calls:
+            if name == 'mapPartitions':
+                break
+            else:
+                self.assertEqual(kwargs.get('preservesPartitioning'), True)


### PR DESCRIPTION
This ensures that the Spark harness doesn't inadvertently re-partition after it groups together key-value pairs for the reducer. Fixes #1973.

Also fixed and tested a loose end: the spark harness can handle combiners that run commands, but it does so by skipping them.