### PR TITLE
max_clusters_in_pool, pool_timeout_minutes, and bypassing of pool_wait_minutes

### DIFF
--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -710,6 +710,8 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         self._add_master_node_setup_files_for_upload()
         self._add_job_files_for_upload()
         self._upload_local_files()
+        # make sure we can see the files we copied to S3
+        self._wait_for_s3_eventual_consistency()
 
     def _launch(self):
         """Set up files and then launch our job on EMR."""
@@ -1105,9 +1107,6 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         persistent -- if this is true, create the cluster with the keep_alive
             option, indicating the job will have to be manually terminated.
         """
-        # make sure we can see the files we copied to S3
-        self._wait_for_s3_eventual_consistency()
-
         log.debug('Creating Elastic MapReduce cluster')
         emr_client = self.make_emr_client()
 
@@ -2365,6 +2364,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
         self._add_bootstrap_files_for_upload(persistent=True)
         self._upload_local_files()
+
+        # make sure we can see the files we copied to S3
+        self._wait_for_s3_eventual_consistency()
 
         # don't allow user to call run()
         self._ran_job = True

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -86,6 +86,7 @@ from mrjob.parse import _parse_progress_from_job_tracker
 from mrjob.parse import _parse_progress_from_resource_manager
 from mrjob.pool import _attempt_to_lock_cluster
 from mrjob.pool import _attempt_to_unlock_cluster
+from mrjob.pool import _cluster_name_suffix
 from mrjob.pool import _instance_fleets_satisfy
 from mrjob.pool import _instance_groups_satisfy
 from mrjob.py2 import PY2
@@ -2685,14 +2686,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         """Extra info added to the cluster name, for pooling."""
         if not self._opts['pool_clusters']:
             return ''
-
-        fields = [
-            mrjob.__version__,
-            self._opts['pool_name'],
-            self._pool_hash(),
-        ]
-
-        return ' pooling:%s' % ','.join(fields)
+        else:
+            return _cluster_name_suffix(
+                self._pool_hash(), self._opts['pool_name'])
 
     ### EMR-specific Stuff ###
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -306,6 +306,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'min_available_virtual_cores',
         'pool_clusters',
         'pool_jitter_seconds',
+        'pool_timeout_seconds',
         'pool_name',
         'pool_wait_minutes',
         'release_label',

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -289,6 +289,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'instance_fleets',
         'instance_groups',
         'master_instance_bid_price',
+        'max_clusters_in_pool',
         'max_concurrent_steps',
         'min_available_mb',
         'min_available_virtual_cores',

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -304,6 +304,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         'min_available_mb',
         'min_available_virtual_cores',
         'pool_clusters',
+        'pool_jitter_seconds',
         'pool_name',
         'pool_wait_minutes',
         'release_label',
@@ -472,6 +473,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                 num_task_instances=0,
                 pool_clusters=False,
                 pool_name='default',
+                pool_jitter_seconds=60,
                 pool_wait_minutes=0,
                 region=_DEFAULT_EMR_REGION,
             )

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2676,8 +2676,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                     return cluster_id, step_concurrency_level
 
             keep_waiting = (
-                datetime.now() + timedelta(seconds=_POOLING_SLEEP_INTERVAL) <=
-                start + timedelta(minutes=wait_mins))
+                datetime.now() < start + timedelta(minutes=wait_mins))
 
             # if we haven't exhausted pool_wait_minutes, and there are
             # clusters we might eventually join, sleep and try again
@@ -2721,7 +2720,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                     new_num_in_pool, _plural(new_num_in_pool)))
 
                 if ((not max_in_pool or new_num_in_pool < max_in_pool) and
-                        (not keep_waiting or new_cluster_ids['matching'])):
+                        (not keep_waiting or not new_cluster_ids['matching'])):
 
                     # allow creating a new cluster
                     return None, None

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2374,7 +2374,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         """Get the ID of the cluster our job is running on, or ``None``."""
         return self._cluster_id
 
-    def _yield_clusters_to_join(self):
+    def _yield_clusters_to_join(self, available_cluster_ids):
         """Get a list of IDs of pooled clusters that this runner can join,
         sorted so that the ones with the greatest CPU capacity come first.
 
@@ -2384,9 +2384,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
         """
         emr_client = self.make_emr_client()
 
-        cluster_ids = self._list_cluster_ids_for_pooling()
-
-        for cluster_id in cluster_ids['available']:
+        for cluster_id in available_cluster_ids:
             if not self._cluster_has_adequate_capacity(cluster_id):
                 continue
 
@@ -2623,8 +2621,10 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
         log.info('Attempting to find an available cluster...')
         while True:
+            cluster_ids = self._list_cluster_ids_for_pooling()
+
             for cluster, when_cluster_described in (
-                    self._yield_clusters_to_join()):
+                    self._yield_clusters_to_join(cluster_ids['available'])):
                 cluster_id = cluster['Id']
                 step_concurrency_level = cluster['StepConcurrencyLevel']
 

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -22,7 +22,6 @@ import os
 import os.path
 import pipes
 import posixpath
-import random
 import re
 import time
 from collections import OrderedDict
@@ -30,6 +29,7 @@ from collections import defaultdict
 from datetime import datetime
 from datetime import timedelta
 from math import ceil
+from random import randint
 
 try:
     import botocore.client
@@ -2672,7 +2672,7 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                     num_in_pool, _plural(num_in_pool), pool_name, max_in_pool))
 
                 if num_in_pool < max_in_pool:
-                    jitter_seconds = random.randint(
+                    jitter_seconds = randint(
                         0, self._opts['pool_jitter_seconds'])
                     log.info('  waiting %d seconds and double-checking number'
                              ' of clusters in pool...' % jitter_seconds)
@@ -2685,9 +2685,9 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
                         cluster_ids['in_pool'] | new_cluster_ids['in_pool'])
 
                     log.info('    %d cluster%s in pool' % (
-                        num_in_pool, _plural(num_in_pool)))
+                        new_num_in_pool, _plural(new_num_in_pool)))
 
-                    if num_in_pool < max_in_pool:
+                    if new_num_in_pool < max_in_pool:
                         # allow creating a new cluster
                         return None, None
 

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1072,6 +1072,14 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    pool_timeout_minutes=dict(
+        switches=[
+            (['--pool-timeout-minutes'], dict(
+                help=("If pooling can't join or create a cluster within this"
+                      " many minutes, raise an exception")
+            )),
+        ],
+    ),
     pool_wait_minutes=dict(
         switches=[
             (['--pool-wait-minutes'], dict(

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1076,7 +1076,9 @@ _RUNNER_OPTS = dict(
         switches=[
             (['--pool-timeout-minutes'], dict(
                 help=("If pooling can't join or create a cluster within this"
-                      " many minutes, raise an exception")
+                      " many minutes, raise an exception. (0 means don't"
+                      " timeout"),
+                type=int,
             )),
         ],
     ),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -931,6 +931,16 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    max_clusters_in_pool=dict(
+        switches=[
+            (['--max-clusters-in-pool'], dict(
+                help=("If attempting to join a pooled cluster, don't bail"
+                      " out and create a new one if there are at least"
+                      " this many clusters already in the pool."),
+                type=int,
+            )),
+        ],
+    ),
     max_concurrent_steps=dict(
         cloud_role='launch',
         switches=[

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1053,6 +1053,17 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    pool_jitter_seconds=dict(
+        switches=[
+            (['--pool-jitter-seconds'], dict(
+                help=('If --max-pools-in-cluster is set, before launching a'
+                      ' cluster, wait a random amount of time between 0 and'
+                      ' this many seconds and then double-check the number'
+                      ' of clusters in the pool before launching'),
+                type=int,
+            )),
+        ],
+    ),
     pool_name=dict(
         cloud_role='launch',
         switches=[

--- a/mrjob/pool.py
+++ b/mrjob/pool.py
@@ -68,25 +68,38 @@ def _pool_name(cluster):
 # this may change between versions of mrjob
 
 def _cluster_name_suffix(hash, name):
-    fields = [mrjob.__version__, hash, name]
+    fields = [mrjob.__version__, name, hash]
     return ' pooling:%s' % ','.join(fields)
 
 
 def _parse_cluster_name_suffix(cluster_name):
+    """Return a dictionary possibly containing the keys:
+
+    mrjob_version: version of mrjob that created this cluster
+    pool_hash: hash representing bootstrap setup etc.
+    pool_name: name of the cluster pool
+
+    If the cluster is not pooled or we can't parse its pooling suffix,
+    return ``{}``.
+    """
     # return version, hash, and name from cluster pool suffix
 
     i = cluster_name.find(' pooling:')
     if i == -1:
-        return (None, None, None)
+        return {}
 
     suffix = cluster_name[i + len(' pooling:'):]
 
     parts = suffix.split(',', 3)
 
     if len(parts) == 3:
-        return tuple(parts)
+        return dict(
+            mrjob_version=parts[0],
+            pool_name=parts[1],
+            pool_hash=parts[2],
+        )
     else:
-        return (None, None, None)
+        return {}
 
 
 ### instance groups ###


### PR DESCRIPTION
Cluster pooling tries to ensure jobs re-use existing clusters rather than creating their own. However, this can go wrong when multiple jobs start simultaneously (the "thundering herd" problem).

This patch creates the `max_clusters_in_pool` option (fixes #2192 ) to check if the pool is already "full" of clusters before creating one. If it is, the job will wait until a cluster is available to join or one or more clusters in the pool terminate. To handle the "thundering herd" problem, once we've determined that we're allowed to create a new cluster, we wait a random number of seconds and double-check. This is controlled by the `pool_jitter_seconds` option (fixes #2200).

The `pool_wait_minutes` option also handles the "thundering herd" problem badly, since every cluster will wait, even though there isn't any cluster to wait *for*. mrjob will now bypass `pool_wait_minutes` if there aren't active clusters which match our job's pool name and hash (fixes #2198). Like with `max_clusters_in_pool`, we wait a random number of seconds and double-check before launching our own cluster. 

Previously, the `pool_wait_minutes` option was interpreted to mean we should refuse to wait any longer than this many minutes. Now we wait at least this many minutes before launching a new cluster (unless there is no cluster we could plausibly wait for).

Finally, this change adds the `pool_timeout_minutes` option, which causes mrjob to raise an exception and bail out if a pooled job has been unable to join or a create a cluster (fixes #2199).