### PR TITLE
stop reading pre-v0.6.0 pool names

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,7 @@ v0.7.0, 2019-10-?? -- fall cleaning
    * arguments to CompositeFilesystem constructor
    * MRJobLauncher class
    * the `mrjob run` command
+ * mrjob audit-emr-usage no longer reads pre-v0.6.0 cluster pool names
 
 v0.6.12, 2019-10-23 -- unbreak Google
  * default image_version on Dataproc is now 1.3 (#2110)

--- a/mrjob/pool.py
+++ b/mrjob/pool.py
@@ -55,17 +55,6 @@ def _pool_hash_and_name(cluster):
     return tags.get('__mrjob_pool_hash'), tags.get('__mrjob_pool_name')
 
 
-def _legacy_pool_hash_and_name(bootstrap_actions):
-    """Get pool hash and name from a pre-v0.6.0 job."""
-    for ba in bootstrap_actions:
-        if ba['Name'] == 'master':
-            args = ba['Args']
-            if len(args) == 2 and args[0].startswith('pool-'):
-                return args[0][5:], args[1]
-
-    return None, None
-
-
 ### instance groups ###
 
 def _instance_groups_satisfy(actual_igs, requested_igs):

--- a/mrjob/tools/emr/audit_usage.py
+++ b/mrjob/tools/emr/audit_usage.py
@@ -63,7 +63,6 @@ from mrjob.options import _add_basic_args
 from mrjob.options import _add_runner_args
 from mrjob.options import _alphabetize_actions
 from mrjob.options import _filter_by_role
-from mrjob.pool import _legacy_pool_hash_and_name
 from mrjob.pool import _pool_hash_and_name
 from mrjob.util import strip_microseconds
 
@@ -132,8 +131,7 @@ def _runner_kwargs(options):
 def _clusters_to_stats(clusters, now=None):
     r"""Aggregate statistics for several clusters into a dictionary.
 
-    :param clusters: a sequence of dicts with the keys ``bootstrap_actions``,
-                     ``cluster``, ``steps``.
+    :param clusters: a sequence of dicts with the keys ``cluster``, ``steps``.
     :param now: the current UTC time, as a :py:class:`datetime.datetime`.
                 Defaults to the current time.
 
@@ -339,9 +337,6 @@ def _cluster_to_basic_summary(cluster, now=None):
     bcs['num_steps'] = len(cluster['Steps'])
 
     _, bcs['pool'] = _pool_hash_and_name(cluster)
-    if not bcs['pool']:
-        _, bcs['pool'] = _legacy_pool_hash_and_name(
-            cluster['BootstrapActions'])
 
     m = _JOB_KEY_RE.match(bcs['name'] or '')
     if m:
@@ -619,10 +614,6 @@ def _yield_clusters(max_days_ago=None, now=None, **runner_kwargs):
         cluster['Steps'] = list(reversed(list(_boto3_paginate(
             'Steps', emr_client, 'list_steps',
             ClusterId=cluster_id, _delay=_DELAY))))
-
-        cluster['BootstrapActions'] = list(_boto3_paginate(
-            'BootstrapActions', emr_client, 'list_bootstrap_actions',
-            ClusterId=cluster_id, _delay=_DELAY))
 
         yield cluster
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -14,7 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mrjob.pool import _legacy_pool_hash_and_name
 from mrjob.pool import _pool_hash_and_name
 
 from tests.sandbox import BasicTestCase
@@ -47,92 +46,3 @@ class TestPoolHashAndName(BasicTestCase):
 
         self.assertEqual(_pool_hash_and_name(cluster),
                          ('0123456789abcdef0123456789abcdef', 'reflecting'))
-
-
-class TestLegacyPoolHashAndName(BasicTestCase):
-
-    def test_empty(self):
-        actions = []
-
-        self.assertEqual(_legacy_pool_hash_and_name(actions), (None, None))
-
-    def test_pooled_cluster(self):
-        actions = [
-            dict(
-                Args=['pool-0123456789abcdef0123456789abcdef', 'reflecting'],
-                Name='master',
-            ),
-        ]
-
-        self.assertEqual(_legacy_pool_hash_and_name(actions),
-                         ('0123456789abcdef0123456789abcdef', 'reflecting'))
-
-    def test_pooled_cluster_with_other_bootstrap_actions(self):
-        actions = [
-            dict(Args=[], Name='action 0'),
-            dict(Args=[], Name='action 1'),
-            dict(
-                Args=['pool-0123456789abcdef0123456789abcdef', 'reflecting'],
-                Name='master',
-            ),
-        ]
-
-        self.assertEqual(_legacy_pool_hash_and_name(actions),
-                         ('0123456789abcdef0123456789abcdef', 'reflecting'))
-
-    def test_pooled_cluster_with_max_mins_idle(self):
-        # max-mins-idle script is added AFTER the master bootstrap script,
-        # which was a problem when we just look at the last action
-        actions = [
-            dict(
-                Args=['pool-0123456789abcdef0123456789abcdef', 'reflecting'],
-                Name='master',
-            ),
-            dict(
-                Args=['900', '300'],
-                Name='idle timeout',
-            ),
-        ]
-
-        self.assertEqual(_legacy_pool_hash_and_name(actions),
-                         ('0123456789abcdef0123456789abcdef', 'reflecting'))
-
-    def test_first_arg_doesnt_start_with_pool(self):
-        actions = [
-            dict(
-                Args=['cowsay', 'mrjob'],
-                Name='master',
-            ),
-        ]
-
-        self.assertEqual(_legacy_pool_hash_and_name(actions), (None, None))
-
-    def test_too_many_args(self):
-        actions = [
-            dict(
-                Args=['cowsay', '-b', 'mrjob'],
-                Name='master',
-            ),
-        ]
-
-        self.assertEqual(_legacy_pool_hash_and_name(actions), (None, None))
-
-    def test_too_few_args(self):
-        actions = [
-            dict(
-                Args=['pool-0123456789abcdef0123456789abcdef'],
-                Name='master',
-            ),
-        ]
-
-        self.assertEqual(_legacy_pool_hash_and_name(actions), (None, None))
-
-    def test_bootstrap_action_isnt_named_master(self):
-        actions = [
-            dict(
-                Args=['pool-0123456789abcdef0123456789abcdef', 'reflecting'],
-                Name='apprentice',
-            ),
-        ]
-
-        self.assertEqual(_legacy_pool_hash_and_name(actions), (None, None))

--- a/tests/tools/emr/test_audit_usage.py
+++ b/tests/tools/emr/test_audit_usage.py
@@ -663,25 +663,7 @@ class ClusterToFullSummaryTestCase(BasicTestCase):
             }],
         })
 
-    def test_pooled_cluster(self):
-        self._test_new_or_legacy_pooled_cluster(Tags=[
-            dict(Key='__mrjob_pool_hash',
-                 Value='0123456789abcdef0123456789abcdef'),
-            dict(Key='__mrjob_pool_name',
-                 Value='reflecting'),
-        ])
-
-    def test_legacy_pooled_cluster(self):
-        # audit clusters from previous versions of mrjob
-        self._test_new_or_legacy_pooled_cluster(
-            BootstrapActions=[
-                dict(Args=[], Name='empty'),
-                dict(Args=['pool-0123456789abcdef0123456789abcdef',
-                           'reflecting'], Name='master'),
-            ],
-        )
-
-    def _test_new_or_legacy_pooled_cluster(self, **kwargs):
+    def test_pooled_cluster(self, **kwargs):
         # same as test case above with different job keys
         cluster = dict(
             Id='j-ISFORJOB',
@@ -725,7 +707,12 @@ class ClusterToFullSummaryTestCase(BasicTestCase):
                     ),
                 ),
             ],
-            **kwargs
+            Tags=[
+                dict(Key='__mrjob_pool_hash',
+                     Value='0123456789abcdef0123456789abcdef'),
+                dict(Key='__mrjob_pool_name',
+                     Value='reflecting'),
+            ],
         )
 
         summary = _cluster_to_full_summary(cluster)


### PR DESCRIPTION
`mrjob audit-emr-usage` no longer reads pool names from clusters launched by pre-0.6.0 versions of mrjob. Fixes #1815.