### PR TITLE
make fs method args consistent

### DIFF
--- a/mrjob/fs/base.py
+++ b/mrjob/fs/base.py
@@ -145,6 +145,6 @@ class Filesystem(object):
         """
         raise NotImplementedError
 
-    def md5sum(self, path_glob):
-        """Generate the md5 sum of the file at ``path``"""
+    def md5sum(self, path):
+        """Generate the md5 sum of the file at *path*"""
         raise NotImplementedError

--- a/mrjob/fs/composite.py
+++ b/mrjob/fs/composite.py
@@ -156,5 +156,5 @@ class CompositeFilesystem(Filesystem):
     def touchz(self, path):
         return self._do('touchz', path)
 
-    def md5sum(self, path_glob):
-        return self._do('md5sum', path_glob)
+    def md5sum(self, path):
+        return self._do('md5sum', path)

--- a/mrjob/fs/hadoop.py
+++ b/mrjob/fs/hadoop.py
@@ -261,14 +261,14 @@ class HadoopFilesystem(Filesystem):
             else:
                 yield hdfs_prefix + path
 
-    def _cat_file(self, filename):
+    def _cat_file(self, path):
         # stream from HDFS
-        cat_args = self.get_hadoop_bin() + ['fs', '-cat', filename]
+        cat_args = self.get_hadoop_bin() + ['fs', '-cat', path]
         log.debug('> %s' % cmd_line(cat_args))
 
         cat_proc = Popen(cat_args, stdout=PIPE, stderr=PIPE)
 
-        for chunk in decompress(cat_proc.stdout, filename):
+        for chunk in decompress(cat_proc.stdout, path):
             yield chunk
 
         # this does someties happen; see #1396
@@ -281,7 +281,7 @@ class HadoopFilesystem(Filesystem):
         returncode = cat_proc.wait()
 
         if returncode != 0:
-            raise IOError("Could not stream %s" % filename)
+            raise IOError("Could not stream %s" % path)
 
     def mkdir(self, path):
         version = self.get_hadoop_version()
@@ -337,8 +337,8 @@ class HadoopFilesystem(Filesystem):
         except CalledProcessError:
             raise IOError("Could not rm %s" % path_glob)
 
-    def touchz(self, dest):
+    def touchz(self, path):
         try:
-            self.invoke_hadoop(['fs', '-touchz', dest])
+            self.invoke_hadoop(['fs', '-touchz', path])
         except CalledProcessError:
-            raise IOError("Could not touchz %s" % dest)
+            raise IOError("Could not touchz %s" % path)

--- a/mrjob/fs/local.py
+++ b/mrjob/fs/local.py
@@ -49,10 +49,10 @@ class LocalFilesystem(Filesystem):
             else:
                 yield uri_scheme + path
 
-    def _cat_file(self, filename):
-        filename = _from_file_uri(filename)
-        with open(filename, 'rb') as f:
-            for chunk in decompress(f, filename):
+    def _cat_file(self, path):
+        path = _from_file_uri(path)
+        with open(path, 'rb') as f:
+            for chunk in decompress(f, path):
                 yield chunk
 
     def exists(self, path_glob):

--- a/mrjob/fs/s3.py
+++ b/mrjob/fs/s3.py
@@ -168,12 +168,12 @@ class S3Filesystem(Filesystem):
             raise IOError('Key %r does not exist' % (path,))
         return k.e_tag.strip('"')
 
-    def _cat_file(self, filename):
+    def _cat_file(self, path):
         # stream lines from the s3 key
-        s3_key = self._get_s3_key(filename)
+        s3_key = self._get_s3_key(path)
         body = s3_key.get()['Body']
 
-        return decompress(body, filename)
+        return decompress(body, path)
 
     def exists(self, path_glob):
         """Does the given path exist?
@@ -184,12 +184,12 @@ class S3Filesystem(Filesystem):
         # just fall back on _ls(); it's smart
         return any(self._ls(path_glob))
 
-    def mkdir(self, dest):
+    def mkdir(self, path):
         """Make a directory. This doesn't actually create directories on S3
         (because there is no such thing), but it will create the corresponding
         bucket if it doesn't exist.
         """
-        bucket_name, key_name = parse_s3_uri(dest)
+        bucket_name, key_name = parse_s3_uri(path)
 
         client = self.make_s3_client()
 
@@ -222,10 +222,10 @@ class S3Filesystem(Filesystem):
             log.debug('deleting ' + uri)
             key.delete()
 
-    def touchz(self, dest):
+    def touchz(self, path):
         """Make an empty file in the given location. Raises an error if
         a non-empty file already exists in that location."""
-        key = self._get_s3_key(dest)
+        key = self._get_s3_key(path)
 
         data = None
         try:
@@ -236,7 +236,7 @@ class S3Filesystem(Filesystem):
                 raise
 
         if data and data['ContentLength'] != 0:
-            raise OSError('Non-empty file %r already exists!' % (dest,))
+            raise OSError('Non-empty file %r already exists!' % (path,))
 
         key.put(Body=b'')
 

--- a/mrjob/fs/ssh.py
+++ b/mrjob/fs/ssh.py
@@ -179,8 +179,8 @@ class SSHFilesystem(Filesystem):
     def du(self, path_glob):
         raise IOError()  # not implemented
 
-    def ls(self, uri_glob):
-        m = _SSH_URI_RE.match(uri_glob)
+    def ls(self, path_glob):
+        m = _SSH_URI_RE.match(path_glob)
         addr = m.group('hostname')
         path_to_ls = m.group('filesystem_path')
 
@@ -196,19 +196,19 @@ class SSHFilesystem(Filesystem):
     def md5sum(self, path):
         raise IOError()  # not implemented
 
-    def _cat_file(self, filename):
-        m = _SSH_URI_RE.match(filename)
+    def _cat_file(self, path):
+        m = _SSH_URI_RE.match(path)
         addr = m.group('hostname')
-        path = m.group('filesystem_path')
+        fs_path = m.group('filesystem_path')
 
-        p = self._ssh_launch(addr, ['cat', path])
+        p = self._ssh_launch(addr, ['cat', fs_path])
 
-        for chunk in decompress(p.stdout, path):
+        for chunk in decompress(p.stdout, fs_path):
             yield chunk
 
         self._ssh_finish_run(p)
 
-    def mkdir(self, dest):
+    def mkdir(self, path):
         raise IOError()  # not implemented
 
     def exists(self, path_glob):
@@ -221,7 +221,7 @@ class SSHFilesystem(Filesystem):
     def rm(self, path_glob):
         raise IOError()  # not implemented
 
-    def touchz(self, dest):
+    def touchz(self, path):
         raise IOError()  # not implemented
 
     def use_sudo_over_ssh(self, sudo=True):


### PR DESCRIPTION
Args to FS method names were an inconsistent mess. Now that we're in a new series of versions (v0.7), we can rename them!

Fixes #1979