### PR TITLE
MRJobs take intermixed input file args in Python 3.7+

### DIFF
--- a/mrjob/launch.py
+++ b/mrjob/launch.py
@@ -311,7 +311,11 @@ class MRJobLauncher(object):
                 self.stop_words = self.options.stop_words.split(',')
                 ...
         """
-        self.options = self.arg_parser.parse_args(args)
+        if hasattr(self.arg_parser, 'parse_intermixed_args'):
+            # restore old optparse behavior on Python 3.7+. See #1701
+            self.options = self.arg_parser.parse_intermixed_args(args)
+        else:
+            self.options = self.arg_parser.parse_args(args)
 
         if self.options.help:
             self._print_help(self.options)


### PR DESCRIPTION
This uses `parse_intermixed_args()` to restore option-parsing behavior that went away when we switched from `optparse` to `argparse`. Only works in versions of Python that have `parse_intermixed_args()` (which is to say, Python 3.7 and later). Fixes #1701