### PR TITLE
default python_bin can be pypy

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -342,6 +342,11 @@ Job execution context
 
        added ``'pypy'`` and ``'pypy3'`` as possible defaults
 
+    .. note::
+
+       mrjob does not auto-install PyPy for you on EMR; see
+       :ref:`installing-pypy-on-emr` for how to do this
+
 .. mrjob-opt::
     :config: setup
     :switch: --setup

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -329,11 +329,18 @@ Job execution context
     If you're on Python 2, this defaults to ``'python'`` (except on EMR
     AMIs prior to 4.3.0, where it will be ``'python2.7'``).
 
+    Likewise, if you're using PyPy, this defaults to ``'pypy'`` or ``'pypy3'``
+    depending on your version.
+
     This option also affects which Python binary is used for file locking in
     :mrjob-opt:`setup` scripts, so it might be useful to set even if you're
     using a non-Python :mrjob-opt:`interpreter` (deprecated). It's also
     used by :py:class:`~mrjob.emr.EMRJobRunner` to compile mrjob after
     bootstrapping it (see :mrjob-opt:`bootstrap_mrjob`).
+
+    .. versionchanged:: 0.6.10
+
+       added ``'pypy'`` and ``'pypy3'`` as possible defaults
 
 .. mrjob-opt::
     :config: setup

--- a/docs/guides/emr-bootstrap-cookbook.rst
+++ b/docs/guides/emr-bootstrap-cookbook.rst
@@ -72,6 +72,23 @@ Or a tarball:
    :command:`pip` appears not to work due to out-of-date SSL
    certificate information.
 
+.. _installing-pypy-on-emr:
+
+Installing PyPy
+===============
+
+First, download the version of PyPy you want to use from
+`Portable PyPy Distributions for Linux <https://bitbucket.org/squeaky/portable-pypy/downloads/>`__.
+
+Then instruct EMR to un-tar it and link to the binary in ``/usr/bin``. For example:
+
+.. code-block:: yaml
+
+   runners:
+     emr:
+       bootstrap:
+       - sudo tar xvfj /local/path/to/pypy-7.1.1-linux_x86_64-portable.tar.bz2# -C /opt
+       - sudo ln -s /opt/pypy-7.1.1-linux_x86_64-portable/bin/pypy /usr/bin/pypy
 
 .. _installing-packages:
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -24,6 +24,7 @@ import os.path
 import pipes
 import re
 import sys
+from platform import python_implementation
 from subprocess import Popen
 from subprocess import PIPE
 
@@ -228,13 +229,21 @@ class MRJobBinRunner(MRJobRunner):
 
         This returns a single-item list (because it's a command).
         """
+        major_version = sys.version_info[0]
+        is_pypy = (python_implementation() == 'PyPy')
+
         if local and sys.executable:
             return [sys.executable]
         elif PY2:
-            return ['python']
+            if is_pypy:
+                return ['pypy']
+            else:
+                return ['python']
         else:
-            # e.g. python3
-            return ['python%d' % sys.version_info[0]]
+            if is_pypy:
+                return ['pypy%d' % major_version]
+            else:
+                return ['python%d' % major_version]
 
     ### running MRJob scripts ###
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -543,13 +543,13 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         except when running Python 2, we explicitly pick :command:`python2.7`
         on AMIs prior to 4.3.0 where's it's not the default.
         """
-        if local or not PY2:
-            return super(EMRJobRunner, self)._default_python_bin(local=local)
+        python_bin = super(EMRJobRunner, self)._default_python_bin(local=local)
 
-        if self._image_version_gte('4.3.0'):
-            return ['python']
-        else:
+        if python_bin == ['python'] and not (
+                self._image_version_gte('4.3.0') or local):
             return ['python2.7']
+        else:
+            return python_bin
 
     def _image_version_gte(self, version):
         """Check if the requested image version is greater than

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -23,6 +23,7 @@ from io import BytesIO
 from os.path import exists
 from os.path import getsize
 from os.path import join
+from platform import python_implementation
 from shutil import make_archive
 from unittest import skipIf
 from zipfile import ZipFile
@@ -61,10 +62,11 @@ from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_conf_patcher
 
 # used to match command lines
-if PY2:
-    PYTHON_BIN = 'python'
-else:
-    PYTHON_BIN = 'python3'
+is_pypy = (python_implementation() == 'PyPy')
+PYTHON_BIN = (
+    ('pypy' if PY2 else 'pypy3') if is_pypy else
+    ('python' if PY2 else 'python3')
+)
 
 # a --spark-master that has a working directory and is available from pyspark
 _LOCAL_CLUSTER_MASTER = 'local-cluster[2,1,4096]'

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -66,12 +66,7 @@ from tests.py2 import mock
 from tests.py2 import patch
 from tests.sandbox import BasicTestCase
 from tests.sandbox import mrjob_conf_patcher
-
-# used to match command lines
-if PY2:
-    PYTHON_BIN = 'python'
-else:
-    PYTHON_BIN = 'python3'
+from tests.test_bin import PYTHON_BIN
 
 US_EAST_GCE_REGION = 'us-east1'
 EU_WEST_GCE_REGION = 'europe-west1'

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -29,6 +29,7 @@ import socket
 import sys
 import time
 from io import BytesIO
+from platform import python_implementation
 from shutil import make_archive
 
 import boto3
@@ -82,15 +83,9 @@ from tests.py2 import call
 from tests.py2 import patch
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_conf_patcher
+from tests.test_bin import PYTHON_BIN
 from tests.test_hadoop import HadoopExtraArgsTestCase
 from tests.test_inline import InlineInputManifestTestCase
-
-# used to match command lines
-if PY2:
-    PYTHON_BIN = 'python'
-    # prior to AMI 4.3.0, we use python2.7
-else:
-    PYTHON_BIN = 'python3'
 
 # EMR configurations used for testing
 # from http://docs.aws.amazon.com/ElasticMapReduce/latest/ReleaseGuide/emr-configure-apps.html  # noqa
@@ -2477,10 +2472,10 @@ class DefaultPythonBinTestCase(MockBoto3TestCase):
 
     def test_2_4_3_ami(self):
         runner = EMRJobRunner(image_version='2.4.3')
-        if PY2:
+        if PY2 and python_implementation() == 'CPython':
             self.assertEqual(runner._default_python_bin(), ['python2.7'])
         else:
-            self.assertEqual(runner._default_python_bin(), ['python3'])
+            self.assertEqual(runner._default_python_bin(), [PYTHON_BIN])
 
     def test_local_python_bin(self):
         # just make sure we don't break this

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -87,6 +87,12 @@ from tests.test_bin import PYTHON_BIN
 from tests.test_hadoop import HadoopExtraArgsTestCase
 from tests.test_inline import InlineInputManifestTestCase
 
+
+if PYTHON_BIN == 'python':
+    OLD_AMI_PYTHON_BIN = 'python2.7'
+else:
+    OLD_AMI_PYTHON_BIN = PYTHON_BIN
+
 # EMR configurations used for testing
 # from http://docs.aws.amazon.com/ElasticMapReduce/latest/ReleaseGuide/emr-configure-apps.html  # noqa
 
@@ -1626,13 +1632,13 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
 
     def test_create_master_bootstrap_script_on_3_11_0_ami(self):
         self._test_create_master_bootstrap_script(
-            expected_python_bin=('python2.7' if PY2 else PYTHON_BIN),
+            expected_python_bin=(OLD_AMI_PYTHON_BIN),
             image_version='3.11.0')
 
     def test_create_master_bootstrap_script_on_2_4_11_ami(self):
         self._test_create_master_bootstrap_script(
             image_version='2.4.11',
-            expected_python_bin=('python2.7' if PY2 else PYTHON_BIN))
+            expected_python_bin=(OLD_AMI_PYTHON_BIN))
 
     def test_no_bootstrap_script_if_not_needed(self):
         runner = EMRJobRunner(conf_paths=[], bootstrap_mrjob=False,
@@ -2462,20 +2468,15 @@ class DefaultPythonBinTestCase(MockBoto3TestCase):
 
     def test_4_x_release_label(self):
         runner = EMRJobRunner(release_label='emr-4.0.0')
-        self.assertEqual(runner._default_python_bin(),
-                         ['python2.7'] if PY2 else [PYTHON_BIN])
+        self.assertEqual(runner._default_python_bin(), [OLD_AMI_PYTHON_BIN])
 
     def test_3_11_0_ami(self):
         runner = EMRJobRunner(image_version='3.11.0')
-        self.assertEqual(runner._default_python_bin(),
-                         ['python2.7'] if PY2 else [PYTHON_BIN])
+        self.assertEqual(runner._default_python_bin(), [OLD_AMI_PYTHON_BIN])
 
     def test_2_4_3_ami(self):
         runner = EMRJobRunner(image_version='2.4.3')
-        if PY2 and python_implementation() == 'CPython':
-            self.assertEqual(runner._default_python_bin(), ['python2.7'])
-        else:
-            self.assertEqual(runner._default_python_bin(), [PYTHON_BIN])
+        self.assertEqual(runner._default_python_bin(), [OLD_AMI_PYTHON_BIN])
 
     def test_local_python_bin(self):
         # just make sure we don't break this


### PR DESCRIPTION
If you launch a mrjob script with PyPy, this sets the default python_bin used by Hadoop/Spark to PyPy as well. Fixes #1011.