### PR TITLE
don't treat --file etc. as canonical in docs and tests

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -137,7 +137,7 @@ options related to file uploading.
 
     On the command line::
 
-        --file file_1.txt --file file_2.sqlite
+        --files file_1.txt,file_2.sqlite
 
     .. versionchanged:: 0.5.7
 

--- a/docs/guides/spark.rst
+++ b/docs/guides/spark.rst
@@ -241,7 +241,7 @@ uploaded via :mrjob-opt:`setup` scripts all should work as expected (except
 on ``local`` masters because there is no working directory).
 
 Note that you can give files a different name in the working directory
-(e.g. ``--file foo#bar``) on all Spark masters, even though Spark treats
+(e.g. ``--files foo#bar``) on all Spark masters, even though Spark treats
 that as a YARN-specific feature.
 
 Archives and directories

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -1178,7 +1178,7 @@ class MRJob(MRJobLauncher):
         (not the script). Note that the job runner will *always* expand
         environment variables and ``~`` in paths returned by this method.
 
-        You do not have to worry about inadvertently disabling ``--archive``;
+        You do not have to worry about inadvertently disabling ``--archives``;
         this switch is handled separately.
 
         .. versionadded:: 0.6.4

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -1210,7 +1210,7 @@ class MRJob(MRJobLauncher):
         (not the script). Note that the job runner will *always* expand
         environment variables and ``~`` in paths returned by this method.
 
-        You do not have to worry about inadvertently disabling ``--file``;
+        You do not have to worry about inadvertently disabling ``--files``;
         this switch is handled separately.
 
         .. versionadded:: 0.6.4

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -1194,7 +1194,7 @@ class MRJob(MRJobLauncher):
         (not the script). Note that the job runner will *always* expand
         environment variables and ``~`` in paths returned by this method.
 
-        You do not have to worry about inadvertently disabling ``--dir``;
+        You do not have to worry about inadvertently disabling ``--dirs``;
         this switch is handled separately.
 
         .. versionadded:: 0.6.4

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -1073,8 +1073,8 @@ class MRJob(MRJobLauncher):
 
         .. versionchanged:: 0.6.6
 
-           re-defining this no longer clobbers command-line
-           ``--libjar`` options.
+           re-defining this no longer clobbers the command-line
+           ``--libjars`` option
         """
         script_dir = os.path.dirname(self.mr_job_script())
 

--- a/mrjob/tools/spark_submit.py
+++ b/mrjob/tools/spark_submit.py
@@ -200,7 +200,7 @@ _DEFAULT_RUNNER = 'spark'  # just find spark-submit and use it
 # for the --help message. Differences:
 #
 # spark_master (--master) is in its own "Spark and Hadoop runners only" group
-# added upload_dirs (--dirs) which is similar to --archive
+# added upload_dirs (--dirs) which is similar to --archives
 #
 # --runner and other basic options are patched into the first ("None")
 # argument group in _make_basic_help_parser(), below

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -266,8 +266,8 @@ class SparkWorkingDirTestCase(MockFilesystemsTestCase):
         # doesn't have a working directory
         job = MRSparkOSWalk(['-r', 'spark',
                              '--spark-master', _LOCAL_CLUSTER_MASTER,
-                             '--file', fish_path + '#ghoti',
-                             '--file', fowl_path])
+                             '--files',
+                             '%s#ghoti,%s' % (fish_path, fowl_path)])
         job.sandbox()
 
         file_sizes = {}
@@ -313,9 +313,9 @@ class SparkWorkingDirTestCase(MockFilesystemsTestCase):
         job = MRSparkOSWalk(['-r', 'spark',
                              '--spark-master', 'mesos://host:9999',
                              '--spark-tmp-dir', 's3://walrus/tmp',
-                             '--file', 's3://walrus/fish#ghoti',
-                             '--file', 's3://walrus/fowl',
-                             '--file', foe_path])
+                             '--files',
+                             ('s3://walrus/fish#ghoti,s3://walrus/fowl,%s' %
+                              foe_path)])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1818,7 +1818,7 @@ class SparkUploadArgsTestCase(MockHadoopTestCase):
         self.log = self.start(patch('mrjob.bin.log'))
 
     def test_no_setup(self):
-        job = MRNullSpark(['-r', 'hadoop', '--file', 'foo'])
+        job = MRNullSpark(['-r', 'hadoop', '--files', 'foo'])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1833,7 +1833,7 @@ class SparkUploadArgsTestCase(MockHadoopTestCase):
         job = MRNullSpark(
             ['-r', 'hadoop',
              '--setup', 'make -f Makefile#',
-             '--file', 'foo',
+             '--files', 'foo',
              ])
         job.sandbox()
 
@@ -1853,7 +1853,7 @@ class SparkUploadArgsTestCase(MockHadoopTestCase):
         job = MRNullSpark(
             ['-r', 'hadoop',
              '--setup', 'make -f Makefile#',
-             '--file', 'foo',
+             '--files', 'foo',
              '--spark-master', 'local[*]',
              ])
         job.sandbox()

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2570,7 +2570,7 @@ class JarStepTestCase(MockBoto3TestCase):
             pass
 
         job = MRJarWithGenericArgs(
-            ['-r', 'emr', '--jar', fake_jar, '--libjar', fake_libjar])
+            ['-r', 'emr', '--jar', fake_jar, '--libjars', fake_libjar])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -5390,7 +5390,7 @@ class BadBashWorkaroundTestCase(MockBoto3TestCase):
         cookie_jar = self.makefile('cookie.jar')
 
         job = MRTwoStepJob(['-r', 'emr', '--image-version', image_version,
-                            '--libjar', cookie_jar])
+                            '--libjars', cookie_jar])
         job.sandbox()
 
         def check_script(path):

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -301,8 +301,8 @@ class InlineRunnerSparkTestCase(SandboxedTestCase, SingleSparkContextTestCase):
         # executors' working directory to match the driver on local master
         job = MRSparkOSWalk(['-r', 'inline',
                              '--use-driver-cwd',
-                             '--file', fish_path + '#ghoti',
-                             '--file', fowl_path])
+                             '--files',
+                             '%s#ghoti,%s' % (fish_path, fowl_path)])
         job.sandbox()
 
         file_sizes = {}

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1750,7 +1750,7 @@ class UploadAttrsTestCase(SandboxedTestCase):
         )
 
     def test_deprecated_archive_dir_file_switches(self):
-        job = MRJob(['--archive', 'stuff.zip',
+        job = MRJob(['--archives', 'stuff.zip',
                      '--dir', 'foo',
                      '--files', 'foo/bar.txt'])
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1751,7 +1751,7 @@ class UploadAttrsTestCase(SandboxedTestCase):
 
     def test_deprecated_archive_dir_file_switches(self):
         job = MRJob(['--archives', 'stuff.zip',
-                     '--dir', 'foo',
+                     '--dirs', 'foo',
                      '--files', 'foo/bar.txt'])
 
         self.assertEqual(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1752,7 +1752,7 @@ class UploadAttrsTestCase(SandboxedTestCase):
     def test_deprecated_archive_dir_file_switches(self):
         job = MRJob(['--archive', 'stuff.zip',
                      '--dir', 'foo',
-                     '--file', 'foo/bar.txt'])
+                     '--files', 'foo/bar.txt'])
 
         self.assertEqual(
             job._runner_kwargs()['upload_archives'], ['stuff.zip'])

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1750,9 +1750,9 @@ class UploadAttrsTestCase(SandboxedTestCase):
         )
 
     def test_deprecated_archive_dir_file_switches(self):
-        job = MRJob(['--archives', 'stuff.zip',
-                     '--dirs', 'foo',
-                     '--files', 'foo/bar.txt'])
+        job = MRJob(['--archive', 'stuff.zip',
+                     '--dir', 'foo',
+                     '--file', 'foo/bar.txt'])
 
         self.assertEqual(
             job._runner_kwargs()['upload_archives'], ['stuff.zip'])

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1152,8 +1152,8 @@ class LocalRunnerSparkTestCase(SandboxedTestCase):
         fowl_path = self.makefile('fowl', b'goose')
 
         job = MRSparkOSWalk(['-r', 'local',
-                             '--file', fish_path + '#ghoti',
-                             '--file', fowl_path])
+                             '--files',
+                             '%s#ghoti,%s' % (fish_path, fowl_path)])
         job.sandbox()
 
         file_sizes = {}


### PR DESCRIPTION
We moved over to `--files`, `--archives`, etc. in v0.6.7, but didn't update all of the docs or relevant tests. Fixes #2057