### PR TITLE
No archives in wd mirror

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -510,7 +510,7 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     def _add_job_files_for_upload(self):
         """Add files needed for running the job (setup and input)
         to self._upload_mgr."""
-        for path in self._working_dir_mgr.paths('archives'):
+        for path in self._working_dir_mgr.paths('archive'):
             self._upload_mgr.add(path)
 
         if self._opts['hadoop_streaming_jar']:

--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -510,6 +510,9 @@ class DataprocJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     def _add_job_files_for_upload(self):
         """Add files needed for running the job (setup and input)
         to self._upload_mgr."""
+        for path in self._working_dir_mgr.paths('archives'):
+            self._upload_mgr.add(path)
+
         if self._opts['hadoop_streaming_jar']:
             self._upload_mgr.add(self._opts['hadoop_streaming_jar'])
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -811,7 +811,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     def _add_job_files_for_upload(self):
         """Add files needed for running the job (setup and input)
         to self._upload_mgr."""
-        for path in self._working_dir_mgr.paths():
+        for path in self._working_dir_mgr.paths('archive'):
             self._upload_mgr.add(path)
 
         for path in self._py_files():

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -811,6 +811,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     def _add_job_files_for_upload(self):
         """Add files needed for running the job (setup and input)
         to self._upload_mgr."""
+        for path in self._working_dir_mgr.paths():
+            self._upload_mgr.add(path)
+
         for path in self._py_files():
             self._upload_mgr.add(path)
 

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -345,7 +345,7 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
     def _add_job_files_for_upload(self):
         """Add files needed for running the job (setup and input)
         to self._upload_mgr."""
-        for path in self._working_dir_mgr.paths('archives'):
+        for path in self._working_dir_mgr.paths('archive'):
             self._upload_mgr.add(path)
 
         for path in self._py_files():

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -345,6 +345,9 @@ class HadoopJobRunner(MRJobBinRunner, LogInterpretationMixin):
     def _add_job_files_for_upload(self):
         """Add files needed for running the job (setup and input)
         to self._upload_mgr."""
+        for path in self._working_dir_mgr.paths('archives'):
+            self._upload_mgr.add(path)
+
         for path in self._py_files():
             self._upload_mgr.add(path)
 

--- a/mrjob/inline.py
+++ b/mrjob/inline.py
@@ -49,7 +49,7 @@ class InlineMRJobRunner(SimMRJobRunner):
 
     .. versionadded:: 0.6.8
 
-       can run :py:class:`~mrjob.step.SparkStep`\s via the
+       can run :py:class:`~mrjob.step.SparkStep`\\s via the
        :py:mod:`pyspark` library.
     """
     alias = 'inline'

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -1261,6 +1261,7 @@ class MRJobRunner(object):
             log.debug('  %s -> %s' % (path, dest))
             self.fs.put(path, dest)
 
+    # TODO: this should be only for files, not archives
     def _copy_files_to_wd_mirror(self):
         """Upload working archives/files (determined by *type*) to the
         working dir mirror, if necessary."""
@@ -1387,6 +1388,7 @@ class MRJobRunner(object):
             args.append(files_opt_str)
             args.append(','.join(file_hash_paths))
 
+        # TODO: always use hash with archives
         archive_hash_paths = list(
             self._arg_hash_paths('archive', archives,
                                  always_use_hash=always_use_hash))

--- a/mrjob/setup.py
+++ b/mrjob/setup.py
@@ -453,12 +453,17 @@ class WorkingDirManager(object):
                     in self._name_to_typed_path.items()
                     if (type is None or typed_path[0] == type))
 
-    def paths(self):
+    def paths(self, type=None):
         """Get a set of all paths tracked by this WorkingDirManager."""
         paths = set()
 
-        paths.update(p for (t, p) in self._typed_path_to_auto_name)
-        paths.update(p for (t, p) in self._name_to_typed_path.values())
+        for path_type, path in self._typed_path_to_auto_name:
+            if type is None or path_type == type:
+                paths.add(path)
+
+        for path_type, path in self._name_to_typed_path.values():
+            if type is None or path_type == type:
+                paths.add(path)
 
         return paths
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1518,10 +1518,10 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
                      runner._dest_in_wd_mirror(runner._script_path,
                                                'mr_null_spark.py')),
                     '--archives',
-                    (runner._dest_in_wd_mirror(baz_path, 'baz.tar.gz') +
+                    (runner._upload_mgr.uri(baz_path) + '#baz.tar.gz' +
                      ',' +
-                     runner._dest_in_wd_mirror(
-                         runner._dir_archive_path(qux_path), 'qux')),
+                     runner._upload_mgr.uri(
+                         runner._dir_archive_path(qux_path)) + '#qux')
                 ]
             )
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -462,7 +462,7 @@ class WorkingDirManagerTestCase(BasicTestCase):
                           'baz.tar.gz': 's3://bucket/path/to/baz.tar.gz'})
         self.assertEqual(
             wd.paths(),
-            set(['foo/bar.py', 's3://bucket/path/to/baz.tar.gz']))
+            {'foo/bar.py', 's3://bucket/path/to/baz.tar.gz'})
 
     def test_explicit_name_collision(self):
         wd = WorkingDirManager()
@@ -483,7 +483,7 @@ class WorkingDirManagerTestCase(BasicTestCase):
         self.assertEqual(wd.name_to_path('file'),
                          {'qux.py': 'foo/bar.py',
                           'bar.py': 'foo/bar.py'})
-        self.assertEqual(wd.paths(), set(['foo/bar.py']))
+        self.assertEqual(wd.paths(), {'foo/bar.py'})
 
     def test_cant_give_same_path_different_types(self):
         wd = WorkingDirManager()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -448,6 +448,9 @@ class WorkingDirManagerTestCase(BasicTestCase):
         self.assertEqual(wd.name_to_path('file'), {})
         self.assertEqual(wd.name_to_path(), {})
         self.assertEqual(wd.paths(), set())
+        self.assertEqual(wd.paths('archive'), set())
+        self.assertEqual(wd.paths('file'), set())
+
 
     def test_basic(self):
         wd = WorkingDirManager()
@@ -463,6 +466,10 @@ class WorkingDirManagerTestCase(BasicTestCase):
         self.assertEqual(
             wd.paths(),
             {'foo/bar.py', 's3://bucket/path/to/baz.tar.gz'})
+        self.assertEqual(
+            wd.paths('archive'), {'s3://bucket/path/to/baz.tar.gz'})
+        self.assertEqual(
+            wd.paths('file'), {'foo/bar.py'})
 
     def test_explicit_name_collision(self):
         wd = WorkingDirManager()


### PR DESCRIPTION
This partially undoes a change in v0.6.8 that moved all working dir files and archives to the working dir mirror, where they're uploaded with the same name they're going to have in the job's working dir. Not only is this pointless (either Spark fully supports `--archives` or it ignores it), but it messes up archives on Hadoop because Hadoop rely's on the path's file extension to un-archive archives.

Fixes #2059.