### PR TITLE
override earlier emr_configurations

### DIFF
--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -345,6 +345,14 @@ See also :mrjob-opt:`bootstrap`, :mrjob-opt:`image_id`, and
 
     .. versionadded:: 0.5.3
 
+    .. versionchanged:: 0.6.11
+
+       ``!clear`` tag works. Later config dicts will overwrite earlier ones
+       with the same ``Classification``. If the later dict has empty
+       ``Properties`` and ``Configurations``, the earlier dict will be simply
+       deleted.
+
+
 .. mrjob-opt::
     :config: release_label
     :switch: --release-label

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2983,6 +2983,17 @@ def _get_reason(cluster_or_step):
     return cluster_or_step['Status']['StateChangeReason'].get('Message', '')
 
 
+def _combine_emr_configurations(*confs):
+    """Combine zero or more EMR configurations, which are lists
+    of dicts with the key ``Classification`` and optionally ``Properties``
+    and ``Configurations`` (a sub-list with the same properties).
+    Configurations may also be a :py:class:`~mrjob.conf.ClearedValue`
+    wrapping said type of list.
+    """
+    # TODO: start here
+    pass
+
+
 def _fix_configuration_opt(c):
     """Return copy of *c* with *Properties* is always set
     (defaults to {}) and with *Configurations* is not set if empty.

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -128,10 +128,7 @@ class EmptyMrjobConfTestCase(BasicTestCase):
         super(EmptyMrjobConfTestCase, self).setUp()
 
         if self.MRJOB_CONF_CONTENTS is not None:
-            self.mrjob_conf_patcher = mrjob_conf_patcher(
-                self.MRJOB_CONF_CONTENTS)
-            self.mrjob_conf_patcher.start()
-            self.addCleanup(self.mrjob_conf_patcher.stop)
+            self.start(mrjob_conf_patcher(self.MRJOB_CONF_CONTENTS))
 
 
 class SandboxedTestCase(EmptyMrjobConfTestCase):

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -502,8 +502,10 @@ class GCEClusterConfigTestCase(MockGoogleTestCase):
 
 class ClusterPropertiesTestCase(MockGoogleTestCase):
 
+    MRJOB_CONF_CONTENTS = None
+
     def _get_cluster_properties(self, *args):
-        job = MRWordCount(['-r', 'dataproc'] + list(args))
+        job = MRWordCount(['--no-conf', '-r', 'dataproc'] + list(args))
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -534,9 +536,7 @@ class ClusterPropertiesTestCase(MockGoogleTestCase):
             b"      'dataproc:dataproc.allow.zero.workers': true\n"
             b"      'hdfs:dfs.namenode.handler.count': 40\n")
 
-        self.mrjob_conf_patcher.stop()
         props = self._get_cluster_properties('-c', conf_path)
-        self.mrjob_conf_patcher.start()
 
         self.assertEqual(props['dataproc:dataproc.allow.zero.workers'], 'true')
         self.assertEqual(props['hdfs:dfs.namenode.handler.count'], '40')
@@ -2261,8 +2261,10 @@ class HadoopStreamingJarTestCase(MockGoogleTestCase):
 
 class NetworkAndSubnetworkTestCase(MockGoogleTestCase):
 
+    MRJOB_CONF_CONTENTS = None
+
     def _get_project_id_and_gce_config(self, *args):
-        job = MRWordCount(['-r', 'dataproc'] + list(args))
+        job = MRWordCount(['--no-conf', '-r', 'dataproc'] + list(args))
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -2349,10 +2351,8 @@ class NetworkAndSubnetworkTestCase(MockGoogleTestCase):
             'mrjob.conf',
             b'runners:\n  dataproc:\n    subnet: default')
 
-        self.mrjob_conf_patcher.stop()
         project_id, gce_config = self._get_project_id_and_gce_config(
             '-c', conf_path, '--network', 'test')
-        self.mrjob_conf_patcher.start()
 
         self.assertEqual(
             gce_config.network_uri,
@@ -2365,10 +2365,8 @@ class NetworkAndSubnetworkTestCase(MockGoogleTestCase):
             'mrjob.conf',
             b'runners:\n  dataproc:\n    network: default')
 
-        self.mrjob_conf_patcher.stop()
         project_id, gce_config = self._get_project_id_and_gce_config(
             '-c', conf_path, '--subnet', 'test')
-        self.mrjob_conf_patcher.start()
 
         self.assertEqual(
             gce_config.subnetwork_uri,

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4206,6 +4206,9 @@ class EMRApplicationsTestCase(MockBoto3TestCase):
 
 class EMRConfigurationsTestCase(MockBoto3TestCase):
 
+    # don't patch load_opts_from_mrjob_confs()
+    MRJOB_CONF_CONTENTS = None
+
     # example from:
     # http://docs.aws.amazon.com/ElasticMapReduce/latest/ReleaseGuide/emr-configure-apps.html  # noqa
 


### PR DESCRIPTION
This fixes a couple of bugs with the `emr_configurations` option. You can now override an earlier config with the same `Classification` (used to send both configs to EMR, causing an error). You may also simply clear out any existing configs with the `!clear` tag (which used to cause a crash).

Fixes #2097.