### PR TITLE
move google and aws deps to extras_require

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - "pip install -e .[aws]"
   - "pip install -e .[google]"
   - "pip install simplejson ujson warcio"
-  - "pip install rapidjson || true"
+  - "pip install python-rapidjson || true"
   - "pip install pyspark || true"
   - "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"
   - "export PATH=$JAVA_HOME/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
   - "pip install -e .[aws]"
   - "pip install -e .[google]"
-  - "pip install ujson warcio"
+  - "pip install simplejson ujson warcio"
   - "pip install rapidjson || true"
   - "pip install pyspark || true"
   - "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ dist: xenial
 before_install:
   - sudo apt-get install openjdk-8-jdk
 install:
-  - "pip install ."
+  - "pip install -e .[aws]"
+  - "pip install -e .[google]"
   - "pip install ujson warcio"
   - "pip install rapidjson || true"
   - "pip install pyspark || true"

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ try:
                 'boto3>=1.4.6',
                 'botocore>=1.6.0',
             ],
+            'simplejson': ['simplejson'],
             'ujson': ['ujson'],
         },
         'install_requires': [
@@ -61,8 +62,8 @@ try:
 
     # rapidjson exists on Python 3 only
     if sys.version_info >= (3, 0):
-        setuptools_kwargs['extras_require']['rapidjson'] = ['rapidjson']
-        setuptools_kwargs['tests_require'].append('rapidjson')
+        setuptools_kwargs['extras_require']['rapidjson'] = ['python-rapidjson']
+        setuptools_kwargs['tests_require'].append('python-rapidjson')
 
 except ImportError:
     from distutils.core import setup

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,14 @@ try:
     # arguments that distutils doesn't understand
     setuptools_kwargs = {
         'extras_require': {
+            'aws': [
+                'boto3>=1.4.6',
+                'botocore>=1.6.0',
+            ],
             'ujson': ['ujson'],
         },
         'install_requires': [
-            'boto3>=1.4.6',
-            'botocore>=1.6.0',
-            'PyYAML>=3.10',
+             'PyYAML>=3.10',
         ],
         'provides': ['mrjob'],
         'test_suite': 'tests',
@@ -46,15 +48,16 @@ try:
     # reason we support Python 3.4 at all is to support earlier
     # AMIs on EMR. See #2090
     if sys.version_info[0] == 2 or sys.version_info >= (3, 5):
-        setuptools_kwargs['install_requires'].extend([
+        setuptools_kwargs['extras_require']['google'] = [
             'google-cloud-dataproc>=0.3.0',
             'google-cloud-logging>=1.9.0',
             'google-cloud-storage>=1.13.1',
-        ])
+        ]
 
         # grpcio 1.11.0 and 1.12.0 seem not to compile with PyPy
         if hasattr(sys, 'pypy_version_info'):
-            setuptools_kwargs['install_requires'].append('grpcio<=1.10.0')
+            setuptools_kwargs['extras_require']['google'].append(
+                'grpcio<=1.10.0')
 
     # rapidjson exists on Python 3 only
     if sys.version_info >= (3, 0):


### PR DESCRIPTION
This means mrjob can install with less dependencies if people aren't using Google or AWS. Fixes #1935.

This also fixes a problem with the `rapidjson` entry in `extras_require` (fixes #2120), and adds `simplejson` to `extras_require`.