### PR TITLE
add --skip-internal-protocol to Spark runner

### DIFF
--- a/docs/guides/spark-runner-opts.rst
+++ b/docs/guides/spark-runner-opts.rst
@@ -62,6 +62,30 @@ Options unique to the Spark runner:
     (not GCS)
 
 .. mrjob-opt::
+    :config: skip_internal_protocol
+    :switch: --skip-internal-protocol, --no-skip-internal-protocol
+    :type: boolean
+    :set: spark
+    :default: ``False``
+
+    Don't emulate the job's internal protocol (used for communicating between
+    job steps and tasks in the same step), instead relying on Spark to encode
+    and decode data structures.
+
+    This should work for most but not all jobs, and make them run at least
+    somewhat faster. Some things to keep in mind:
+
+    * data will no longer be "normalized" by being converted to and from string
+      representation. For example, running a tuple through
+      :py:class:`~mrjob.protocol.JSONProtocol` (the default) implicitly
+      converts it to a list because there are no tuples in JSON. With internal
+      protocols skipped, it would remain a tuple.
+    * if your job uses :py:attr:`~mrjob.job.MRJob.SORT_VALUES`, keep in mind
+      that your values will need to be comparable as Spark will be comparing
+      them directly, rather than comparing their internal-protocol-encoded
+      representation. This may also affect sorting order.
+
+.. mrjob-opt::
     :config: spark_tmp_dir
     :switch: --spark-tmp-dir
     :type: :ref:`string <data-type-string>`

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1197,6 +1197,20 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    skip_internal_protocol=dict(
+        switches=[
+            (['--skip-internal-protocol'], dict(
+                action='store_true',
+                help=("Don't use the job's internal protocol to communicate"
+                      " between tasks internal to the job, instead relying"
+                      " on Spark to encode and decode raw data structures.")
+            )),
+            (['--no-skip-internal-protocol'], dict(
+                action='store_false',
+                help='Use internal protocols as usual',
+            )),
+        ],
+    ),
     sort_bin=dict(
         combiner=combine_cmds,
         switches=[

--- a/mrjob/spark/harness.py
+++ b/mrjob/spark/harness.py
@@ -610,10 +610,18 @@ def _make_arg_parser():
         '--emulate-map-input-file',
         dest='emulate_map_input_file',
         action='store_true',
-        help=('set mapreduce_map_input_file to the input file path'
+        help=('Set mapreduce_map_input_file to the input file path'
               ' in the first mapper function, so we can read it'
               ' with mrjob.compat.jobconf_from_env(). Ignored if'
               ' job has a Hadoop input format'),
+    )
+    parser.add_argument(
+        '--skip-internal-protocol',
+        dest='skip_internal_protocol',
+        action='store_true',
+        help=("Don't use the job's internal protocol to communicate"
+              " between tasks internal to the job, instead relying"
+              " on Spark to encode and decode raw data structures.")
     )
 
     for args, kwargs in _PASSTHRU_OPTIONS:

--- a/mrjob/spark/runner.py
+++ b/mrjob/spark/runner.py
@@ -82,6 +82,7 @@ class SparkMRJobRunner(MRJobBinRunner):
         'project_id',  # used by GCS filesystem
         's3_endpoint',
         's3_region',  # used when creating buckets on S3
+        'skip_internal_protocol',
         'spark_deploy_mode',
         'spark_master',
         'spark_tmp_dir',  # where to put temp files in Spark
@@ -458,8 +459,13 @@ class SparkMRJobRunner(MRJobBinRunner):
             args.extend(['--max-output-files',
                          str(self._max_output_files)])
 
+        # --emulate-map-input-file
         if self._opts['emulate_map_input_file']:
             args.append('--emulate-map-input-file')
+
+        # --skip_internal-protocol
+        if self._opts['skip_internal_protocol']:
+            args.append('--skip-internal-protocol')
 
         return args
 

--- a/tests/mr_sort_and_group_reversed_text.py
+++ b/tests/mr_sort_and_group_reversed_text.py
@@ -1,0 +1,50 @@
+# Copyright 2016 Yelp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""For each key, return a sorted list of values corresponding to that key."""
+from mrjob.job import MRJob
+from mrjob.protocol import TextProtocol
+
+
+def _rev(s):
+    return ''.join(reversed(s))
+
+
+class ReversedTextProtocol(TextProtocol):
+    """Like TextProtocol, but stores text backwards."""
+
+    def read(self, line):
+        key, value = super(ReversedTextProtocol, self).read(line)
+
+        return _rev(key), _rev(value)
+
+    def write(self, key, value):
+        return super(ReversedTextProtocol, self).write(
+            _rev(key), _rev(value))
+
+
+class MRSortAndGroupReversedText(MRJob):
+
+    INTERNAL_PROTOCOL = ReversedTextProtocol
+    SORT_VALUES = True
+
+    def mapper(self, _, line):
+        line = line.rstrip()
+        yield line[:1], line
+
+    def reducer(self, key, values):
+        yield key, list(values)
+
+
+if __name__ == '__main__':
+    MRSortAndGroupReversedText.run()

--- a/tests/mr_spark_harness.py
+++ b/tests/mr_spark_harness.py
@@ -22,8 +22,11 @@ from mrjob.spark.harness import main as harness_main
 _PASSTHRU_OPTION_STRINGS = {
     arg for args, kwargs in _PASSTHRU_OPTIONS for arg in args}
 # handled separately because these are also runner options
-_PASSTHRU_OPTION_STRINGS.update(
-    {'--max-output-files', '--emulate-map-input-file'})
+_PASSTHRU_OPTION_STRINGS.update({
+    '--emulate-map-input-file',
+    '--max-output-files',
+    '--skip-internal-protocol',
+})
 
 
 class MRSparkHarness(MRJob):
@@ -41,8 +44,9 @@ class MRSparkHarness(MRJob):
             self.add_passthru_arg(*args, **kwargs)
 
         # these are both runner and harness switches
-        self.pass_arg_through('--max-output-files')
         self.pass_arg_through('--emulate-map-input-file')
+        self.pass_arg_through('--max-output-files')
+        self.pass_arg_through('--skip-internal-protocol')
 
     def spark(self, input_path, output_path):
         harness_args = [

--- a/tests/spark/test_harness.py
+++ b/tests/spark/test_harness.py
@@ -45,6 +45,7 @@ from tests.mr_no_mapper import MRNoMapper
 from tests.mr_pass_thru_arg_test import MRPassThruArgTest
 from tests.mr_streaming_and_spark import MRStreamingAndSpark
 from tests.mr_sort_and_group import MRSortAndGroup
+from tests.mr_sort_and_group_reversed_text import MRSortAndGroupReversedText
 from tests.mr_spark_harness import MRSparkHarness
 from tests.mr_two_step_job import MRTwoStepJob
 from tests.mr_word_freq_count_with_combiner_cmd import \
@@ -52,28 +53,6 @@ from tests.mr_word_freq_count_with_combiner_cmd import \
 from tests.py2 import Mock
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import SingleSparkContextTestCase
-
-
-def _rev(s):
-    return ''.join(reversed(s))
-
-
-class ReversedTextProtocol(TextProtocol):
-    """Like TextProtocol, but stores text backwards."""
-
-    def read(self, line):
-        key, value = super(ReversedTextProtocol, self).read(line)
-
-        return _rev(key), _rev(value)
-
-    def write(self, key, value):
-        return super(ReversedTextProtocol, self).write(
-            _rev(key), _rev(value))
-
-
-class MRSortAndGroupReversedText(MRSortAndGroup):
-
-    INTERNAL_PROTOCOL = ReversedTextProtocol
 
 
 class MRWordFreqCountCombinerYieldsTwo(MRWordFreqCount):


### PR DESCRIPTION
This gives the Spark runner the ability to disable internal protocols and leave encoding and decoding data between job tasks and steps up to Spark. This should make any job run faster, but could break jobs that rely implicitly on the internal protocol in some way, so it's not enabled by default. Fixes #1952.