### PR TITLE
remove part_size kwarg from fs.put()

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -407,19 +407,12 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             self._fs.add_fs('gcs', GCSFilesystem(
                 credentials=self._credentials,
                 project_id=self._project_id,
+                part_size=self._upload_part_size(),
             ))
 
             self._fs.add_fs('local', LocalFilesystem())
 
         return self._fs
-
-    def _fs_chunk_size(self):
-        """Chunk size for cloud storage Blob objects. Currently
-        only used for uploading."""
-        if self._opts['cloud_part_size_mb']:
-            return int(self._opts['cloud_part_size_mb'] * 1024 * 1024)
-        else:
-            return None
 
     def _get_tmpdir(self, given_tmpdir):
         """Helper for _fix_tmpdir"""
@@ -531,7 +524,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         for path, gcs_uri in self._upload_mgr.path_to_uri().items():
             log.debug('uploading %s -> %s' % (path, gcs_uri))
 
-            self.fs.put(path, gcs_uri, part_size_mb=self._fs_chunk_size())
+            self.fs.put(path, gcs_uri)
 
         self._wait_for_fs_sync()
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -208,9 +208,6 @@ _CHEAPEST_INSTANCE_TYPE = 'm4.large'
 # these are the only kinds of instance roles that exist
 _INSTANCE_ROLES = ('MASTER', 'CORE', 'TASK')
 
-# use to disable multipart uploading
-_HUGE_PART_THRESHOLD = 2 ** 256
-
 # where to find the history log in HDFS
 _YARN_HDFS_HISTORY_LOG_DIR = 'hdfs:///tmp/hadoop-yarn/staging/history'
 

--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -111,14 +111,10 @@ class Filesystem(object):
         """
         raise NotImplementedError
 
-    def put(self, src, path, part_size_mb=None):
+    def put(self, src, path):
         """Upload a file on the local filesystem (*src*) to *path*.
         Like with :py:func:`shutil.copyfile`, *path* should be the full path
         of the new file, not a directory which should contain it.
-
-        You may optionally specify *part_size_mb*, the part size in megabytes
-        for multi-part uploading. Filesystems that do not support multi-part
-        uploading will ignore this.
 
         Corresponds roughly to ``hadoop fs -put src path``.
         """

--- a/mrjob/fs/composite.py
+++ b/mrjob/fs/composite.py
@@ -155,8 +155,8 @@ class CompositeFilesystem(Filesystem):
     def join(self, path, *paths):
         return self._handle('join', path, path, *paths)
 
-    def put(self, src, path, part_size_mb=None):
-        return self._handle('put', path, src, path, part_size_mb)
+    def put(self, src, path):
+        return self._handle('put', path, src, path)
 
     def rm(self, path_glob):
         return self._do('rm', path_glob)

--- a/mrjob/fs/gcs.py
+++ b/mrjob/fs/gcs.py
@@ -53,15 +53,21 @@ def _path_glob_to_parsed_gcs_uri(path_glob):
 
 
 class GCSFilesystem(Filesystem):
-    """Filesystem for Google Cloud Storage (GCS) URIs. Typically you will get
-    one of these via
-    ``DataprocJobRunner().fs``, composed with
-    :py:class:`~mrjob.fs.ssh.SSHFilesystem` and
-    :py:class:`~mrjob.fs.local.LocalFilesystem`.
+    """Filesystem for Google Cloud Storage (GCS) URIs
+
+    :param local_tmp_dir: deprecated, does nothing, do not use
+    :param credentials: an optional
+                        :py:class:`google.auth.credentials.Credentials`, used
+                        to initialize the storage client
+    :param project_id: an optional project ID, used to initialize the storage
+                       client
+    :param part_size: Part size for multi-part uploading, in bytes, or ``None``
     """
-    def __init__(self, local_tmp_dir=None, credentials=None, project_id=None):
+    def __init__(self, local_tmp_dir=None, credentials=None, project_id=None,
+                 part_size=None):
         self._credentials = credentials
         self._project_id = project_id
+        self._part_size = part_size
 
         if local_tmp_dir is not None:
             log.warning('local_tmp_dir does nothing and will be removed'
@@ -195,24 +201,25 @@ class GCSFilesystem(Filesystem):
 
         self._blob(dest_uri).upload_from_string(b'')
 
-    def put(self, src_path, dest_uri, part_size_mb=None, chunk_size=None):
+    def put(self, src_path, dest_uri, chunk_size=None):
         """Uploads a local file to a specific destination.
 
-        *chunk_size* is a deprecated alias for *part_size_mb* and will
-        be removed in v0.7.0.
+        *chunk_size* is a deprecated alias for *part_size* (set at init
+        time) and will be removed in v0.7.0.
         """
-        # support old name for *part_size_mb*
+        part_size = self._part_size
+
+        # support old way of setting *part_size* at call time
         if chunk_size:
-            log.warning('chunk_size is a deprecated alias for part_size_mb'
-                        ' and will be removed in v0.7.0')
-        if part_size_mb is None:
-            part_size_mb = chunk_size
+            log.warning('chunk_size is deprecated and will be removed in'
+                        ' v0.7.0 (set part_size at init time).')
+            part_size = chunk_size
 
         old_blob = self._get_blob(dest_uri)
         if old_blob:
             raise IOError('File already exists: %s' % dest_uri)
 
-        self._blob(dest_uri, chunk_size=part_size_mb).upload_from_filename(
+        self._blob(dest_uri, chunk_size=part_size).upload_from_filename(
             src_path)
 
     def get_all_bucket_names(self, prefix=None):

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -313,12 +313,11 @@ class HadoopFilesystem(Filesystem):
         except CalledProcessError:
             raise IOError("Could not check path %s" % path_glob)
 
-    def put(self, src, path, part_size_mb=None):
+    def put(self, src, path):
         # don't inadvertently support cp syntax
         if path.endswith('/'):
             raise ValueError('put() destination may not be a directory')
 
-        # ignore part_size_mb, not supported by `hadoop fs`
         self.invoke_hadoop(['fs', '-put', src, path])
 
     def rm(self, path_glob):

--- a/mrjob/fs/local.py
+++ b/mrjob/fs/local.py
@@ -56,7 +56,7 @@ class LocalFilesystem(Filesystem):
         if not os.path.isdir(path):
             os.makedirs(path)
 
-    def put(self, src, path, part_size_mb=None):
+    def put(self, src, path):
         """Copy a file from *src* to *path*"""
         shutil.copyfile(src, path)
 

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1143,6 +1143,14 @@ class MRJobRunner(object):
             for path in self._get_input_paths():
                 self._upload_mgr.add(path)
 
+    def _upload_part_size(self):
+        """Part size for uploads, in bytes, or ``None``,
+        from :mrjob-opt:`cloud_part_size_mb`"""
+        if self._opts.get('cloud_part_size_mb'):
+            return int(self._opts['cloud_part_size_mb'] * 1024 * 1024)
+        else:
+            return None
+
     def _intermediate_output_dir(self, step_num, local=False):
         """A directory for intermediate output for the given step number."""
         join = os.path.join if local else posixpath.join

--- a/tests/fs/test_composite.py
+++ b/tests/fs/test_composite.py
@@ -87,16 +87,7 @@ class CompositeFilesystemTestCase(BasicTestCase):
 
         fs.put('/path/to/file', 's3://walrus/file')
         self.s3_fs.put.assert_called_once_with(
-            '/path/to/file', 's3://walrus/file', None)
-
-    def test_forward_put_with_part_size(self):
-        fs = CompositeFilesystem()
-
-        fs.add_fs('s3', self.s3_fs)
-
-        fs.put('/path/to/file', 's3://walrus/file', part_size_mb=99999)
-        self.s3_fs.put.assert_called_once_with(
-            '/path/to/file', 's3://walrus/file', 99999)
+            '/path/to/file', 's3://walrus/file')
 
     def test_forward_fs_extensions(self):
         fs = CompositeFilesystem()

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -196,14 +196,16 @@ class GCSFSTestCase(MockGoogleTestCase):
         self.fs.put(local_path, dest)
         self.assertEqual(b''.join(self.fs.cat(dest)), b'bar')
 
-    def test_put_part_size_mb(self):
+    def test_put_with_part_size(self):
         local_path = self.makefile('foo', contents=b'bar')
         dest = 'gs://bar-files/foo'
         self.storage_client().bucket('bar-files').create()
 
+        fs = GCSFilesystem(part_size=12345)
+
         with patch.object(GCSFilesystem, '_blob') as blob_meth:
-            self.fs.put(local_path, dest, part_size_mb=99999)
-            blob_meth.assert_called_once_with(dest, chunk_size=99999)
+            fs.put(local_path, dest)
+            blob_meth.assert_called_once_with(dest, chunk_size=12345)
 
     def test_put_chunk_size(self):
         local_path = self.makefile('foo', contents=b'bar')

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -168,22 +168,24 @@ class S3FSTestCase(MockBoto3TestCase):
         self.fs.put(local_path, dest)
         self.assertEqual(b''.join(self.fs.cat(dest)), b'bar')
 
-    def test_put_part_size_mb(self):
+    def test_put_with_part_size(self):
         self.add_mock_s3_data({'bar-files': {}})
 
         local_path = self.makefile('foo', contents=b'bar')
         dest = 's3://bar-files/foo'
 
+        fs = S3Filesystem(part_size=12345)
+
         with patch.object(MockS3Object, 'upload_file') as upload_file:
             with patch('boto3.s3.transfer.TransferConfig') as TransferConfig:
-                self.fs.put(local_path, dest, part_size_mb=99999)
+                fs.put(local_path, dest)
 
                 upload_file.assert_called_once_with(
                     local_path, Config=TransferConfig.return_value)
 
                 TransferConfig.assert_called_once_with(
-                    multipart_chunksize=99999,
-                    multipart_threshold=99999,
+                    multipart_chunksize=12345,
+                    multipart_threshold=12345,
                 )
 
     def test_rm(self):

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -2061,17 +2061,17 @@ class CloudPartSizeTestCase(MockGoogleTestCase):
     def test_default(self):
         runner = DataprocJobRunner()
 
-        self.assertEqual(runner._fs_chunk_size(), 100 * 1024 * 1024)
+        self.assertEqual(runner._upload_part_size(), 100 * 1024 * 1024)
 
     def test_float(self):
         runner = DataprocJobRunner(cloud_part_size_mb=0.25)
 
-        self.assertEqual(runner._fs_chunk_size(), 256 * 1024)
+        self.assertEqual(runner._upload_part_size(), 256 * 1024)
 
     def test_zero(self):
         runner = DataprocJobRunner(cloud_part_size_mb=0)
 
-        self.assertEqual(runner._fs_chunk_size(), None)
+        self.assertEqual(runner._upload_part_size(), None)
 
     def test_multipart_upload(self):
         job = MRWordCount(

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2974,7 +2974,7 @@ class MultiPartUploadTestCase(MockBoto3TestCase):
         with open(data_path, 'wb') as fp:
             fp.write(data)
 
-        runner._upload_contents(self.TEST_S3_URI, data_path)
+        runner.fs.put(data_path, self.TEST_S3_URI)
 
     def assert_upload_succeeds(self, runner, data, expected_part_size):
         """Write the data to a temp file, and then upload it to (mock) S3,
@@ -2985,7 +2985,7 @@ class MultiPartUploadTestCase(MockBoto3TestCase):
         with open(data_path, 'wb') as fp:
             fp.write(data)
 
-        runner._upload_contents(self.TEST_S3_URI, data_path)
+        runner.fs.put(data_path, self.TEST_S3_URI)
 
         s3_key = runner.fs.s3._get_s3_key(self.TEST_S3_URI)
         self.assertEqual(s3_key.get()['Body'].read(), data)
@@ -3019,7 +3019,7 @@ class MultiPartUploadTestCase(MockBoto3TestCase):
         runner = EMRJobRunner(cloud_part_size_mb=0)
 
         data = b'Mew' * 20
-        self.assert_upload_succeeds(runner, data, _HUGE_PART_THRESHOLD)
+        self.assert_upload_succeeds(runner, data, None)
 
 
 class AWSSessionTokenTestCase(MockBoto3TestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -45,7 +45,6 @@ from mrjob.emr import _3_X_SPARK_SUBMIT
 from mrjob.emr import _4_X_COMMAND_RUNNER_JAR
 from mrjob.emr import _BAD_BASH_IMAGE_VERSION
 from mrjob.emr import _DEFAULT_IMAGE_VERSION
-from mrjob.emr import _HUGE_PART_THRESHOLD
 from mrjob.emr import _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH
 from mrjob.emr import _PRE_4_X_STREAMING_JAR
 from mrjob.job import MRJob


### PR DESCRIPTION
`part_size` (for multi-part upload on S3 and GCS) is now set when filesystems are initialized. Also removed unnecessary shim methods for uploading, and moved the code for determining part size into `mrjob.runner`.

This is a mid-release change, so there's no issue number, but this is relevant to #1977 (adding `put()` to fs).