### PR TITLE
move _spark_script_args() into base runner

### DIFF
--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -413,12 +413,9 @@ class MRJobBinRunner(MRJobRunner):
         """
         return self._opts['libjars']
 
-    def _interpolate_step_args(self, args, step_num):
-        """Replace :py:data:`~mrjob.step.INPUT` and
-        :py:data:`~mrjob.step.OUTPUT` in arguments to a jar or Spark
-        step.
-
-        Also replaces `~mrjob.step.GENERIC_ARGS` with
+    def _interpolate_jar_step_args(self, args, step_num):
+        """Like :py:meth:`_interpolate_step_args` except it
+        also replaces `~mrjob.step.GENERIC_ARGS` with
         :py:meth:`_hadoop_generic_args_for_step`. This only
         makes sense for jar steps; Spark should raise an error
         if `~mrjob.step.GENERIC_ARGS` is encountered.
@@ -429,19 +426,10 @@ class MRJobBinRunner(MRJobRunner):
             if arg == mrjob.step.GENERIC_ARGS:
                 result.extend(
                     self._hadoop_generic_args_for_step(step_num))
-
-            elif arg == mrjob.step.INPUT:
-                result.append(
-                    ','.join(self._step_input_uris(step_num)))
-
-            elif arg == mrjob.step.OUTPUT:
-                result.append(
-                    self._step_output_uri(step_num))
-
             else:
-                result.append(arg)
+                result.append(args)
 
-        return result
+        return self._interpolate_step_args(result, step_num)
 
     ### setup scripts ###
 
@@ -832,36 +820,6 @@ class MRJobBinRunner(MRJobRunner):
             [self._spark_script_path(step_num)] +
             self._spark_script_args(step_num, last_step_num)
         )
-
-    def _spark_script_args(self, step_num, last_step_num=None):
-        """A list of args to the spark script/jar, used by
-        _args_for_spark_step().
-
-        *last_step_num* is only used by the Spark runner, where multiple
-        streaming steps are run in a single Spark job."""
-        # TODO: this can also return args to the MRJob, which is confusing
-        step = self._get_step(step_num)
-
-        if step['type'] == 'spark':
-            args = (
-                [
-                    '--step-num=%d' % step_num,
-                    '--spark',
-                ] + self._mr_job_extra_args() + [
-                    mrjob.step.INPUT,
-                    mrjob.step.OUTPUT,
-                ]
-            )
-        elif step['type'] in ('spark_jar', 'spark_script'):
-            args = step['args']
-
-            if mrjob.step.GENERIC_ARGS in args:
-                raise ValueError(
-                    'GENERIC_ARGS is not allowed in spark steps')
-        else:
-            raise TypeError('Bad step type: %r' % step['type'])
-
-        return self._interpolate_step_args(args, step_num)
 
     def _run_spark_submit(self, spark_submit_args, env, record_callback):
         """Run the spark submit binary in a subprocess, using a PTY if possible

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -427,7 +427,7 @@ class MRJobBinRunner(MRJobRunner):
                 result.extend(
                     self._hadoop_generic_args_for_step(step_num))
             else:
-                result.append(args)
+                result.append(arg)
 
         return self._interpolate_step_args(result, step_num)
 

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -647,7 +647,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         hadoop_job = {}
 
         hadoop_job['args'] = (
-            self._interpolate_step_args(step['args'], step_num))
+            self._interpolate_jar_step_args(step['args'], step_num))
 
         jar_uri = self._upload_mgr.uri(step['jar'])
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1375,7 +1375,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         jar = self._upload_uri_or_remote_path(step['jar'])
 
         args = (
-            self._interpolate_step_args(step['args'], step_num))
+            self._interpolate_jar_step_args(step['args'], step_num))
 
         hadoop_jar_step = dict(Jar=jar, Args=args)
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -510,7 +510,7 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
 
         if step.get('args'):
             args.extend(
-                self._interpolate_step_args(step['args'], step_num))
+                self._interpolate_jar_step_args(step['args'], step_num))
 
         return args
 

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -179,21 +179,3 @@ class InlineMRJobRunner(SimMRJobRunner):
         """Get step descriptions without calling a subprocess."""
         job_args = ['--steps'] + self._mr_job_extra_args(local=True)
         return self._mrjob_cls(args=job_args)._steps_desc()
-
-    def _spark_script_args(self, step_num):
-        # TODO: this is a simpler version of _spark_script_args() in bin.py.
-        # Some of this code should be pushed up into runner.py
-        step = self._get_step(step_num)
-
-        if step['type'] != 'spark':
-            raise TypeError('Bad step type: %r' % step['type'])
-
-        return (
-            [
-                '--step-num=%d' % step_num,
-                '--spark',
-            ] + self._mr_job_extra_args() + [
-                ','.join(self._step_input_uris(step_num)),
-                self._step_output_uri(step_num),
-            ]
-        )

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -30,9 +30,6 @@ from zipfile import ZIP_DEFLATED
 from mrjob.bin import MRJobBinRunner
 from mrjob.local import LocalMRJobRunner
 from mrjob.py2 import PY2
-from mrjob.step import GENERIC_ARGS
-from mrjob.step import INPUT
-from mrjob.step import OUTPUT
 from mrjob.util import cmd_line
 from mrjob.util import which
 
@@ -161,35 +158,6 @@ class BootstrapMRJobTestCase(BasicTestCase):
         runner = MRJobBinRunner(
             conf_paths=[], interpreter=['ruby'], bootstrap_mrjob=True)
         self.assertEqual(runner._bootstrap_mrjob(), True)
-
-
-class GetSparkSubmitBinTestCase(GenericLocalRunnerTestCase):
-
-    def test_default(self):
-        job = MRNullSpark(['-r', 'local'])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertEqual(runner.get_spark_submit_bin(),
-                             ['spark-submit'])
-
-    def test_spark_submit_bin_option(self):
-        job = MRNullSpark(['-r', 'local',
-                           '--spark-submit-bin', 'spork-submit -kfc'])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertEqual(runner.get_spark_submit_bin(),
-                             ['spork-submit', '-kfc'])
-
-    def test_empty_spark_submit_bin_means_default(self):
-        job = MRNullSpark(['-r', 'local',
-                           '--spark-submit-bin', ''])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertEqual(runner.get_spark_submit_bin(),
-                             ['spork-submit'])
 
 
 class HadoopArgsForStepTestCase(EmptyMrjobConfTestCase):
@@ -1114,134 +1082,6 @@ class SparkScriptPathTestCase(GenericLocalRunnerTestCase):
                 runner._spark_script_path, 0)
 
 
-class SparkScriptArgsTestCase(GenericLocalRunnerTestCase):
-
-    def setUp(self):
-        super(SparkScriptArgsTestCase, self).setUp()
-
-        # don't bother with actual input/output URIs, which
-        # are tested elsewhere
-        def mock_interpolate_step_args(args, step_num):
-            def interpolate(arg):
-                if arg == INPUT:
-                    return '<step %d input>' % step_num
-                elif arg == OUTPUT:
-                    return '<step %d output>' % step_num
-                else:
-                    return arg
-
-            return [interpolate(arg) for arg in args]
-
-        self.start(patch(
-            'mrjob.bin.MRJobBinRunner._interpolate_step_args',
-            side_effect=mock_interpolate_step_args))
-
-    def test_spark_mr_job(self):
-        job = MRNullSpark(['-r', 'local'])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertEqual(
-                runner._spark_script_args(0),
-                ['--step-num=0',
-                 '--spark',
-                 '<step 0 input>',
-                 '<step 0 output>'])
-
-    def test_spark_passthrough_arg(self):
-        job = MRNullSpark(['-r', 'local', '--extra-spark-arg=--verbose'])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertEqual(
-                runner._spark_script_args(0),
-                ['--step-num=0',
-                 '--spark',
-                 '--extra-spark-arg=--verbose',
-                 '<step 0 input>',
-                 '<step 0 output>'])
-
-    def test_spark_file_arg(self):
-        foo_path = self.makefile('foo')
-
-        job = MRNullSpark(['-r', 'local', '--extra-file', foo_path])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertEqual(
-                runner._spark_script_args(0),
-                ['--step-num=0',
-                 '--spark',
-                 '--extra-file',
-                 'foo',
-                 '<step 0 input>',
-                 '<step 0 output>'])
-
-            name_to_path = runner._working_dir_mgr.name_to_path('file')
-            self.assertIn('foo', name_to_path)
-            self.assertEqual(name_to_path['foo'], foo_path)
-
-    def test_spark_jar(self):
-        job = MRSparkJar(['-r', 'local',
-                          '--jar-arg', 'foo', '--jar-arg', 'bar'])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertEqual(
-                runner._spark_script_args(0),
-                ['foo', 'bar'])
-
-    def test_spark_jar_interpolation(self):
-        job = MRSparkJar(['-r', 'local',
-                          '--jar-arg', OUTPUT, '--jar-arg', INPUT])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertEqual(
-                runner._spark_script_args(0),
-                ['<step 0 output>', '<step 0 input>'])
-
-    def test_spark_script(self):
-        job = MRSparkScript(['-r', 'local',
-                             '--script-arg', 'foo', '--script-arg', 'bar'])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertEqual(
-                runner._spark_script_args(0),
-                ['foo', 'bar'])
-
-    def test_spark_script_interpolation(self):
-        job = MRSparkScript(['-r', 'local',
-                             '--script-arg', OUTPUT, '--script-arg', INPUT])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertEqual(
-                runner._spark_script_args(0),
-                ['<step 0 output>', '<step 0 input>'])
-
-    def test_generic_args_not_okay(self):
-        # GENERIC_ARGS is only for JarSteps (they're Hadoop generic args)
-        job = MRSparkScript(['-r', 'local',
-                             '--script-arg', GENERIC_ARGS])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertRaises(
-                ValueError,
-                runner._spark_script_args, 0)
-
-    def test_streaming_step_not_okay(self):
-        job = MRTwoStepJob(['-r', 'local'])
-        job.sandbox()
-
-        with job.make_runner() as runner:
-            self.assertRaises(
-                TypeError,
-                runner._spark_script_args, 0)
-
-
 class SparkSubmitArgsTestCase(GenericLocalRunnerTestCase):
 
     def setUp(self):
@@ -1988,10 +1828,10 @@ class GetSparkSubmitBinTestCase(SandboxedTestCase):
             'mrjob.bin.MRJobBinRunner._find_spark_submit_bin'))
 
     def test_do_nothing_on_init(self):
-        runner = MRJobBinRunner()
+        MRJobBinRunner()
         self.assertFalse(self.find_spark_submit_bin.called)
 
-    def test_find_spark_submit(self):
+    def test_default(self):
         runner = MRJobBinRunner()
         self.assertEqual(runner.get_spark_submit_bin(),
                          self.find_spark_submit_bin.return_value)
@@ -2010,6 +1850,15 @@ class GetSparkSubmitBinTestCase(SandboxedTestCase):
         self.assertEqual(runner.get_spark_submit_bin(),
                          ['/path/to/spark-submit'])
         self.assertFalse(self.find_spark_submit_bin.called)
+
+    def test_empty_string_submit_bin_means_default(self):
+        job = MRNullSpark(['-r', 'local',
+                           '--spark-submit-bin', ''])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(runner.get_spark_submit_bin(),
+                             self.find_spark_submit_bin.return_value)
 
 
 class FindSparkSubmitBinTestCase(SandboxedTestCase):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -29,11 +29,13 @@ from mrjob.conf import dump_mrjob_conf
 from mrjob.emr import EMRJobRunner
 from mrjob.examples.mr_phone_to_url import MRPhoneToURL
 from mrjob.inline import InlineMRJobRunner
-from mrjob.local import LocalMRJobRunner
 from mrjob.job import MRJob
+from mrjob.local import LocalMRJobRunner
 from mrjob.parse import to_uri
 from mrjob.runner import MRJobRunner
+from mrjob.step import INPUT
 from mrjob.step import MRStep
+from mrjob.step import OUTPUT
 from mrjob.tools.emr.audit_usage import _JOB_KEY_RE
 from mrjob.util import to_lines
 
@@ -1250,3 +1252,120 @@ class UnexpectedOptsWarningTestCase(SandboxedTestCase):
             self.assertIn('Unexpected option', warnings)
             self.assertIn('zone', warnings)
             self.assertIn('command line', warnings)
+
+
+class SparkScriptArgsTestCase(SandboxedTestCase):
+
+    def setUp(self):
+        super(SparkScriptArgsTestCase, self).setUp()
+
+        # don't bother with actual input/output URIs, which
+        # are tested elsewhere
+        def mock_interpolate_step_args(args, step_num):
+            def interpolate(arg):
+                if arg == INPUT:
+                    return '<step %d input>' % step_num
+                elif arg == OUTPUT:
+                    return '<step %d output>' % step_num
+                else:
+                    return arg
+
+            return [interpolate(arg) for arg in args]
+
+        self.start(patch(
+            'mrjob.bin.MRJobRunner._interpolate_step_args',
+            side_effect=mock_interpolate_step_args))
+
+        self.start(patch(
+            'mrjob.inline.InlineMRJobRunner._STEP_TYPES',
+            {'spark', 'spark_jar', 'spark_script', 'streaming'}))
+
+    def test_spark_mr_job(self):
+        job = MRNullSpark()
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_args(0),
+                ['--step-num=0',
+                 '--spark',
+                 '<step 0 input>',
+                 '<step 0 output>'])
+
+    def test_spark_passthrough_arg(self):
+        job = MRNullSpark(['--extra-spark-arg=--verbose'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_args(0),
+                ['--step-num=0',
+                 '--spark',
+                 '--extra-spark-arg=--verbose',
+                 '<step 0 input>',
+                 '<step 0 output>'])
+
+    def test_spark_file_arg(self):
+        foo_path = self.makefile('foo')
+
+        job = MRNullSpark(['--extra-file', foo_path])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_args(0),
+                ['--step-num=0',
+                 '--spark',
+                 '--extra-file',
+                 'foo',
+                 '<step 0 input>',
+                 '<step 0 output>'])
+
+            name_to_path = runner._working_dir_mgr.name_to_path('file')
+            self.assertIn('foo', name_to_path)
+            self.assertEqual(name_to_path['foo'], foo_path)
+
+    def test_spark_jar(self):
+        job = MRSparkJar(['--jar-arg', 'foo', '--jar-arg', 'bar'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_args(0),
+                ['foo', 'bar'])
+
+    def test_spark_jar_interpolation(self):
+        job = MRSparkJar(['--jar-arg', OUTPUT, '--jar-arg', INPUT])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_args(0),
+                ['<step 0 output>', '<step 0 input>'])
+
+    def test_spark_script(self):
+        job = MRSparkScript(['--script-arg', 'foo', '--script-arg', 'bar'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_args(0),
+                ['foo', 'bar'])
+
+    def test_spark_script_interpolation(self):
+        job = MRSparkScript(['--script-arg', OUTPUT, '--script-arg', INPUT])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertEqual(
+                runner._spark_script_args(0),
+                ['<step 0 output>', '<step 0 input>'])
+
+    def test_streaming_step_not_okay(self):
+        job = MRTwoStepJob()
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.assertRaises(
+                TypeError,
+                runner._spark_script_args, 0)


### PR DESCRIPTION
This moves `_spark_script_args()` (and most of the argument interpolation code) into the base runner. Fixes #1967.