### PR TITLE
sim runners set mapreduce.map.input.file to a file:// URL

### DIFF
--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -381,11 +381,9 @@ class SimMRJobRunner(MRJobRunner):
                 join(working_dir, name) for name, path in named_paths)
 
         if map_split:
-            # mapreduce.map.input.file
-            # mapreduce.map.input.start
-            # mapreduce.map.input.length
-            for key, value in map_split.items():
-                j['mapreduce.map.input.' + key] = str(value)
+            j['mapreduce.map.input.file'] = 'file://' + map_split['file']
+            j['mapreduce.map.input.length'] = str(map_split['length'])
+            j['mapreduce.map.input.start'] = str(map_split['start'])
 
         # translate to correct version
 

--- a/tests/spark/test_harness.py
+++ b/tests/spark/test_harness.py
@@ -680,10 +680,14 @@ class HadoopFormatsTestCase(SparkHarnessOutputComparisonBaseTestCase):
 
 class EmulateMapInputFileTestCase(SparkHarnessOutputComparisonBaseTestCase):
 
-    # dataframes (which emulate_map_input_file uses) don't seem to work
-    # with the Spark harness in the inline runner. the local runner can
-    # do it, but it's super slow because it uses the local-cluster master
-    @skip('fails due to #2060, faster to test in Spark runner anyhow')
+    # this test is rather slow because emulate_map_input_file uses dataframes,
+    # which don't seem to work properly directly through the pyspark library,
+    # which is what the inline runner uses (see comment in
+    # _assert_output_matches(), above), so we have to use local mode, which
+    # uses local-cluster master.
+    #
+    # this feature is more fully tested in test_runner.py, which can run tests
+    # through spark-submit on the local[*] master.
     def test_one_file(self):
         two_lines_path = self.makefile('two_lines', b'line\nother line\n')
 

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -203,7 +203,8 @@ class SimRunnerJobConfTestCase(SandboxedTestCase):
             self.assertGreater(runner.counters()[0]['count']['combiners'], 2)
 
         self.assertEqual(sorted(results),
-                         [(input_path, 3), (input_gz_path, 1)])
+                         [('file://' + input_path, 3),
+                          ('file://' + input_gz_path, 1)])
 
     def _extra_expected_local_files(self, runner):
         """A list of additional local files expected, as tuples
@@ -276,7 +277,8 @@ class SimRunnerJobConfTestCase(SandboxedTestCase):
             sorted(expected_local_files))
         self.assertEqual(results['mapreduce.job.id'], runner._job_key)
 
-        self.assertEqual(results['mapreduce.map.input.file'], input_gz_path)
+        self.assertEqual(results['mapreduce.map.input.file'],
+                         'file://' + input_gz_path)
         self.assertEqual(results['mapreduce.map.input.length'],
                          str(input_gz_size))
         self.assertEqual(results['mapreduce.map.input.start'], '0')


### PR DESCRIPTION
This makes the sim runners better match Hadoop (and Spark). Fixes #2066.