### PR TITLE
fix part_size=0 on S3, default Spark part size to 100 MB

### DIFF
--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -51,6 +51,8 @@ _EXT_TO_UNARCHIVE_CMD = {
 # issue a warning if max_mins_idle is set to less than this
 _DEFAULT_MAX_MINS_IDLE = 10.0
 
+# default part size (so we can share with Spark runner)
+_DEFAULT_CLOUD_PART_SIZE_MB = 100
 
 class HadoopInTheCloudJobRunner(MRJobBinRunner):
     """Abstract base class for all Hadoop-in-the-cloud services."""
@@ -130,7 +132,7 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
         return combine_dicts(
             super(HadoopInTheCloudJobRunner, self)._default_opts(),
             dict(
-                cloud_part_size_mb=100,  # 100 MB
+                cloud_part_size_mb=_DEFAULT_CLOUD_PART_SIZE_MB,
                 max_mins_idle=_DEFAULT_MAX_MINS_IDLE,
                 # don't use a list because it makes it hard to read option
                 # values when running in verbose mode. See #1284

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -34,7 +34,6 @@ except ImportError:
 
 try:
     import boto3
-    import boto3.s3.transfer
     boto3  # quiet "redefinition of unused ..." warning from pyflakes
 except ImportError:
     # don't require boto3; MRJobs don't actually need it when running

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -267,13 +267,14 @@ class S3Filesystem(Filesystem):
         """Uploads a local file to a specific destination."""
         s3_key = self._get_s3_key(path)
 
-        s3_key.upload_file(
-            src,
-            Config=boto3.s3.transfer.TransferConfig(
+        transfer_config = None
+        if self._part_size:
+            transfer_config = boto3.s3.transfer.TransferConfig(
                 multipart_chunksize=self._part_size,
                 multipart_threshold=self._part_size,
-            ),
-        )
+            )
+
+        s3_key.upload_file(src, Config=transfer_config)
 
     def rm(self, path_glob):
         """Remove all files matching the given glob."""

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -60,6 +60,9 @@ _AWS_BACKOFF = 20
 _AWS_BACKOFF_MULTIPLIER = 1.5
 _AWS_MAX_TRIES = 20  # this takes about a day before we run out of tries
 
+# used to disable multipart upload
+_HUGE_PART_SIZE = 2 ** 256
+
 
 def _client_error_code(ex):
     """Get the error code for the given ClientError"""
@@ -267,14 +270,16 @@ class S3Filesystem(Filesystem):
         """Uploads a local file to a specific destination."""
         s3_key = self._get_s3_key(path)
 
-        transfer_config = None
-        if self._part_size:
-            transfer_config = boto3.s3.transfer.TransferConfig(
-                multipart_chunksize=self._part_size,
-                multipart_threshold=self._part_size,
-            )
+        # if part_size is None or 0, disable multipart upload
+        part_size = self._part_size or _HUGE_PART_SIZE
 
-        s3_key.upload_file(src, Config=transfer_config)
+        s3_key.upload_file(
+            src,
+            Config=boto3.s3.transfer.TransferConfig(
+                multipart_chunksize=part_size,
+                multipart_threshold=part_size,
+            ),
+        )
 
     def rm(self, path_glob):
         """Remove all files matching the given glob."""

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -22,6 +22,7 @@ from subprocess import CalledProcessError
 from tempfile import gettempdir
 
 from mrjob.bin import MRJobBinRunner
+from mrjob.cloud import _DEFAULT_CLOUD_PART_SIZE_MB
 from mrjob.compat import jobconf_from_dict
 from mrjob.dataproc import _DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS
 from mrjob.fs.composite import CompositeFilesystem
@@ -139,6 +140,15 @@ class SparkMRJobRunner(MRJobBinRunner):
                             "step %d's %s runs a command, but spark"
                             " runner does not support commands" % (
                                 step_num, mrc))
+
+    def _default_opts(self):
+        return combine_dicts(
+            super(SparkMRJobRunner, self)._default_opts(),
+            dict(
+                cloud_part_size_mb=_DEFAULT_CLOUD_PART_SIZE_MB,
+            ),
+        )
+
 
     def _run(self):
         self.get_spark_submit_bin()  # find spark-submit up front

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -23,6 +23,7 @@ from tempfile import gettempdir
 
 from mrjob.bin import MRJobBinRunner
 from mrjob.cloud import _DEFAULT_CLOUD_PART_SIZE_MB
+from mrjob.conf import combine_dicts
 from mrjob.compat import jobconf_from_dict
 from mrjob.dataproc import _DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS
 from mrjob.fs.composite import CompositeFilesystem
@@ -265,9 +266,9 @@ class SparkMRJobRunner(MRJobBinRunner):
         """Group streaming steps together."""
         # a list of dicts with:
         #
-        # type: shared type of steps
-        # steps: list of steps in group
-        # step_num: (0-indexed) number of first step
+        # type -- shared type of steps
+        # steps -- list of steps in group
+        # step_num -- (0-indexed) number of first step
         groups = []
 
         for step_num, step in enumerate(steps):

--- a/tests/mock_boto3/s3.py
+++ b/tests/mock_boto3/s3.py
@@ -322,6 +322,16 @@ class MockS3Object(object):
                     path, self.bucket_name, self.key,
                     str(_no_such_bucket_error('PutObject'))))
 
+        # verify that config doesn't have empty part size (see #2033)
+        #
+        # config is a boto3.s3.transfer.TransferConfig (we don't mock it),
+        # which is actually part of s3transfer. Very old versions of s3transfer
+        # (e.g. 0.10.0) disallow initializing TransferConfig with part sizes
+        # that are zero or None
+        if Config and not (Config.multipart_chunksize and
+                           Config.multipart_threshold):
+            raise TypeError('part size may not be 0 or None')
+
         mock_keys = self._mock_bucket_keys('PutObject')
         with open(path, 'rb') as f:
             mock_keys[self.key] = dict(

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -47,6 +47,7 @@ from mrjob.emr import _BAD_BASH_IMAGE_VERSION
 from mrjob.emr import _DEFAULT_IMAGE_VERSION
 from mrjob.emr import _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH
 from mrjob.emr import _PRE_4_X_STREAMING_JAR
+from mrjob.fs.s3 import _HUGE_PART_SIZE
 from mrjob.job import MRJob
 from mrjob.parse import parse_s3_uri
 from mrjob.pool import _extract_tags
@@ -3018,7 +3019,7 @@ class MultiPartUploadTestCase(MockBoto3TestCase):
         runner = EMRJobRunner(cloud_part_size_mb=0)
 
         data = b'Mew' * 20
-        self.assert_upload_succeeds(runner, data, None)
+        self.assert_upload_succeeds(runner, data, _HUGE_PART_SIZE)
 
 
 class AWSSessionTokenTestCase(MockBoto3TestCase):


### PR DESCRIPTION
This fixes a bug I introduced when I moved uploading out of the EMR runner and into the S3 filesystem (see #1977).  Basically, if you tell boto3 you want a part size of 0 or `None`, it causes a `TypeError`. Fixes #2033.

Also used the same default part size (100 MB) on the Spark runner that we do on Dataproc and EMR.

As noted in #2033, this is a non-issue for Google Cloud Storage, which falls back on a "resumable" upload if you don't set part size.