### PR TITLE
harness can simulate jobs that it can't init in Spark driver

### DIFF
--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -335,11 +335,22 @@ class MRJobLauncher(object):
         option, but with the local name of the file in the script's working
         directory.
 
-        We suggest against sending Berkeley DBs to your job, as
-        Berkeley DB is not forwards-compatible (so a Berkeley DB that you
-        construct on your computer may not be readable from within
-        Hadoop). Use SQLite databases instead. If all you need is an on-disk
-        hash table, try out the :py:mod:`sqlite3dbm` module.
+        .. note::
+
+           If you pass a file to a job, best practice is to lazy-load its
+           contents (e.g. make a method that opens the file the first time
+           you call it) rather than loading it in your job's constructor or
+           :py:meth:`load_args`. Not only is this more efficient, it's
+           necessary if you want to run your job in a Spark executor
+           (because the file may not be in the same place in a Spark driver).
+
+        .. note::
+
+           We suggest against sending Berkeley DBs to your job, as
+           Berkeley DB is not forwards-compatible (so a Berkeley DB that you
+           construct on your computer may not be readable from within
+           Hadoop). Use SQLite databases instead. If all you need is an on-disk
+           hash table, try out the :py:mod:`sqlite3dbm` module.
 
         .. versionchanged:: 0.6.6
 

--- a/mrjob/spark/harness.py
+++ b/mrjob/spark/harness.py
@@ -144,7 +144,8 @@ def main(cmd_line_args=None):
 
     if args.steps_desc is None:
         job = job or job_class(job_args)
-        steps = [step.description() for step in job.steps()]
+        steps = [step.description(step_num)
+                 for step_num, step in enumerate(job.steps())]
     else:
         steps = json.loads(args.steps_desc)
 

--- a/mrjob/spark/harness.py
+++ b/mrjob/spark/harness.py
@@ -200,7 +200,7 @@ def main(cmd_line_args=None):
         if hadoop_input_format:
             rdd = sc.hadoopFile(
                 args.input_path,
-                inputFormatClass=job.hadoop_input_format(),
+                inputFormatClass=hadoop_input_format,
                 keyClass='org.apache.hadoop.io.Text',
                 valueClass='org.apache.hadoop.io.Text')
 
@@ -228,7 +228,7 @@ def main(cmd_line_args=None):
                 x.decode('utf-8') for x in line.split(b'\t', 1)))
             rdd.saveAsHadoopFile(
                 args.output_path,
-                outputFormatClass=job.hadoop_output_format(),
+                outputFormatClass=hadoop_output_format,
                 compressionCodecClass=args.compression_codec)
         else:
             rdd.saveAsTextFile(

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -353,14 +353,14 @@ class SparkMRJobRunner(MRJobBinRunner):
         """Generate spark harness args for streaming steps (and handle
         other spark step types the usual way).
         """
-        step = self._get_step(step_num)
-
-        if step['type'] != 'streaming':
-            return super(SparkMRJobRunner, self)._spark_script_args(
-                step_num, last_step_num)
-
         if last_step_num is None:
             last_step_num = step_num
+
+        steps = self._get_steps()[step_num:last_step_num + 1]
+
+        if steps[0]['type'] != 'streaming':
+            return super(SparkMRJobRunner, self)._spark_script_args(
+                step_num, last_step_num)
 
         args = []
 
@@ -390,9 +390,7 @@ class SparkMRJobRunner(MRJobBinRunner):
                      job.hadoop_output_format() or ''])
 
         # --steps-desc
-        steps_desc = [step.description(step_num)
-                      for step_num, step in enumerate(job.steps())]
-        args.extend(['--steps-desc', json.dumps(steps_desc)])
+        args.extend(['--steps-desc', json.dumps(steps)])
 
         # --counter-output-dir, to simulate counters
         args.extend(['--counter-output-dir',

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -385,6 +385,12 @@ class SparkMRJobRunner(MRJobBinRunner):
         args.extend(['--hadoop-output-format',
                      self._hadoop_output_format or ''])
 
+        # --sort-values
+        if self._sort_values:
+            args.append('--sort-values')
+        else:
+            args.append('--no-sort-values')
+
         # --steps-desc
         args.extend(['--steps-desc', json.dumps(steps)])
 

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -377,17 +377,13 @@ class SparkMRJobRunner(MRJobBinRunner):
         args.append(
             self._step_output_uri(last_step_num))
 
-        # instantiate a job we can get steps and hadoop formats from, so we
-        # don't have to in the Spark driver (see #2044)
-        job = self._mrjob_cls(self._mr_job_extra_args(local=True))
-
         # --hadoop-input-format. Pass '' to indicate we know there is none
         args.extend(['--hadoop-input-format',
-                     job.hadoop_input_format() or ''])
+                     self._hadoop_input_format or ''])
 
         # --hadoop-output-format. Pass '' to indicate we know there is none
         args.extend(['--hadoop-output-format',
-                     job.hadoop_output_format() or ''])
+                     self._hadoop_output_format or ''])
 
         # --steps-desc
         args.extend(['--steps-desc', json.dumps(steps)])

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -390,7 +390,8 @@ class SparkMRJobRunner(MRJobBinRunner):
                      job.hadoop_output_format() or ''])
 
         # --steps-desc
-        steps_desc = [step.description() for step in job.steps()]
+        steps_desc = [step.description(step_num)
+                      for step_num, step in enumerate(job.steps())]
         args.extend(['--steps-desc', json.dumps(steps_desc)])
 
         # --counter-output-dir, to simulate counters

--- a/tests/spark/test_harness.py
+++ b/tests/spark/test_harness.py
@@ -597,8 +597,8 @@ class HadoopFormatsTestCase(SparkHarnessOutputComparisonBaseTestCase):
                 join(runner.get_output_dir(), 'o')))
 
             output_counts = dict(
-                line.strip().split(b'\t')
-                for line in to_lines(runner.cat_output()))
+                (line.strip().split(b'\t')
+                 for line in to_lines(runner.cat_output())))
 
         expected_output_counts = {
             b'"ee"': b'2', b'"eye"': b'2', b'"oh"': b'1'}

--- a/tests/spark/test_harness.py
+++ b/tests/spark/test_harness.py
@@ -40,6 +40,7 @@ from mrjob.util import to_lines
 
 from tests.mr_counting_job import MRCountingJob
 from tests.mr_doubler import MRDoubler
+from tests.mr_no_mapper import MRNoMapper
 from tests.mr_pass_thru_arg_test import MRPassThruArgTest
 from tests.mr_streaming_and_spark import MRStreamingAndSpark
 from tests.mr_sort_and_group import MRSortAndGroup
@@ -410,6 +411,12 @@ class SparkHarnessOutputComparisonTestCase(
                     ).collect()[0])
 
         self.assertEqual(harness_counters, reference_counters)
+
+    def test_job_with_no_mapper_in_second_step(self):
+        # mini-regression test for not passing step_num to step.description()
+        input_bytes = b'one fish\ntwo fish\nred fish\nblue fish\n'
+
+        self._assert_output_matches(MRNoMapper, input_bytes=input_bytes)
 
 
 class SparkConfigureReducerTestCase(SparkHarnessOutputComparisonBaseTestCase):

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -467,7 +467,8 @@ class SparkRunnerStreamingStepsTestCase(MockFilesystemsTestCase):
 
 class RunnerIgnoresJobKwargsTestCase(MockFilesystemsTestCase):
 
-    def test_ignore_format_and_sort_kwargs(self):
+    # TODO: this is no longer true, test formats and sort_values
+    def _test_ignore_format_and_sort_kwargs(self):
         # hadoop formats and SORT_VALUES are read directly from the job,
         # so the runner's constructor ignores the corresponding kwargs
         #


### PR DESCRIPTION
This gracefully handles an edge case: jobs that load files uploaded with file args at init time. This isn't best practice (much better to lazy-load files as needed), but it's something people do in practice and that they'd expect to work in the Spark runner's emulation. Fixes #2044.

To make this work, I had to add arguments to the Spark harness for hadoop formats, step description, and sort_values. This seems like fair game because all of these are passed to the runner by the original job instance. If these *aren't* passed in, the Spark harness can still get by (as long as it can initialize the job).
