### PR TITLE
bump default instance type to m5.xlarge

### DIFF
--- a/docs/guides/cloud-opts.rst
+++ b/docs/guides/cloud-opts.rst
@@ -101,15 +101,9 @@ Number and type of instances
     :switch: --instance-type
     :type: :ref:`string <data-type-string>`
     :set: cloud
-    :default: ``m1.medium`` (usually) on EMR, ``n1-standard-1`` on Dataproc
+    :default: ``m5.xlarge`` on EMR, ``n1-standard-1`` on Dataproc
 
     Type of instance that runs your Hadoop tasks.
-
-    On Amazon EMR, mrjob picks the cheapest instance type that will work at
-    all. This is ``m1.medium``, with two exceptions:
-
-    * ``m1.large`` if you're running Spark (see :mrjob-opt:`bootstrap_spark`)
-    * ``m1.small`` if you're running on the (deprecated) 2.x AMIs
 
     Once you've tested a job and want to run it at scale, it's usually a good
     idea to use instances larger than the default. For EMR, see
@@ -127,9 +121,19 @@ Number and type of instances
     coordinating tasks, not running them. Use :mrjob-opt:`master_instance_type`
     instead.
 
+    .. versionchanged:: 0.6.10
+
+       Default on EMR is now ``m5.xlarge``
+
+    .. versionchanged:: 0.6.6
+
+       Default on EMR was ``m4.large``
+
     .. versionchanged:: 0.5.6
 
-       Used to default to ``m1.medium`` in all cases.
+       On EMR, defaulted to ``m1.large`` if running Spark, ``m1.small`` if
+       running on the (deprecated) 2.x AMIs, and ``m1.medium`` otherwise
+       (``m1.medium`` was previously the default in all cases).
 
     .. versionchanged:: 0.5.4
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -201,10 +201,6 @@ _DEFAULT_INSTANCE_TYPE = 'm5.xlarge'
 # m1.medium (3.75) definitely doesn't work.
 _MIN_SPARK_INSTANCE_MEMORY = 7.5
 
-# cheapest instance type that can run everything (resource manager, Hadoop
-# tasks, Spark tasks) and is available on almost all regions. See #1932.
-_CHEAPEST_INSTANCE_TYPE = 'm4.large'
-
 # these are the only kinds of instance roles that exist
 _INSTANCE_ROLES = ('MASTER', 'CORE', 'TASK')
 
@@ -1011,16 +1007,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
     # instance types
 
-    def _cheapest_manager_instance_type(self):
-        """What's the cheapest instance type we can get away with
-        for the master node (when it's not also running jobs)?"""
-        return _CHEAPEST_INSTANCE_TYPE
-
-    def _cheapest_worker_instance_type(self):
-        """What's the cheapest instance type we can get away with
-        running tasks on?"""
-        return _CHEAPEST_INSTANCE_TYPE
-
     def _instance_type(self, role):
         """What instance type should we use for the given role?
         (one of 'MASTER', 'CORE', 'TASK')"""
@@ -1035,11 +1021,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             # using *instance_type* here is defensive programming;
             # if set, it should have already been popped into the worker
             # instance type option(s) by _fix_instance_opts() above
-            return (self._opts['instance_type'] or
-                    self._cheapest_worker_instance_type())
-
+            return self._opts['instance_type'] or 'm5.xlarge'
         else:
-            return self._cheapest_manager_instance_type()
+            return 'm5.xlarge'
 
     def _instance_is_worker(self, role):
         """Do instances of the given role run tasks? True for non-master

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -191,9 +191,9 @@ _MIN_SPARK_PY3_AMI_VERSION = '4.0.0'
 # 5 minutes plus time to copy the logs, or something like that.
 _S3_LOG_WAIT_MINUTES = 10
 
-# a relatively cheap instance type that's available on (almost) all regions
-# and is big enough to support Spark. See #1932.
-_DEFAULT_INSTANCE_TYPE = 'm4.large'
+# a relatively cheap instance type that's available on all regions
+# and is big enough to support Spark. See #2071.
+_DEFAULT_INSTANCE_TYPE = 'm5.xlarge'
 
 # minimum amount of memory to run spark jobs
 #

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1015,7 +1015,7 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
     def test_defaults(self):
         self._test_instance_groups(
             {},
-            master=(1, 'm4.large', None))
+            master=(1, 'm5.xlarge', None))
 
     def test_instance_type_single_instance(self):
         self._test_instance_groups(
@@ -1026,7 +1026,7 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
         self._test_instance_groups(
             {'instance_type': 'c1.xlarge', 'num_core_instances': 2},
             core=(2, 'c1.xlarge', None),
-            master=(1, 'm4.large', None))
+            master=(1, 'm5.xlarge', None))
 
     def test_explicit_master_and_core_instance_types(self):
         self._test_instance_groups(
@@ -1037,7 +1037,7 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
             {'core_instance_type': 'm2.xlarge',
              'num_core_instances': 2},
             core=(2, 'm2.xlarge', None),
-            master=(1, 'm4.large', None))
+            master=(1, 'm5.xlarge', None))
 
         self._test_instance_groups(
             {'master_instance_type': 'm1.large',
@@ -1050,26 +1050,26 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
         # used to default to m1.small on 2.x AMIs (see #1932)
         self._test_instance_groups(
             dict(image_version='2.4.11'),
-            master=(1, 'm4.large', None))
+            master=(1, 'm5.xlarge', None))
 
     def test_2_x_ami_defaults_multiple_nodes(self):
         # used to default to m1.small on 2.x AMIs (see #1932)
         self._test_instance_groups(
             dict(image_version='2.4.11', num_core_instances=2),
-            core=(2, 'm4.large', None),
-            master=(1, 'm4.large', None))
+            core=(2, 'm5.xlarge', None),
+            master=(1, 'm5.xlarge', None))
 
     def test_release_label_hides_image_version(self):
         self._test_instance_groups(
             dict(release_label='emr-4.0.0', image_version='2.4.11'),
-            master=(1, 'm4.large', None))
+            master=(1, 'm5.xlarge', None))
 
     def test_spark_defaults_single_node(self):
         # when the default instance type was m1.medium, Spark needed
         # m1.large to run tasks, so we needed a separate test. See #1932
         self._test_instance_groups(
             dict(image_version='4.0.0', applications=['Spark']),
-            master=(1, 'm4.large', None))
+            master=(1, 'm5.xlarge', None))
 
     def test_spark_defaults_multiple_nodes(self):
         # This used to test whether we could get away with a smaller
@@ -1078,8 +1078,8 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
             dict(image_version='4.0.0',
                  applications=['Spark'],
                  num_core_instances=2),
-            core=(2, 'm4.large', None),
-            master=(1, 'm4.large', None))
+            core=(2, 'm5.xlarge', None),
+            master=(1, 'm5.xlarge', None))
 
     def test_explicit_instance_types_take_precedence(self):
         self._test_instance_groups(
@@ -1114,7 +1114,7 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
         self._test_instance_groups(
             {},
             core=(2, 'c1.xlarge', None),
-            master=(1, 'm4.large', None))
+            master=(1, 'm5.xlarge', None))
 
         self._test_instance_groups(
             {'master_instance_type': 'm1.large',
@@ -1231,23 +1231,23 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
         self._test_instance_groups(
             {'master_instance_bid_price': '0',
              },
-            master=(1, 'm4.large', None))
+            master=(1, 'm5.xlarge', None))
 
         self._test_instance_groups(
             {'num_core_instances': 3,
              'core_instance_bid_price': '0.00',
              },
-            core=(3, 'm4.large', None),
-            master=(1, 'm4.large', None))
+            core=(3, 'm5.xlarge', None),
+            master=(1, 'm5.xlarge', None))
 
         self._test_instance_groups(
             {'num_core_instances': 3,
              'num_task_instances': 5,
              'task_instance_bid_price': '',
              },
-            core=(3, 'm4.large', None),
-            master=(1, 'm4.large', None),
-            task=(5, 'm4.large', None))
+            core=(3, 'm5.xlarge', None),
+            master=(1, 'm5.xlarge', None),
+            task=(5, 'm5.xlarge', None))
 
     def test_pass_invalid_bid_prices_through_to_emr(self):
         self.assertRaises(
@@ -1262,7 +1262,7 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
              'num_task_instances': 20,
              },
             core=(5, 'c1.medium', None),
-            master=(1, 'm4.large', None),
+            master=(1, 'm5.xlarge', None),
             task=(20, 'c1.medium', None))
 
     def test_explicit_instance_groups(self):
@@ -1296,7 +1296,7 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
             dict(
                 instance_fleets=[dict(
                     InstanceFleetType='MASTER',
-                    InstanceTypeConfigs=[dict(InstanceType='m4.large')],
+                    InstanceTypeConfigs=[dict(InstanceType='m5.xlarge')],
                     TargetOnDemandCapacity=1)]
             )
         )
@@ -1306,7 +1306,7 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
             dict(
                 instance_fleets=[dict(
                     InstanceFleetType='MASTER',
-                    InstanceTypeConfigs=[dict(InstanceType='m4.large')],
+                    InstanceTypeConfigs=[dict(InstanceType='m5.xlarge')],
                     TargetOnDemandCapacity=1)],
                 instance_groups=[dict(
                     InstanceRole='MASTER',
@@ -1322,15 +1322,15 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
         self.set_in_mrjob_conf(
             instance_fleets=[dict(
                 InstanceFleetType='MASTER',
-                InstanceTypeConfigs=[dict(InstanceType='m4.large')],
+                InstanceTypeConfigs=[dict(InstanceType='m5.xlarge')],
                 TargetOnDemandCapacity=1)])
 
         self._test_uses_instance_fleets({})
 
         self._test_instance_groups(
             dict(num_core_instances=3),
-            master=(1, 'm4.large', None),
-            core=(3, 'm4.large', None)
+            master=(1, 'm5.xlarge', None),
+            core=(3, 'm5.xlarge', None)
         )
 
     def test_command_line_beats_instance_fleets_in_config_file(self):
@@ -1347,8 +1347,8 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
 
         self._test_instance_groups(
             dict(num_core_instances=3),
-            master=(1, 'm4.large', None),
-            core=(3, 'm4.large', None)
+            master=(1, 'm5.xlarge', None),
+            core=(3, 'm5.xlarge', None)
         )
 
 

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -576,17 +576,17 @@ class PoolMatchingTestCase(MockBoto3TestCase):
 
     def test_master_alone_requires_big_enough_core_instances(self):
         _, cluster_id = self.make_pooled_cluster(
-            master_instance_type='c1.xlarge',
-            num_core_instances=2)  # core instances are c1.medium
+            master_instance_type='c3.4xlarge',
+            num_core_instances=2)  # core instances are m5.xlarge
 
         self.assertDoesNotJoin(cluster_id, [
             '-r', 'emr', '-v', '--pool-clusters',
-            '--master-instance-type', 'c1.xlarge'])
+            '--master-instance-type', 'c3.4xlarge'])
 
     def test_master_alone_requires_big_enough_master_when_with_core(self):
         _, cluster_id = self.make_pooled_cluster(
             core_instance_type='c1.xlarge',
-            num_core_instances=2)  # master instances are c1.medium
+            num_core_instances=2)  # master instances are m5.xlarge
 
         self.assertDoesNotJoin(cluster_id, [
             '-r', 'emr', '-v', '--pool-clusters',
@@ -766,7 +766,7 @@ class PoolMatchingTestCase(MockBoto3TestCase):
             EbsConfiguration=ebs_config,
             InstanceRole=role,
             InstanceCount=1,
-            InstanceType='m4.large',
+            InstanceType='m5.xlarge',
         )
 
     def test_can_join_cluster_with_same_ebs_config(self):
@@ -1050,7 +1050,7 @@ class PoolMatchingTestCase(MockBoto3TestCase):
         _, cluster_id = self.make_pooled_cluster(
             core_instance_bid_price='0.25',
             task_instance_bid_price='25.00',
-            task_instance_type='c3.2xlarge',
+            task_instance_type='c3.4xlarge',
             num_core_instances=2,
             num_task_instances=3)
 


### PR DESCRIPTION
This allows Spark to work on all AMIs, and works on all regions, even the new ones that don't allow `m4.large`, the previous default. Fixes #2071