### PR TITLE
fully test cat_output()

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -268,15 +268,15 @@ class TestCatOutput(SandboxedTestCase):
         self.assertEqual(chunks[3], b'')
 
     def test_deprecated_stream_output(self):
-        self.makefile('part-00000', contents=b'1\n2')
-        self.makefile('part-00001', contents=b'3\n4\n')
-
-        runner = InlineMRJobRunner(conf_paths=[], output_dir=self.tmp_dir)
+        self.makefile(os.path.join(self.output_dir, 'part-00000'),
+                      b'1\n2')
+        self.makefile(os.path.join(self.output_dir, 'part-00001'),
+                      b'3\n4\n')
 
         log = self.start(patch('mrjob.runner.log'))
 
         # should group output into lines, but not join across files
-        self.assertEqual(sorted(runner.stream_output()),
+        self.assertEqual(sorted(self.runner.stream_output()),
                          [b'1\n', b'2', b'3\n', b'4\n'])
 
         # should issue deprecation warning

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -267,6 +267,17 @@ class TestCatOutput(SandboxedTestCase):
         self.assertEqual(chunks[1], b'')
         self.assertEqual(chunks[3], b'')
 
+    def test_output_dir_not_considered_hidden(self):
+        output_dir = os.path.join(self.tmp_dir, '_hidden', '_output_dir')
+
+        self.makefile(os.path.join(output_dir, 'part-00000'),
+                      b'cats\n')
+
+        runner = InlineMRJobRunner(conf_paths=[], output_dir=output_dir)
+
+        self.assertEqual(sorted(to_lines(runner.stream_output())),
+                         [b'cats\n'])
+
     def test_deprecated_stream_output(self):
         self.makefile(os.path.join(self.output_dir, 'part-00000'),
                       b'1\n2')

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -195,8 +195,20 @@ class TestJobName(BasicTestCase):
 
 class TestCatOutput(SandboxedTestCase):
 
+    def setUp(self):
+        super(TestCatOutput, self).setUp()
+
+        self.output_dir = os.path.join(self.tmp_dir, 'job_output')
+        os.mkdir(self.output_dir)
+
+        self.runner = InlineMRJobRunner(
+            conf_paths=[], output_dir=self.output_dir)
+
+    # TODO: basic test, break up test below, test hidden files inside dirs,
+    # test "hidden" output dir
+
     # Test regression for #269
-    def test_cat_output(self):
+    def test_part_files_in_subdirs_and_hidden_dirs(self):
         a_dir_path = os.path.join(self.tmp_dir, 'a')
         b_dir_path = os.path.join(self.tmp_dir, 'b')
         l_dir_path = os.path.join(self.tmp_dir, '_logs')


### PR DESCRIPTION
cat_output() now imitates Hadoop's output format as fully as it can without choking on non-hidden subdirectories. Fixes #1337.

Though honestly, it was already fixed by #1962; this just adds extensive tests, now that we're confident which behavior we want.