### PR TITLE
recursively merge extra_cluster_params

### DIFF
--- a/docs/guides/cloud-opts.rst
+++ b/docs/guides/cloud-opts.rst
@@ -364,6 +364,19 @@ Cluster software configuration
               SupportedProducts:
               - mapr-m3
 
+    .. versionchanged:: 0.7.2
+
+       Dictionaries will be recursively merged into existing
+       parameters. For example:
+
+       .. code-block:: yaml
+
+          runners:
+            emr:
+              extra_cluster_params:
+                Instances:
+                  EmrManagedMasterSecurityGroup: sg-foo
+
     .. versionchanged:: 0.6.8
 
        You may use a *name* with dots in it to set (or unset) nested

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -607,5 +607,9 @@ def _patch_params(params, name, value):
     elif value is None:
         if name in params:
             del params[name]
+    elif isinstance(value, dict) and isinstance(params.get(name), dict):
+        # recursively patch dicts rather than clobbering them (see #2154)
+        for k, v in value.items():
+            _patch_params(params[name], k, v)
     else:
         params[name] = value

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -694,6 +694,22 @@ class ExtraClusterParamsTestCase(MockBoto3TestCase):
             cluster['Ec2InstanceAttributes']['Ec2SubnetId'],
             'subnet-ffffffff')
 
+    def test_set_nested_param_with_dict(self):
+        cluster = self.run_and_get_cluster(
+            '--zone', 'us-west-1a',
+            '--subnet', 'subnet-ffffffff',
+            '--extra-cluster-param',
+            'Instances={"Placement": {"AvailabilityZone": "danger-2a"}}')
+
+        self.assertEqual(
+            cluster['Ec2InstanceAttributes']['Ec2AvailabilityZone'],
+            'danger-2a')
+
+        # shoudn't blow away subnet, also set in Instances
+        self.assertEqual(
+            cluster['Ec2InstanceAttributes']['Ec2SubnetId'],
+            'subnet-ffffffff')
+
 
 class AMIAndHadoopVersionTestCase(MockBoto3TestCase):
 


### PR DESCRIPTION
Make something like this:

```
runners:
  emr:
    extra_cluster_params:
      Instances:
        EmrManagedMasterSecurityGroup: sg-00000000000000000
```

add `EmrManagedMasterSecurityGroup` to the `Instances` API parameter, rather than clobbering it.

Fixes #2154.