### PR TITLE
Make unpacking archives optional

### DIFF
--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -583,6 +583,16 @@ URIs of input files) to Hadoop, and instructs Hadoop to send one line to
 each mapper. In most cases, this should be seamless, even to the point of
 telling you which file was being read when a task fails.
 
+By default, files in recognized compressed formats (`.gz`, `.bz2`) are 
+decompressed after being download. If you want to handle the original
+file directly and unpack the contents in your mapper, you can set 
+`unpack_archives: false` in your runner configuration.
+
+
+   runners:
+       hadoop:
+           unpack_archives: false
+
 .. warning::
 
    For all runners except EMR, mrjob uses :command:`hadoop fs` to download

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -583,7 +583,6 @@ URIs of input files) to Hadoop, and instructs Hadoop to send one line to
 each mapper. In most cases, this should be seamless, even to the point of
 telling you which file was being read when a task fails.
 
-
 .. warning::
 
    For all runners except EMR, mrjob uses :command:`hadoop fs` to download

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -583,15 +583,6 @@ URIs of input files) to Hadoop, and instructs Hadoop to send one line to
 each mapper. In most cases, this should be seamless, even to the point of
 telling you which file was being read when a task fails.
 
-By default, files in recognized compressed formats (`.gz`, `.bz2`) are 
-decompressed after being download. If you want to handle the original
-file directly and unpack the contents in your mapper, you can set 
-`unpack_archives: false` in your runner configuration::
-
-   runners:
-       hadoop:
-           unpack_archives: false
-
 
 .. warning::
 
@@ -599,6 +590,22 @@ file directly and unpack the contents in your mapper, you can set
    files to the local filesystem, which means Hadoop has to invoke
    itself. If your cluster has tightly tuned memory requirements, this can
    sometimes cause an out-of-memory error.
+
+
+Passing raw archive files to your job 
+
+.. versionadded:: 0.?.?
+
+By default, files in recognized compressed formats (e.g. `.gz`, `.bz2`) are 
+decompressed after being download. If you want to handle the original
+file directly in your mapper, you can set `unpack_archives: false` in your 
+runner configuration. For example, to configure this setting for the Hadoop 
+runner, use::
+
+   runners:
+       hadoop:
+           unpack_archives: false
+
 
 .. _non-hadoop-streaming-jar-steps:
 

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -586,12 +586,12 @@ telling you which file was being read when a task fails.
 By default, files in recognized compressed formats (`.gz`, `.bz2`) are 
 decompressed after being download. If you want to handle the original
 file directly and unpack the contents in your mapper, you can set 
-`unpack_archives: false` in your runner configuration.
-
+`unpack_archives: false` in your runner configuration::
 
    runners:
        hadoop:
            unpack_archives: false
+
 
 .. warning::
 

--- a/docs/guides/writing-mrjobs.rst
+++ b/docs/guides/writing-mrjobs.rst
@@ -593,6 +593,7 @@ telling you which file was being read when a task fails.
 
 
 Passing raw archive files to your job 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. versionadded:: 0.?.?
 

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -700,8 +700,9 @@ class MRJobBinRunner(MRJobRunner):
                             r"$(echo $INPUT_PATH | sed -e 's/\.%s$//')" % ext)
                 lines.append('      ;;')
             lines.append('  esac')
-            lines.append('} 1>&2')
-            lines.append('')
+
+        lines.append('} 1>&2')
+        lines.append('')
 
         # don't exit if script fails
         lines.append('# run our mrjob script')

--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -139,6 +139,7 @@ class MRJobBinRunner(MRJobRunner):
             super(MRJobBinRunner, cls)._default_opts(),
             dict(
                 read_logs=True,
+                unpack_archives=True
             )
         )
 
@@ -689,17 +690,18 @@ class MRJobBinRunner(MRJobRunner):
         lines.append('')
 
         # unpack .bz2 and .gz files
-        lines.append('  # if input file is compressed, unpack it')
-        lines.append('  case $INPUT_PATH in')
-        for ext, cmd in self._manifest_uncompress_commands():
-            lines.append('    *.%s)' % ext)
-            lines.append('      %s $INPUT_PATH' % cmd)
-            lines.append("      INPUT_PATH="
-                         r"$(echo $INPUT_PATH | sed -e 's/\.%s$//')" % ext)
-            lines.append('      ;;')
-        lines.append('  esac')
-        lines.append('} 1>&2')
-        lines.append('')
+        if self._opts['unpack_archives']:
+            lines.append('  # if input file is compressed, unpack it')
+            lines.append('  case $INPUT_PATH in')
+            for ext, cmd in self._manifest_uncompress_commands():
+                lines.append('    *.%s)' % ext)
+                lines.append('      %s $INPUT_PATH' % cmd)
+                lines.append("      INPUT_PATH="
+                            r"$(echo $INPUT_PATH | sed -e 's/\.%s$//')" % ext)
+                lines.append('      ;;')
+            lines.append('  esac')
+            lines.append('} 1>&2')
+            lines.append('')
 
         # don't exit if script fails
         lines.append('# run our mrjob script')

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1411,6 +1411,18 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    unpack_archives=dict(
+        switches=[
+            (['--unpack-archives'], dict(
+                action='store_true',
+                help=('Unpack archives when processing entire files (the default).')
+            )),
+            (['--no-unpack-archives'], dict(
+                action='store_false',
+                help="Don't unpack archive formats when processing entire files."
+            )),
+        ],
+    ),
     upload_archives=dict(
         combiner=combine_path_lists,
         switches=[

--- a/mrjob/runner.py
+++ b/mrjob/runner.py
@@ -105,6 +105,7 @@ class MRJobRunner(object):
         'py_files',
         'read_logs',
         'setup',
+        'unpack_archives',
         'upload_archives',
         'upload_dirs',
         'upload_files'


### PR DESCRIPTION
We are using MrJob to process WARC files, in similar manner to [this example given in the Writing Jobs guide](https://github.com/Yelp/mrjob/blob/master/docs/guides/writing-mrjobs.rst#passing-entire-files-to-the-mapper).

For our use case, it is crucial that the `.gz` compressed file is not automatically decompressed before use.

This PR proposes a new setting that would allow this to be controlled via a `unpack_archives` option passed to the MrJob runner. This new option defaults to `True` to maintain the expected default behaviour, while allowing us to set it to `False` when needed. We have tested this locally and it seems to work just fine.

I've attempted to document this new option, as per the contributing guidelines, but I'm not sure I've covered everything.  Is there any other documentation I should add?