### PR TITLE
get file upload args working on local[*] master

### DIFF
--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -1001,13 +1001,11 @@ class MRJobBinRunner(MRJobRunner):
 
         return args
 
-    def _spark_master(self):
-        return self._opts.get('spark_master') or 'local[*]'
-
-    def _spark_deploy_mode(self):
-        return self._opts.get('spark_deploy_mode') or 'client'
-
     def _spark_upload_args(self):
+        # don't bother if there isn't a working directory to upload to
+        if not self._spark_executors_have_own_wd():
+            return []
+
         # if using a setup script, upload all files to working dir
         if self._spark_python_wrapper_path:
             return self._upload_args_helper(

--- a/mrjob/examples/mr_most_used_word.py
+++ b/mrjob/examples/mr_most_used_word.py
@@ -32,8 +32,21 @@ class MRMostUsedWord(MRJob):
 
     OUTPUT_PROTOCOL = JSONValueProtocol
 
+    def configure_args(self):
+        super(MRMostUsedWord, self).configure_args()
+
+        # allow for alternate stop words file
+        self.add_file_arg(
+            '--stop-words-file',
+            dest='stop_words_file',
+            default=None,
+            help='alternate stop words file. lowercase words, one per line',
+        )
+
     def mapper_init(self):
-        with open('stop_words.txt') as f:
+        stop_words_path = self.options.stop_words_file or 'stop_words.txt'
+
+        with open(stop_words_path) as f:
             self.stop_words = set(line.strip() for line in f)
 
     def mapper_get_words(self, _, line):

--- a/mrjob/examples/mr_most_used_word.py
+++ b/mrjob/examples/mr_most_used_word.py
@@ -2,6 +2,7 @@
 # Copyright 2009-2010 Yelp
 # Copyright 2013 David Marin
 # Copyright 2018 Yelp
+# Copyright 2019 Yelp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,10 +20,11 @@
 Shows how to do a multi-step job, and how to load a support file
 from the same directory.
 """
+import re
+
 from mrjob.job import MRJob
 from mrjob.protocol import JSONValueProtocol
 from mrjob.step import MRStep
-import re
 
 WORD_RE = re.compile(r"[\w']+")
 
@@ -54,7 +56,7 @@ class MRMostUsedWord(MRJob):
         for word in WORD_RE.findall(line):
             word = word.lower()
             if word not in self.stop_words:
-                yield (word.lower(), 1)
+                yield (word, 1)
 
     def combiner_count_words(self, word, counts):
         # sum the words we've seen so far

--- a/mrjob/examples/mr_spark_most_used_word.py
+++ b/mrjob/examples/mr_spark_most_used_word.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+# Copyright 2019 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Like mr_most_used_word.py, but on Spark.
+
+To make this work on the local[*] master, pass in your own --stop-words-file
+(it won't be able to see stop_words.txt because --files doesn't work
+on local[*] master)
+"""
+import json
+import re
+from operator import add
+
+from mrjob.job import MRJob
+
+WORD_RE = re.compile(r"[\w']+")
+
+
+class MRSparkMostUsedWord(MRJob):
+
+    FILES = ['stop_words.txt']
+
+    def configure_args(self):
+        super(MRSparkMostUsedWord, self).configure_args()
+
+        # allow for alternate stop words file
+        self.add_file_arg(
+            '--stop-words-file',
+            dest='stop_words_file',
+            default=None,
+            help='alternate stop words file. lowercase words, one per line',
+        )
+
+    def spark(self, input_path, output_path):
+        from pyspark import SparkContext
+
+        sc = SparkContext()
+
+        lines = sc.textFile(input_path)
+
+        # do a word frequency count
+        words_and_ones = lines.mapPartitions(self.get_words)
+        word_counts = words_and_ones.reduceByKey(add)
+
+        # pick pair with highest count (now in count, word format)
+        max_count, word = word_counts.map(lambda w_c: (w_c[1], w_c[0])).max()
+
+        # output our word
+        output = sc.parallelize([json.dumps(word)])
+        output.saveAsTextFile(output_path)
+
+        sc.stop()
+
+    def get_words(self, line_iterator):
+        # this only happens once per partition
+        stop_words = self.load_stop_words()
+
+        for line in line_iterator:
+            for word in WORD_RE.findall(line):
+                word = word.lower()
+                if word not in stop_words:
+                    yield (word, 1)
+
+    def load_stop_words(self):
+        # this should only be called inside executors (i.e. inside functions
+        # passed to RDDs)
+        stop_words_path = self.options.stop_words_file or 'stop_words.txt'
+
+        with open(stop_words_path) as f:
+            return set(line.strip() for line in f)
+
+
+if __name__ == '__main__':
+    MRSparkMostUsedWord.run()

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -188,3 +188,12 @@ class InlineMRJobRunner(SimMRJobRunner):
         """Get step descriptions without calling a subprocess."""
         job_args = ['--steps'] + self._mr_job_extra_args(local=True)
         return self._mrjob_cls(args=job_args)._steps_desc()
+
+    def _spark_executors_have_own_wd(self):
+        return True  # because we fake it
+
+    def _spark_driver_has_own_wd(self):
+        return True  # because we fake it
+
+    def _wd_mirror(self):
+        return None  # no need for this, we set up the working dir (Spark too)

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -935,7 +935,7 @@ class MRJobRunner(object):
         (True on everything but local.)
         """
         # note: local-cluster[...] master does in fact have working dirs
-        self._spark_master().split('[')[0] == 'local'
+        return self._spark_master().split('[')[0] != 'local'
 
     def _args_for_task(self, step_num, mrc):
         return [

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1192,7 +1192,7 @@ class MRJobRunner(object):
         :py:attr:`_working_dir_mgr`. This will be a subdir of
         ``self._upload_mgr.prefix`, if it exists, and otherwise will
         be ``None``."""
-        if self._upload_mgr and self._upload_mgr.prefix:
+        if self._upload_mgr and is_uri(self._upload_mgr.prefix):
             return posixpath.join(self._upload_mgr.prefix, 'wd')
         elif (self._has_spark_steps() and self._spark_executors_have_own_wd()):
             return os.path.join(self._get_local_tmp_dir(), 'wd-mirror')

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -387,11 +387,10 @@ class SparkMRJobRunner(MRJobBinRunner):
 
         # --job-args (passthrough args)
 
-        # on local (but not local-cluster) Spark master, just use the actual
-        # path of the file, since they don't support a working directory
-        master_is_local = (self._spark_master().split('[')[0] == 'local')
+        # if on local[*] master, keep file upload args as-is (see #2031)
+        local = not self._spark_executors_have_own_wd()
+        job_args = self._mr_job_extra_args(local=local)
 
-        job_args = self._mr_job_extra_args(local=master_is_local)
         if job_args:
             args.extend(['--job-args', cmd_line(job_args)])
 

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -419,3 +419,13 @@ class SparkMRJobRunner(MRJobBinRunner):
         if path.endswith('.pyc'):
             path = path[:-1]
         return path
+
+    def _has_spark_steps(self):
+        """Treat streaming steps as Spark steps."""
+        return (super(SparkMRJobRunner, self)._has_spark_steps() or
+                self._has_streaming_steps())
+
+    def _has_pyspark_steps(self):
+        """Treat streaming steps as Spark steps that use Python."""
+        return (super(SparkMRJobRunner, self)._has_pyspark_steps() or
+                self._has_streaming_steps())

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -386,7 +386,12 @@ class SparkMRJobRunner(MRJobBinRunner):
                      '--last-step-num', str(last_step_num)])
 
         # --job-args (passthrough args)
-        job_args = self._mr_job_extra_args()
+
+        # on local (but not local-cluster) Spark master, just use the actual
+        # path of the file, since they don't support a working directory
+        master_is_local = (self._spark_master().split('[')[0] == 'local')
+
+        job_args = self._mr_job_extra_args(local=master_is_local)
         if job_args:
             args.extend(['--job-args', cmd_line(job_args)])
 

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -24,6 +24,7 @@ except ImportError:
     pyspark = None
 
 from mrjob.examples.mr_most_used_word import MRMostUsedWord
+from mrjob.examples.mr_spark_most_used_word import MRSparkMostUsedWord
 from mrjob.examples.mr_spark_wordcount import MRSparkWordcount
 from mrjob.examples.mr_spark_wordcount_script import MRSparkScriptWordcount
 from mrjob.examples.mr_sparkaboom import MRSparKaboom
@@ -392,7 +393,7 @@ class SparkRunnerStreamingStepsTestCase(MockFilesystemsTestCase):
                 ]
             )
 
-    def _test_file_args(self, spark_master):
+    def _test_file_upload_args(self, job_class, spark_master):
         input_bytes = (b'Market Song:\n'
                        b'To market, to market, to buy a fat pig.\n'
                        b'Home again, home again, jiggety-jig')
@@ -404,9 +405,9 @@ class SparkRunnerStreamingStepsTestCase(MockFilesystemsTestCase):
             'stop_words.txt',
             b'again\nmarket\nto\n')
 
-        job = MRMostUsedWord(['-r', 'spark',
-                              '--spark-master', spark_master,
-                              '--stop-words-file', stop_words_file])
+        job = job_class(['-r', 'spark',
+                         '--spark-master', spark_master,
+                         '--stop-words-file', stop_words_file])
         job.sandbox(stdin=BytesIO(input_bytes))
 
         with job.make_runner() as runner:
@@ -417,11 +418,17 @@ class SparkRunnerStreamingStepsTestCase(MockFilesystemsTestCase):
             self.assertEqual(output, b'"home"')
 
 
-    def test_file_args_with_working_dir(self):
-        self._test_file_args(_LOCAL_CLUSTER_MASTER)
+    def test_streaming_step_file_upload_args_with_working_dir(self):
+        self._test_file_upload_args(MRMostUsedWord, _LOCAL_CLUSTER_MASTER)
 
-    def test_file_args_without_working_dir(self):
-        self._test_file_args('local[*]')
+    def test_streaming_step_file_upload_args_without_working_dir(self):
+        self._test_file_upload_args(MRMostUsedWord, 'local[*]')
+
+    def test_spark_step_file_upload_args_with_working_dir(self):
+        self._test_file_upload_args(MRSparkMostUsedWord, _LOCAL_CLUSTER_MASTER)
+
+    def test_spark_step_file_upload_args_without_working_dir(self):
+        self._test_file_upload_args(MRSparkMostUsedWord, 'local[*]')
 
 
 class RunnerIgnoresJobKwargsTestCase(MockFilesystemsTestCase):

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -395,7 +395,7 @@ class SparkRunnerStreamingStepsTestCase(MockFilesystemsTestCase):
                 ]
             )
 
-    def test_file_args(self):
+    def _test_file_args(self, spark_master):
         input_bytes = (b'Market Song:\n'
                        b'To market, to market, to buy a fat pig.\n'
                        b'Home again, home again, jiggety-jig')
@@ -408,7 +408,7 @@ class SparkRunnerStreamingStepsTestCase(MockFilesystemsTestCase):
             b'again\nmarket\nto\n')
 
         job = MRMostUsedWord(['-r', 'spark',
-                              '--spark-master', _LOCAL_CLUSTER_MASTER,
+                              '--spark-master', spark_master,
                               '--stop-words-file', stop_words_file])
         job.sandbox(stdin=BytesIO(input_bytes))
 
@@ -418,6 +418,13 @@ class SparkRunnerStreamingStepsTestCase(MockFilesystemsTestCase):
             output = b''.join(runner.cat_output()).strip()
 
             self.assertEqual(output, b'"home"')
+
+
+    def test_file_args_with_working_dir(self):
+        self._test_file_args(_LOCAL_CLUSTER_MASTER)
+
+    def test_file_args_without_working_dir(self):
+        self._test_file_args('local[*]')
 
 
 class RunnerIgnoresJobKwargsTestCase(MockFilesystemsTestCase):

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -51,10 +51,7 @@ from tests.py2 import call
 from tests.py2 import patch
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_conf_patcher
-
-# a --spark-master that has a working directory and is available from pyspark
-# (the local runner uses a local-cluster master to run spark steps)
-_LOCAL_CLUSTER_MASTER = 'local-cluster[2,1,4096]'
+from tests.test_bin import _LOCAL_CLUSTER_MASTER
 
 
 class MockFilesystemsTestCase(

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1548,12 +1548,12 @@ class SparkSubmitArgsTestCase(GenericLocalRunnerTestCase):
                 ]
             )
 
-    def test_file_upload_args(self):
+    def test_file_upload_args_in_cloud(self):
         qux_path = self.makefile('qux')
 
         job = MRNullSpark([
             '-r', 'spark',
-            '--spark-master', _LOCAL_CLUSTER_MASTER,
+            '--spark-master', 'mock',
             '--extra-file', qux_path,  # file upload arg
         ])
         job.sandbox()
@@ -1564,10 +1564,32 @@ class SparkSubmitArgsTestCase(GenericLocalRunnerTestCase):
             self.assertEqual(
                 runner._spark_submit_args(0), [
                     '--conf', 'spark.executorEnv.PYSPARK_PYTHON=' + PYTHON_BIN,
-                    '--master', _LOCAL_CLUSTER_MASTER,
+                    '--master', 'mock',
                     '--deploy-mode', 'client',
                     '--files',
-                    runner._dest_in_wd_mirror(qux_path, 'qux'),
+                    runner._dest_in_wd_mirror(qux_path, 'qux')
+                ]
+            )
+
+    def test_file_upload_args_on_local_cluster(self):
+        qux_path = self.makefile('qux')
+
+        job = MRNullSpark([
+            '-r', 'spark',
+            '--spark-master', _LOCAL_CLUSTER_MASTER,
+            '--extra-file', qux_path,  # file upload arg
+        ])
+        job.sandbox()
+
+        with job.make_runner() as runner:
+            runner._copy_files_to_wd_mirror()
+
+            self.assertEqual(
+                runner._spark_submit_args(0), [
+                    '--conf', 'spark.executorEnv.PYSPARK_PYTHON=' + PYTHON_BIN,
+                    '--master', _LOCAL_CLUSTER_MASTER,
+                    '--deploy-mode', 'client',
+                    '--files', qux_path,
                 ]
             )
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1833,7 +1833,7 @@ class SparkUploadArgsTestCase(MockHadoopTestCase):
             ['-r', 'hadoop',
              '--setup', 'make -f Makefile#',
              '--file', 'foo',
-             '--spark-master', 'local',
+             '--spark-master', _LOCAL_CLUSTER_MASTER,
              ])
         job.sandbox()
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1091,7 +1091,7 @@ class SparkScriptPathTestCase(GenericLocalRunnerTestCase):
                 runner._spark_script_path, 0)
 
 
-class SparkSubmitArgsTestCase(GenericLocalRunnerTestCase):
+class SparkSubmitArgsTestCase(SandboxedTestCase):
     # mostly testing on the spark runner because it doesn't override
     # _spark_submit_args(), _spark_master(), or _spark_deploy_mode()
 


### PR DESCRIPTION
This makes file upload args (the ones that use `add_file_arg()`) work on local Spark masters. Fixes #2031.

Also pushed some Spark logic that was in `mrjob/bin.py` up into `mrjob/runner.py` and stopped creating a working dir mirror when there's no working directory.