### PR TITLE
restore m4.large for pre-5.13.0 AMIs, bump default AMI version

### DIFF
--- a/docs/guides/cloud-opts.rst
+++ b/docs/guides/cloud-opts.rst
@@ -269,7 +269,7 @@ Cluster software configuration
     :switch: --image-version
     :type: :ref:`string <data-type-string>`
     :set: cloud
-    :default: ``'5.8.0'`` on EMR, ``'1.0'`` on Dataproc
+    :default: ``'5.27.0'`` on EMR, ``'1.0'`` on Dataproc
 
     Machine image version to use. This controls which Hadoop
     version(s) are available and which version of Python is installed, among
@@ -287,9 +287,21 @@ Cluster software configuration
     You can use this instead of :mrjob-opt:`release_label` on EMR, even for
     4.x+ AMIs; mrjob will just prepend ``emr-`` to form the release label.
 
+    .. versionchanged:: 0.6.11
+
+       Default on EMR is now ``5.27.0``
+
+    .. versionchanged:: 0.6.5
+
+       Default on EMR is now ``5.16.0``
+
+    .. versionchanged:: 0.6.0
+
+       Default on EMR is now ``5.8.0``
+
     .. versionchanged:: 0.5.7
 
-       Default on EMR used to be ``'3.11.0'``.
+       Default on EMR is now ``4.8.2`` (used to be ``'3.11.0'``).
 
     .. versionchanged:: 0.5.4
 

--- a/docs/guides/cloud-opts.rst
+++ b/docs/guides/cloud-opts.rst
@@ -101,7 +101,7 @@ Number and type of instances
     :switch: --instance-type
     :type: :ref:`string <data-type-string>`
     :set: cloud
-    :default: ``m5.xlarge`` on EMR, ``n1-standard-1`` on Dataproc
+    :default: ``m4.large`` or ``m5.xlarge`` on EMR, ``n1-standard-1`` on Dataproc
 
     Type of instance that runs your Hadoop tasks.
 
@@ -120,6 +120,10 @@ Number and type of instances
     this option *doesn't* apply to the master node because it's just
     coordinating tasks, not running them. Use :mrjob-opt:`master_instance_type`
     instead.
+
+    .. versionchanged:: 0.6.11
+
+       Default on EMR is ``m5.xlarge`` on AMI version 5.13.0 and later, ``m4.large`` on earlier versions
 
     .. versionchanged:: 0.6.10
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -193,10 +193,6 @@ _MIN_SPARK_PY3_AMI_VERSION = '4.0.0'
 # 5 minutes plus time to copy the logs, or something like that.
 _S3_LOG_WAIT_MINUTES = 10
 
-# a relatively cheap instance type that's available on all regions
-# and is big enough to support Spark. See #2071.
-_DEFAULT_INSTANCE_TYPE = 'm5.xlarge'
-
 # minimum amount of memory to run spark jobs
 #
 # it's possible that we could get by with slightly less memory, but
@@ -1027,9 +1023,18 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             # using *instance_type* here is defensive programming;
             # if set, it should have already been popped into the worker
             # instance type option(s) by _fix_instance_opts() above
-            return self._opts['instance_type'] or 'm5.xlarge'
+            return self._opts['instance_type'] or self._default_instance_type()
         else:
+            return self._default_instance_type()
+
+    def _default_instance_type(self):
+        """Default instance type if not set by the user."""
+        # m5.xlarge is available on all regions, but only works in AMI 5.13.0
+        # or later. See #2098.
+        if self._image_version_gte('5.13.0'):
             return 'm5.xlarge'
+        else:
+            return 'm4.large'
 
     def _instance_is_worker(self, role):
         """Do instances of the given role run tasks? True for non-master

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -156,7 +156,7 @@ _MAX_MINS_IDLE_BOOTSTRAP_ACTION_PATH = os.path.join(
 _DEFAULT_EMR_REGION = 'us-west-2'
 
 # default AMI to use on EMR. This may be updated with each version
-_DEFAULT_IMAGE_VERSION = '5.16.0'
+_DEFAULT_IMAGE_VERSION = '5.27.0'
 
 # first AMI version that we can't run bash -e on (see #1548)
 _BAD_BASH_IMAGE_VERSION = '5.2.0'

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1049,26 +1049,26 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
         # used to default to m1.small on 2.x AMIs (see #1932)
         self._test_instance_groups(
             dict(image_version='2.4.11'),
-            master=(1, 'm5.xlarge', None))
+            master=(1, 'm4.large', None))
 
     def test_2_x_ami_defaults_multiple_nodes(self):
         # used to default to m1.small on 2.x AMIs (see #1932)
         self._test_instance_groups(
             dict(image_version='2.4.11', num_core_instances=2),
-            core=(2, 'm5.xlarge', None),
-            master=(1, 'm5.xlarge', None))
+            core=(2, 'm4.large', None),
+            master=(1, 'm4.large', None))
 
     def test_release_label_hides_image_version(self):
         self._test_instance_groups(
             dict(release_label='emr-4.0.0', image_version='2.4.11'),
-            master=(1, 'm5.xlarge', None))
+            master=(1, 'm4.large', None))
 
     def test_spark_defaults_single_node(self):
         # when the default instance type was m1.medium, Spark needed
         # m1.large to run tasks, so we needed a separate test. See #1932
         self._test_instance_groups(
             dict(image_version='4.0.0', applications=['Spark']),
-            master=(1, 'm5.xlarge', None))
+            master=(1, 'm4.large', None))
 
     def test_spark_defaults_multiple_nodes(self):
         # This used to test whether we could get away with a smaller
@@ -1077,8 +1077,8 @@ class InstanceGroupAndFleetTestCase(MockBoto3TestCase):
             dict(image_version='4.0.0',
                  applications=['Spark'],
                  num_core_instances=2),
-            core=(2, 'm5.xlarge', None),
-            master=(1, 'm5.xlarge', None))
+            core=(2, 'm4.large', None),
+            master=(1, 'm4.large', None))
 
     def test_explicit_instance_types_take_precedence(self):
         self._test_instance_groups(


### PR DESCRIPTION
In v0.6.10, we bumped the default instance type on EMR to ``m5.xlarge``. However, it turns out that only AMIs 5.13.0 and newer support this instance type. This change restores ``m4.large`` for earlier instance types. Fixes #2098 

This also bumps the default AMI to 5.27.0 (fixes #2105).