### PR TITLE
Match increment_counter arguments in spark harness with base job

### DIFF
--- a/mrjob/spark/harness.py
+++ b/mrjob/spark/harness.py
@@ -181,8 +181,8 @@ def main(cmd_line_args=None):
     def make_increment_counter(step_num):
         counter_accumulator = counter_accumulators[step_num - start]
 
-        def increment_counter(group, name, amount=1):
-            counter_accumulator.add({group: {name: amount}})
+        def increment_counter(group, counter, amount=1):
+            counter_accumulator.add({group: {counter: amount}})
 
         return increment_counter
 

--- a/tests/mr_counting_job.py
+++ b/tests/mr_counting_job.py
@@ -25,7 +25,7 @@ class MRCountingJob(MRJob):
                 MRStep(mapper=self.mapper)]
 
     def mapper(self, _, value):
-        self.increment_counter('group', 'counter_name', 1)
+        self.increment_counter(group='group', counter='counter_name', amount=1)
         yield _, value
 
 


### PR DESCRIPTION
Fixes #2060.

The updated test `tests.spark.test_harness.SparkHarnessOutputComparisonTestCase.test_increment_counter` failed before the change to the harness, and now passes. The non-spark tests using MRCountingJob still pass.