### PR TITLE
Correct the link to the configuration documentation (README.rst).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,8 @@ for its conf file in:
 * ``/etc/mrjob.conf``
 
 See `the mrjob.conf documentation
-<http://packages.python.org/mrjob/guides/configs-basics.html>`_ for more information.
+<https://mrjob.readthedocs.io/en/latest/guides/configs-basics.html>`_ for more
+information.
 
 
 Project Links


### PR DESCRIPTION
The original link on the README to the mrjob.conf documentation (http://packages.python.org/mrjob/guides/configs-basics.html) is a dead link.  I have updated it to https://mrjob.readthedocs.io/en/latest/guides/configs-basics.html