### PR TITLE
--subnet '' means no subnet

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -3035,7 +3035,7 @@ def _fix_configuration_opt(c):
 
 def _fix_subnet_opt(subnet):
     """Return either None, a string, or a list with at least two items."""
-    if not subnet:
+    if subnet is None:
         return None
 
     if isinstance(subnet, string_types):

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2503,7 +2503,8 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             if isinstance(self._opts['subnet'], list):
                 matches = (subnet in self._opts['subnet'])
             else:
-                matches = (subnet == self._opts['subnet'])
+                # empty subnet is the same as no subnet. see #1931
+                matches = (subnet == (self._opts['subnet'] or None))
 
             if not matches:
                 log.debug('    subnet mismatch')

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -508,6 +508,15 @@ class SubnetTestCase(MockBoto3TestCase):
         self.assertEqual(cluster['Ec2InstanceAttributes'].get('Ec2SubnetId'),
                          None)
 
+    def test_blank_out_subnet_in_mrjob_conf(self):
+        # regression test for #1931
+        self.start(mrjob_conf_patcher(dict(runners=dict(emr=dict(
+            subnet='subnet-ffffffff')))))
+
+        cluster = self.run_and_get_cluster('--subnet', '')
+        self.assertEqual(cluster['Ec2InstanceAttributes'].get('Ec2SubnetId'),
+                         None)
+
     def test_subnets_option(self):
         instance_fleets = [dict(
             InstanceFleetType='MASTER',


### PR DESCRIPTION
Fixes a bug that made it impossible to turn off subnets on the command line if you specified them in your config file. `--subnet ''` once again means don't use a VPC. Fixes #1931.

