### PR TITLE
fix re-uploading of renamed remote files

### DIFF
--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1232,7 +1232,7 @@ class MRJobRunner(object):
         if is_uri(path):
             # file is visible to non-YARN Spark, but has the wrong name, so
             # download and re-upload it
-            wd_tmp = os.path.join(self._get_local_tmp_dir, 'wd-mirror')
+            wd_tmp = os.path.join(self._get_local_tmp_dir(), 'wd-mirror')
             self.fs.mkdir(wd_tmp)
 
             tmp_path = os.path.join(wd_tmp, name)

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -294,11 +294,21 @@ class SparkWorkingDirTestCase(MockFilesystemsTestCase):
             # need to upload from local to remote
             self.assertTrue(fs.exists(fs.join(wd_mirror, 'foe')))
 
-            # TODO: look at spark submit args
+            run_spark_submit.assert_called_once_with(
+                ANY, ANY, record_callback=ANY)
 
+            spark_submit_args = run_spark_submit.call_args[0][0]
+            self.assertIn('--files', spark_submit_args)
+            files_arg = spark_submit_args[
+                spark_submit_args.index('--files') + 1]
 
-
-
+            self.assertEqual(
+                files_arg, ','.join([
+                    fs.join(wd_mirror, 'foe'),
+                    's3://walrus/fowl',
+                    fs.join(wd_mirror, 'ghoti'),
+                    fs.join(wd_mirror, 'mr_spark_os_walk.py'),
+                ]))
 
 
 @skipIf(pyspark is None, 'no pyspark module')


### PR DESCRIPTION
Fix essentially a typo that broke mrjob's ability to download a remote file and re-upload it using the same name (which we need to fully support file uploads on Spark). Added a fairly extensive test. Fixes #1922.