### PR TITLE
bump default image on Dataproc to 1.3

### DIFF
--- a/mrjob/dataproc.py
+++ b/mrjob/dataproc.py
@@ -68,7 +68,7 @@ _DEFAULT_INSTANCE_TYPE = 'n1-standard-1'
 
 # default imageVersion to use on Dataproc. This may be updated with each
 # version of mrjob
-_DEFAULT_IMAGE_VERSION = '1.0'
+_DEFAULT_IMAGE_VERSION = '1.3'
 _DEFAULT_CHECK_CLUSTER_EVERY = 10.0
 _DEFAULT_CLOUD_FS_SYNC_SECS = 5.0
 _DEFAULT_CLOUD_TMP_DIR_OBJECT_TTL_DAYS = 90
@@ -87,7 +87,10 @@ _STATE_MATCHER_ACTIVE = 1
 # for the full list.
 _DATAPROC_IMAGE_TO_HADOOP_VERSION = {
     '0.1': '2.7.1',
-    '1.0': '2.7.2'
+    '1.0': '2.7.2',
+    '1.1': '2.7.7',
+    '1.2': '2.8.5',
+    '1.3': '2.9.2',
 }
 
 _HADOOP_STREAMING_JAR_URI = (

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -388,7 +388,7 @@ class CloudAndHadoopVersionTestCase(MockGoogleTestCase):
             runner.run()
             self.assertEqual(runner.get_image_version(),
                              _DEFAULT_IMAGE_VERSION)
-            self.assertEqual(runner.get_hadoop_version(), '2.7.2')
+            self.assertEqual(runner.get_hadoop_version(), '2.9.2')
 
     def test_image_0_1(self):
         self._assert_cloud_hadoop_version('0.1', '2.7.1')
@@ -403,8 +403,12 @@ class CloudAndHadoopVersionTestCase(MockGoogleTestCase):
         # regression test for #1428
         self._assert_cloud_hadoop_version('1.0.11', '2.7.2')
 
+    def test_image_1_2(self):
+        # regression test for #1428
+        self._assert_cloud_hadoop_version('1.2', '2.8.5')
+
     def test_future_proofing(self):
-        self._assert_cloud_hadoop_version('5.0', '2.7.2')
+        self._assert_cloud_hadoop_version('5.0', '2.9.2')
 
     def _assert_cloud_hadoop_version(self, image_version, hadoop_version):
         with self.make_runner('--image-version', image_version) as runner:
@@ -417,7 +421,7 @@ class CloudAndHadoopVersionTestCase(MockGoogleTestCase):
             runner.run()
             self.assertEqual(runner.get_image_version(),
                              _DEFAULT_IMAGE_VERSION)
-            self.assertEqual(runner.get_hadoop_version(), '2.7.2')
+            self.assertEqual(runner.get_hadoop_version(), '2.9.2')
 
 
 class AvailabilityZoneConfigTestCase(MockGoogleTestCase):


### PR DESCRIPTION
Bump the default image on Google Cloud Dataproc from 1.0 (which is no longer supported) to 1.3. Fixes #2110.

Note that the latest image version is 1.4; however, there is an issue with bootstrapping mrjob on the 1.4 images, see #2111.