### PR TITLE
nested extra_cluster_params

### DIFF
--- a/docs/guides/cloud-opts.rst
+++ b/docs/guides/cloud-opts.rst
@@ -392,6 +392,12 @@ Cluster software configuration
               SupportedProducts:
               - mapr-m3
 
+    .. versionchanged:: 0.6.8
+
+       You may use a *name* with dots in it to set (or unset) nested
+       properties. For example:
+       ``--extra-cluster-param Instances.EmrManagedMasterSecurityGroup=sg-foo``.
+
     .. versionadded:: 0.6.0
 
        This replaces the old `emr_api_params` option, which only worked

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -20,6 +20,7 @@ import socket
 import random
 import signal
 import time
+from copy import deepcopy
 from os.path import basename
 from subprocess import Popen
 from subprocess import PIPE
@@ -410,9 +411,10 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
     def _add_extra_cluster_params(self, params):
         """Return a dict with the *extra_cluster_params* opt patched into
         *params*, and ``None`` values removed."""
-        params = params.copy()
-        params.update(self._opts['extra_cluster_params'])
-        params = {k: v for k, v in params.items() if v is not None}
+        params = deepcopy(params)
+
+        for k, v in sorted(self._opts['extra_cluster_params'].items()):
+            _patch_params(params, k, v)
 
         return params
 
@@ -597,3 +599,29 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
             return random.sample(self._opts['ssh_bind_ports'], num_picks)
         finally:
             random.setstate(random_state)
+
+
+def _patch_params(params, name, value):
+    """Helper method for _add_extra_cluster_params().
+
+    Set *name* in *params* to *value*
+
+    If *name* has one or more dots in it, recursively set the value
+    in successive nested dictionaries, creating them if necessary.
+    For example, if *name* is ``Instances.EmrManagedMasterSecurityGroup``,
+    set ``params['Instances']['EmrManagedMasterSecurityGroup']``
+
+    If *value* is ``None``, delete the value (if it exists), rather than
+    setting it to ``None``.
+    """
+    if not isinstance(params, dict):
+        raise TypeError('must be a dictionary')
+
+    if '.' in name:
+        head, rest = name.split('.', 1)
+        _patch_params(params.setdefault(head, {}), rest, value)
+    elif value is None:
+        if name in params:
+            del params[name]
+    else:
+        params[name] = value

--- a/mrjob/parse.py
+++ b/mrjob/parse.py
@@ -72,7 +72,7 @@ def parse_s3_uri(uri):
 
 
 def to_uri(path_or_uri):
-    """If *path_or_uri* is not a URI already, convert it to a ``file:///`
+    """If *path_or_uri* is not a URI already, convert it to a ``file:///``
     URI."""
     if is_uri(path_or_uri):
         return path_or_uri

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -671,6 +671,37 @@ class ExtraClusterParamsTestCase(MockBoto3TestCase):
         self.assertEqual(cluster['AutoScalingRole'], 'HankPym')
         self.assertEqual(cluster['Name'], 'Dave')
 
+    def test_set_nested_param(self):
+        cluster = self.run_and_get_cluster(
+            '--zone', 'us-west-1a',
+            '--subnet', 'subnet-ffffffff',
+            '--extra-cluster-param',
+            'Instances.Placement.AvailabilityZone=danger-2a')
+
+        self.assertEqual(
+            cluster['Ec2InstanceAttributes']['Ec2AvailabilityZone'],
+            'danger-2a')
+
+        # shoudn't blow away subnet, also set in Instances
+        self.assertEqual(
+            cluster['Ec2InstanceAttributes']['Ec2SubnetId'],
+            'subnet-ffffffff')
+
+    def test_unset_nested_param(self):
+        cluster = self.run_and_get_cluster(
+            '--zone', 'us-west-1a',
+            '--subnet', 'subnet-ffffffff',
+            '--extra-cluster-param',
+            'Instances.Placement=null')
+
+        self.assertIsNone(
+            cluster['Ec2InstanceAttributes'].get('Ec2AvailabilityZone'))
+
+        # shoudn't blow away subnet, also set in Instances
+        self.assertEqual(
+            cluster['Ec2InstanceAttributes']['Ec2SubnetId'],
+            'subnet-ffffffff')
+
 
 class DeprecatedEMRAPIParamsTestCase(MockBoto3TestCase):
 


### PR DESCRIPTION
This change allows you to set API parameters to `RunJobFlow` (or the Google Cloud Dataproc equivalent) *inside* other parameter dictionaries. For example, you can use ``--extra-cluster-param Instances.EmrManagedMasterSecurityGroup=sg-foo`` to set a managed security group, without perturbing all the other parameters in the ``Instances`` dict. Fixes #1934.