### PR TITLE
upgrade google-cloud-services to 1.11.0, remove shim

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -406,7 +406,6 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
             self._fs.add_fs('gcs', GCSFilesystem(
                 credentials=self._credentials,
-                local_tmp_dir=self._get_local_tmp_dir(),
                 project_id=self._project_id,
             ))
 

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -242,12 +242,7 @@ class GCSFilesystem(Filesystem):
         and time-to-live."""
         bucket = self.client.bucket(name)
 
-        # as of google-cloud 0.32.0, there isn't a direct way to set location
-        if location:
-            bucket._changes.add('location')
-            bucket._properties['location'] = location
-
-        bucket.create()
+        bucket.create(location=location)
 
         bucket.lifecycle_rules = [
             dict(

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ try:
             'PyYAML>=3.08',
             'google-cloud-dataproc>=0.2.0',
             'google-cloud-logging>=1.5.0',
-            'google-cloud-storage>=1.9.0',
+            'google-cloud-storage>=1.11.0',
         ],
         'provides': ['mrjob'],
         'test_suite': 'tests',

--- a/tests/mock_google/case.py
+++ b/tests/mock_google/case.py
@@ -58,8 +58,8 @@ class MockGoogleTestCase(SandboxedTestCase):
         # mock project ID, returned by mock google.auth.default()
         self.mock_project_id = 'mock-project-12345'
 
-        # Maps bucket name to a dictionary with the key
-        # *blobs*. *blobs* maps object name to
+        # Maps bucket name to a dictionary with the keys
+        # *blobs* and *location*. *blobs* maps object name to
         # a dictionary with the key *data*, which is
         # a bytestring.
         self.mock_gcs_fs = {}

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -664,7 +664,7 @@ class TmpBucketTestCase(MockGoogleTestCase):
         self.assertEqual(current_bucket.location, location.upper())
 
         # Verify that we setup bucket lifecycle rules of 28-day retention
-        first_lifecycle_rule = current_bucket.lifecycle_rules[0]
+        first_lifecycle_rule = list(current_bucket.lifecycle_rules)[0]
         self.assertEqual(first_lifecycle_rule['action'], dict(type='Delete'))
         self.assertEqual(first_lifecycle_rule['condition'],
                          dict(age=_DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS))


### PR DESCRIPTION
This removes a weird, roundabout way of setting bucket location and instead does it a straightforward way (now that it's available in version 1.11.0). Fixes #2019.