### PR TITLE
MRJobBinRunner: make script compatible with dash

### DIFF
--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -710,7 +710,7 @@ class MRJobBinRunner(MRJobRunner):
 
         # save return code, turn off echo
         lines.append('# if script fails, print input URI before exiting')
-        lines.append('{ RETURNCODE=$?; set +x; } &> /dev/null')
+        lines.append('{ RETURNCODE=$?; set +x; } 1>&2 2>/dev/null')
         lines.append('')
 
         lines.append('{')


### PR DESCRIPTION
/bin/sh points to dash on Ubuntu 18.04 LTS. The construct

	{ VAR=1; } &>/dev/null

doesn't set VAR for dash but it does for bash. Previously the script
would (benignly?) succeed, regardless of python's exit code. Here is a
typical output prior to this patch:

+ set +e
+ python args ...
+
+ [ -ne 0 ]
manifest-setup.sh: 67: [: -ne: unexpected operator
+ rm ./input-jrOOHByJvm.blf
+ RETURNCODE=0
+ set +x
+ exit