### PR TITLE
add archives to pool hash

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2647,24 +2647,36 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         The way the hash is calculated may vary between point releases
         (pooling requires the exact same version of :py:mod:`mrjob` anyway).
         """
+        # exclude mrjob.zip because it's only created if the
+        # job starts its own cluster (also, its hash changes every time
+        # since the zip file contains different timestamps).
+        # The filenames/md5sums are sorted because we need to
+        # ensure the order they're added doesn't affect the hash
+        # here
+        file_md5sums = sorted(
+            (name, self.fs.md5sum(path)) for name, path
+            in self._bootstrap_dir_mgr.name_to_path().items()
+            if not path == self._mrjob_zip_path)
+
+        # original path of the file doesn't matter, just its name and contents
+        bootstrap_without_paths = [
+            [
+                dict(type=x['type'], name=self._bootstrap_dir_mgr.name(**x))
+                if isinstance(x, dict) else x
+                for x in cmd
+            ]
+            for cmd in self._bootstrap
+        ]
+
         things_to_hash = [
-            # exclude mrjob.zip because it's only created if the
-            # job starts its own cluster (also, its hash changes every time
-            # since the zip file contains different timestamps).
-            # The filenames/md5sums are sorted because we need to
-            # ensure the order they're added doesn't affect the hash
-            # here. Previously this used a dict, but Python doesn't
-            # guarantee the ordering of dicts -- they can vary
-            # depending on insertion/deletion order.
-            sorted(
-                (name, self.fs.md5sum(path)) for name, path
-                in self._bootstrap_dir_mgr.name_to_path().items()
-                if not path == self._mrjob_zip_path),
+            file_md5sums,
             self._opts['additional_emr_info'],
-            self._bootstrap,
+            bootstrap_without_paths,
             self._bootstrap_actions(),
             self._bootstrap_mrjob(),
         ]
+
+        #import pdb; pdb.set_trace()
 
         if self._bootstrap_mrjob():
             things_to_hash.append(mrjob.__version__)

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2658,7 +2658,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             # depending on insertion/deletion order.
             sorted(
                 (name, self.fs.md5sum(path)) for name, path
-                in self._bootstrap_dir_mgr.name_to_path('file').items()
+                in self._bootstrap_dir_mgr.name_to_path().items()
                 if not path == self._mrjob_zip_path),
             self._opts['additional_emr_info'],
             self._bootstrap,

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -1763,10 +1763,22 @@ class PoolMatchingTestCase(MockBoto3TestCase):
 
         _, cluster_id = self.make_pooled_cluster(bootstrap=[true_story])
 
+        # same bootstrap command, same file (matches)
         self.assertJoins(cluster_id, [
             '-r', 'emr', '--pool-clusters',
             '--bootstrap', true_story])
 
+        # same command, different file path with same contents (matches)
+        story_2_path = self.makefile('story-2.txt', b'Once upon a time')
+        self.assertNotEqual(story_2_path, story_path)
+
+        true_story_2 = 'true %s#story.txt' % story_2_path
+
+        self.assertJoins(cluster_id, [
+            '-r', 'emr', '--pool-clusters',
+            '--bootstrap', true_story_2])
+
+        # same command, same file path, different contents (does not match)
         with open(story_path, 'wb') as f:
             f.write(b'Call me Ishmael.')  # same file size, different letters
 

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -1795,7 +1795,7 @@ class PoolMatchingTestCase(MockBoto3TestCase):
         os.remove(story_path)
 
         empty_story_path = make_archive(join(self.tmp_dir, 'story'),
-                                           'gztar', story_dir)
+                                        'gztar', empty_dir)
 
         self.assertEqual(story_path, empty_story_path)
 

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -1755,6 +1755,31 @@ class PoolMatchingTestCase(MockBoto3TestCase):
             '-r', 'emr', '-v', '--pool-clusters',
             '--bootstrap-action', bootstrap_path + ' a b c'])
 
+    def test_join_with_same_file_contents(self):
+        story_path = self.makefile('story.txt', b'Once upon a time')
+
+        true_story = 'true %s#' % story_path
+
+        _, cluster_id = self.make_pooled_cluster(bootstrap=[true_story])
+
+        self.assertJoins(cluster_id, [
+            '-r', 'emr', '--pool-clusters',
+            '--bootstrap', true_story])
+
+    def test_dont_join_with_different_file_contents(self):
+        story_path = self.makefile('story.txt', b'Once upon a time')
+
+        true_story = 'true %s#' % story_path
+
+        _, cluster_id = self.make_pooled_cluster(bootstrap=[true_story])
+
+        with open(story_path, 'wb') as f:
+            f.write(b'Call me Ishmael.')  # same length, different letters
+
+        self.assertDoesNotJoin(cluster_id, [
+            '-r', 'emr', '--pool-clusters',
+            '--bootstrap', true_story])
+
     def test_pool_contention(self):
         _, cluster_id = self.make_pooled_cluster('robert_downey_jr')
 


### PR DESCRIPTION
Check the contents of archives used in bootstrapping to ensure that clusters have the same setup. Fixes #2136.

Also, the original path of files and archives no longer matters when creating the bootstrap hash, just the name and contents.