### PR TITLE
add --emulate-map-input-file

### DIFF
--- a/docs/guides/spark-runner-opts.rst
+++ b/docs/guides/spark-runner-opts.rst
@@ -20,6 +20,22 @@ runners:
 Options unique to the Spark runner:
 
 .. mrjob-opt::
+   :config: emulate_map_input_file
+   :switch: --emulate-map-input-file, --no-emulate-map-input-file
+   :type: boolean
+   :set: spark
+   :default: ``False``
+
+   Imitate Hadoop by setting :envvar:`$mapreduce_map_input_file`
+   to the path of the input file for the current partition. This
+   helps support jobs that rely on
+   :py:func:`jobconf_from_env('mapreduce.map.input.file') <mrjob.compat.jobconf_from_env>`.
+
+   This feature only applies to the mapper of the job's first step,
+   and is ignored by jobs that set
+   :py:attr:`~mrjob.job.MRJob.HADOOP_INPUT_FORMAT`.
+
+.. mrjob-opt::
     :config: gcs_region
     :switch: --gcs-region
     :type: :ref:`string <data-type-string>`

--- a/mrjob/examples/mr_count_lines_by_file.py
+++ b/mrjob/examples/mr_count_lines_by_file.py
@@ -1,3 +1,16 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Which files are we reading input from?"""
 from mrjob.compat import jobconf_from_env
 from mrjob.job import MRJob

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -668,6 +668,21 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    emulate_map_input_file=dict(
+        switches=[
+            (['--emulate-map-input-file'], dict(
+                action='store_true',
+                help=('Set $mapreduce_map_input_file to the input file path'
+                      ' in the first mapper function, so we can read it'
+                      ' with mrjob.compat.jobconf_from_env(). Ignored if'
+                      ' job has a Hadoop input format'),
+            )),
+            (['--no-emulate-map-input-file'], dict(
+                action='store_true',
+                help=("Don't set $mapreduce_map_input_file"),
+            )),
+        ],
+    ),
     enable_emr_debugging=dict(
         cloud_role='launch',
         switches=[

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -678,7 +678,7 @@ _RUNNER_OPTS = dict(
                       ' job has a Hadoop input format'),
             )),
             (['--no-emulate-map-input-file'], dict(
-                action='store_true',
+                action='store_false',
                 help=("Don't set $mapreduce_map_input_file"),
             )),
         ],

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -672,14 +672,15 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--emulate-map-input-file'], dict(
                 action='store_true',
-                help=('Set $mapreduce_map_input_file to the input file path'
-                      ' in the first mapper function, so we can read it'
-                      ' with mrjob.compat.jobconf_from_env(). Ignored if'
-                      ' job has a Hadoop input format'),
+                help=("In the first mapper, set $mapreduce_map_input_file to"
+                      " the input file path, like Hadoop would, to support"
+                      " jobs that use"
+                      " jobconf_from_env('mapreduce.map.input.file')."
+                      " Ignored if job sets HADOOP_INPUT_FORMAT."),
             )),
             (['--no-emulate-map-input-file'], dict(
                 action='store_false',
-                help=("Don't set $mapreduce_map_input_file"),
+                help=("Disables setting $mapreduce_map_input_file"),
             )),
         ],
     ),

--- a/mrjob/spark/harness.py
+++ b/mrjob/spark/harness.py
@@ -366,9 +366,6 @@ def _run_mapper(make_mrc_job, step_num, rdd, rdd_includes_input_path):
 
             # reconstruct *lines* (without dumping to memory)
             lines = chain([first_line], (line for _, line in path_line_pairs))
-            # convert unicode back to bytes
-            lines = (line if isinstance(line, bytes) else line.encode('utf_8')
-                     for line in lines)
 
         # decode lines into key-value pairs (as a generator, not a list)
         #

--- a/mrjob/spark/harness.py
+++ b/mrjob/spark/harness.py
@@ -283,7 +283,6 @@ def _run_step(step, step_num, rdd, make_mrc_job,
         rdd = _run_mapper(
             make_mrc_job, step_num, rdd,
             emulate_map_input_file=(emulate_map_input_file and step_num == 0))
-    # TODO: unwind rdd if emulate_map_input_file and no mapper
 
     # combiner/shuffle-and-sort
     combiner_job = None
@@ -345,6 +344,11 @@ def _run_mapper(make_mrc_job, step_num, rdd, emulate_map_input_file):
                     # *input_path* is the same for every line in the
                     # partition, but it doesn't hurt to set it
                     os.environ['mapreduce_map_input_file'] = input_path
+
+                    # data frame reader converts input text to unicode
+                    if not isinstance(line, bytes):
+                        line = line.encode('utf_8')
+
                     yield read(line)
 
             pairs = read_kv_pairs_from_path_line_pairs(lines)

--- a/mrjob/spark/harness.py
+++ b/mrjob/spark/harness.py
@@ -559,7 +559,8 @@ def _make_arg_parser():
         action='store_true',
         help=('set mapreduce_map_input_file to the input file path'
               ' in the first mapper function, so we can read it'
-              ' with mrjob.compat.jobconf_from_env()'),
+              ' with mrjob.compat.jobconf_from_env(). Ignored if'
+              ' job has a Hadoop input format'),
     )
 
     for args, kwargs in _PASSTHRU_OPTIONS:

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -72,6 +72,7 @@ class SparkMRJobRunner(MRJobBinRunner):
         'aws_session_token',
         'cloud_fs_sync_secs',
         'cloud_part_size_mb',
+        'emulate_map_input_file',
         'gcs_region',  # used when creating buckets on GCS
         'hadoop_bin',
         'project_id',  # used by GCS filesystem
@@ -431,6 +432,9 @@ class SparkMRJobRunner(MRJobBinRunner):
         if self._max_output_files:
             args.extend(['--max-output-files',
                          str(self._max_output_files)])
+
+        if self._opts['emulate_map_input_file']:
+            args.append('--emulate-map-input-file')
 
         return args
 

--- a/tests/mr_count_lines_by_filename.py
+++ b/tests/mr_count_lines_by_filename.py
@@ -1,0 +1,34 @@
+# Copyright 2019 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trivial extension to MRCountLinesByFile to ensure that Spark harness'
+map_input_file emulation handles multiple mappers okay."""
+from posixpath import basename
+
+from mrjob.examples.mr_count_lines_by_file import MRCountLinesByFile
+from mrjob.step import MRStep
+
+
+class MRCountLinesByFilename(MRCountLinesByFile):
+
+    def mapper2(self, path, count):
+        yield basename(path), count
+
+    def steps(self):
+        return [
+            MRStep(mapper=self.mapper, reducer=self.reducer),
+            MRStep(mapper=self.mapper2)
+        ]
+
+if __name__ == '__main__':
+    MRCountLinesByFilename.run()

--- a/tests/mr_spark_harness.py
+++ b/tests/mr_spark_harness.py
@@ -21,8 +21,9 @@ from mrjob.spark.harness import main as harness_main
 
 _PASSTHRU_OPTION_STRINGS = {
     arg for args, kwargs in _PASSTHRU_OPTIONS for arg in args}
-# handled separately because this is also a runner option
-_PASSTHRU_OPTION_STRINGS.add('--max-output-files')
+# handled separately because these are also runner options
+_PASSTHRU_OPTION_STRINGS.update(
+    {'--max-output-files', '--emulate-map-input-file'})
 
 
 class MRSparkHarness(MRJob):
@@ -39,8 +40,9 @@ class MRSparkHarness(MRJob):
         for args, kwargs in _PASSTHRU_OPTIONS:
             self.add_passthru_arg(*args, **kwargs)
 
-        # this is both a runner and harness switch
+        # these are both runner and harness switches
         self.pass_arg_through('--max-output-files')
+        self.pass_arg_through('--emulate-map-input-file')
 
     def spark(self, input_path, output_path):
         harness_args = [

--- a/tests/spark/test_harness.py
+++ b/tests/spark/test_harness.py
@@ -226,6 +226,7 @@ class SparkHarnessOutputComparisonBaseTestCase(
 
         if emulate_map_input_file:
             # uses dataframes, which don't seem to work in inline mode:
+            #
             # java.util.ArrayList cannot be cast to org.apache.spark.sql.Column
             harness_job_runner_alias = 'local'
         else:
@@ -679,7 +680,10 @@ class HadoopFormatsTestCase(SparkHarnessOutputComparisonBaseTestCase):
 
 class EmulateMapInputFileTestCase(SparkHarnessOutputComparisonBaseTestCase):
 
-    @skip('fails due to #2060, faster to just test in the spark runner')
+    # dataframes (which emulate_map_input_file uses) don't seem to work
+    # with the Spark harness in the inline runner. the local runner can
+    # do it, but it's super slow because it uses the local-cluster master
+    @skip('fails due to #2060, faster to test in Spark runner anyhow')
     def test_one_file(self):
         two_lines_path = self.makefile('two_lines', b'line\nother line\n')
 

--- a/tests/spark/test_harness.py
+++ b/tests/spark/test_harness.py
@@ -24,6 +24,7 @@ from os.path import dirname
 from os.path import join
 from tempfile import gettempdir
 from shutil import rmtree
+from unittest import skip
 
 import mrjob.spark.harness
 from mrjob.examples.mr_count_lines_by_file import MRCountLinesByFile
@@ -678,6 +679,7 @@ class HadoopFormatsTestCase(SparkHarnessOutputComparisonBaseTestCase):
 
 class EmulateMapInputFileTestCase(SparkHarnessOutputComparisonBaseTestCase):
 
+    @skip('fails due to #2060, faster to just test in the spark runner')
     def test_one_file(self):
         two_lines_path = self.makefile('two_lines', b'line\nother line\n')
 

--- a/tests/spark/test_harness.py
+++ b/tests/spark/test_harness.py
@@ -26,6 +26,7 @@ from tempfile import gettempdir
 from shutil import rmtree
 
 import mrjob.spark.harness
+from mrjob.examples.mr_count_lines_by_file import MRCountLinesByFile
 from mrjob.examples.mr_nick_nack import MRNickNack
 from mrjob.examples.mr_nick_nack_input_format import \
     MRNickNackWithHadoopInputFormat
@@ -152,7 +153,8 @@ class SparkHarnessOutputComparisonBaseTestCase(
                      runner_alias='inline', compression_codec=None,
                      job_args=None, spark_conf=None, first_step_num=None,
                      last_step_num=None, counter_output_dir=None,
-                     num_reducers=None, max_output_files=None):
+                     num_reducers=None, max_output_files=None,
+                     emulate_map_input_file=False):
         job_class_path = '%s.%s' % (job_class.__module__, job_class.__name__)
 
         harness_job_args = ['-r', runner_alias, '--job-class', job_class_path]
@@ -180,6 +182,9 @@ class SparkHarnessOutputComparisonBaseTestCase(
             harness_job_args.extend(
                 ['--max-output-files', str(max_output_files)])
 
+        if emulate_map_input_file:
+            harness_job_args.append('--emulate-map-input-file')
+
         harness_job_args.extend(input_paths)
 
         harness_job = MRSparkHarness(harness_job_args)
@@ -196,33 +201,43 @@ class SparkHarnessOutputComparisonBaseTestCase(
 
     def _assert_output_matches(
             self, job_class, input_bytes=b'', input_paths=(), job_args=[],
-            num_reducers=None, max_output_files=None):
+            num_reducers=None, max_output_files=None,
+            emulate_map_input_file=False):
 
         # run classes defined in this module in inline mode, classes
         # with their own script files in local mode. used by
         # test_skip_combiner_that_runs_cmd()
         if job_class.__module__ == __name__:
-            runner_alias = 'inline'
+            ref_job_runner_alias = 'inline'
         else:
-            runner_alias = 'local'
+            ref_job_runner_alias = 'local'
 
         reference_job = self._reference_job(
             job_class, input_bytes=input_bytes,
             input_paths=input_paths,
             job_args=job_args,
-            runner_alias=runner_alias)
+            runner_alias=ref_job_runner_alias)
 
         with reference_job.make_runner() as runner:
             runner.run()
 
             reference_output = sorted(to_lines(runner.cat_output()))
 
+        if emulate_map_input_file:
+            # uses dataframes, which don't seem to work in inline mode:
+            # java.util.ArrayList cannot be cast to org.apache.spark.sql.Column
+            harness_job_runner_alias = 'local'
+        else:
+            harness_job_runner_alias = 'inline'
+
         harness_job = self._harness_job(
             job_class, input_bytes=input_bytes,
             input_paths=input_paths,
             job_args=job_args,
             max_output_files=max_output_files,
-            num_reducers=num_reducers)
+            num_reducers=num_reducers,
+            emulate_map_input_file=emulate_map_input_file,
+            runner_alias=harness_job_runner_alias)
 
         with harness_job.make_runner() as runner:
             runner.run()
@@ -659,6 +674,17 @@ class HadoopFormatsTestCase(SparkHarnessOutputComparisonBaseTestCase):
 
         expected_output_counts = {b'"tomato"': b'2', b'"potato"': b'2'}
         self.assertEqual(expected_output_counts, output_counts)
+
+
+class EmulateMapInputFileTestCase(SparkHarnessOutputComparisonBaseTestCase):
+
+    def test_one_file(self):
+        two_lines_path = self.makefile('two_lines', b'line\nother line\n')
+
+        self._assert_output_matches(
+            MRCountLinesByFile,
+            emulate_map_input_file=True,
+            input_paths=[two_lines_path])
 
 
 class PreservesPartitioningTestCase(SandboxedTestCase):

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -22,6 +22,7 @@ try:
     import pyspark
 except ImportError:
     pyspark = None
+
 from mrjob.examples.mr_count_lines_by_file import MRCountLinesByFile
 from mrjob.examples.mr_most_used_word import MRMostUsedWord
 from mrjob.examples.mr_nick_nack import MRNickNack


### PR DESCRIPTION
This gives the Spark runner the ability to support jobs that use `jobconf_from_env('mapreduce.map.input.file')` to look at the name of the input file. Fixes #2061.
