### PR TITLE
use 'python2.7' as default python_bin for Python 2

### DIFF
--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -275,10 +275,9 @@ Job execution context
 
     If you're on Python 3, this always defaults to ``'python3'``.
 
-    If you're on Python 2, this defaults to ``'python2.7'`` (except on EMR
-    AMIs prior to 4.3.0, where it will be ``'python2.7'``).
+    If you're on Python 2, this defaults to ``'python2.7'``.
 
-    If you're using PyPy, this defaults to ``'pypy'`` (not ``'pypy2'``) or
+    If you're using PyPy, this defaults to ``'pypy'`` (not ``'pypy2.7'``) or
     ``'pypy3'`` depending on your version.
 
     This option also affects which Python binary is used for file locking in

--- a/docs/guides/configs-all-runners.rst
+++ b/docs/guides/configs-all-runners.rst
@@ -275,7 +275,7 @@ Job execution context
 
     If you're on Python 3, this always defaults to ``'python3'``.
 
-    If you're on Python 2, this defaults to ``'python2'`` (except on EMR
+    If you're on Python 2, this defaults to ``'python2.7'`` (except on EMR
     AMIs prior to 4.3.0, where it will be ``'python2.7'``).
 
     If you're using PyPy, this defaults to ``'pypy'`` (not ``'pypy2'``) or
@@ -288,7 +288,7 @@ Job execution context
 
     .. versionchanged:: 0.7.2
 
-       Defaults to ``'python2'`` (not ``'python'``) on Python 2.
+       Defaults to ``'python2.7'`` (not ``'python'``) on Python 2.
 
     .. versionchanged:: 0.6.10
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -190,7 +190,7 @@ class MRJobBinRunner(MRJobRunner):
 
     def _default_python_bin(self, local=False):
         """The default python command. If local is true, try to use
-        sys.executable. Otherwise use 'python2' or 'python3' as appropriate.
+        sys.executable. Otherwise use 'python2.7' or 'python3' as appropriate.
 
         This returns a single-item list (because it's a command).
         """

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -195,7 +195,6 @@ class MRJobBinRunner(MRJobRunner):
 
         This returns a single-item list (because it's a command).
         """
-        major_version = sys.version_info[0]
         is_pypy = (python_implementation() == 'PyPy')
 
         if local and sys.executable:

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -23,6 +23,7 @@ import os.path
 import pipes
 import re
 import sys
+from mrjob.py2 import PY2
 from platform import python_implementation
 from subprocess import Popen
 from subprocess import PIPE
@@ -200,13 +201,10 @@ class MRJobBinRunner(MRJobRunner):
         if local and sys.executable:
             return [sys.executable]
         else:
-            if is_pypy:
-                if major_version == 2:
-                    return ['pypy']
-                else:
-                    return ['pypy%d' % major_version]
+            if PY2:
+                return ['pypy'] if is_pypy else ['python2.7']
             else:
-                return ['python%d' % major_version]
+                return ['pypy3'] if is_pypy else ['python3']
 
     ### running MRJob scripts ###
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -529,19 +529,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         else:
             return opt_value
 
-    def _default_python_bin(self, local=False):
-        """Like :py:meth:`mrjob.runner.MRJobRunner._default_python_bin`,
-        except when running Python 2, we explicitly pick :command:`python2.7`
-        on AMIs prior to 4.3.0 where's it's not the default.
-        """
-        python_bin = super(EMRJobRunner, self)._default_python_bin(local=local)
-
-        if python_bin == ['python2.7'] and not (
-                self._image_version_gte('4.3.0') or local):
-            return ['python2.7']
-        else:
-            return python_bin
-
     def _image_version_gte(self, version):
         """Check if the requested image version is greater than
         or equal to *version*. If the *release_label* opt is set,

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -536,7 +536,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         """
         python_bin = super(EMRJobRunner, self)._default_python_bin(local=local)
 
-        if python_bin == ['python2'] and not (
+        if python_bin == ['python2.7'] and not (
                 self._image_version_gte('4.3.0') or local):
             return ['python2.7']
         else:

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -65,7 +65,7 @@ from tests.sandbox import mrjob_conf_patcher
 is_pypy = (python_implementation() == 'PyPy')
 PYTHON_BIN = (
     ('pypy' if PY2 else 'pypy3') if is_pypy else
-    ('python2' if PY2 else 'python3')
+    ('python2.7' if PY2 else 'python3')
 )
 
 # a --spark-master that has a working directory and is available from pyspark

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -87,11 +87,6 @@ from tests.test_hadoop import HadoopExtraArgsTestCase
 from tests.test_inline import InlineInputManifestTestCase
 
 
-if PYTHON_BIN == 'python2.7':
-    OLD_AMI_PYTHON_BIN = 'python2.7'
-else:
-    OLD_AMI_PYTHON_BIN = PYTHON_BIN
-
 # EMR configurations used for testing
 # from http://docs.aws.amazon.com/ElasticMapReduce/latest/ReleaseGuide/emr-configure-apps.html  # noqa
 
@@ -1617,13 +1612,13 @@ class MasterBootstrapScriptTestCase(MockBoto3TestCase):
 
     def test_create_master_bootstrap_script_on_3_11_0_ami(self):
         self._test_create_master_bootstrap_script(
-            expected_python_bin=(OLD_AMI_PYTHON_BIN),
+            expected_python_bin=(PYTHON_BIN),
             image_version='3.11.0')
 
     def test_create_master_bootstrap_script_on_2_4_11_ami(self):
         self._test_create_master_bootstrap_script(
             image_version='2.4.11',
-            expected_python_bin=(OLD_AMI_PYTHON_BIN))
+            expected_python_bin=(PYTHON_BIN))
 
     def test_no_bootstrap_script_if_not_needed(self):
         runner = EMRJobRunner(conf_paths=[], bootstrap_mrjob=False,
@@ -2417,33 +2412,6 @@ class LibjarPathsTestCase(MockBoto3TestCase):
                 '/left/dora.jar',
             ]
         )
-
-
-class DefaultPythonBinTestCase(MockBoto3TestCase):
-
-    def test_default_ami(self):
-        # this tests 4.x AMIs
-        runner = EMRJobRunner()
-        self.assertTrue(runner._opts['image_version'].startswith('5.'))
-        self.assertEqual(runner._default_python_bin(), [PYTHON_BIN])
-
-    def test_4_x_release_label(self):
-        runner = EMRJobRunner(release_label='emr-4.0.0')
-        self.assertEqual(runner._default_python_bin(), [OLD_AMI_PYTHON_BIN])
-
-    def test_3_11_0_ami(self):
-        runner = EMRJobRunner(image_version='3.11.0')
-        self.assertEqual(runner._default_python_bin(), [OLD_AMI_PYTHON_BIN])
-
-    def test_2_4_3_ami(self):
-        runner = EMRJobRunner(image_version='2.4.3')
-        self.assertEqual(runner._default_python_bin(), [OLD_AMI_PYTHON_BIN])
-
-    def test_local_python_bin(self):
-        # just make sure we don't break this
-        runner = EMRJobRunner()
-        self.assertEqual(runner._default_python_bin(local=True),
-                         [sys.executable])
 
 
 class StreamingJarAndStepArgPrefixTestCase(MockBoto3TestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -87,7 +87,7 @@ from tests.test_hadoop import HadoopExtraArgsTestCase
 from tests.test_inline import InlineInputManifestTestCase
 
 
-if PYTHON_BIN == 'python2':
+if PYTHON_BIN == 'python2.7':
     OLD_AMI_PYTHON_BIN = 'python2.7'
 else:
     OLD_AMI_PYTHON_BIN = PYTHON_BIN

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -26,7 +26,6 @@ import os.path
 import posixpath
 import signal
 import socket
-import sys
 import time
 from io import BytesIO
 from shutil import make_archive


### PR DESCRIPTION
It turns out that `python2` isn't as common a binary name as i though; this changes it to `python2.7`. This is a second try at fixing #2151, and supersedes pull request #2156.

This also allows us to remove a special case that was already defaulting python_bin to `python2.7` on some old AMIs.