### PR TITLE
mrjob spark-submit can now pass switches to spark scripts

### DIFF
--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -154,6 +154,7 @@ from __future__ import print_function
 import os
 import sys
 from argparse import ArgumentParser
+from argparse import REMAINDER
 from argparse import SUPPRESS
 from logging import getLogger
 
@@ -485,7 +486,7 @@ def _make_arg_parser():
 
     # add positional arguments
     parser.add_argument(dest='script_or_jar', nargs='?')
-    parser.add_argument(dest='args', nargs='*')
+    parser.add_argument(dest='args', nargs=REMAINDER)
 
     _add_basic_args(parser)
     _add_runner_alias_arg(parser)

--- a/tests/tools/test_spark_submit.py
+++ b/tests/tools/test_spark_submit.py
@@ -118,6 +118,27 @@ class SparkSubmitToolTestCase(SandboxedTestCase):
             )
         ])
 
+    def test_switches_to_spark_script(self):
+        # regression test for #2070
+        spark_submit_main(['foo.py', '--bar', 'baz'])
+
+        self.assertEqual(self.runner_class.alias, 'spark')
+
+        self.assertTrue(self.runner_class.called)
+        self.assertTrue(self.runner.run.called)
+
+        kwargs = self.get_runner_kwargs()
+
+        self.assertEqual(kwargs['steps'], [
+            dict(
+                args=['--bar', 'baz'],
+                jobconf={},
+                script='foo.py',
+                spark_args=[],
+                type='spark_script',
+            )
+        ])
+
     def test_jar_step(self):
         spark_submit_main(['dora.jar', 'arg1', 'arg2', 'arg3'])
 


### PR DESCRIPTION
You used to have to use `--` to make this possible. Fixes #2055.