### PR TITLE
better error when loading conf file without PyYAML

### DIFF
--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -225,14 +225,10 @@ def _conf_object_at_path(conf_path):
             try:
                 return json.load(f)
             except (ValueError, JSONDecodeError) as e:
-                msg = ('If your mrjob.conf is in YAML, you need to install'
-                       ' yaml; see http://pypi.python.org/pypi/PyYAML/')
-                # Use msg attr if it's set
-                if hasattr(e, 'msg'):
-                    e.msg = '%s (%s)' % (e.msg, msg)
-                else:
-                    e.msg = msg
-                raise e
+                raise ValueError(
+                    'Could not read JSON from %s\n  %s\n\n'
+                    'If your conf file is in YAML, you need to'
+                    ' `pip install PyYAML` to read it' % (conf_path, str(e)))
 
 
 def load_opts_from_mrjob_conf(runner_alias, conf_path=None,

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -30,7 +30,11 @@ try:
 except ImportError:
     yaml = None
 
-from mrjob.py2 import JSONDecodeError
+try:
+    from json import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError  # Python 2 doesn't have JSONDecodeError
+
 from mrjob.py2 import string_types
 from mrjob.util import expand_path
 from mrjob.util import shlex_split

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -30,6 +30,7 @@ try:
 except ImportError:
     yaml = None
 
+from mrjob.py2 import JSONDecodeError
 from mrjob.py2 import string_types
 from mrjob.util import expand_path
 from mrjob.util import shlex_split
@@ -223,7 +224,7 @@ def _conf_object_at_path(conf_path):
         else:
             try:
                 return json.load(f)
-            except ValueError as e:
+            except (ValueError, JSONDecodeError) as e:
                 msg = ('If your mrjob.conf is in YAML, you need to install'
                        ' yaml; see http://pypi.python.org/pypi/PyYAML/')
                 # Use msg attr if it's set

--- a/mrjob/conf.py
+++ b/mrjob/conf.py
@@ -30,11 +30,6 @@ try:
 except ImportError:
     yaml = None
 
-try:
-    from json import JSONDecodeError
-except ImportError:
-    JSONDecodeError = ValueError  # Python 2 doesn't have JSONDecodeError
-
 from mrjob.py2 import string_types
 from mrjob.util import expand_path
 from mrjob.util import shlex_split
@@ -228,7 +223,7 @@ def _conf_object_at_path(conf_path):
         else:
             try:
                 return json.load(f)
-            except (ValueError, JSONDecodeError) as e:
+            except ValueError as e:
                 raise ValueError(
                     'Could not read JSON from %s\n  %s\n\n'
                     'If your conf file is in YAML, you need to'

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -157,12 +157,6 @@ urljoin
 urlopen
 urlparse
 
-# error types
-try:
-    from json import JSONDecodeError
-except ImportError:
-    JSONDecodeError = ValueError
-
 
 def to_unicode(s):
     """Convert ``bytes`` to unicode.

--- a/mrjob/py2.py
+++ b/mrjob/py2.py
@@ -157,6 +157,12 @@ urljoin
 urlopen
 urlparse
 
+# error types
+try:
+    from json import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
+
 
 def to_unicode(s):
     """Convert ``bytes`` to unicode.

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -41,6 +41,7 @@ from mrjob.conf import expand_path
 from mrjob.conf import find_mrjob_conf
 from mrjob.conf import load_opts_from_mrjob_conf
 from mrjob.conf import load_opts_from_mrjob_confs
+from mrjob.py2 import JSONDecodeError
 
 from tests.py2 import patch
 from tests.sandbox import BasicTestCase
@@ -376,8 +377,8 @@ class MRJobConfNoYAMLTestCase(MRJobConfTestCase):
         try:
             load_mrjob_conf(conf_path)
             assert False
-        except ValueError as e:
-            self.assertIn('If your mrjob.conf is in YAML', e.msg)
+        except Exception as e:
+            self.assertIn('If your mrjob.conf is in YAML', str(e))
 
 
 class CombineValuesTestCase(BasicTestCase):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -41,7 +41,6 @@ from mrjob.conf import expand_path
 from mrjob.conf import find_mrjob_conf
 from mrjob.conf import load_opts_from_mrjob_conf
 from mrjob.conf import load_opts_from_mrjob_confs
-from mrjob.py2 import JSONDecodeError
 
 from tests.py2 import patch
 from tests.sandbox import BasicTestCase

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -378,7 +378,7 @@ class MRJobConfNoYAMLTestCase(MRJobConfTestCase):
             load_mrjob_conf(conf_path)
             assert False
         except Exception as e:
-            self.assertIn('If your mrjob.conf is in YAML', str(e))
+            self.assertIn('If your conf file is in YAML', str(e))
 
 
 class CombineValuesTestCase(BasicTestCase):


### PR DESCRIPTION
For a long time, there has been a code path for loading mrjob's conf files in JSON if the YAML module is installed, but its error reporting didn't actually work. This change ensures the user gets a friendly, clear message if they try to load a (YAML) mrjob.conf without PyYAML installed. Fixes #2047.