### PR TITLE
enable setup scripts on non-YARN Spark masters

### DIFF
--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -92,11 +92,6 @@ class MRJobBinRunner(MRJobRunner):
         # interleaved; see mrjob.setup.parse_setup_cmd() for details
         self._setup = [parse_setup_cmd(cmd) for cmd in self._opts['setup']]
 
-        if self._setup and self._has_pyspark_steps() and not (
-                self._spark_setup_is_supported()):
-            log.warning("setup commands aren't supported on Spark master %r" %
-                        self._spark_master())
-
         for cmd in self._setup:
             for token in cmd:
                 if isinstance(token, dict):
@@ -482,21 +477,9 @@ class MRJobBinRunner(MRJobRunner):
                 wrap_python=True)
 
     def _uses_spark_setup_script(self):
-        if not self._has_pyspark_steps():
-            return False
-
-        if not self._setup:
-            return False  # nothing to do
-
-        if not self._spark_setup_is_supported():
-            return False
-
-        return True
-
-    def _spark_setup_is_supported(self):
-        """Can we run setup scripts on Spark?"""
-        # for now, we only support setup scripts on YARN (see #1376)
-        return self._spark_master() == 'yarn'
+        return (self._setup and
+                self._has_pyspark_steps() and
+                self._spark_executors_have_own_wd())
 
     def _py_files_setup(self):
         """A list of additional setup commands to emulate Spark's
@@ -1002,22 +985,10 @@ class MRJobBinRunner(MRJobRunner):
         return args
 
     def _spark_upload_args(self):
-        # don't bother if there isn't a working directory to upload to
-        if not self._spark_executors_have_own_wd():
-            return []
-
-        # if using a setup script, upload all files to working dir
-        if self._spark_python_wrapper_path:
-            return self._upload_args_helper(
-                '--files', None,
-                '--archives', None,
-                always_use_hash=False)
-        else:
-            # otherwise, just pass through --files and --archives
-            return self._upload_args_helper(
-                '--files', self._spark_files,
-                '--archives', self._spark_archives,
-                always_use_hash=False)
+        return self._upload_args_helper(
+            '--files', None,
+            '--archives', None,
+            always_use_hash=False)
 
     def _spark_script_path(self, step_num):
         """The path of the spark script or JAR, used by

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -985,10 +985,14 @@ class MRJobBinRunner(MRJobRunner):
         return args
 
     def _spark_upload_args(self):
-        return self._upload_args_helper(
-            '--files', None,
-            '--archives', None,
-            always_use_hash=False)
+        if self._spark_executors_have_own_wd():
+            return self._upload_args_helper(
+                '--files', None,
+                '--archives', None,
+                always_use_hash=False)
+        else:
+            # don't bother, there's no working dir to upload to
+            return []
 
     def _spark_script_path(self, step_num):
         """The path of the spark script or JAR, used by

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -456,7 +456,7 @@ class MRJobBinRunner(MRJobRunner):
         If *local* is true, use local line endings (e.g. Windows). Otherwise,
         use UNIX line endings (see #1071).
         """
-        if self._has_streaming_steps():
+        if self._has_hadoop_streaming_steps():
             streaming_setup = self._py_files_setup() + self._setup
 
             if streaming_setup and not self._setup_wrapper_script_path:

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -1028,7 +1028,7 @@ class MRJobBinRunner(MRJobRunner):
 
         cmdenv = {}
 
-        if step['type'] in ('spark', 'spark_script'):  # not spark_jar
+        if self._is_pyspark_step(step):
             driver_python = cmd_line(self._python_bin())
 
             if self._spark_python_wrapper_path:

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -103,13 +103,18 @@ class MRJobBinRunner(MRJobRunner):
 
                     self._working_dir_mgr.add(**token)
 
+        # warning: no setup scripts on Spark when no working dir
+        if self._setup and self._has_pyspark_steps() and not(
+                self._spark_executors_have_own_wd()):
+            log.warning("setup commands aren't supported on Spark master %r" %
+                        self._spark_master())
+
         # --py-files on Spark doesn't allow '#' (see #1375)
         if any('#' in path for path in self._opts['py_files']):
             raise ValueError("py_files cannot contain '#'")
 
         # Keep track of where the spark-submit binary is
         self._spark_submit_bin = self._opts['spark_submit_bin']
-
 
     def _default_opts(self):
         return combine_dicts(

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -336,7 +336,7 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
         # this triggers looking for Hadoop binary
         self.get_hadoop_version()
 
-        if self._has_streaming_steps():
+        if self._has_hadoop_streaming_steps():
             self.get_hadoop_streaming_jar()
 
         if self._has_spark_steps():

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -879,7 +879,7 @@ class MRJobRunner(object):
         """Does the first step take an input manifest?"""
         return bool(self._get_step(0).get('input_manifest'))
 
-    def _has_streaming_steps(self):
+    def _has_hadoop_streaming_steps(self):
         """Are any of our steps Hadoop Streaming steps?"""
         return any(step['type'] == 'streaming'
                    for step in self._get_steps())

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -899,8 +899,11 @@ class MRJobRunner(object):
 
         Generally used to tell if we need a Spark setup script.
         """
-        return any(_is_pyspark_step_type(step['type'])
-                   for step in self._get_steps())
+        return any(self._is_pyspark_step(step) for step in self._get_steps())
+
+    def _is_pyspark_step(self, step):
+        """Does this step involve running Python on Spark?"""
+        return _is_pyspark_step_type(step['type'])
 
     def _spark_master(self):
         return self._opts.get('spark_master') or 'local[*]'

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -243,11 +243,6 @@ class MRJobRunner(object):
         # set of dir_archives that have actually been created
         self._dir_archives_created = set()
 
-        # track (name, path) of files and archives to upload to spark
-        # if not using a setup script.
-        self._spark_files = []
-        self._spark_archives = []
-
         # set this to an :py:class:`~mrjob.setup.UploadDirManager` in
         # runners that upload files to HDFS, S3, etc.
         #
@@ -270,8 +265,6 @@ class MRJobRunner(object):
                 if extra_arg.get('type') != 'file':
                     raise NotImplementedError
                 self._working_dir_mgr.add(**extra_arg)
-                self._spark_files.append(
-                    (extra_arg['name'], extra_arg['path']))
 
         # extra file arguments to our job
         if file_upload_args:
@@ -281,20 +274,17 @@ class MRJobRunner(object):
                 arg_file = parse_legacy_hash_path('file', path)
                 self._working_dir_mgr.add(**arg_file)
                 self._extra_args.extend([arg, arg_file])
-                self._spark_files.append((arg_file['name'], arg_file['path']))
 
         # set up uploading
         for hash_path in self._opts['upload_files']:
             uf = parse_legacy_hash_path('file', hash_path,
                                         must_name='upload_files')
             self._working_dir_mgr.add(**uf)
-            self._spark_files.append((uf['name'], uf['path']))
 
         for hash_path in self._opts['upload_archives']:
             ua = parse_legacy_hash_path('archive', hash_path,
                                         must_name='upload_archives')
             self._working_dir_mgr.add(**ua)
-            self._spark_archives.append((ua['name'], ua['path']))
 
         for hash_path in self._opts['upload_dirs']:
             # pick name based on directory path
@@ -304,7 +294,6 @@ class MRJobRunner(object):
             archive_path = self._dir_archive_path(ud['path'])
             self._working_dir_mgr.add(
                 'archive', archive_path, name=ud['name'])
-            self._spark_archives.append((ud['name'], archive_path))
 
         # Where to read input from (log files, etc.)
         self._input_paths = input_paths or ['-']  # by default read from stdin

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -82,19 +82,13 @@ class SparkMRJobRunner(MRJobBinRunner):
     }
 
     def __init__(self, max_output_files=None, mrjob_cls=None, **kwargs):
-        """Create a spark runner
+        """Create a Spark runner.
 
         :param max_output_files: limit on number of output files when
                                  running streaming jobs. Can only be
                                  set on command line (not config file)
         :param mrjob_cls: class of the job you want to run. Used for
                           running streaming steps in Spark
-
-        SparkMRJobRunner ignores the keyword arguments *hadoop_input_format*,
-        *hadoop_output_format*, and *sort_values* (see
-        :py:meth:`MRJobRunner.__init__`). These are only set by the job as a
-        way to communicate certain attributes to the runner, and the Spark
-        runner instead inspects the job directly.
         """
         # need to set this before checking steps in superclass __init__()
         self._mrjob_cls = mrjob_cls

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -440,6 +440,16 @@ class SparkMRJobRunner(MRJobBinRunner):
         return (super(SparkMRJobRunner, self)._has_spark_steps() or
                 self._has_streaming_steps())
 
+    def _has_hadoop_streaming_steps(self):
+        # the Spark runner doesn't run "streaming" steps on Hadoop
+        return False
+
+    def _has_streaming_steps(self):
+        """Are any of our steps "streaming" steps that would normally run
+        on Hadoop Streaming?"""
+        return any(step['type'] == 'streaming'
+                   for step in self._get_steps())
+
     def _has_pyspark_steps(self):
         """Treat streaming steps as Spark steps that use Python."""
         return (super(SparkMRJobRunner, self)._has_pyspark_steps() or

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -435,6 +435,8 @@ class SparkMRJobRunner(MRJobBinRunner):
             path = path[:-1]
         return path
 
+    # "streaming" steps run on Spark too
+
     def _has_spark_steps(self):
         """Treat streaming steps as Spark steps."""
         return (super(SparkMRJobRunner, self)._has_spark_steps() or
@@ -450,7 +452,7 @@ class SparkMRJobRunner(MRJobBinRunner):
         return any(step['type'] == 'streaming'
                    for step in self._get_steps())
 
-    def _has_pyspark_steps(self):
+    def _is_pyspark_step(self, step):
         """Treat streaming steps as Spark steps that use Python."""
-        return (super(SparkMRJobRunner, self)._has_pyspark_steps() or
-                self._has_streaming_steps())
+        return (super(SparkMRJobRunner, self)._is_pyspark_step(step) or
+                step['type'] == 'streaming')

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1777,7 +1777,7 @@ class PySparkPythonTestCase(MockHadoopTestCase):
         self.assertNotIn('PYSPARK_DRIVER_PYTHON', env)
         self.assertEqual(env['PYSPARK_PYTHON'], './python-wrapper.sh')
 
-    def test_setup_wrapper_requires_yarn(self):
+    def test_no_setup_scripts_on_local_master(self):
         env, runner = self._env_and_runner(
             '--setup', 'true', '--spark-master', 'local')
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1135,6 +1135,9 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                     '--conf', 'spark.executorEnv.PYSPARK_PYTHON=' + PYTHON_BIN,
                     '--master', 'yoda',
                     '--deploy-mode', 'the-force',
+                    '--files',
+                    runner._dest_in_wd_mirror(runner._script_path,
+                                              'mr_null_spark.py'),
                 ]
             )
 
@@ -1297,6 +1300,9 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                     'spark.yarn.appMasterEnv.PYSPARK_PYTHON=' + PYTHON_BIN,
                     '--master', 'yarn',
                     '--deploy-mode', 'client',
+                    '--files',
+                    runner._dest_in_wd_mirror(runner._script_path,
+                                              'mr_null_spark.py'),
                 ]
             )
 
@@ -1317,6 +1323,9 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                     'spark.yarn.appMasterEnv.PYSPARK_PYTHON=' + PYTHON_BIN,
                     '--master', 'yarn',
                     '--deploy-mode', 'client',
+                    '--files',
+                    runner._dest_in_wd_mirror(runner._script_path,
+                                              'mr_null_spark.py')
                 ]
             )
 
@@ -1497,17 +1506,20 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                     '--master', 'yarn',
                     '--deploy-mode', 'client',
                     '--files',
-                    (runner._dest_in_wd_mirror(foo1_path, 'foo1') +
-                     ',' +
-                     runner._dest_in_wd_mirror(foo2_path, 'bar') +
+                    (runner._dest_in_wd_mirror(foo2_path, 'bar') +
                      ',' +
                      # we're in YARN, so we can just add #baz to rename foo3
-                     'hdfs:///path/to/foo3#baz'),
-                     '--archives',
+                     'hdfs:///path/to/foo3#baz' +
+                     ',' +
+                     runner._dest_in_wd_mirror(foo1_path, 'foo1') +
+                     ',' +
+                     runner._dest_in_wd_mirror(runner._script_path,
+                                               'mr_null_spark.py')),
+                    '--archives',
                     (runner._dest_in_wd_mirror(baz_path, 'baz.tar.gz') +
                      ',' +
                      runner._dest_in_wd_mirror(
-                         runner._dir_archive_path(qux_path), 'qux'))
+                         runner._dir_archive_path(qux_path), 'qux')),
                 ]
             )
 
@@ -1535,16 +1547,19 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                     '--master', 'mesos://host:12345',
                     '--deploy-mode', 'client',
                     '--files',
-                    (runner._dest_in_wd_mirror(foo1_path, 'foo1') +
+                    (runner._dest_in_wd_mirror(foo2_path, 'bar') +
                      ',' +
-                     runner._dest_in_wd_mirror(foo2_path, 'bar') +
+                     # but URIs with different name have to be re-uploaded
+                     runner._dest_in_wd_mirror(foo4_uri, 'baz') +
+                     ',' +
+                     runner._dest_in_wd_mirror(foo1_path, 'foo1') +
                      ',' +
                      # can use URIs with same name as-is
                      foo3_uri +
                      ',' +
-                     # but URIs with different name have to be re-uploaded
-                     runner._dest_in_wd_mirror(foo4_uri, 'baz')
-                     ),
+                     runner._dest_in_wd_mirror(runner._script_path,
+                                               'mr_null_spark.py')
+                    ),
                 ]
             )
 
@@ -1567,7 +1582,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                     '--master', 'mock',
                     '--deploy-mode', 'client',
                     '--files',
-                    runner._dest_in_wd_mirror(qux_path, 'qux')
+                    'uri-of://files/wd/mr_null_spark.py,uri-of://files/wd/qux',
                 ]
             )
 
@@ -1589,7 +1604,7 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                     '--conf', 'spark.executorEnv.PYSPARK_PYTHON=' + PYTHON_BIN,
                     '--master', _LOCAL_CLUSTER_MASTER,
                     '--deploy-mode', 'client',
-                    '--files', qux_path,
+                    '--files', ('%s,%s' % (runner._script_path, qux_path)),
                 ]
             )
 
@@ -1833,7 +1848,7 @@ class SparkUploadArgsTestCase(MockHadoopTestCase):
             ['-r', 'hadoop',
              '--setup', 'make -f Makefile#',
              '--file', 'foo',
-             '--spark-master', _LOCAL_CLUSTER_MASTER,
+             '--spark-master', 'local[*]',
              ])
         job.sandbox()
 
@@ -1843,7 +1858,8 @@ class SparkUploadArgsTestCase(MockHadoopTestCase):
 
             upload_args = cmd_line(runner._spark_upload_args())
 
-            self.assertIn('foo', upload_args)
+            # nothing is uploaded in local[*] mode
+            self.assertNotIn('foo', upload_args)
 
             self.assertNotIn('Makefile', upload_args)
             self.assertNotIn('python-wrapper.sh', upload_args)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -5347,9 +5347,9 @@ class SparkMasterAndDeployModeTestCase(MockBoto3TestCase):
             self.start(patch('mrjob.emr.EMRJobRunner.get_hadoop_version',
                              return_value='2'))
 
-            self.assertEqual(
-                runner._spark_submit_args(0)[-4:],
-                ['--master', 'yarn', '--deploy-mode', 'cluster']
+            self.assertIn(
+                cmd_line(['--master', 'yarn', '--deploy-mode', 'cluster']),
+                cmd_line(runner._spark_submit_args(0))
             )
 
     def test_spark_master_and_deploy_mode_are_hard_coded(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -990,7 +990,6 @@ class DeprecatedFileUploadArgsTestCase(SandboxedTestCase):
                 path='/tmp/.fooconf', name='dot-fooconf', type='file')])
 
         self.assertEqual(old_runner._extra_args, new_runner._extra_args)
-        self.assertEqual(old_runner._spark_files, new_runner._spark_files)
         self.assertEqual(old_runner._working_dir_mgr._name_to_typed_path,
                          new_runner._working_dir_mgr._name_to_typed_path)
 


### PR DESCRIPTION
This turns on setup scripts on all Spark masters that give executors their own working dir (fixes #2048).

Also removed removed `_spark_files` and `_spark_archives` attributes from the runner. At this point, we put the same files in Spark's working directory that we would in Hadoop Streaming's; the only special case is local Spark masters, where we don't bother with `--files` and `--archives` at all.
