### PR TITLE
note that Spark runner ignores some kwargs

### DIFF
--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -78,6 +78,12 @@ class SparkMRJobRunner(MRJobBinRunner):
 
         :param mrjob_cls: class of the job you want to run. Used for
                           running streaming steps in Spark
+
+        SparkMRJobRunner ignores the keyword arguments *hadoop_input_format*,
+        *hadoop_output_format*, and *sort_values* (see
+        :py:meth:`MRJobRunner.__init__`). These are only set by the job as a
+        way to communicate certain attributes to the runner, and the Spark
+        runner instead inspects the job directly.
         """
         # need to set this before checking steps in superclass __init__()
         self._mrjob_cls = mrjob_cls

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -298,6 +298,33 @@ class SparkRunnerStreamingStepsTestCase(MockFilesystemsTestCase):
     # TODO: add test of file upload args once we fix #1922
 
 
+class RunnerIgnoresJobKwargsTestCase(MockFilesystemsTestCase):
+
+    def test_ignore_format_and_sort_kwargs(self):
+        # hadoop formats and SORT_VALUES are read directly from the job,
+        # so the runner's constructor ignores the corresponding kwargs
+        #
+        # see #2022
+
+        # same set up as test_sort_values(), above
+        runner = SparkMRJobRunner(
+            mr_job_script=MRSortAndGroup.mr_job_script(),
+            mrjob_cls=MRSortAndGroup,
+            stdin=BytesIO(
+                b'alligator\nactuary\nbowling\nartichoke\nballoon\nbaby\n'),
+            hadoop_input_format='TerribleInputFormat',
+            hadoop_output_format='AwfulOutputFormat',
+            sort_values=False)
+
+        runner.run()
+
+        self.assertEqual(
+            dict(MRSortAndGroup().parse_output(runner.cat_output())),
+            dict(a=['actuary', 'alligator', 'artichoke'],
+                 b=['baby', 'balloon', 'bowling']))
+
+
+
 class GroupStepsTestCase(MockFilesystemsTestCase):
     # test the way the runner groups multiple streaming steps together
 


### PR DESCRIPTION
The Spark runner's constructor ignores some keyword args (`hadoop_input_format`, `hadoop_output_format`, `sort_values`) that are redundant when you can actually look at the job class (which it does, through the harness). This makes it explicit in the constructor's docstring and nails it down with a unit test. Fixes #2022.
