### PR TITLE
empty *_bin opt always means to use the default

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -349,7 +349,6 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 check_cluster_every=_DEFAULT_CHECK_CLUSTER_EVERY,
                 cleanup=['CLUSTER', 'JOB', 'LOCAL_TMP'],
                 cloud_fs_sync_secs=_DEFAULT_CLOUD_FS_SYNC_SECS,
-                gcloud_bin=['gcloud'],
                 image_version=_DEFAULT_IMAGE_VERSION,
                 instance_type=_DEFAULT_INSTANCE_TYPE,
                 master_instance_type=_DEFAULT_INSTANCE_TYPE,
@@ -1334,17 +1333,15 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         return min(20.0, self._opts['check_cluster_every'])
 
     def _ssh_tunnel_args(self, bind_port):
-        if not self._opts['gcloud_bin']:
-            self._give_up_on_ssh_tunnel = True
-            return None
-
         if not self._cluster_id:
             return
+
+        gcloud_bin = self._opts['gcloud_bin'] or ['gcloud']
 
         cluster = self._get_cluster(self._cluster_id)
         zone = cluster.config.gce_cluster_config.zone_uri.split('/')[-1]
 
-        return self._opts['gcloud_bin'] + [
+        return gcloud_bin + [
             'compute', 'ssh',
             '--zone', zone,
             self._job_tracker_host(),

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -461,8 +461,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 pool_name='default',
                 pool_wait_minutes=0,
                 region=_DEFAULT_EMR_REGION,
-                sh_bin=None,  # see _sh_bin(), below
-                ssh_bin=['ssh'],
                 visible_to_all_users=True,
             )
         )
@@ -674,9 +672,8 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
             if self._opts['ec2_key_pair_file']:
                 self._fs.add_fs('ssh', SSHFilesystem(
-                    ssh_bin=self._opts['ssh_bin'],
+                    ssh_bin=self._ssh_bin(),
                     ec2_key_pair_file=self._opts['ec2_key_pair_file']))
-
 
             self._fs.add_fs('s3', S3Filesystem(
                 aws_access_key_id=self._opts['aws_access_key_id'],
@@ -870,6 +867,10 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         # part size is in MB, as the minimum is 5 MB
         return int((self._opts['cloud_part_size_mb'] or 0) * 1024 * 1024)
 
+    def _ssh_bin(self):
+        # the args of the ssh binary
+        return self._opts['ssh_bin'] or ['ssh']
+
     def _set_up_ssh_tunnel_and_hdfs(self):
         if hasattr(self.fs, 'hadoop'):
             self.fs.hadoop.set_hadoop_bin(self._ssh_hadoop_bin())
@@ -903,7 +904,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
     def _ssh_tunnel_args(self, bind_port):
         for opt_name in ('ec2_key_pair', 'ec2_key_pair_file',
-                         'ssh_bin', 'ssh_bind_ports'):
+                         'ssh_bind_ports'):
             if not self._opts[opt_name]:
                 log.warning(
                     "  You must set %s in order to set up the SSH tunnel!"
@@ -915,7 +916,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         if not host:
             return
 
-        return self._opts['ssh_bin'] + [
+        return self._ssh_bin() + [
             '-o', 'VerifyHostKeyDNS=no',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'ExitOnForwardFailure=yes',
@@ -926,15 +927,14 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         ]
 
     def _ssh_hadoop_bin(self):
-        if not (self._opts['ec2_key_pair_file'] and
-                self._opts['ssh_bin']):
+        if not self._opts['ec2_key_pair_file']:
             return []
 
         host = self._address_of_master()
         if not host:
             return []
 
-        return self._opts['ssh_bin'] + [
+        return self._ssh_bin() + [
             '-o', 'VerifyHostKeyDNS=no',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'ExitOnForwardFailure=yes',
@@ -1750,9 +1750,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         ``None``"""
         host = self._address_of_master()
 
-        if not (self._opts['ssh_bin'] and
-                self._opts['ec2_key_pair_file'] and
-                host):
+        if not self._opts['ec2_key_pair_file']:
             return None
 
         if not host:

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -652,10 +652,8 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         # where this issue is fixed. See #1548
         return self._image_version_gte(_BAD_BASH_IMAGE_VERSION)
 
-    def _sh_bin(self):
-        if self._opts['sh_bin']:
-            return self._opts['sh_bin']
-        elif self._bash_is_bad():
+    def _default_sh_bin(self):
+        if self._bash_is_bad():
             return _BAD_BASH_SH_BIN
         else:
             return _GOOD_BASH_SH_BIN

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -194,8 +194,12 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
         if self._fs is None:
             self._fs = CompositeFilesystem()
 
+            # don't pass [] to fs; this means not to use hadoop until
+            # fs.set_hadoop_bin() is called (used for running hadoop over SSH).
+            hadoop_bin = self._opts['hadoop_bin'] or None
+
             self._fs.add_fs('hadoop',
-                            HadoopFilesystem(self._opts['hadoop_bin']))
+                            HadoopFilesystem(hadoop_bin))
             self._fs.add_fs('local', LocalFilesystem())
 
         return self._fs

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -182,6 +182,15 @@ class GetSparkSubmitBinTestCase(GenericLocalRunnerTestCase):
             self.assertEqual(runner.get_spark_submit_bin(),
                              ['spork-submit', '-kfc'])
 
+    def test_empty_spark_submit_bin_means_default(self):
+        job = MRNullSpark(['-r', 'local',
+                           '--spark-submit-bin', ''])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(runner.get_spark_submit_bin(),
+                             ['spork-submit'])
+
 
 class HadoopArgsForStepTestCase(EmptyMrjobConfTestCase):
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -352,6 +352,16 @@ class InterpreterTestCase(BasicTestCase):
         self.assertEqual(runner._interpreter(steps=True),
                          [sys.executable])
 
+    def test_empty_python_bin_means_default(self):
+        # interpreter and steps_python_bin opts are deprecated, so
+        # not bothering to test them
+        runner = MRJobBinRunner(python_bin=[], task_python_bin=[])
+
+        self.assertEqual(runner._python_bin(), [PYTHON_BIN])
+        self.assertEqual(runner._interpreter(), [PYTHON_BIN])
+        self.assertEqual(runner._interpreter(steps=True),
+                         [sys.executable])
+
     def test_interpreter(self):
         runner = MRJobBinRunner(interpreter=['ruby'])
         self.assertEqual(runner._interpreter(), ['ruby'])

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1937,8 +1937,12 @@ class ShBinValidationTestCase(SandboxedTestCase):
 
         self.log = self.start(patch('mrjob.bin.log'))
 
-    def test_empty_sh_bin(self):
-        self.assertRaises(ValueError, MRJobBinRunner, sh_bin=[])
+    def test_empty_sh_bin_means_default(self):
+        runner = MRJobBinRunner(sh_bin=[])
+        self.assertFalse(self.log.warning.called)
+
+        default_sh_bin = MRJobBinRunner()._sh_bin()
+        self.assertEqual(runner._sh_bin(), default_sh_bin)
 
     def test_absolute_sh_bin(self):
         MRJobBinRunner(sh_bin=['/bin/zsh'])

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -1651,6 +1651,22 @@ class SetUpSSHTunnelTestCase(MockGoogleTestCase):
 
         self.assertEqual(args[:4], ['/path/to/gcloud', '-v', 'compute', 'ssh'])
 
+    def test_empty_gcloud_bin_means_default(self):
+        job = MRWordCount(
+            ['-r', 'dataproc', '--ssh-tunnel', '--gcloud-bin', ''])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner.run()
+
+        self.assertEqual(self.mock_Popen.call_count, 1)
+        args_tuple, kwargs = self.mock_Popen.call_args
+        args = args_tuple[0]
+
+        self.assertEqual(kwargs, dict(stdin=PIPE, stdout=PIPE, stderr=PIPE))
+
+        self.assertEqual(args[:3], ['gcloud', 'compute', 'ssh'])
+
     def test_missing_gcloud_bin(self):
         self.mock_Popen.side_effect = OSError(2, 'No such file or directory')
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5589,10 +5589,15 @@ class ProgressHtmlOverSshTestCase(MockBoto3TestCase):
 
         self.assertFalse(self._ssh_run.called)
 
-    def test_no_ssh_bin(self):
-        self.assertIsNone(self._launch_and_get_progress_html('--ssh-bin', ''))
+    def test_empty_ssh_bin_means_default(self):
+        html = self._launch_and_get_progress_html('--ssh-bin', '')
 
-        self.assertFalse(self._ssh_run.called)
+        self.assertIsNotNone(html)
+        self._ssh_run.assert_called_once_with(
+            self.MOCK_MASTER,
+            ['curl', self.MOCK_JOB_TRACKER_URL])
+
+        self.assertEqual(html, self._ssh_run.return_value[0])
 
     def test_no_key_pair_file(self):
         self.assertIsNone(self._launch_and_get_progress_html(

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1548,3 +1548,31 @@ class WarnAboutSparkArchivesTestCase(MockHadoopTestCase):
             runner._warn_about_spark_archives(runner._get_step(0))
 
         self.assertFalse(self.log.warning.called)
+
+
+class GetHadoopBinTestCase(MockHadoopTestCase):
+    # mostly exists to test --hadoop-bin ''
+
+    def test_default(self):
+        job = MRTwoStepJob(['-r', 'hadoop'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(runner.get_hadoop_bin(),
+                             [self.hadoop_bin])
+
+    def test_custom_hadoop_bin(self):
+        job = MRTwoStepJob(['-r', 'hadoop', '--hadoop-bin', 'hadoop -v'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(runner.get_hadoop_bin(),
+                             ['hadoop', '-v'])
+
+    def test_empty_hadoop_bin_means_find_hadoop_bin(self):
+        job = MRTwoStepJob(['-r', 'hadoop', '--hadoop-bin', ''])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(runner.get_hadoop_bin(),
+                             [self.hadoop_bin])

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -896,6 +896,25 @@ class SortBinTestCase(SandboxedTestCase):
 
         self.assertEqual(sort_args[:2], ['sort', '-r'])
 
+    def test_empty_sort_bin_means_default(self):
+        job = MRGroup(['-r', 'local', '--sort-bin', ''])
+        job.sandbox(stdin=BytesIO(
+            b'apples\nbuffaloes\nbears'))
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            self.assertEqual(
+                sorted(job.parse_output(runner.cat_output())),
+                [('a', ['apples']), ('b', ['buffaloes', 'bears'])])
+
+        self.assertTrue(self.check_call.called)
+        self.assertFalse(self._sort_lines_in_memory.called)
+
+        sort_args = self.check_call.call_args[0][0]
+        self.assertEqual(sort_args[:6],
+                         ['sort', '-t', '\t', '-k', '1,1', '-s'])
+
     def test_sort_in_memory_on_windows(self):
         self.start(patch('platform.system', return_value='Windows'))
 


### PR DESCRIPTION
Carefully updated the handling of every `*_bin` option so that if you set it to an empty value (e.g. `--sh-bin ''`) it uses the default.

This keeps us from having binaries with zero arguments (which can lead to weird results), and gives a convenient way to say, ignore the config file, just use the default.

Fixes #1926 