### PR TITLE
Re-enable Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ mrjob: the Python MapReduce library
 
 .. image:: https://github.com/Yelp/mrjob/raw/master/docs/logos/logo_medium.png
 
-mrjob is a Python 2.7/3.5+ package that helps you write and run Hadoop
+mrjob is a Python 2.7/3.4+ package that helps you write and run Hadoop
 Streaming jobs.
 
 `Stable version (v0.6.10) documentation <http://mrjob.readthedocs.org/en/stable/>`_

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,6 @@ try:
             'boto3>=1.4.6',
             'botocore>=1.6.0',
             'PyYAML>=3.10',
-            'google-cloud-dataproc>=0.3.0',
-            'google-cloud-logging>=1.9.0',
-            'google-cloud-storage>=1.13.1',
         ],
         'provides': ['mrjob'],
         'test_suite': 'tests',
@@ -45,9 +42,19 @@ try:
         'zip_safe': False,  # so that we can bootstrap mrjob
     }
 
-    # grpcio 1.11.0 and 1.12.0 seem not to compile with PyPy
-    if hasattr(sys, 'pypy_version_info'):
-        setuptools_kwargs['install_requires'].append('grpcio<=1.10.0')
+    # Google libs don't install on Python 3.4. Which is fine, the only
+    # reason we support Python 3.4 at all is to support earlier
+    # AMIs on EMR. See #2090
+    if sys.version_info[0] == 2 or sys.version_info >= (3, 5):
+        setuptools_kwargs['install_requires'].extend([
+            'google-cloud-dataproc>=0.3.0',
+            'google-cloud-logging>=1.9.0',
+            'google-cloud-storage>=1.13.1',
+        ])
+
+        # grpcio 1.11.0 and 1.12.0 seem not to compile with PyPy
+        if hasattr(sys, 'pypy_version_info'):
+            setuptools_kwargs['install_requires'].append('grpcio<=1.10.0')
 
     # rapidjson exists on Python 3 only
     if sys.version_info >= (3, 0):
@@ -71,6 +78,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -15,7 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import bz2
+import syst
 from hashlib import md5
+from unittest import SkipTest
+
+if sys.version_info[:2] == (3, 4):
+    raise SkipTest('Google libraries are not supported on Python 3.4')
 
 from mrjob.fs.gcs import GCSFilesystem
 from mrjob.fs.gcs import _CAT_CHUNK_SIZE

--- a/tests/fs/test_gcs.py
+++ b/tests/fs/test_gcs.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import bz2
-import syst
+import sys
 from hashlib import md5
 from unittest import SkipTest
 

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -66,15 +66,14 @@ from tests.test_bin import _LOCAL_CLUSTER_MASTER
 
 # Google libs don't work in Python 3.4. The tests don't actually use
 # Google Cloud Storage, just mocking out Google out of an abundance of caution
-if sys.version_info[:2] != (3, 4):
-    from tests.mock_google import MockGoogleTestCase
+if sys.version_info[:2] == (3, 4):
+    class MockFilesystemsTestCase(MockBoto3TestCase, MockHadoopTestCase):
+        pass
 else:
-    MockGoogleTestCase = object
-
-
-class MockFilesystemsTestCase(
-        MockBoto3TestCase, MockGoogleTestCase, MockHadoopTestCase):
-    pass
+    from tests.mock_google import MockGoogleTestCase
+    class MockFilesystemsTestCase(
+            MockBoto3TestCase, MockGoogleTestCase, MockHadoopTestCase):
+        pass
 
 
 class SparkTmpDirTestCase(MockFilesystemsTestCase):

--- a/tests/spark/test_runner.py
+++ b/tests/spark/test_runner.py
@@ -18,6 +18,7 @@ from os import listdir
 from os.path import exists
 from os.path import join
 from unittest import skipIf
+import sys
 
 try:
     import pyspark
@@ -43,7 +44,6 @@ from mrjob.util import safeeval
 from mrjob.util import to_lines
 
 from tests.mock_boto3 import MockBoto3TestCase
-from tests.mock_google import MockGoogleTestCase
 from tests.mockhadoop import MockHadoopTestCase
 from tests.mr_count_lines_by_filename import MRCountLinesByFilename
 from tests.mr_doubler import MRDoubler
@@ -63,6 +63,13 @@ from tests.py2 import patch
 from tests.sandbox import SandboxedTestCase
 from tests.sandbox import mrjob_conf_patcher
 from tests.test_bin import _LOCAL_CLUSTER_MASTER
+
+# Google libs don't work in Python 3.4. The tests don't actually use
+# Google Cloud Storage, just mocking out Google out of an abundance of caution
+if sys.version_info[:2] != (3, 4):
+    from tests.mock_google import MockGoogleTestCase
+else:
+    MockGoogleTestCase = object
 
 
 class MockFilesystemsTestCase(

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1106,10 +1106,6 @@ class SparkSubmitArgsTestCase(SandboxedTestCase):
         self.start(patch('mrjob.bin.MRJobBinRunner._bootstrap_mrjob',
                          return_value=False))
 
-    def _expected_conf_args(self, cmdenv=None, jobconf=None, yarn=False):
-        from unittest import SkipTest
-        raise SkipTest
-
     def test_default(self):
         job = MRNullSpark(['-r', 'spark'])
         job.sandbox()

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -18,10 +18,15 @@
 import getpass
 import os
 import os.path
+import sys
 from contextlib import contextmanager
 from copy import deepcopy
 from io import BytesIO
 from subprocess import PIPE
+from unittest import SkipTest
+
+if sys.version_info[:2] == (3, 4):
+    raise SkipTest('Google libraries are not supported on Python 3.4')
 
 from google.api_core.exceptions import InvalidArgument
 from google.api_core.exceptions import NotFound


### PR DESCRIPTION
This adds back official support for Python 3.4, so we can be sure that mrjob works on EMR AMIs that use Python 3.4. Fixes #2090.

There is not support for Google libraries or services in Python 3.4, as the recent Google libraries don't seem to support it. Python 3.4 has reached end-of-life earlier this year, so that shouldn't be much of a barrier to using mrjob with Google Cloud and Python 3.

