### PR TITLE
Ensure that Spark can serialize job methods

### DIFF
--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -142,41 +142,25 @@ class MRJobLauncher(object):
         self._stdout = None
         self._stderr = None
 
+
+    # by default, self.stdin, self.stdout, and self.stderr are sys.std*.buffer
+    # if it exists, and otherwise sys.std* otherwise (they should always deal
+    # with bytes, not Unicode).
+    #
+    # *buffer* is pretty much a Python 3 thing, though some platforms
+    # (notably Jupyterhub) don't have it. See #1441
+
     @property
     def stdin(self):
-        if self._stdin:
-            # allow sandboxing a path, which becomes a filehandle once
-            # *self* is serialized
-            if isinstance(self._stdin, str):
-                self._stdin = open(self._stdin, 'rb')
-            return self._stdin
-        else:
-            # should always read bytes, not unicode. sys.stdin.buffer
-            # is a Python 3 thing, though it's not present in all
-            # environments (e.g. Jupyter notebook). See #1441
-            return getattr(sys.stdin, 'buffer', sys.stdin)
+        return self._stdin or getattr(sys.stdin, 'buffer', sys.stdin)
 
     @property
     def stdout(self):
-        if self._stdout:
-            # allow sandboxing a path
-            if isinstance(self._stdout, str):
-                self._stdout = open(self._stdout, 'wb')
-            return self._stdout
-        else:
-            # should always write bytes, not unicode
-            return getattr(sys.stdout, 'buffer', sys.stdout)
+        return self._stdout or getattr(sys.stdout, 'buffer', sys.stdout)
 
     @property
     def stderr(self):
-        if self._stderr:
-            # allow sandboxing a path
-            if isinstance(self._stderr, str):
-                self._stderr = open(self._stderr, 'wb')
-            return self._stderr
-        else:
-            # should always write bytes, not unicode
-            return getattr(sys.stderr, 'buffer', sys.stderr)
+        return self._stderr or getattr(sys.stderr, 'buffer', sys.stderr)
 
     @classmethod
     def _usage(cls):

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -165,7 +165,7 @@ class MRJobLauncher(object):
             return self._stdout
         else:
             # should always write bytes, not unicode
-            return getattr(sys.stdout, 'buffer', sys.stdin)
+            return getattr(sys.stdout, 'buffer', sys.stdout)
 
     @property
     def stderr(self):
@@ -176,7 +176,7 @@ class MRJobLauncher(object):
             return self._stderr
         else:
             # should always write bytes, not unicode
-            return getattr(sys.stderr, 'buffer', sys.stdin)
+            return getattr(sys.stderr, 'buffer', sys.stderr)
 
     @classmethod
     def _usage(cls):

--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -656,6 +656,14 @@ class MRJobLauncher(object):
 
             self.assertEqual(mrjob.stdout.getvalue(), ...)
             self.assertEqual(parse_mr_job_stderr(mr_job.stderr), ...)
+
+        .. note::
+
+           If you are using Spark, it's recommended you only pass in
+           :py:class:`io.BytesIO` or other serializable alternatives to file
+           objects. *stdin*, *stdout*, and *stderr* get stored as job
+           attributes, which means if they aren't serializable, neither
+           is the job instance or its methods.
         """
         self._stdin = stdin or BytesIO()
         self._stdout = stdout or BytesIO()

--- a/mrjob/spark/mrjob_spark_harness.py
+++ b/mrjob/spark/mrjob_spark_harness.py
@@ -135,7 +135,6 @@ def main(cmd_line_args=None):
         j = job_class(job_args + [
             '--%s' % mrc, '--step-num=%d' % step_num
         ])
-        j.sandbox()  # so Spark doesn't try to serialize stdin
 
         # patch increment_counter() to update the accumulator for this step
         j.increment_counter = make_increment_counter(step_num)

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -338,6 +338,7 @@ def save_cwd():
     finally:
         os.chdir(original_cwd)
 
+
 @contextmanager
 def save_sys_std():
     """Context manager that saves the current values of `sys.stdin`,
@@ -352,9 +353,14 @@ def save_sys_std():
 
         yield
 
+        # at this point, sys.stdout/stderr may have been patched. Don't
+        # raise an exception if flush() fails
         try:
-            # at this point, sys.stdout/stderr may have been patched
             sys.stdout.flush()
+        except:
+            pass
+
+        try:
             sys.stderr.flush()
         except:
             pass

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -338,6 +338,29 @@ def save_cwd():
     finally:
         os.chdir(original_cwd)
 
+@contextmanager
+def save_sys_std():
+    """Context manager that saves the current values of `sys.stdin`,
+    `sys.stdout`, and `sys.stderr`, and flushes these filehandles before
+    and after switching them out."""
+
+    stdin, stdout, stderr = sys.stdin, sys.stdout, sys.stderr
+
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        yield
+
+        try:
+            # at this point, sys.stdout/stderr may have been patched
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except:
+            pass
+    finally:
+        sys.stdin, sys.stdout, sys.stderr = stdin, stdout, stderr
+
 
 @contextmanager
 def save_sys_path():

--- a/tests/mr_spark_method_wordcount.py
+++ b/tests/mr_spark_method_wordcount.py
@@ -1,0 +1,49 @@
+# Copyright 2016 Yelp
+# Copyright 2019 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+from operator import add
+
+from mrjob.job import MRJob
+
+WORD_RE = re.compile(r"[\w']+")
+
+
+class MRSparkMethodWordcount(MRJob):
+    # like MRSparkWordcount, except that we pass methods to Spark,
+    # which means we have to be able to serialize *self*.
+
+    def spark(self, input_path, output_path):
+        # Spark may not be available where script is launched
+        from pyspark import SparkContext
+
+        sc = SparkContext(appName='mrjob Spark wordcount script')
+
+        lines = sc.textFile(input_path)
+
+        counts = (
+            lines.flatMap(self.line_to_words)
+            .map(lambda word: (word, 1))
+            .reduceByKey(add))
+
+        counts.saveAsTextFile(output_path)
+
+        sc.stop()
+
+    def line_to_words(self, line):
+        return WORD_RE.findall(line)
+
+
+if __name__ == '__main__':
+    MRSparkMethodWordcount.run()

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -33,6 +33,7 @@ except ImportError:
 
 import mrjob
 from mrjob import runner
+from mrjob.py2 import PY2
 from mrjob.util import NullHandler
 
 from tests.py2 import patch
@@ -190,8 +191,9 @@ class SingleSparkContextTestCase(BasicTestCase):
     def setUpClass(cls):
         super(SingleSparkContextTestCase, cls).setUpClass()
 
-        # don't warn about running processes or unclosed filehandles
-        filterwarnings('ignore', category=ResourceWarning)
+        if not PY2:
+            # ignore Python 3 warnings about unclosed filehandles
+            filterwarnings('ignore', category=ResourceWarning)
 
         from pyspark import SparkContext
         cls.spark_context = SparkContext()
@@ -205,8 +207,9 @@ class SingleSparkContextTestCase(BasicTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # don't warn about running processes or unclosed filehandles
-        filterwarnings('ignore', category=ResourceWarning)
+        if not PY2:
+            # ignore Python 3 warnings about unclosed filehandles
+            filterwarnings('ignore', category=ResourceWarning)
 
         cls.spark_context.stop()
 

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -203,6 +203,7 @@ class SingleSparkContextTestCase(BasicTestCase):
     def tearDownClass(cls):
         cls.spark_context.stop()
 
+        super(SingleSparkContextTestCase, cls).tearDownClass()
 
     def setUp(self):
         super(SingleSparkContextTestCase, self).setUp()

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -24,6 +24,7 @@ from tempfile import mkdtemp
 from shutil import rmtree
 from unittest import TestCase
 from unittest import skipIf
+from warnings import filterwarnings
 
 try:
     import pyspark
@@ -189,6 +190,9 @@ class SingleSparkContextTestCase(BasicTestCase):
     def setUpClass(cls):
         super(SingleSparkContextTestCase, cls).setUpClass()
 
+        # don't warn about running processes or unclosed filehandles
+        filterwarnings('ignore', category=ResourceWarning)
+
         from pyspark import SparkContext
         cls.spark_context = SparkContext()
 
@@ -201,6 +205,9 @@ class SingleSparkContextTestCase(BasicTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        # don't warn about running processes or unclosed filehandles
+        filterwarnings('ignore', category=ResourceWarning)
+
         cls.spark_context.stop()
 
         super(SingleSparkContextTestCase, cls).tearDownClass()

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -58,7 +58,6 @@ from tests.py2 import patch
 from tests.sandbox import BasicTestCase
 from tests.sandbox import EmptyMrjobConfTestCase
 from tests.sandbox import SandboxedTestCase
-from tests.sandbox import SingleSparkContextTestCase
 from tests.sandbox import mrjob_conf_patcher
 
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1761,6 +1761,9 @@ class SparkJobMethodsTestCase(SandboxedTestCase, SingleSparkContextTestCase):
     def setUp(self):
         super(SparkJobMethodsTestCase, self).setUp()
 
+        import warnings
+        warnings.filterwarnings('error')
+
         # ensure that we aren't sandboxing the job. This used to be
         # the way we made Spark jobs serializable; see #2039
         self.job_sandbox = self.start(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -44,12 +44,15 @@ from mrjob.py2 import StringIO
 from mrjob.step import JarStep
 from mrjob.step import MRStep
 from mrjob.step import SparkStep
+from mrjob.util import safeeval
+from mrjob.util import to_lines
 
 from tests.job import run_job
 from tests.mr_hadoop_format_job import MRHadoopFormatJob
 from tests.mr_cmd_job import MRCmdJob
 from tests.mr_rot13lib import MRRot13Lib
 from tests.mr_sort_values import MRSortValues
+from tests.mr_spark_method_wordcount import MRSparkMethodWordcount
 from tests.mr_tower_of_powers import MRTowerOfPowers
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_upload_attrs_job import MRUploadAttrsJob
@@ -59,6 +62,13 @@ from tests.py2 import patch
 from tests.sandbox import BasicTestCase
 from tests.sandbox import EmptyMrjobConfTestCase
 from tests.sandbox import SandboxedTestCase
+from tests.sandbox import SingleSparkContextTestCase
+
+try:
+    import pyspark
+    pyspark
+except ImportError:
+    pyspark = None
 
 
 # These can't be invoked as a separate script, but they don't need to be
@@ -1742,3 +1752,44 @@ class UploadAttrsTestCase(SandboxedTestCase):
             job._runner_kwargs()['upload_dirs'], ['foo'])
         self.assertEqual(
             job._runner_kwargs()['upload_files'], ['foo/bar.txt'])
+
+
+# SingleSparkContextTestCase is skipped if there's no pyspark
+class SparkJobMethodsTestCase(SandboxedTestCase, SingleSparkContextTestCase):
+    # regression test for #2039
+
+    def setUp(self):
+        super(SparkJobMethodsTestCase, self).setUp()
+
+        # ensure that we aren't sandboxing the job. This used to be
+        # the way we made Spark jobs serializable; see #2039
+        self.job_sandbox = self.start(
+            patch('mrjob.launch.MRJobLauncher.sandbox'))
+
+    def test_job_can_be_pickled_and_unpicked(self):
+        job = MRJob()
+
+        pickled_job = pyspark.cloudpickle.dumps(job)
+        pyspark.cloudpickle.loads(pickled_job)
+
+    def test_spark_can_serialize_job_methods(self):
+        input_path = self.makefile(
+            'input', b'one fish\ntwo fish\nred fish\nblue fish\n')
+
+        job = MRSparkMethodWordcount(['-r', 'inline', input_path])
+        # don't sandbox; we want to see if Spark can handle an un-sandboxed job
+
+        counts = {}
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            for line in to_lines(runner.cat_output()):
+                k, v = safeeval(line)
+                counts[k] = v
+
+        self.assertEqual(counts, dict(
+            blue=1, fish=4, one=1, red=1, two=1))
+
+        # check that we didn't alter the job to make it serializable
+        self.assertFalse(self.job_sandbox.called)

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Copyright 2012-2013 Yelp
 # Copyright 2014 Yelp and Contributors
-# Copyright 2015-2017 Yelp
-# Copyright 2018 Yelp
+# Copyright 2015-2018 Yelp
+# Copyright 2019 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -448,9 +448,9 @@ class StdStreamTestCase(BasicTestCase):
                             stdout=mock_stdout, stderr=mock_stderr):
             launcher = MRJobLauncher(args=['/path/to/script'])
 
-        self.assertEqual(launcher.stdin, mock_stdin.buffer)
-        self.assertEqual(launcher.stdout, mock_stdout)
-        self.assertEqual(launcher.stderr, mock_stderr)
+            self.assertEqual(launcher.stdin, mock_stdin.buffer)
+            self.assertEqual(launcher.stdout, mock_stdout)
+            self.assertEqual(launcher.stderr, mock_stderr)
 
 
 class DeprecatedOptionHooksTestCase(SandboxedTestCase):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -33,11 +33,13 @@ from mrjob.util import random_identifier
 from mrjob.util import read_file
 from mrjob.util import read_input
 from mrjob.util import safeeval
+from mrjob.util import save_sys_std
 from mrjob.util import to_lines
 from mrjob.util import unarchive
 from mrjob.util import unique
 from mrjob.util import which
 
+from tests.py2 import Mock
 from tests.py2 import patch
 from tests.sandbox import BasicTestCase
 from tests.sandbox import SandboxedTestCase
@@ -547,6 +549,72 @@ class RandomIdentifierTestCase(BasicTestCase):
         # heh
         with random_seed(0):
             self.assertNotEqual(random_identifier(), random_identifier())
+
+
+class SaveSysStdTestCase(BasicTestCase):
+
+    def setUp(self):
+        # if save_sys_std() *doesn't* work, don't mess up other tests
+        super(SaveSysStdTestCase, self).setUp()
+
+        self.stdin = self.start(patch('sys.stdin'))
+        self.stdout = self.start(patch('sys.stdout'))
+        self.stderr = self.start(patch('sys.stderr'))
+
+    def test_basic(self):
+        fake_stdin = BytesIO(b'HI')
+        fake_stdout = BytesIO()
+        fake_stderr = BytesIO()
+
+        with save_sys_std():
+            sys.stdin = fake_stdin
+            self.assertEqual(sys.stdin.read(), b'HI')
+
+            sys.stdout = fake_stdout
+            sys.stdout.write(b'Hello!\n')
+
+            sys.stderr = fake_stderr
+            sys.stderr.write(b'!!!')
+
+        self.assertEqual(sys.stdin, self.stdin)
+        self.assertEqual(sys.stdout, self.stdout)
+        self.assertEqual(sys.stderr, self.stderr)
+
+        self.assertFalse(self.stdin.read.called)
+        self.assertFalse(self.stdout.write.called)
+        self.assertFalse(self.stderr.write.called)
+
+        self.assertEqual(fake_stdout.getvalue(), b'Hello!\n')
+        self.assertEqual(fake_stderr.getvalue(), b'!!!')
+
+    def test_flushing(self):
+        fake_stderr = Mock()
+
+        with save_sys_std():
+            sys.stderr = fake_stderr
+            sys.stderr.write(b'Hello!\n')
+
+        self.assertEqual(self.stderr.flush.call_count, 1)
+        self.assertEqual(fake_stderr.flush.call_count, 1)
+
+        # stdout was never patched, so it gets flushed twice
+        self.assertEqual(self.stdout.flush.call_count, 2)
+
+        # we don't flush stdin
+        self.assertFalse(self.stdin.flush.called)
+
+    def test_bad_flush(self):
+        fake_stdout = "LOOK AT ME I'M STDOUT"
+        self.assertFalse(hasattr(fake_stdout, 'flush'))
+
+        with save_sys_std():
+            sys.stdout = fake_stdout
+
+        self.assertEqual(sys.stdout, self.stdout)
+        self.assertEqual(self.stdout.flush.call_count, 1)
+
+        # sys.stderr, which was not patched, should be flushed twice
+        self.assertEqual(self.stderr.flush.call_count, 2)
 
 
 class UniqueTestCase(BasicTestCase):


### PR DESCRIPTION
You can write a Spark MRJob just by defining `spark()`, but on most runners, that `spark()` method can't pass other job methods to Spark because the job stores `sys.stdin` in `job.stdin` (and likewise for stdout and stderr).

This pull request makes `job.stdin`, `job.stdout`, and `job.stderr` into properties, so we never have to store filehandles in the job instance unless someone passed them in via `job.sandbox()` (this would be rare; usually `job.sandbox()` sets `job.std*` to `BytesIO`s, which are serializable).

As a result, we were able to stop using `job.sandbox()` in the Spark harness and inline runner; `job.sandbox()` is once again just for testing.

Fixes #2039.