### PR TITLE
initializing a MRJob with no args means to read from sys.argv

### DIFF
--- a/docs/guides/testing.rst
+++ b/docs/guides/testing.rst
@@ -269,8 +269,3 @@ the job's output protocol using :py:meth:`~mrjob.job.MRJob.parse_output`::
 .. warning:: Do not let your tests depend on the input lines being processed in
              a certain order. Both mrjob and Hadoop divide input
              non-deterministically.
-
-.. note::
-
-   In mrjob versions prior to 0.6.0, you have to parse output line by line;
-   see :ref:`runners-programmatically` for an example.

--- a/docs/guides/testing.rst
+++ b/docs/guides/testing.rst
@@ -220,7 +220,7 @@ sure our methods are behaving as expected::
     class MRInitTestCase(TestCase):
 
         def test_mapper(self):
-            j = MRInitJob()
+            j = MRInitJob([])
             j.mapper_init()
             self.assertEqual(j.mapper(None, None).next(), (None, j.sum_amount))
 
@@ -241,7 +241,7 @@ This example reads from **stdin** (hence the ``-`` parameter)::
         def test_init_funcs(self):
             num_inputs = 2
             stdin = BytesIO(b'x\n' * num_inputs)
-            mr_job = MRInitJob(['--no-conf', '-'])
+            mr_job = MRInitJob(['--no-conf'])
             mr_job.sandbox(stdin=stdin)
 
 To run the job without leaving temp files on your system, use the

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -237,7 +237,7 @@ lines containing the string "kitty"::
 
 
     if __name__ == '__main__':
-        KittyJob().run()
+        KittyJob.run()
 
 Step commands are run without a shell, so if you want to use pipes, etc, you'll
 need to run them in a subshell. For example:
@@ -304,7 +304,7 @@ Here's a job that tests filters using :command:`grep`::
 
 
     if __name__ == '__main__':
-        KittiesJob().run()
+        KittiesJob.run()
 
 The output of the job should always be ``0``, since every line that gets to
 :py:func:`test_for_kitty()` is filtered by :command:`grep` to have "kitty" in

--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -100,8 +100,7 @@ class MRJob(object):
             with mr_job.make_runner() as runner:
                 ...
 
-        Passing in ``None`` is the same as passing in ``[]`` (if you want
-        to parse args from ``sys.argv``, call :py:meth:`MRJob.run`).
+        Passing in ``None`` is the same as passing in ``sys.argv[1:]``
 
         For a full list of command-line arguments, run:
         ``python -m mrjob.job --help``
@@ -120,15 +119,13 @@ class MRJob(object):
                                          add_help=False)
         self.configure_args()
 
-        # don't pass None to parse_args unless we're actually running
-        # the MRJob script
-        if args is _READ_ARGS_FROM_SYS_ARGV:
+        if args is None:
             self._cl_args = sys.argv[1:]
         else:
             # don't pass sys.argv to self.arg_parser, and have it
             # raise an exception on error rather than printing to stderr
             # and exiting.
-            self._cl_args = args or []
+            self._cl_args = args
 
             def error(msg):
                 raise ValueError(msg)
@@ -615,8 +612,7 @@ class MRJob(object):
         * Run the entire job. See :py:meth:`run_job`
         """
         # load options from the command line
-        mr_job = cls(args=_READ_ARGS_FROM_SYS_ARGV)
-        mr_job.execute()
+        cls().execute()
 
     def run_job(self):
         """Run the all steps of the job, logging errors (and debugging output

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -555,18 +555,6 @@ class MRJobRunner(object):
             for chunk in self.fs._cat_file(filename):
                 yield chunk
 
-    def stream_output(self):
-        """Like :py:meth:`cat_output` except that it groups bytes into
-        lines. Equivalent to ``mrjob.util.to_lines(runner.cat_output())``.
-
-        .. deprecated:: 0.6.0
-        """
-        log.warning('stream_output() is deprecated and will be removed in'
-                    ' v0.7.0. use mrjob.util.to_lines(runner.cat_output())'
-                    ' instead.')
-
-        return to_lines(self.cat_output())
-
     def _cleanup_mode(self, mode=None):
         """Actual cleanup action to take based on various options"""
         if self._script_path and not self._ran_job:

--- a/tests/examples/test_mr_most_used_word.py
+++ b/tests/examples/test_mr_most_used_word.py
@@ -20,7 +20,7 @@ from tests.sandbox import BasicTestCase
 class MRMostUsedWordTestCase(BasicTestCase):
 
     def test_empty(self):
-        self.assertEqual(run_job(MRMostUsedWord()), {})
+        self.assertEqual(run_job(MRMostUsedWord([])), {})
 
     def test_ignore_stop_words(self):
         RAW_INPUT = b"""
@@ -33,5 +33,5 @@ class MRMostUsedWordTestCase(BasicTestCase):
             None: u'car',
         }
 
-        self.assertEqual(run_job(MRMostUsedWord(), RAW_INPUT),
+        self.assertEqual(run_job(MRMostUsedWord([]), RAW_INPUT),
                          EXPECTED_OUTPUT)

--- a/tests/examples/test_mr_phone_to_url.py
+++ b/tests/examples/test_mr_phone_to_url.py
@@ -25,7 +25,7 @@ from tests.job import run_job
 class MRPhoneToURLTestCase(SandboxedTestCase):
 
     def test_empty(self):
-        self.assertEqual(run_job(MRPhoneToURL()), {})
+        self.assertEqual(run_job(MRPhoneToURL([])), {})
 
     def test_three_pages(self):
         wet1 = BytesIO()

--- a/tests/examples/test_mr_word_freq_count.py
+++ b/tests/examples/test_mr_word_freq_count.py
@@ -22,7 +22,7 @@ from tests.sandbox import BasicTestCase
 class MRWordFreqCountTestCase(BasicTestCase):
 
     def test_empty(self):
-        self.assertEqual(run_job(MRWordFreqCount()), {})
+        self.assertEqual(run_job(MRWordFreqCount([])), {})
 
     def test_the_wheels_on_the_bus(self):
         RAW_INPUT = b"""
@@ -45,5 +45,5 @@ class MRWordFreqCountTestCase(BasicTestCase):
             u'wheels': 2,
         }
 
-        self.assertEqual(run_job(MRWordFreqCount(), RAW_INPUT),
+        self.assertEqual(run_job(MRWordFreqCount([]), RAW_INPUT),
                          EXPECTED_OUTPUT)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -277,7 +277,7 @@ class TestCatOutput(SandboxedTestCase):
 
         runner = InlineMRJobRunner(conf_paths=[], output_dir=output_dir)
 
-        self.assertEqual(sorted(to_lines(runner.stream_output())),
+        self.assertEqual(sorted(to_lines(runner.cat_output())),
                          [b'cats\n'])
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1060,7 +1060,7 @@ class PassStepsToRunnerTestCase(BasicTestCase):
             self.assertFalse(self.log.warning.called)
 
     def test_no_steps(self):
-        job = MRJob()
+        job = MRJob([])
         job.sandbox()
 
         # it's possible to make a runner with the base MRJob, but it has
@@ -1138,7 +1138,7 @@ class TestStepsWithoutMRJobScript(MockBoto3TestCase):
 class UnsupportedStepsTestCase(MockBoto3TestCase):
 
     def test_base_classes_cant_have_steps(self):
-        steps = MRTwoStepJob()._steps_desc()
+        steps = MRTwoStepJob([])._steps_desc()
 
         self.assertRaises(NotImplementedError, MRJobRunner, steps=steps)
 
@@ -1311,7 +1311,7 @@ class SparkScriptArgsTestCase(SandboxedTestCase):
                 ['<step 0 output>', '<step 0 input>'])
 
     def test_streaming_step_not_okay(self):
-        job = MRTwoStepJob()
+        job = MRTwoStepJob([])
         job.sandbox()
 
         with job.make_runner() as runner:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -309,7 +309,7 @@ class CheckInputPathsTestCase(SandboxedTestCase):
             self.assertRaises(StopIteration, runner.run)
 
     def test_stdin_is_fine(self):
-        job = MRWordCount()
+        job = MRWordCount([])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -323,7 +323,7 @@ class CheckInputPathsTestCase(SandboxedTestCase):
             runner.run()
 
     def test_check_input_paths_enabled_by_default(self):
-        job = MRWordCount()
+        job = MRWordCount([])
         with job.make_runner() as runner:
             self.assertTrue(runner._opts['check_input_paths'])
 
@@ -333,7 +333,7 @@ class CheckInputPathsTestCase(SandboxedTestCase):
             self.assertFalse(runner._opts['check_input_paths'])
 
     def test_can_disable_check_input_paths_in_config(self):
-        job = MRWordCount()
+        job = MRWordCount([])
         with mrjob_conf_patcher(
                 {'runners': {'inline': {'check_input_paths': False}}}):
             with job.make_runner() as runner:
@@ -343,7 +343,7 @@ class CheckInputPathsTestCase(SandboxedTestCase):
 class ClosedRunnerTestCase(EmptyMrjobConfTestCase):
 
     def test_job_closed_on_cleanup(self):
-        job = MRWordCount()
+        job = MRWordCount([])
         with job.make_runner() as runner:
             # do nothing
             self.assertFalse(runner._closed)
@@ -1038,7 +1038,7 @@ class PassStepsToRunnerTestCase(BasicTestCase):
         self.log = self.start(patch('mrjob.runner.log'))
 
     def test_job_passes_in_steps(self):
-        job = MRWordCount()
+        job = MRWordCount([])
         job.sandbox()
 
         with job.make_runner() as runner:
@@ -1085,7 +1085,7 @@ class TestStepsWithoutMRJobScript(MockBoto3TestCase):
 
     def test_classic_streaming_step_without_mr_job_script(self):
         # classic MRJob mappers and reducers require a MRJob script
-        steps = MRWordCount()._steps_desc()
+        steps = MRWordCount([])._steps_desc()
 
         self.assertRaises(ValueError,
                           LocalMRJobRunner,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1110,7 +1110,7 @@ class TestStepsWithoutMRJobScript(MockBoto3TestCase):
         runner.cleanup()
 
     def test_spark_step_without_mr_job_script(self):
-        steps = MRNullSpark()._steps_desc()
+        steps = MRNullSpark([])._steps_desc()
 
         # need to be able to call the script's spark() method
         self.assertRaises(ValueError,
@@ -1230,7 +1230,7 @@ class SparkScriptArgsTestCase(SandboxedTestCase):
             {'spark', 'spark_jar', 'spark_script', 'streaming'}))
 
     def test_spark_mr_job(self):
-        job = MRNullSpark()
+        job = MRNullSpark([])
         job.sandbox()
 
         with job.make_runner() as runner:


### PR DESCRIPTION
Initializing a `MRJob` without arguments or with `args=None` now makes it read args from `sys.argv[1:]` (it used to mean the same thing as `[]`). Fixes #2124 

This is theoretically a breaking change, but it should probably only affect testing, as `MRJobs` are usually either initialized by `run()` or with arguments. This follows up on getting rid of `MRJobLauncher` (see #2088).

Also removed the deprecated `stream_output()` (which I thought I had in a previous branch) and references to it.