### PR TITLE
default python_bin on Python 2 to 'python2'

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -278,8 +278,8 @@ Job execution context
     If you're on Python 2, this defaults to ``'python2'`` (except on EMR
     AMIs prior to 4.3.0, where it will be ``'python2.7'``).
 
-    Likewise, if you're using PyPy, this defaults to ``'pypy2'`` or ``'pypy3'``
-    depending on your version.
+    If you're using PyPy, this defaults to ``'pypy'`` (not ``'pypy2'``) or
+    ``'pypy3'`` depending on your version.
 
     This option also affects which Python binary is used for file locking in
     :mrjob-opt:`setup` scripts. It's also

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -275,16 +275,20 @@ Job execution context
 
     If you're on Python 3, this always defaults to ``'python3'``.
 
-    If you're on Python 2, this defaults to ``'python'`` (except on EMR
+    If you're on Python 2, this defaults to ``'python2'`` (except on EMR
     AMIs prior to 4.3.0, where it will be ``'python2.7'``).
 
-    Likewise, if you're using PyPy, this defaults to ``'pypy'`` or ``'pypy3'``
+    Likewise, if you're using PyPy, this defaults to ``'pypy2'`` or ``'pypy3'``
     depending on your version.
 
     This option also affects which Python binary is used for file locking in
     :mrjob-opt:`setup` scripts. It's also
     used by :py:class:`~mrjob.emr.EMRJobRunner` to compile mrjob after
     bootstrapping it (see :mrjob-opt:`bootstrap_mrjob`).
+
+    .. versionchanged:: 0.7.2
+
+       Defaults to ``'python2'`` (not ``'python'``) on Python 2.
 
     .. versionchanged:: 0.6.10
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -201,7 +201,10 @@ class MRJobBinRunner(MRJobRunner):
             return [sys.executable]
         else:
             if is_pypy:
-                return ['pypy%d' % major_version if major_version > 2 else '']
+                if major_version == 2:
+                    return ['pypy']
+                else:
+                    return ['pypy%d' % major_version]
             else:
                 return ['python%d' % major_version]
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -201,7 +201,7 @@ class MRJobBinRunner(MRJobRunner):
             return [sys.executable]
         else:
             if is_pypy:
-                return ['pypy%d' % major_version]
+                return ['pypy%d' % major_version if major_version > 2 else '']
             else:
                 return ['python%d' % major_version]
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -190,7 +190,7 @@ class MRJobBinRunner(MRJobRunner):
 
     def _default_python_bin(self, local=False):
         """The default python command. If local is true, try to use
-        sys.executable. Otherwise use 'python' or 'python3' as appropriate.
+        sys.executable. Otherwise use 'python2' or 'python3' as appropriate.
 
         This returns a single-item list (because it's a command).
         """
@@ -199,11 +199,6 @@ class MRJobBinRunner(MRJobRunner):
 
         if local and sys.executable:
             return [sys.executable]
-        elif PY2:
-            if is_pypy:
-                return ['pypy']
-            else:
-                return ['python']
         else:
             if is_pypy:
                 return ['pypy%d' % major_version]

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -536,7 +536,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         """
         python_bin = super(EMRJobRunner, self)._default_python_bin(local=local)
 
-        if python_bin == ['python'] and not (
+        if python_bin == ['python2'] and not (
                 self._image_version_gte('4.3.0') or local):
             return ['python2.7']
         else:

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -64,8 +64,8 @@ from tests.sandbox import mrjob_conf_patcher
 # used to match command lines
 is_pypy = (python_implementation() == 'PyPy')
 PYTHON_BIN = (
-    ('pypy' if PY2 else 'pypy3') if is_pypy else
-    ('python' if PY2 else 'python3')
+    ('pypy2' if PY2 else 'pypy3') if is_pypy else
+    ('python2' if PY2 else 'python3')
 )
 
 # a --spark-master that has a working directory and is available from pyspark

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -64,7 +64,7 @@ from tests.sandbox import mrjob_conf_patcher
 # used to match command lines
 is_pypy = (python_implementation() == 'PyPy')
 PYTHON_BIN = (
-    ('pypy2' if PY2 else 'pypy3') if is_pypy else
+    ('pypy' if PY2 else 'pypy3') if is_pypy else
     ('python2' if PY2 else 'python3')
 )
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -87,7 +87,7 @@ from tests.test_hadoop import HadoopExtraArgsTestCase
 from tests.test_inline import InlineInputManifestTestCase
 
 
-if PYTHON_BIN == 'python':
+if PYTHON_BIN == 'python2':
     OLD_AMI_PYTHON_BIN = 'python2.7'
 else:
     OLD_AMI_PYTHON_BIN = PYTHON_BIN


### PR DESCRIPTION
Python 2 has reached end-of-life, so the default `python` binary is finally Python 3 on some systems (notably, EMR AMI 6.x). Fixes #2151.

`python_bin` on Python 3 still defaults to `python3`.

PyPy has a different naming convention, so the default binary for PyPy 2 is still `pypy`.
