### PR TITLE
add_steps_in_batch option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v0.7.4, 2020-??-?? -- ???
+ * EMR Runner:
+   * get_job_steps() is deprecated
+
 v0.7.3, 2020-06-05 -- API-efficient cluster pooling
  * cluster pooling changes:
    * clusters locking now uses EMR tags, not S3 objects (#2160)

--- a/docs/guides/emr-opts.rst
+++ b/docs/guides/emr-opts.rst
@@ -519,6 +519,19 @@ Other rarely used options
 -------------------------
 
 .. mrjob-opt::
+    :config: add_steps_in_batch
+    :switch: --add-steps-in-batch, --no-add-steps-in-batch
+    :type: boolean
+    :set: emr
+    :default: ``True`` for AMIs before 5.28.0, ``False`` otherwise
+
+    For a multi-step job, should we submit all steps at once, or one at
+    a time? By default, we only submit steps all at once if the AMI doesn't
+    support running concurrent steps (that is, before AMI 5.28.0).
+
+    .. versionadded:: 0.7.4
+
+.. mrjob-opt::
     :config: additional_emr_info
     :switch: --additional-emr-info
     :type: special

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -366,6 +366,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         # did we acquire a lock on self._cluster_id? (used for pooling)
         self._locked_cluster = None
 
+        # IDs of steps we have submitted to the cluster
+        self._step_ids = []
+
         # we don't upload the ssh key to master until it's needed
         self._ssh_key_is_copied = False
 
@@ -668,6 +671,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         assert not self._opts['cluster_id']
         self._cluster_id = None
         self._created_cluster = False
+        self._step_ids = []
 
         # old SSH tunnel isn't valid for this cluster (see #1549)
         if self._ssh_proc:
@@ -1249,7 +1253,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         else:
             return self._opts['add_steps_in_batch']
 
-    def _build_steps(self):
+    def _steps_to_submit(self):
         """Return a step data structures to pass to ``boto3``"""
         # quick, add the other steps before the job spins up and
         # then shuts itself down! (in practice that won't happen
@@ -1401,8 +1405,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         """Create an empty cluster on EMR, and set self._cluster_id to
         its ID.
         """
-        emr_client = self.make_emr_client()
-
         # try to find a cluster from the pool. basically auto-fill
         # 'cluster_id' if possible and then follow normal behavior.
         if (self._opts['pool_clusters'] and not self._cluster_id):
@@ -1425,11 +1427,13 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
             self._check_cluster_spark_support()
 
         # define our steps
-        steps = self._build_steps()
-        steps_kwargs = dict(JobFlowId=self._cluster_id, Steps=steps)
-        log.debug('Calling add_job_flow_steps(%s)' % ','.join(
-            ('%s=%r' % (k, v)) for k, v in steps_kwargs.items()))
-        emr_client.add_job_flow_steps(**steps_kwargs)
+        steps = self._steps_to_submit()
+
+        if self._add_steps_in_batch():
+            self._add_steps_to_cluster(steps)
+        else:
+            # later steps will be added one at a time
+            self._add_steps_to_cluster(steps[:1])
 
         # learn about how fast the cluster state switches
         cluster = self._describe_cluster()
@@ -1439,6 +1443,17 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         if hasattr(self.fs, 'ssh') and version_gte(
                 self.get_image_version(), '4.3.0'):
             self.fs.ssh.use_sudo_over_ssh()
+
+    def _add_steps_to_cluster(self, steps):
+        """Add steps (from _steps_to_submit()) to our cluster and append their
+         IDs to self._step_ids"""
+        emr_client = self.make_emr_client()
+
+        steps_kwargs = dict(JobFlowId=self._cluster_id, Steps=steps)
+        log.debug('Calling add_job_flow_steps(%s)' % ','.join(
+            ('%s=%r' % (k, v)) for k, v in steps_kwargs.items()))
+        step_ids = emr_client.add_job_flow_steps(**steps_kwargs)['StepIds']
+        self._step_ids.extend(step_ids)
 
     def get_job_steps(self):
         """Fetch the steps submitted by this runner from the EMR API.
@@ -1450,19 +1465,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
     def _wait_for_steps_to_complete(self):
         """Wait for every step of the job to complete, one by one."""
-        # get info about expected number of steps
-        num_steps = len(self._get_steps())
-
-        expected_num_steps = num_steps
-        if self._master_node_setup_script_path:
-            expected_num_steps += 1
-
-        # get info about steps submitted to cluster
-        steps = self.get_job_steps()
-
-        if len(steps) < expected_num_steps:
-            log.warning('Expected to find %d steps on cluster, found %d' %
-                        (expected_num_steps, len(steps)))
+        steps = self._steps_to_submit()
 
         # clear out log interpretations if they were filled somehow
         self._log_interpretations = []
@@ -1474,23 +1477,27 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         if cluster['Status']['State'] in ('RUNNING', 'WAITING'):
             self._set_up_ssh_tunnel_and_hdfs()
 
-        # treat master node setup as step -1
-        start = 0
-        if self._master_node_setup_script_path:
-            start -= 1
+        for i, step in enumerate(steps):
+            # if our step isn't already submitted, submit it
+            if len(self._step_ids) <= i:
+                self._add_steps_to_cluster(
+                    steps[len(self._step_ids):i + 1])
 
-        for step_num, step in enumerate(steps, start=start):
-            step_id = step['Id']
-            # don't include job_key in logging messages
+            step_id = self._step_ids[i]
             step_name = step['Name'].split(': ')[-1]
+
+            # treat master node setup script is treated as step -1
+            if self._master_node_setup_script_path:
+                step_num = i - 1
+            else:
+                step_num = i
 
             log.info('Waiting for %s (%s) to complete...' %
                      (step_name, step_id))
 
-            self._wait_for_step_to_complete(step_id, step_num, num_steps)
+            self._wait_for_step_to_complete(step_id, step_num)
 
-    def _wait_for_step_to_complete(
-            self, step_id, step_num=None, num_steps=None):
+    def _wait_for_step_to_complete(self, step_id, step_num=None):
         """Helper for _wait_for_step_to_complete(). Wait for
         step with the given ID to complete, and fetch counters.
         If it fails, attempt to diagnose the error, and raise an
@@ -1498,13 +1505,11 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
         :param step_id: the s-XXXXXXX step ID on EMR
         :param step_num: which step this is out of the steps
-                         belonging to our job (0-indexed)
-        :param num_steps: number of steps in our job
+                         belonging to our job (0-indexed). Master node
+                         setup script, if there is one, is step -1
 
-        *step_num* and *num_steps* are optional and only used when raising
-        a :py:class:`~mrjob.step.StepFailedException`.
-
-        This also adds an item to self._log_interpretations
+        This also adds an item to self._log_interpretations or sets
+        self._mns_log_interpretation
         """
         log_interpretation = dict(step_id=step_id)
 
@@ -1627,7 +1632,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                     _log_probable_cause_of_failure(log, error)
 
             raise StepFailedException(
-                step_num=step_num, num_steps=num_steps,
+                step_num=step_num, num_steps=self._num_steps(),
                 # "Step 0 of ... failed" looks weird
                 step_desc=(
                     'Master node setup step' if step_num == -1 else None))

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -1458,8 +1458,13 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     def get_job_steps(self):
         """Fetch the steps submitted by this runner from the EMR API.
 
+        .. deprecated:: 0.7.4
+
         .. versionadded:: 0.6.1
         """
+        log.warning(
+            'get_job_steps() is deprecated and will be removed in v0.8.0')
+
         return _get_job_steps(
             self.make_emr_client(), self.get_cluster_id(), self.get_job_key())
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -247,6 +247,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
     alias = 'emr'
 
     OPT_NAMES = HadoopInTheCloudJobRunner.OPT_NAMES | {
+        'add_steps_in_batch',
         'additional_emr_info',
         'applications',
         'aws_access_key_id',

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -310,11 +310,13 @@ _RUNNER_OPTS = dict(
     add_steps_in_batch=dict(
         switches=[
             (['--add-steps-in-batch'], dict(
-                'For multi-step jobs, submit all steps at once',
+                action='store_true',
+                help='For multi-step jobs, submit all steps at once',
             )),
             (['--no-add-steps-in-batch'], dict(
-                'For multi-step jobs, submit steps successively after'
-                ' the previous one completes',
+                action='store_false',
+                help=('For multi-step jobs, submit steps successively after'
+                      ' the previous one completes'),
             )),
         ]
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -307,6 +307,17 @@ _DEPRECATED_NON_RUNNER_OPTS = {'deprecated'}
 # the list of which options apply to which runner is in the runner class
 # itself (e.g. EMRJobRunner.OPT_NAMES)
 _RUNNER_OPTS = dict(
+    add_steps_in_batch=dict(
+        switches=[
+            (['--add-steps-in-batch'], dict(
+                'For multi-step jobs, submit all steps at once',
+            )),
+            (['--no-add-steps-in-batch'], dict(
+                'For multi-step jobs, submit steps successively after'
+                ' the previous one completes',
+            )),
+        ]
+    ),
     additional_emr_info=dict(
         cloud_role='launch',
         switches=[

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -2842,15 +2842,30 @@ class ActionOnFailureTestCase(MockBoto3TestCase):
     def test_default(self):
         runner = EMRJobRunner()
         self.assertEqual(runner._action_on_failure(),
-                         'TERMINATE_CLUSTER')
+                         'CONTINUE')
 
     def test_default_with_pooling(self):
         runner = EMRJobRunner(pool_clusters=True)
         self.assertEqual(runner._action_on_failure(),
-                         'CANCEL_AND_WAIT')
+                         'CONTINUE')
 
     def test_default_with_cluster_id(self):
         runner = EMRJobRunner(cluster_id='j-CLUSTER')
+        self.assertEqual(runner._action_on_failure(),
+                         'CONTINUE')
+
+    def test_add_steps_in_batch(self):
+        runner = EMRJobRunner(add_steps_in_batch=True)
+        self.assertEqual(runner._action_on_failure(),
+                         'TERMINATE_CLUSTER')
+
+    def test_pooling_with_add_steps_in_batch(self):
+        runner = EMRJobRunner(add_steps_in_batch=True, pool_clusters=True)
+        self.assertEqual(runner._action_on_failure(),
+                         'CANCEL_AND_WAIT')
+
+    def test_cluster_id_with_add_steps_in_batch(self):
+        runner = EMRJobRunner(add_steps_in_batch=True, cluster_id='j-CLUSTER')
         self.assertEqual(runner._action_on_failure(),
                          'CANCEL_AND_WAIT')
 

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -4294,6 +4294,9 @@ class EMRConfigurationsTestCase(MockBoto3TestCase):
 
 class GetJobStepsTestCase(MockBoto3TestCase):
 
+    # get_job_steps() was designed with the assumption that all job steps
+    # will be submitted at once, and is now obsolete
+
     def test_empty(self):
         runner = EMRJobRunner()
         runner.make_persistent_cluster()
@@ -4301,7 +4304,7 @@ class GetJobStepsTestCase(MockBoto3TestCase):
         self.assertEqual(runner.get_job_steps(), [])
 
     def test_own_cluster(self):
-        job = MRTwoStepJob(['-r', 'emr']).sandbox()
+        job = MRTwoStepJob(['-r', 'emr', '--add-steps-in-batch']).sandbox()
 
         with job.make_runner() as runner:
             self.launch(runner)
@@ -4325,7 +4328,9 @@ class GetJobStepsTestCase(MockBoto3TestCase):
                             HadoopJarStep=(dict(Jar='dummy.jar')))] * n,
             )
 
-        job = MRTwoStepJob(['-r', 'emr', '--cluster-id', cluster_id]).sandbox()
+        job = MRTwoStepJob([
+            '-r', 'emr', '--add-steps-in-batch', '--cluster-id', cluster_id]
+        ).sandbox()
 
         with job.make_runner() as runner:
             add_other_steps(runner, 50)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -260,7 +260,7 @@ class EMRJobRunnerEndToEndTestCase(MockBoto3TestCase):
         self.assertEqual(step_ids, [step['Id'] for step in steps])
 
     def test_failed_job(self):
-        mr_job = MRTwoStepJob(['-r', 'emr', '-v'])
+        mr_job = MRTwoStepJob(['-r', 'emr'])
         mr_job.sandbox()
 
         self.add_mock_s3_data({'walrus': {}})
@@ -279,15 +279,7 @@ class EMRJobRunnerEndToEndTestCase(MockBoto3TestCase):
 
             cluster = runner._describe_cluster()
             self.assertEqual(cluster['Status']['State'],
-                             'TERMINATED_WITH_ERRORS')
-
-        # job should get terminated on cleanup
-        cluster_id = runner.get_cluster_id()
-        for _ in range(10):
-            self.simulate_emr_progress(cluster_id)
-
-        cluster = runner._describe_cluster()
-        self.assertEqual(cluster['Status']['State'], 'TERMINATED_WITH_ERRORS')
+                             'TERMINATED')
 
     def _test_cloud_tmp_cleanup(self, mode, tmp_len, log_len):
         self.add_mock_s3_data({'walrus': {'logs/j-MOCKCLUSTER0/1': b'1\n'}})

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -1917,6 +1917,9 @@ class PoolingRecoveryTestCase(MockBoto3TestCase):
 
         return cluster_id
 
+    def step_ids(self, cluster_id):
+        return [s['Id'] for s in self.mock_emr_clusters[cluster_id]['_Steps']]
+
     def num_steps(self, cluster_id):
         return len(self.mock_emr_clusters[cluster_id]['_Steps'])
 
@@ -1942,11 +1945,15 @@ class PoolingRecoveryTestCase(MockBoto3TestCase):
         with job.make_runner() as runner:
             runner.run()
 
-            # tried to add steps to pooled cluster, had to try again
-            self.assertEqual(self.num_steps(cluster_id), 2)
+            # tried to add step to pooled cluster, had to try again
+            self.assertEqual(self.num_steps(cluster_id), 1)
 
             self.assertNotEqual(runner.get_cluster_id(), cluster_id)
             self.assertEqual(self.num_steps(runner.get_cluster_id()), 2)
+
+            # make sure self._step_ids got cleared
+            self.assertEqual(runner._step_ids,
+                             self.step_ids(runner.get_cluster_id()))
 
     def test_launch_new_multi_node_cluster_after_self_termination(self):
         # the error message is different when a multi-node cluster
@@ -1960,11 +1967,15 @@ class PoolingRecoveryTestCase(MockBoto3TestCase):
         with job.make_runner() as runner:
             runner.run()
 
-            # tried to add steps to pooled cluster, had to try again
-            self.assertEqual(self.num_steps(cluster_id), 2)
+            # tried to add step to pooled cluster, had to try again
+            self.assertEqual(self.num_steps(cluster_id), 1)
 
             self.assertNotEqual(runner.get_cluster_id(), cluster_id)
             self.assertEqual(self.num_steps(runner.get_cluster_id()), 2)
+
+            # make sure self._step_ids got cleared
+            self.assertEqual(runner._step_ids,
+                             self.step_ids(runner.get_cluster_id()))
 
     def test_reset_ssh_tunnel_and_hadoop_fs_on_launch(self):
         # regression test for #1549
@@ -2007,8 +2018,8 @@ class PoolingRecoveryTestCase(MockBoto3TestCase):
 
             runner.run()
 
-            # tried to add steps to pooled cluster, had to try again
-            self.assertEqual(self.num_steps(cluster_id), 2)
+            # tried to add step to pooled cluster, had to try again
+            self.assertEqual(self.num_steps(cluster_id), 1)
 
             self.assertNotEqual(runner.get_cluster_id(), cluster_id)
             self.assertEqual(self.num_steps(runner.get_cluster_id()), 2)
@@ -2035,10 +2046,13 @@ class PoolingRecoveryTestCase(MockBoto3TestCase):
         with job.make_runner() as runner:
             runner.run()
 
-            self.assertEqual(self.num_steps(cluster1_id), 2)
+            self.assertEqual(self.num_steps(cluster1_id), 1)
 
             self.assertEqual(runner.get_cluster_id(), cluster2_id)
             self.assertEqual(self.num_steps(cluster2_id), 2)
+
+            # make sure self._step_ids got cleared
+            self.assertEqual(runner._step_ids, self.step_ids(cluster2_id))
 
     def test_multiple_failover(self):
         cluster_ids = []
@@ -2068,7 +2082,8 @@ class PoolingRecoveryTestCase(MockBoto3TestCase):
         with job.make_runner() as runner:
             self.assertRaises(StepFailedException, runner.run)
 
-            self.assertEqual(self.num_steps(cluster_id), 2)
+            # steps are added one at a time
+            self.assertEqual(self.num_steps(cluster_id), 1)
 
     def test_dont_recover_from_user_termination(self):
         cluster_id = self.make_pooled_cluster()
@@ -2082,7 +2097,8 @@ class PoolingRecoveryTestCase(MockBoto3TestCase):
             self.launch(runner)
 
             self.assertEqual(runner.get_cluster_id(), cluster_id)
-            self.assertEqual(self.num_steps(cluster_id), 2)
+            # steps are added one at a time
+            self.assertEqual(self.num_steps(cluster_id), 1)
 
             self.client('emr').terminate_job_flows(JobFlowIds=[cluster_id])
 
@@ -2096,7 +2112,8 @@ class PoolingRecoveryTestCase(MockBoto3TestCase):
             self.launch(runner)
 
             cluster_id = runner.get_cluster_id()
-            self.assertEqual(self.num_steps(cluster_id), 2)
+            # steps are added one at a time
+            self.assertEqual(self.num_steps(cluster_id), 1)
             self.mock_emr_self_termination.add(cluster_id)
 
             self.assertRaises(StepFailedException, runner._finish_run)

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -178,6 +178,12 @@ class PoolMatchingTestCase(MockBoto3TestCase):
             '--cluster-id', cluster_id,
             '--image-version', '2.2'])
 
+    def test_add_batch_in_steps_does_not_affect_pooling(self):
+        _, cluster_id = self.make_pooled_cluster()
+
+        self.assertJoins(cluster_id, [
+            '-r', 'emr', '--pool-clusters', '--add-steps-in-batch'])
+
     def test_pooling_with_image_version(self):
         _, cluster_id = self.make_pooled_cluster(image_version='2.4.9')
 


### PR DESCRIPTION
Now that EMR can run steps concurrently, it can be a problem to submit all of the steps of a multi-step job concurrently. This change makes it so that for AMIs that can run steps concurrently (5.28.0 and later), the runner submits multi-step jobs one step at a time. This behavior can be changed explicitly with the `add_steps_in_batch` option.

This is a first step toward full support for concurrent steps (#2185).