### PR TITLE
add missing spark runner options

### DIFF
--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -701,6 +701,22 @@ _RUNNER_OPTS = dict(
             (['--gcloud-bin'], dict(help='path to gcloud binary')),
         ],
     ),
+    google_project_id=dict(
+        cloud_role='connect',
+        switches=[
+            (['--google-project-id'], dict(
+                help='project ID to use when connecting to GCS',
+            )),
+        ],
+    ),
+    google_region=dict(
+        cloud_role='connect',
+        switches=[
+            (['--google-region'], dict(
+                help='Google cloud region to create GCS buckets in',
+            )),
+        ],
+    ),
     hadoop_bin=dict(
         combiner=combine_cmds,
         switches=[
@@ -1107,6 +1123,14 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    s3_region=dict(
+        cloud_role='connect',
+        switches=[
+            (['--s3-region'], dict(
+                help='AWS region to create s3 buckets in',
+            )),
+        ],
+    ),
     service_account=dict(
         cloud_role='launch',
         switches=[
@@ -1198,6 +1222,16 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--spark-submit-bin'], dict(
                 help='spark-submit binary. You may include arguments.'
+            )),
+        ],
+    ),
+    spark_tmp_dir=dict(
+        cloud_role='launch',
+        combiner=combine_paths,
+        switches=[
+            (['--spark-tmp-dir'], dict(
+                help=('optional URI visible to Spark executors to use as our'
+                      ' temp directory.'),
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -701,14 +701,6 @@ _RUNNER_OPTS = dict(
             (['--gcloud-bin'], dict(help='path to gcloud binary')),
         ],
     ),
-    google_project_id=dict(
-        cloud_role='connect',
-        switches=[
-            (['--google-project-id'], dict(
-                help='project ID to use when connecting to GCS',
-            )),
-        ],
-    ),
     gcs_region=dict(
         cloud_role='connect',
         switches=[
@@ -1053,7 +1045,8 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--project-id'], dict(
                 deprecated_aliases=['--gcp-project'],
-                help='Project to run Dataproc jobs in'
+                help=('Project to use when connecting to Google Cloud Services'
+                      ' and to run Cloud Dataproc jobs in')
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -709,11 +709,11 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
-    google_region=dict(
+    gcs_region=dict(
         cloud_role='connect',
         switches=[
-            (['--google-region'], dict(
-                help='Google cloud region to create GCS buckets in',
+            (['--gcs-region'], dict(
+                help='region to create Google Cloud Storage buckets in',
             )),
         ],
     ),

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -188,7 +188,7 @@ class SparkMRJobRunner(MRJobBinRunner):
 
             if google_libs_installed:
                 self._fs.add_fs('gcs', GCSFilesystem(
-                    project_id=self._opts['google_project_id'],
+                    project_id=self._opts['project_id'],
                     location=self._opts['gcs_region'],
                     object_ttl_days=_DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS,
                 ), disable_if=_is_permanent_google_error)

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -60,7 +60,7 @@ class SparkMRJobRunner(MRJobBinRunner):
         'cloud_fs_sync_secs',
         'cloud_part_size_mb',
         'google_project_id',  # used by GCS filesystem
-        'google_region',  # used when creating buckets on GCS
+        'gcs_region',  # used when creating buckets on GCS
         'hadoop_bin',
         's3_endpoint',
         's3_region',  # only used along with s3_endpoint
@@ -189,7 +189,7 @@ class SparkMRJobRunner(MRJobBinRunner):
             if google_libs_installed:
                 self._fs.add_fs('gcs', GCSFilesystem(
                     project_id=self._opts['google_project_id'],
-                    location=self._opts['google_region'],
+                    location=self._opts['gcs_region'],
                     object_ttl_days=_DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS,
                 ), disable_if=_is_permanent_google_error)
 

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -59,9 +59,9 @@ class SparkMRJobRunner(MRJobBinRunner):
         'aws_session_token',
         'cloud_fs_sync_secs',
         'cloud_part_size_mb',
-        'google_project_id',  # used by GCS filesystem
         'gcs_region',  # used when creating buckets on GCS
         'hadoop_bin',
+        'project_id',  # used by GCS filesystem
         's3_endpoint',
         's3_region',  # only used along with s3_endpoint
         'spark_deploy_mode',

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -29,6 +29,7 @@ from mrjob.conf import combine_envs
 from mrjob.job import MRJob
 from mrjob.job import UsageError
 from mrjob.job import _im_func
+from mrjob.options import _RUNNER_ALIASES
 from mrjob.options import _RUNNER_OPTS
 from mrjob.parse import parse_mr_job_stderr
 from mrjob.protocol import BytesValueProtocol
@@ -1288,6 +1289,10 @@ class PrintHelpTestCase(SandboxedTestCase):
 
         # deprecated options
         self.assertIn('--max-hours-idle', output)
+
+    def test_runner_help_works_for_all_runners(self):
+        for alias in _RUNNER_ALIASES:
+            MRJob(['--help', '-r', alias])
 
     def test_steps_help(self):
         MRJob(['--help', '--steps'])


### PR DESCRIPTION
The Spark runner supports all filesystems, and needs to have platform-specific names for options that are usually generic (e.g. `gcs_region`, `s3_region`), but we forgot to add these options to `mrjob/option.py`.

Added a regression test to ensure we don't do this in the future. Also tweaked the option names used by the Spark runner to be more consistent with existing options.