### PR TITLE
make spark runner run Hadoop streaming steps

### DIFF
--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -1003,7 +1003,9 @@ class MRJobBinRunner(MRJobRunner):
         args.extend(self._spark_upload_args())
 
         # --py-files (Python only)
-        if step['type'] in ('spark', 'spark_script'):
+        # spark runner can run 'streaming' steps, so just exclude
+        # non-Python steps
+        if 'jar' not in step['type']:
             py_file_uris = self._py_files()
 
             if self._upload_mgr:

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -814,22 +814,28 @@ class MRJobBinRunner(MRJobRunner):
 
     ### spark ###
 
-    def _args_for_spark_step(self, step_num):
+    def _args_for_spark_step(self, step_num, last_step_num=None):
         """The actual arguments used to run the spark-submit command.
 
         This handles both all Spark step types (``spark``, ``spark_jar``,
         and ``spark_script``).
+
+        *last_step_num* is only used by the Spark runner, where multiple
+        streaming steps are run in a single Spark job
         """
         return (
             self.get_spark_submit_bin() +
             self._spark_submit_args(step_num) +
             [self._spark_script_path(step_num)] +
-            self._spark_script_args(step_num)
+            self._spark_script_args(step_num, last_step_num)
         )
 
-    def _spark_script_args(self, step_num):
+    def _spark_script_args(self, step_num, last_step_num=None):
         """A list of args to the spark script/jar, used by
-        _args_for_spark_step()."""
+        _args_for_spark_step().
+
+        *last_step_num* is only used by the Spark runner, where multiple
+        streaming steps are run in a single Spark job."""
         # TODO: this can also return args to the MRJob, which is confusing
         step = self._get_step(step_num)
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -1029,14 +1029,6 @@ class MRJobBinRunner(MRJobRunner):
     def _spark_master(self):
         return self._opts.get('spark_master') or None
 
-    def _spark_master_is_local(self):
-        """Utility method, since this comes up so often"""
-        master = self._spark_master()
-        if master:
-            return master.startswith('local')
-        else:
-            return True  # local is the default
-
     def _spark_deploy_mode(self):
         return self._opts.get('spark_deploy_mode') or None
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -968,9 +968,6 @@ class MRJobBinRunner(MRJobRunner):
         the given spark or spark_script step."""
         step = self._get_step(step_num)
 
-        if not _is_spark_step_type(step['type']):
-            raise TypeError('non-Spark step: %r' % step)
-
         args = []
 
         # add --master

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -1041,12 +1041,16 @@ class MRJobBinRunner(MRJobRunner):
     def _spark_upload_args(self):
         # if using a setup script, upload all files to working dir
         if self._spark_python_wrapper_path:
-            return self._upload_args_helper('--files', None,
-                                            '--archives', None)
+            return self._upload_args_helper(
+                '--files', None,
+                '--archives', None,
+                always_use_hash=False)
         else:
             # otherwise, just pass through --files and --archives
-            return self._upload_args_helper('--files', self._spark_files,
-                                            '--archives', self._spark_archives)
+            return self._upload_args_helper(
+                '--files', self._spark_files,
+                '--archives', self._spark_archives,
+                always_use_hash=False)
 
     def _spark_script_path(self, step_num):
         """The path of the spark script or JAR, used by

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -78,19 +78,18 @@ class InlineMRJobRunner(SimMRJobRunner):
         if self._opts['setup']:
             log.warning("inline runner can't run setup commands")
 
-    def _check_steps(self, steps):
+    def _check_step(self, step, step_num):
         """Don't try to run steps that include commands."""
-        super(InlineMRJobRunner, self)._check_steps(steps)
+        super(InlineMRJobRunner, self)._check_step(step, step_num)
 
-        for step_num, step in enumerate(steps):
-            if step['type'] == 'streaming':
-                for mrc in ('mapper', 'combiner', 'reducer'):
-                    if step.get(mrc):
-                        if 'command' in step[mrc] or 'pre_filter' in step[mrc]:
-                            raise NotImplementedError(
-                                "step %d's %s runs a command, but inline"
-                                " runner does not support subprocesses (try"
-                                " -r local)" % (step_num, mrc))
+        if step['type'] == 'streaming':
+            for mrc in ('mapper', 'combiner', 'reducer'):
+                if step.get(mrc):
+                    if 'command' in step[mrc] or 'pre_filter' in step[mrc]:
+                        raise NotImplementedError(
+                            "step %d's %s runs a command, but inline"
+                            " runner does not support subprocesses (try"
+                            " -r local)" % (step_num, mrc))
 
     def _invoke_task_func(self, task_type, step_num, task_num):
         """Just run tasks in the same process."""

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -492,10 +492,11 @@ class MRJob(MRJobLauncher):
             return super(MRJob, self)._runner_class()
 
     def _runner_kwargs(self):
-        """If we're building an inline runner, include mrjob_cls in kwargs."""
+        """If we're building an inline or Spark runner,
+        include mrjob_cls in kwargs."""
         kwargs = super(MRJob, self)._runner_kwargs()
 
-        if self._runner_class().alias == 'inline':
+        if self._runner_class().alias in ('inline', 'spark'):
             kwargs = dict(mrjob_cls=self.__class__, **kwargs)
 
         # pass steps to runner (see #1845)

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -22,11 +22,7 @@ import platform
 from functools import partial
 from multiprocessing import cpu_count
 from os.path import dirname
-from os.path import isdir
 from os.path import join
-from os.path import relpath
-from shutil import copy2
-from shutil import copytree
 
 from mrjob.cat import decompress
 from mrjob.cat import is_compressed
@@ -38,6 +34,7 @@ from mrjob.logs.counters import _format_counters
 from mrjob.parse import parse_mr_job_stderr
 from mrjob.runner import MRJobRunner
 from mrjob.runner import _fix_env
+from mrjob.runner import _symlink_or_copy
 from mrjob.step import _is_spark_step_type
 from mrjob.util import unarchive
 
@@ -779,23 +776,3 @@ def _split_records(record_gen, split_size, reducer_key=None):
     if num_records == 0:
         # special case for empty files
         yield ()
-
-
-def _symlink_or_copy(path, dest):
-    """Symlink from *dest* to *path*, using relative paths if possible.
-
-    If symlinks aren't available, copy path to dest instead.
-    """
-    if hasattr(os, 'symlink'):
-        log.debug('creating symlink %s <- %s' % (path, dest))
-        try:
-            os.symlink(relpath(path, dirname(dest)), dest)
-            return
-        except OSError as ex:
-            log.debug('  %s' % ex)
-
-    log.debug('copying %s -> %s' % (dest, path))
-    if isdir(path):
-        copytree(path, dest)
-    else:
-        copy2(path, dest)

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -22,7 +22,11 @@ import platform
 from functools import partial
 from multiprocessing import cpu_count
 from os.path import dirname
+from os.path import isdir
 from os.path import join
+from os.path import relpath
+from shutil import copy2
+from shutil import copytree
 
 from mrjob.cat import decompress
 from mrjob.cat import is_compressed
@@ -34,7 +38,6 @@ from mrjob.logs.counters import _format_counters
 from mrjob.parse import parse_mr_job_stderr
 from mrjob.runner import MRJobRunner
 from mrjob.runner import _fix_env
-from mrjob.runner import _symlink_or_copy
 from mrjob.step import _is_spark_step_type
 from mrjob.util import unarchive
 
@@ -776,3 +779,23 @@ def _split_records(record_gen, split_size, reducer_key=None):
     if num_records == 0:
         # special case for empty files
         yield ()
+
+
+def _symlink_or_copy(path, dest):
+    """Symlink from *dest* to *path*, using relative paths if possible.
+
+    If symlinks aren't available, copy path to dest instead.
+    """
+    if hasattr(os, 'symlink'):
+        log.debug('creating symlink %s <- %s' % (path, dest))
+        try:
+            os.symlink(relpath(path, dirname(dest)), dest)
+            return
+        except OSError as ex:
+            log.debug('  %s' % ex)
+
+    log.debug('copying %s -> %s' % (dest, path))
+    if isdir(path):
+        copytree(path, dest)
+    else:
+        copy2(path, dest)

--- a/mrjob/spark/mr_spark_harness.py
+++ b/mrjob/spark/mr_spark_harness.py
@@ -27,6 +27,7 @@ class MRSparkHarness(MRJob):
             help='dot-separated module and class name of MRJob',
             default='mrjob.job.MRJob')
 
+        # TODO: these duplicate code in the harness
         self.add_passthru_arg(
             '--compression-codec',
             dest='compression_codec',

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -342,11 +342,9 @@ class SparkMRJobRunner(MRJobBinRunner):
         args.append(
             self._step_output_uri(last_step_num))
 
-        # --first-step-num, --last-step-num, step range
-        if not (step_num == 0 and last_step_num == self._num_steps() - 1):
-            # don't bother with these when running entire job (common case)
-            args.extend(['--first-step-num', step_num,
-                         '--last_step_num', step_num])
+        # --first-step-num, --last-step-num (step range)
+        args.extend(['--first-step-num', str(step_num),
+                     '--last-step-num', str(last_step_num)])
 
         # --job-args (passthrough args)
         job_args = self._mr_job_extra_args()

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -16,6 +16,7 @@ import logging
 import os.path
 import posixpath
 import re
+from shutil import copy2
 from subprocess import CalledProcessError
 from tempfile import gettempdir
 
@@ -35,7 +36,6 @@ from mrjob.fs.s3 import _is_permanent_boto3_error
 from mrjob.hadoop import fully_qualify_hdfs_path
 from mrjob.logs.step import _log_log4j_record
 from mrjob.parse import is_uri
-from mrjob.runner import _symlink_or_copy
 from mrjob.setup import UploadDirManager
 from mrjob.spark import mrjob_spark_harness
 from mrjob.step import StepFailedException
@@ -248,7 +248,8 @@ class SparkMRJobRunner(MRJobBinRunner):
             filename = '%s.py' % self._job_script_module_name()
             dest = os.path.join(self._get_job_script_dir(), filename)
 
-            _symlink_or_copy(self._script_path, dest)
+            log.debug('  copying %s -> %s' % (self._script_path, dest))
+            copy2(self._script_path, dest)
 
             self._spark_files.append([filename, dest])
             self._working_dir_mgr.add('file', dest, filename)

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -355,9 +355,9 @@ class SparkMRJobRunner(MRJobBinRunner):
         jobconf = self._jobconf_for_step(step_num)
 
         compress_conf = jobconf_from_dict(
-            jobconf, 'mapreduce.map.output.compress')
+            jobconf, 'mapreduce.output.fileoutputformat.compress')
         codec_conf = jobconf_from_dict(
-            jobconf, 'mapreduce.map.output.compress.codec')
+            jobconf, 'mapreduce.output.fileoutputformat.compress.codec')
 
         if compress_conf and compress_conf != 'false' and codec_conf:
             args.extend(['--compression-codec', codec_conf])

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -277,3 +277,9 @@ class SparkMRJobRunner(MRJobBinRunner):
 
     def _run_streaming_steps_in_harness(self, steps, step_num, last_step_num):
         raise NotImplementedError
+
+
+# TODO: get job_script_copy into working dir()
+# TODO: check for bad streaming scripts (similar to inline runner)
+#       temporarily reject Hadoop input and output formats
+# TODO: implement _run_streaming_steps_in_harness()

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -522,13 +522,7 @@ def zip_dir(dir, out_path, filter=None, prefix=''):
     if not filter:
         filter = lambda path: True
 
-    def create_zip_file():
-        try:
-            return ZipFile(out_path, mode='w', compression=ZIP_DEFLATED)
-        except RuntimeError:  # zlib not available
-            return ZipFile(out_path, mode='w', compression=ZIP_STORED)
-
-    with create_zip_file() as zip_file:
+    with _create_zip_file(out_path) as zip_file:
         for dirpath, dirnames, filenames in os.walk(dir, followlinks=True):
             for filename in filenames:
                 path = os.path.join(dirpath, filename)
@@ -539,3 +533,11 @@ def zip_dir(dir, out_path, filter=None, prefix=''):
                     real_path = os.path.realpath(path)
                     path_in_zip_file = os.path.join(prefix, rel_path)
                     zip_file.write(real_path, arcname=path_in_zip_file)
+
+
+# this is also used by spark runner
+def _create_zip_file(path):
+    try:
+        return ZipFile(path, mode='w', compression=ZIP_DEFLATED)
+    except RuntimeError:  # zlib not available
+        return ZipFile(path, mode='w', compression=ZIP_STORED)

--- a/tests/py2.py
+++ b/tests/py2.py
@@ -30,6 +30,9 @@ if sys.version_info < (3, 3):
 else:
     from unittest import mock
 
+ANY = mock.ANY
+ANY
+
 MagicMock = mock.MagicMock
 MagicMock
 

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -27,12 +27,12 @@ from mrjob.util import cmd_line
 from mrjob.util import to_lines
 
 from tests.mr_doubler import MRDoubler
+from tests.mr_pass_thru_arg_test import MRPassThruArgTest
 from tests.mr_streaming_and_spark import MRStreamingAndSpark
 from tests.mr_sort_and_group import MRSortAndGroup
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import SingleSparkContextTestCase
-
 
 
 def _rev(s):
@@ -55,27 +55,6 @@ class ReversedTextProtocol(TextProtocol):
 class MRSortAndGroupReversedText(MRSortAndGroup):
 
     INTERNAL_PROTOCOL = ReversedTextProtocol
-
-
-class MRPassThruArgTest(MRJob):
-
-    def configure_args(self):
-        super(MRPassThruArgTest, self).configure_args()
-        self.add_passthru_arg('--chars', action='store_true')
-        self.add_passthru_arg('--ignore')
-
-    def mapper(self, _, value):
-        if self.options.ignore:
-            value = value.replace(self.options.ignore, '')
-        if self.options.chars:
-            for c in value:
-                yield c, 1
-        else:
-            for w in value.split(' '):
-                yield w, 1
-
-    def reducer(self, key, values):
-        yield key, sum(values)
 
 
 class SparkHarnessOutputComparisonTestCase(

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -100,7 +100,7 @@ class SparkHarnessOutputComparisonTestCase(
 
     def _harness_job(self, job_class, input_bytes=b'', input_paths=(),
                      runner_alias='inline', compression_codec=None,
-                     job_args=None, start_step=None, end_step=None):
+                     job_args=None, first_step_num=None, last_step_num=None):
         job_class_path = '%s.%s' % (job_class.__module__, job_class.__name__)
 
         harness_job_args = ['-r', runner_alias, '--job-class', job_class_path]
@@ -109,10 +109,10 @@ class SparkHarnessOutputComparisonTestCase(
             harness_job_args.append(compression_codec)
         if job_args:
             harness_job_args.extend(['--job-args', cmd_line(job_args)])
-        if start_step:
-            harness_job_args.extend(['--start-step', str(start_step)])
-        if end_step:
-            harness_job_args.extend(['--end-step', str(end_step)])
+        if first_step_num is not None:
+            harness_job_args.extend(['--first-step-num', str(first_step_num)])
+        if last_step_num is not None:
+            harness_job_args.extend(['--last-step-num', str(last_step_num)])
 
         harness_job_args.extend(input_paths)
 
@@ -162,7 +162,7 @@ class SparkHarnessOutputComparisonTestCase(
 
         job = self._harness_job(
             MRStreamingAndSpark, input_bytes=input_bytes,
-            start_step=0, end_step=1)
+            first_step_num=0, last_step_num=0)
 
         with job.make_runner() as runner:
             runner.run()
@@ -183,7 +183,7 @@ class SparkHarnessOutputComparisonTestCase(
         # just run two of the five steps
         steps_2_and_3_job = self._harness_job(
             MRDoubler, input_bytes=input_bytes, job_args=['-n', '5'],
-            start_step=2, end_step=4)
+            first_step_num=2, last_step_num=3)
 
         with steps_2_and_3_job.make_runner() as runner:
             runner.run()

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -413,7 +413,7 @@ class PreservesPartitioningTestCase(SandboxedTestCase):
         f_of_values = f([('k', 'v1'), ('k', 'v2')])
         self.assertEqual(type(f_of_values), list)
         self.assertEqual(len(f_of_values), 2)
-        self.assertRaises(TypeError, 123)
+        self.assertRaises(TypeError, f, 123)  # iterables only, fools
 
     def test_shuffle_and_sort_with_sort_values(self):
         self._test_shuffle_and_sort(sort_values=True)

--- a/tests/spark/test_mrjob_spark_harness.py
+++ b/tests/spark/test_mrjob_spark_harness.py
@@ -319,6 +319,3 @@ class SparkHarnessOutputComparisonTestCase(
         ])
 
         self._assert_output_matches(MRSumValuesByWord, input_bytes=input_bytes)
-
-
-# TODO: add back a test of the bare Harness script in local mode (slow)

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -215,7 +215,7 @@ class SparkRunnerStreamingStepsTestCase(MockFilesystemsTestCase):
         # deliberately mix Hadoop 1 and 2 config properties
         jobconf_args = [
             '--jobconf',
-            'mapred.map.output.compression.codec='\
+            'mapred.output.compression.codec='\
             'org.apache.hadoop.io.compress.GzipCodec',
             '--jobconf',
             'mapreduce.output.fileoutputformat.compress=true',

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -282,16 +282,16 @@ class SparkRunnerStreamingStepsTestCase(MockFilesystemsTestCase):
             self.assertEqual(
                 sorted(to_lines(runner.cat_output())),
                 [
-                    '\t 2\n',
-                    '" 4\n',
-                    'a 1\n',
-                    'b 1\n',
-                    'f 1\n',
-                    'l 4\n',
-                    'n 2\n',
-                    'o 2\n',
-                    'r 1\n',
-                    'u 2\n',
+                    b'\t 2\n',
+                    b'" 4\n',
+                    b'a 1\n',
+                    b'b 1\n',
+                    b'f 1\n',
+                    b'l 4\n',
+                    b'n 2\n',
+                    b'o 2\n',
+                    b'r 1\n',
+                    b'u 2\n',
                 ]
             )
 
@@ -359,7 +359,6 @@ class GroupStepsTestCase(MockFilesystemsTestCase):
             call(ANY, 1, 2),
             call(ANY, 3, 3),
         ])
-
 
 
 # TODO: test uploading files and setting up working dir once we fix #1922

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -132,7 +132,7 @@ class ArgsForSparkStepTestCase(GenericLocalRunnerTestCase):
             self.mock_get_spark_submit_bin.assert_called_once_with()
             self.mock_spark_submit_args.assert_called_once_with(step_num)
             self.mock_spark_script_path.assert_called_once_with(step_num)
-            self.mock_spark_script_args.assert_called_once_with(step_num)
+            self.mock_spark_script_args.assert_called_once_with(step_num, None)
 
     def test_step_0(self):
         self._test_step(0)

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1642,15 +1642,6 @@ class SparkSubmitArgsTestCase(GenericLocalRunnerTestCase):
                 self._expected_conf_args(
                     cmdenv=dict(PYSPARK_PYTHON='mypy')))
 
-    def test_streaming_step_not_allowed(self):
-        job = MRTwoStepJob(['-r', 'local'])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertRaises(
-                TypeError,
-                runner._spark_submit_args, 0)
-
 
 class CreateMrjobZipTestCase(SandboxedTestCase):
 


### PR DESCRIPTION
This change adds the magic glue between the Spark runner and the Spark harness, so that the Spark runner can run "classic" Hadoop streaming jobs in Spark. Fixes #1972.