### PR TITLE
fs.mkdir() creates buckets

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -404,10 +404,15 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         if self._fs is None:
             self._fs = CompositeFilesystem()
 
+            location = self._opts['region'] or _zone_to_region(
+                self._opts['zone'])
+
             self._fs.add_fs('gcs', GCSFilesystem(
                 credentials=self._credentials,
                 project_id=self._project_id,
                 part_size=self._upload_part_size(),
+                location=location,
+                object_ttl_days=_DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS,
             ))
 
             self._fs.add_fs('local', LocalFilesystem())
@@ -467,7 +472,8 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         self._create_setup_wrapper_scripts()
         self._add_bootstrap_files_for_upload()
         self._add_job_files_for_upload()
-        self._upload_local_files_to_fs()
+        self._upload_local_files()
+        self._wait_for_fs_sync()
 
     def _check_output_not_exists(self):
         """Verify the output path does not already exist. This avoids
@@ -513,47 +519,6 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         for step in self._get_steps():
             if step.get('jar'):
                 self._upload_mgr.add(step['jar'])
-
-    def _upload_local_files_to_fs(self):
-        """Copy local files tracked by self._upload_mgr to FS."""
-        bucket_name, _ = parse_gcs_uri(self._job_tmpdir)
-        self._create_fs_tmp_bucket(bucket_name)
-
-        log.info('Copying non-input files into %s' % self._upload_mgr.prefix)
-
-        for path, gcs_uri in self._upload_mgr.path_to_uri().items():
-            log.debug('uploading %s -> %s' % (path, gcs_uri))
-
-            self.fs.put(path, gcs_uri)
-
-        self._wait_for_fs_sync()
-
-    def _create_fs_tmp_bucket(self, bucket_name, location=None):
-        """Create a temp bucket if missing
-
-        Tie the temporary bucket to the same region as the GCE job and set a
-        28-day TTL
-        """
-        # Return early if our bucket already exists
-        try:
-            self.fs.gcs.get_bucket(bucket_name)
-            return
-        except google.api_core.exceptions.NotFound:
-            pass
-
-        log.info('creating FS bucket %r' % bucket_name)
-
-        location = location or self._opts['region'] or _zone_to_region(
-            self._opts['zone'])
-
-        # NOTE - By default, we create a bucket in the same GCE region as our
-        # job (tmp buckets ONLY)
-        # https://cloud.google.com/storage/docs/bucket-locations
-        self.fs.gcs.create_bucket(
-            bucket_name, location=location,
-            object_ttl_days=_DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS)
-
-        self._wait_for_fs_sync()
 
     ### Running the job ###
 
@@ -662,8 +627,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     def _launch_cluster(self):
         """Create an empty cluster on Dataproc, and set self._cluster_id to
         its ID."""
-        bucket_name, _ = parse_gcs_uri(self._job_tmpdir)
-        self._create_fs_tmp_bucket(bucket_name)
+        self.fs.mkdir(self._job_tmpdir)
 
         # clusterName must be a match of
         # regex '(?:[a-z](?:[-a-z0-9]{0,53}[a-z0-9])?).'

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -359,11 +359,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         """
         super(EMRJobRunner, self).__init__(**kwargs)
 
-        # if we're going to create a bucket to use as temp space, we don't
-        # want to actually create it until we run the job (Issue #50).
-        # This variable helps us create the bucket as needed
-        self._s3_tmp_bucket_to_create = None
-
         self._fix_s3_tmp_and_log_uri_opts()
 
         # use job key to make a unique tmp dir
@@ -607,7 +602,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
         # That may have all failed. If so, pick a name.
         bucket_name = 'mrjob-' + random_identifier()
-        self._s3_tmp_bucket_to_create = bucket_name
         self._opts['cloud_tmp_dir'] = 's3://%s/tmp/' % bucket_name
         log.info('Auto-created temp S3 bucket %s' % bucket_name)
         self._wait_for_s3_eventual_consistency()
@@ -622,15 +616,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                     log_uri.replace('s3n://', 's3://'), self._cluster_id)
 
         return self._s3_log_dir_uri
-
-    def _create_s3_tmp_bucket_if_needed(self):
-        """Make sure temp bucket exists"""
-        if self._s3_tmp_bucket_to_create:
-            log.debug('creating S3 bucket %r to use as temp space' %
-                      self._s3_tmp_bucket_to_create)
-            self.fs.s3.create_bucket(self._s3_tmp_bucket_to_create,
-                                     self._opts['region'])
-            self._s3_tmp_bucket_to_create = None
 
     def _check_and_fix_s3_dir(self, s3_uri):
         """Helper for __init__"""
@@ -708,7 +693,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         self._add_bootstrap_files_for_upload()
         self._add_master_node_setup_files_for_upload()
         self._add_job_files_for_upload()
-        self._upload_local_files_to_s3()
+        self._upload_local_files()
 
     def _launch(self):
         """Set up files and then launch our job on EMR."""
@@ -840,16 +825,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             for key in 'jar', 'script':
                 if step.get(key):
                     self._upload_mgr.add(step[key])
-
-    def _upload_local_files_to_s3(self):
-        """Copy local files tracked by self._upload_mgr to S3."""
-        self._create_s3_tmp_bucket_if_needed()
-
-        log.info('Copying local files to %s...' % self._upload_mgr.prefix)
-
-        for path, s3_uri in self._upload_mgr.path_to_uri().items():
-            log.debug('  %s -> %s' % (path, s3_uri))
-            self.fs.put(path, s3_uri)
 
     def _ssh_bin(self):
         # the args of the ssh binary
@@ -1455,7 +1430,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         """Create an empty cluster on EMR, and set self._cluster_id to
         its ID.
         """
-        self._create_s3_tmp_bucket_if_needed()
         emr_client = self.make_emr_client()
 
         # try to find a cluster from the pool. basically auto-fill
@@ -2310,7 +2284,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         log.info('Creating persistent cluster to run several jobs in...')
 
         self._add_bootstrap_files_for_upload(persistent=True)
-        self._upload_local_files_to_s3()
+        self._upload_local_files()
 
         # don't allow user to call run()
         self._ran_job = True

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -322,7 +322,7 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
         self._find_binaries_and_jars()
         self._create_setup_wrapper_scripts()
         self._add_job_files_for_upload()
-        self._upload_local_files_to_hdfs()
+        self._upload_local_files()
         self._run_job_in_hadoop()
 
     def _find_binaries_and_jars(self):
@@ -348,19 +348,6 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
             self._upload_mgr.add(path)
         for path in self._py_files():
             self._upload_mgr.add(path)
-
-    def _upload_local_files_to_hdfs(self):
-        """Copy files managed by self._upload_mgr to HDFS
-        """
-        self.fs.mkdir(self._upload_mgr.prefix)
-
-        log.info('Copying local files to %s...' % self._upload_mgr.prefix)
-        for path, uri in self._upload_mgr.path_to_uri().items():
-            self._upload_to_hdfs(path, uri)
-
-    def _upload_to_hdfs(self, path, target):
-        log.debug('  %s -> %s' % (path, target))
-        self.fs.hadoop.put(path, target)
 
     def _dump_stdin_to_local_file(self):
         """Dump sys.stdin to a local file, and return the path to it."""

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1143,6 +1143,18 @@ class MRJobRunner(object):
             for path in self._get_input_paths():
                 self._upload_mgr.add(path)
 
+    def _upload_local_files(self):
+        # in local mode, nothing to upload
+        if not self._upload_mgr:
+            return
+
+        self.fs.mkdir(self._upload_mgr.prefix)
+
+        log.info('Copying local files to %s' % self._upload_mgr.prefix)
+        for src_path, uri in self._upload_mgr.path_to_uri().items():
+            log.debug('  %s -> %s' % (src_path, uri))
+            self.fs.put(src_path, uri)
+
     def _upload_part_size(self):
         """Part size for uploads, in bytes, or ``None``,
         from :mrjob-opt:`cloud_part_size_mb`"""

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -196,18 +196,6 @@ class SparkMRJobRunner(MRJobBinRunner):
 
         return self._fs
 
-    def _upload_local_files(self):
-        # in local mode, nothing to upload
-        if not self._upload_mgr:
-            return
-
-        self.fs.mkdir(self._upload_mgr.prefix)
-
-        log.info('Copying local files to %s' % self._upload_mgr.prefix)
-        for src_path, uri in self._upload_mgr.path_to_uri().items():
-            log.debug('  %s -> %s' % (src_path, uri))
-            self.fs.put(src_path, uri)
-
     # making mr_job_script visible in Spark
 
     def _job_script_module_name(self):

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -24,6 +24,7 @@ from mrjob.bin import MRJobBinRunner
 from mrjob.compat import jobconf_from_dict
 from mrjob.conf import combine_dicts
 from mrjob.conf import combine_local_envs
+from mrjob.dataproc import _DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS
 from mrjob.fs.composite import CompositeFilesystem
 from mrjob.fs.gcs import GCSFilesystem
 from mrjob.fs.gcs import google as google_libs_installed
@@ -59,6 +60,7 @@ class SparkMRJobRunner(MRJobBinRunner):
         'cloud_fs_sync_secs',
         'cloud_part_size_mb',
         'google_project_id',  # used by GCS filesystem
+        'google_region',  # used when creating buckets on GCS
         'hadoop_bin',
         's3_endpoint',
         's3_region',  # only used along with s3_endpoint
@@ -186,9 +188,12 @@ class SparkMRJobRunner(MRJobBinRunner):
 
             if google_libs_installed:
                 self._fs.add_fs('gcs', GCSFilesystem(
-                    project_id=self._opts['google_project_id']
+                    project_id=self._opts['google_project_id'],
+                    location=self._opts['google_region'],
+                    object_ttl_days=_DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS,
                 ), disable_if=_is_permanent_google_error)
 
+            # Hadoop FS is responsible for all URIs that fall through to it
             self._fs.add_fs('hadoop', HadoopFilesystem(
                 self._opts['hadoop_bin']))
 

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -80,6 +80,110 @@ class CatTestCase(MockGoogleTestCase):
             [b'a' * _CAT_CHUNK_SIZE, b'b' * _CAT_CHUNK_SIZE])
 
 
+class CreateBucketTestCase(MockGoogleTestCase):
+
+    def test_default(self):
+        fs = GCSFilesystem()
+
+        fs.create_bucket('walrus')
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(bucket.location, 'US')
+        self.assertEqual(list(bucket.lifecycle_rules), [])
+
+    def test_location(self):
+        fs = GCSFilesystem()
+
+        fs.create_bucket('walrus', location='us-central1')
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(bucket.location, 'US-CENTRAL1')
+
+    def test_location_set_at_init(self):
+        fs = GCSFilesystem(location='us-central1')
+
+        fs.create_bucket('walrus')
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(bucket.location, 'US-CENTRAL1')
+
+    def test_override_location_set_at_init(self):
+        fs = GCSFilesystem(location='us-central1')
+
+        fs.create_bucket('walrus', location='us-east1')
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(bucket.location, 'US-EAST1')
+
+    def test_blank_out_location_set_at_init(self):
+        fs = GCSFilesystem(location='us-central1')
+
+        fs.create_bucket('walrus', location='')
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(bucket.location, 'US')
+
+    def test_lifecycle_rules(self):
+        fs = GCSFilesystem()
+
+        fs.create_bucket('walrus', object_ttl_days=123)
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(
+            list(bucket.lifecycle_rules),
+            [dict(action=dict(type='Delete'), condition=dict(age=123))])
+
+    def test_object_ttl_days_set_at_init(self):
+        fs = GCSFilesystem(object_ttl_days=234)
+
+        fs.create_bucket('walrus')
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(
+            list(bucket.lifecycle_rules),
+            [dict(action=dict(type='Delete'), condition=dict(age=234))])
+
+    def test_override_object_ttl_days_set_at_init(self):
+        fs = GCSFilesystem(object_ttl_days=234)
+
+        fs.create_bucket('walrus', object_ttl_days=123)
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(
+            list(bucket.lifecycle_rules),
+            [dict(action=dict(type='Delete'), condition=dict(age=123))])
+
+    def test_blank_out_object_ttl_days_set_at_init(self):
+        fs = GCSFilesystem(object_ttl_days=234)
+
+        fs.create_bucket('walrus', object_ttl_days=0)
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(list(bucket.lifecycle_rules), [])
+
+    def test_mkdir_bucket(self):
+        fs = GCSFilesystem(location='us-central1', object_ttl_days=123)
+
+        fs.mkdir('gs://walrus/data')
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(bucket.location, 'US-CENTRAL1')
+
+        self.assertEqual(
+            list(bucket.lifecycle_rules),
+            [dict(action=dict(type='Delete'), condition=dict(age=123))])
+
+
 class GCSFSTestCase(MockGoogleTestCase):
 
     def setUp(self):
@@ -187,6 +291,22 @@ class GCSFSTestCase(MockGoogleTestCase):
         })
 
         self.assertRaises(IOError, self.fs.md5sum, 'gs://walrus/data/bar')
+
+    def test_mkdir_creates_buckets(self):
+        self.assertNotIn('walrus', self.mock_gcs_fs)
+
+        self.fs.mkdir('gs://walrus/data')
+
+        self.assertIn('walrus', self.mock_gcs_fs)
+
+    def test_mkdir_does_not_create_directories(self):
+        self.fs.create_bucket('walrus')
+
+        self.assertEqual(list(self.fs.ls('gs://walrus/')), [])
+
+        self.fs.mkdir('gs://walrus/data')
+
+        self.assertEqual(list(self.fs.ls('gs://walrus/')), [])
 
     def test_put(self):
         local_path = self.makefile('foo', contents=b'bar')

--- a/tests/fs/test_s3.py
+++ b/tests/fs/test_s3.py
@@ -241,7 +241,14 @@ class S3FSTestCase(MockBoto3TestCase):
         self.assertRaises(OSError,
                           self.fs.touchz, 's3://walrus/full')
 
-    def test_mkdir_does_nothing(self):
+    def test_mkdir_creates_buckets(self):
+        self.assertNotIn('walrus', self.mock_s3_fs)
+
+        self.fs.mkdir('s3://walrus/data')
+
+        self.assertIn('walrus', self.mock_s3_fs)
+
+    def test_mkdir_does_not_create_directories(self):
         self.add_mock_s3_data({'walrus': {}})
 
         self.assertEqual(list(self.fs.ls('s3://walrus/')), [])
@@ -427,6 +434,34 @@ class S3FSRegionTestCase(MockBoto3TestCase):
                          'https://s3-us-west-2.amazonaws.com')
         self.assertEqual(bucket.meta.client.meta.region_name,
                          'us-west-2')
+
+    def test_create_bucket_in_region_set_at_init_time(self):
+        fs = S3Filesystem(s3_region='us-west-2')
+
+        fs.create_bucket('walrus')
+
+        s3_client = fs.make_s3_client()
+        self.assertEqual(
+            s3_client.get_bucket_location('walrus')['LocationConstraint'],
+            'us-west-2')
+
+        bucket = fs.get_bucket('walrus')
+
+        self.assertEqual(bucket.meta.client.meta.endpoint_url,
+                         'https://s3-us-west-2.amazonaws.com')
+        self.assertEqual(bucket.meta.client.meta.region_name,
+                         'us-west-2')
+
+    def test_create_bucket_with_mkdir(self):
+        # mkdir() doesn't have a way to specify bucket location, so we
+        # do it at init time
+        fs = S3Filesystem(s3_region='us-west-1')
+
+        fs.mkdir('s3://walrus/data')
+
+        bucket = fs.get_bucket('walrus')
+        self.assertEqual(bucket.meta.client.meta.region_name,
+                         'us-west-1')
 
 
 class WrapAWSClientTestCase(MockBoto3TestCase):

--- a/tests/mock_boto3/s3.py
+++ b/tests/mock_boto3/s3.py
@@ -102,6 +102,11 @@ class MockS3Client(object):
 
         return dict(LocationConstraint=location_constraint)
 
+    def head_bucket(self, Bucket):
+        self._check_bucket_exists(Bucket, 'HeadBucket')
+
+        return dict()
+
     def list_buckets(self):
         buckets = [
             dict(CreationDate=b['creation_date'], Name=name)

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -653,7 +653,7 @@ class TmpBucketTestCase(MockGoogleTestCase):
         runner = DataprocJobRunner(conf_paths=[], **runner_kwargs)
 
         bucket_name, path = parse_gcs_uri(runner._cloud_tmp_dir)
-        runner._create_fs_tmp_bucket(bucket_name, location=location)
+        runner._upload_local_files()
 
         self.assertTrue(bucket_name.startswith('mrjob-'))
         self.assertNotIn(bucket_name, existing_buckets)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -877,7 +877,7 @@ class TmpBucketTestCase(MockBoto3TestCase):
         existing_bucket_names = set(self.mock_s3_fs)
 
         runner = EMRJobRunner(conf_paths=[], **runner_kwargs)
-        runner._create_s3_tmp_bucket_if_needed()
+        runner._upload_local_files()
 
         bucket_name, path = parse_s3_uri(runner._opts['cloud_tmp_dir'])
 
@@ -2966,14 +2966,6 @@ class MultiPartUploadTestCase(MockBoto3TestCase):
             'tests.mock_boto3.s3.MockS3Object.upload_file',
             side_effect=tests.mock_boto3.s3.MockS3Object.upload_file,
             autospec=True))
-
-    def upload_data(self, runner, data):
-        """Upload some bytes to S3"""
-        data_path = os.path.join(self.tmp_dir, self.TEST_FILENAME)
-        with open(data_path, 'wb') as fp:
-            fp.write(data)
-
-        runner.fs.put(data_path, self.TEST_S3_URI)
 
     def assert_upload_succeeds(self, runner, data, expected_part_size):
         """Write the data to a temp file, and then upload it to (mock) S3,


### PR DESCRIPTION
`fs.mkdir()` will now implicitly create buckets on the GCS and S3 filesystems. Region and (on GCS) object TTL are now set at fs init time. Fixes #1953.

This change allowed us to simplify a fair amount of runner code having to do with creating buckets and uploading files.