### PR TITLE
handle Spark working dir correctly on local-cluster master

### DIFF
--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -145,6 +145,9 @@ class SimMRJobRunner(MRJobRunner):
         if hasattr(self, '_create_setup_wrapper_scripts'):  # inline doesn't
             self._create_setup_wrapper_scripts()
 
+        # this does nothing in inline mode, since there's no _spark_master()
+        self._copy_files_to_wd_mirror()
+
         # run mapper, combiner, sort, reducer for each step
         for step_num, step in enumerate(self._get_steps()):
             log.info('Running step %d of %d...' % (

--- a/tests/mr_spark_os_walk.py
+++ b/tests/mr_spark_os_walk.py
@@ -26,7 +26,7 @@ class MRSparkOSWalk(MRJob):
         super(MRSparkOSWalk, self).configure_args()
 
         self.add_passthru_arg(
-            '--use-executor-cwd', dest='use_executor_cwd',
+            '--use-driver-cwd', dest='use_driver_cwd',
             default=False, action='store_true')
 
     def spark(self, input_paths, output_path):
@@ -35,9 +35,10 @@ class MRSparkOSWalk(MRJob):
 
         # we'd like to walk the executor's directory. However, when running
         # directly through pyspark (inline runner), there's no way to restart
-        # the JVM with a new CWD, so instead we walk the executor's directory
-        # (which drivers are *supposed* to match, if they have a fresh JVM)
-        if self.options.use_executor_cwd:
+        # the JVM with a new CWD, so instead we walk the driver's directory
+        # (which executors *would* match on local master if we had a fresh
+        # JVM)
+        if self.options.use_driver_cwd:
             cwd = getcwd()
         else:
             cwd = '.'

--- a/tests/mr_spark_os_walk.py
+++ b/tests/mr_spark_os_walk.py
@@ -25,17 +25,16 @@ class MRSparkOSWalk(MRJob):
         sc = SparkContext()
 
         rdd = sc.parallelize(['.'])
-        rdd = rdd.flatMap(walk_dir)
+        rdd = rdd.flatMap(self.walk_dir)
 
         rdd.saveAsTextFile(output_path)
 
-
-def walk_dir(dirname):
-    for dirpath, _, filenames in walk(dirname, followlinks=True):
-        for filename in filenames:
-            path = join(dirpath, filename)
-            size = getsize(path)
-            yield path, size
+    def walk_dir(self, dirname):
+        for dirpath, _, filenames in walk(dirname, followlinks=True):
+            for filename in filenames:
+                path = join(dirpath, filename)
+                size = getsize(path)
+                yield path, size
 
 
 if __name__ == '__main__':

--- a/tests/mr_spark_os_walk.py
+++ b/tests/mr_spark_os_walk.py
@@ -1,0 +1,42 @@
+# Copyright 2019 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+from os import walk
+from os.path import join
+from os.path import getsize
+
+from mrjob.job import MRJob
+
+
+class MRSparkOSWalk(MRJob):
+
+    def spark(self, input_paths, output_path):
+        from pyspark import SparkContext
+        sc = SparkContext()
+
+        rdd = sc.parallelize(['.'])
+        rdd = rdd.flatMap(walk_dir)
+
+        rdd.saveAsTextFile(output_path)
+
+
+def walk_dir(dirname):
+    for dirpath, _, filenames in walk(dirname, followlinks=True):
+        for filename in filenames:
+            path = join(dirpath, filename)
+            size = getsize(path)
+            yield path, size
+
+
+if __name__ == '__main__':
+    MRSparkOSWalk.run()

--- a/tests/mr_spark_os_walk.py
+++ b/tests/mr_spark_os_walk.py
@@ -11,30 +11,48 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+from os import getcwd
 from os import walk
 from os.path import join
 from os.path import getsize
+from os.path import relpath
 
 from mrjob.job import MRJob
 
 
 class MRSparkOSWalk(MRJob):
 
+    def configure_args(self):
+        super(MRSparkOSWalk, self).configure_args()
+
+        self.add_passthru_arg(
+            '--use-executor-cwd', dest='use_executor_cwd',
+            default=False, action='store_true')
+
     def spark(self, input_paths, output_path):
         from pyspark import SparkContext
         sc = SparkContext()
 
-        rdd = sc.parallelize(['.'])
+        # we'd like to walk the executor's directory. However, when running
+        # directly through pyspark (inline runner), there's no way to restart
+        # the JVM with a new CWD, so instead we walk the executor's directory
+        # (which drivers are *supposed* to match, if they have a fresh JVM)
+        if self.options.use_executor_cwd:
+            cwd = getcwd()
+        else:
+            cwd = '.'
+
+        rdd = sc.parallelize([cwd])
         rdd = rdd.flatMap(self.walk_dir)
 
         rdd.saveAsTextFile(output_path)
 
-    def walk_dir(self, dirname):
-        for dirpath, _, filenames in walk(dirname, followlinks=True):
+    def walk_dir(self, root_dir):
+        for dirpath, _, filenames in walk(root_dir, followlinks=True):
             for filename in filenames:
                 path = join(dirpath, filename)
                 size = getsize(path)
-                yield path, size
+                yield relpath(path, root_dir), size
 
 
 if __name__ == '__main__':

--- a/tests/mr_tower_of_powers.py
+++ b/tests/mr_tower_of_powers.py
@@ -41,14 +41,16 @@ class MRTowerOfPowers(MRJob):
             self.n = int(f.read().strip())
 
     def mapper(self, _, value):
-        # mapper should always be reading from the "uploaded" file
-        assert self.options.n_file != os.environ['LOCAL_N_FILE_PATH']
+        # check mapper is reading from the "uploaded" file
+        if os.environ.get('LOCAL_N_FILE_PATH'):
+            assert self.options.n_file != os.environ['LOCAL_N_FILE_PATH']
 
         yield None, value ** self.n
 
     def reducer(self, key, values):
-        # reducer should always be reading from the "uploaded" file
-        assert self.options.n_file != os.environ['LOCAL_N_FILE_PATH']
+        # check reducer is reading from the "uploaded" file
+        if os.environ.get('LOCAL_N_FILE_PATH'):
+            assert self.options.n_file != os.environ['LOCAL_N_FILE_PATH']
 
         # just pass through values as-is
         for value in values:

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -218,6 +218,15 @@ class SingleSparkContextTestCase(BasicTestCase):
     def setUp(self):
         super(SingleSparkContextTestCase, self).setUp()
 
+        cls = self.__class__
+        try:
+            cls.spark_context.attributeId
+        except AttributeError:
+            # spark context was destroyed due to an error
+            cls.spark_context.stop()
+            from pyspark import SparkContext
+            cls.spark_context = SparkContext()
+
         self.start(patch('pyspark.SparkContext',
                          return_value=self.spark_context))
 

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -40,6 +40,7 @@ from tests.mock_google import MockGoogleTestCase
 from tests.mockhadoop import MockHadoopTestCase
 from tests.mr_doubler import MRDoubler
 from tests.mr_null_spark import MRNullSpark
+from tests.mr_spark_os_walk import MRSparkOSWalk
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_pass_thru_arg_test import MRPassThruArgTest
 from tests.mr_sort_and_group import MRSortAndGroup
@@ -49,6 +50,10 @@ from tests.py2 import call
 from tests.py2 import patch
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_conf_patcher
+
+# a --spark-master that has a working directory and is available from pyspark
+# (the local runner uses a local-cluster master to run spark steps)
+_LOCAL_CLUSTER_MASTER = 'local-cluster[2,1,4096]'
 
 
 class MockFilesystemsTestCase(
@@ -200,6 +205,54 @@ class SparkRunnerSparkStepsTestCase(MockFilesystemsTestCase):
             blue=1, fish=4, one=1, red=1, two=1))
 
     # TODO: add a Spark JAR to the repo, so we can test it
+
+
+@skipIf(pyspark is None, 'no pyspark module')
+class SparkWorkingDirTestCase(MockFilesystemsTestCase):
+
+    def test_upload_files_with_rename(self):
+        # see test_upload_files_with_rename() in test_local for comparison
+
+        fish_path = self.makefile('fish', b'salmon')
+        fowl_path = self.makefile('fowl', b'goose')
+
+        # use _LOCAL_CLUSTER_MASTER because the default master (local[*])
+        # doesn't have a working directory
+        job = MRSparkOSWalk(['-r', 'spark',
+                             '--spark-master', _LOCAL_CLUSTER_MASTER,
+                             '--file', fish_path + '#ghoti',
+                             '--file', fowl_path])
+        job.sandbox()
+
+        file_sizes = {}
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            # check working dir mirror
+            wd_mirror = runner._wd_mirror()
+            self.assertIsNotNone(wd_mirror)
+            self.assertFalse(is_uri(wd_mirror))
+
+            self.assertTrue(exists(wd_mirror))
+            # only files which needed to be renamed should be in wd_mirror
+            self.assertTrue(exists(join(wd_mirror, 'ghoti')))
+            self.assertFalse(exists(join(wd_mirror, 'fish')))
+            self.assertFalse(exists(join(wd_mirror, 'fowl')))
+
+            for line in to_lines(runner.cat_output()):
+                path, size = safeeval(line)
+                file_sizes[path] = size
+
+        # check that files were uploaded to working dir
+        self.assertIn('fowl', file_sizes)
+        self.assertEqual(file_sizes['fowl'], 5)
+
+        self.assertIn('ghoti', file_sizes)
+        self.assertEqual(file_sizes['ghoti'], 6)
+
+        # fish was uploaded as "ghoti"
+        self.assertNotIn('fish', file_sizes)
 
 
 @skipIf(pyspark is None, 'no pyspark module')

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -487,9 +487,6 @@ class GroupStepsTestCase(MockFilesystemsTestCase):
         ])
 
 
-# TODO: test uploading files and setting up working dir once we fix #1922
-
-
 class SparkCounterSimulationTestCase(MockFilesystemsTestCase):
     # trying to keep number of tests small, since they run actual Spark jobs
 

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -26,6 +26,7 @@ from os.path import exists
 from os.path import join
 from io import BytesIO
 from unittest import TestCase
+from unittest import skip
 from unittest import skipIf
 
 from warcio.warcwriter import WARCWriter
@@ -285,6 +286,8 @@ class InlineRunnerSparkTestCase(SandboxedTestCase, SingleSparkContextTestCase):
             blue=1, fish=4, one=1, red=1, two=1))
 
     def test_spark_job_failure(self):
+        self.quiet_spark_context_logging()
+
         job = MRSparKaboom(['-r', 'inline'])
         job.sandbox(stdin=BytesIO(b'line\n'))
 
@@ -293,6 +296,7 @@ class InlineRunnerSparkTestCase(SandboxedTestCase, SingleSparkContextTestCase):
         with job.make_runner() as runner:
             self.assertRaises(Py4JJavaError, runner.run)
 
+    @skip("JVM's current working dir can't be changed once it's started")
     def test_upload_files_with_rename(self):
         # see test_upload_files_with_rename() in test_local for comparison
 

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -303,12 +303,10 @@ class InlineRunnerSparkTestCase(SandboxedTestCase, SingleSparkContextTestCase):
         fish_path = self.makefile('fish', b'salmon')
         fowl_path = self.makefile('fowl', b'goose')
 
-        # --use-executor-cwd: Spark drivers may be using whatever working
-        # directory the JVM picked when it was started by some other test.
-        # get around this by passing the working directory of the executor
-        # (i.e. this Python process) through to the driver.
+        # --use-driver-cwd gets around issues with the shared JVM not changing
+        # executors' working directory to match the driver on local master
         job = MRSparkOSWalk(['-r', 'inline',
-                             '--use-executor-cwd',
+                             '--use-driver-cwd',
                              '--file', fish_path + '#ghoti',
                              '--file', fowl_path])
         job.sandbox()

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -286,9 +286,6 @@ class InlineRunnerSparkTestCase(SandboxedTestCase, SingleSparkContextTestCase):
             blue=1, fish=4, one=1, red=1, two=1))
 
     def test_spark_job_failure(self):
-        # this is rather noisy, as it creates an error
-        self.quiet_spark_context_logging()
-
         job = MRSparKaboom(['-r', 'inline'])
         job.sandbox(stdin=BytesIO(b'line\n'))
 

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -54,6 +54,7 @@ from tests.py2 import patch
 from tests.sandbox import EmptyMrjobConfTestCase
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import SingleSparkContextTestCase
+from tests.mr_spark_os_walk import MRSparkOSWalk
 from tests.test_sim import MRIncrementerJob
 
 
@@ -291,3 +292,38 @@ class InlineRunnerSparkTestCase(SandboxedTestCase, SingleSparkContextTestCase):
 
         with job.make_runner() as runner:
             self.assertRaises(Py4JJavaError, runner.run)
+
+    def test_upload_files_with_rename(self):
+        # see test_upload_files_with_rename() in test_local for comparison
+
+        fish_path = self.makefile('fish', b'salmon')
+        fowl_path = self.makefile('fowl', b'goose')
+
+        job = MRSparkOSWalk(['-r', 'inline',
+                             '--file', fish_path + '#ghoti',
+                             '--file', fowl_path])
+        job.sandbox()
+
+        file_sizes = {}
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            # there is no working dir mirror in inline mode; inline
+            # mode simulates the working dir itself
+            wd_mirror = runner._wd_mirror()
+            self.assertIsNone(wd_mirror)
+
+            for line in to_lines(runner.cat_output()):
+                path, size = safeeval(line)
+                file_sizes[path] = size
+
+        # check that files were uploaded to working dir
+        self.assertIn('./fowl', file_sizes)
+        self.assertEqual(file_sizes['./fowl'], 5)
+
+        self.assertIn('./ghoti', file_sizes)
+        self.assertEqual(file_sizes['./ghoti'], 6)
+
+        # fish was uploaded as "ghoti"
+        self.assertNotIn('./fish', file_sizes)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -60,6 +60,7 @@ from tests.mr_job_where_are_you import MRJobWhereAreYou
 from tests.mr_just_a_jar import MRJustAJar
 from tests.mr_null_spark import MRNullSpark
 from tests.mr_sort_and_group import MRSortAndGroup
+from tests.mr_spark_os_walk import MRSparkOSWalk
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_count import MRWordCount
 from tests.py2 import call
@@ -1144,5 +1145,23 @@ class LocalRunnerSparkTestCase(SandboxedTestCase):
 
         self.assertEqual(counts, dict(
             blue=1, fish=4, one=1, red=1, two=1))
+
+    def test_upload_file(self):
+        fish_path = self.makefile('fish', b'ghoti')
+
+        job = MRSparkOSWalk(['-r', 'local', '--file', fish_path])
+        job.sandbox()
+
+        file_sizes = {}
+
+        with job.make_runner() as runner:
+            runner.run()
+
+            for line in to_lines(runner.cat_output()):
+                path, size = safeeval(line)
+                file_sizes[path] = size
+
+        self.assertIn('./fish', file_sizes)
+        self.assertEqual(file_sizes['./fish'], 5)
 
     # TODO: add a Spark JAR to the repo, so we can test it

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1146,10 +1146,10 @@ class LocalRunnerSparkTestCase(SandboxedTestCase):
         self.assertEqual(counts, dict(
             blue=1, fish=4, one=1, red=1, two=1))
 
-    def test_upload_file(self):
-        fish_path = self.makefile('fish', b'ghoti')
+    def test_upload_and_rename_file(self):
+        fish_path = self.makefile('fish', b'salmon')
 
-        job = MRSparkOSWalk(['-r', 'local', '--file', fish_path])
+        job = MRSparkOSWalk(['-r', 'local', '--file', fish_path + '#ghoti'])
         job.sandbox()
 
         file_sizes = {}
@@ -1161,7 +1161,7 @@ class LocalRunnerSparkTestCase(SandboxedTestCase):
                 path, size = safeeval(line)
                 file_sizes[path] = size
 
-        self.assertIn('./fish', file_sizes)
-        self.assertEqual(file_sizes['./fish'], 5)
+        self.assertIn('./ghoti', file_sizes)
+        self.assertEqual(file_sizes['./ghoti'], 6)
 
     # TODO: add a Spark JAR to the repo, so we can test it

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1177,14 +1177,14 @@ class LocalRunnerSparkTestCase(SandboxedTestCase):
                 file_sizes[path] = size
 
         # check that files were uploaded to working dir
-        self.assertIn('./fowl', file_sizes)
-        self.assertEqual(file_sizes['./fowl'], 5)
+        self.assertIn('fowl', file_sizes)
+        self.assertEqual(file_sizes['fowl'], 5)
 
-        self.assertIn('./ghoti', file_sizes)
-        self.assertEqual(file_sizes['./ghoti'], 6)
+        self.assertIn('ghoti', file_sizes)
+        self.assertEqual(file_sizes['ghoti'], 6)
 
         # fish was uploaded as "ghoti"
-        self.assertNotIn('./fish', file_sizes)
+        self.assertNotIn('fish', file_sizes)
 
 
     # TODO: add a Spark JAR to the repo, so we can test it


### PR DESCRIPTION
This handles an edge case where the local working mirror dir isn't a URI because we're running locally. The Spark runner can now upload files with a different name on a local-cluster master, and the local runner can do the same when running Spark scripts. Fixes #2017 

(Inline mode can also do this, but that's because it invokes pyspark from within a simulated working directory. Added a test for this, because it should work.)