### PR TITLE
don't keep running if os.execvpe() fails

### DIFF
--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -1,6 +1,7 @@
 # Copyright 2009-2016 Yelp and Contributors
 # Copyright 2017 Yelp
 # Copyright 2018 Yelp and Google, Inc.
+# Copyright 2019 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -413,7 +413,7 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
                         # the parent process's job
                         os._exit(ex.errno)
                     finally:
-                        # if we get some other exception, also exit hard
+                        # if we got some other exception, still exit hard
                         os._exit(-1)
                 else:
                     log.debug('Invoking Hadoop via PTY')

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -1170,6 +1170,9 @@ class RunJobInHadoopUsesEnvTestCase(MockHadoopTestCase):
         self.mock_execvpe = self.start(patch(
             'os.execvpe', side_effect=StopIteration))
 
+        # don't actually hard-exit the child, since we're not actually forking
+        self.mock_exit = self.start(patch('os._exit'))
+
     def test_with_pty(self):
         job = MRNullSpark(['-r', 'hadoop'])
         job.sandbox()

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -23,12 +23,15 @@ import os.path
 from io import BytesIO
 from subprocess import check_call
 from subprocess import PIPE
+from unittest import skipIf
 
 import mrjob.step
 from mrjob.conf import combine_dicts
 from mrjob.fs.hadoop import HadoopFilesystem
 from mrjob.hadoop import HadoopJobRunner
 from mrjob.hadoop import fully_qualify_hdfs_path
+from mrjob.hadoop import pty
+from mrjob.step import StepFailedException
 from mrjob.util import which
 
 from tests.mockhadoop import add_mock_hadoop_counters
@@ -1193,6 +1196,44 @@ class RunJobInHadoopUsesEnvTestCase(MockHadoopTestCase):
                 stdout=PIPE, stderr=PIPE, env=dict(FOO='bar', BAZ='qux'))
 
             self.assertFalse(self.mock_execvpe.called)
+
+
+
+@skipIf(not (pty and hasattr(pty, 'fork')), 'no pty.fork()')
+class BadHadoopBinAfterFork(MockHadoopTestCase):
+    # test what happens if os.execvpe() fails
+
+    # can't just set --hadoop-bin because this would break checking
+    # Hadoop version and uploading files. Instead, patch _args_for_step()
+
+    def patch_args_for_step(self, runner, bad_hadoop_bin):
+        real_args_for_step = runner._args_for_step
+
+        def args_for_step(*args, **kwargs):
+            args = real_args_for_step(*args, **kwargs)
+            return [bad_hadoop_bin] + args[1:]
+
+        self.start(patch.object(runner, '_args_for_step', args_for_step))
+
+    def test_no_such_file(self):
+        missing_hadoop_bin = os.path.join(self.tmp_dir, 'no-hadoop-here')
+
+        job = MRTwoStepJob(['-r', 'hadoop'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.patch_args_for_step(runner, missing_hadoop_bin)
+            self.assertRaises(StepFailedException, runner.run)
+
+    def test_permissions_error(self):
+        nonexecutable_hadoop_bin = self.makefile('not-really-hadoop')
+
+        job = MRTwoStepJob(['-r', 'hadoop'])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            self.patch_args_for_step(runner, nonexecutable_hadoop_bin)
+            self.assertRaises(StepFailedException, runner.run)
 
 
 class SparkPyFilesTestCase(MockHadoopTestCase):


### PR DESCRIPTION
mrjob prefers to run the `hadoop` and `spark-submit` binaries by opening up a PTY and forking (since they they generally flush their output more often). This fixes an issue where `os.execvpe()` can fail if the binary doesn't exist or can't be run, causing the child process (that only exists to become `hadoop`/`spark-submit`) to continue being Python, raising an exception and then doing cleanup actions (e.g. deleting temp dir) in parallel with the master process.

This change makes it so that if `os.execvpe()` fails, we instead `os._exit()`. Either way, the child process doesn't take on a life of its own.

Fixes #2024.