### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -248,7 +248,7 @@ miscellanous tweaks
 The :command:`mrjob audit-emr-usage` subcommand no longer attempts to read
 cluster pool names from clusters launched by mrjob v0.5.x.
 
-Method arguments in filesystem classes (in ``mrjob.fs``) are now consistenly
+Method arguments in filesystem classes (in ``mrjob.fs``) are now consistently
 named. This probably won't matter in practice, as
 ``runner.fs <mrjob.runner.MRJobRunner.fs>`` is always a
 :py:class:`~mrjob.fs.composite.CompositeFilesystem` anyhow.

--- a/mrjob/examples/mr_text_classifier.py
+++ b/mrjob/examples/mr_text_classifier.py
@@ -47,7 +47,7 @@ Some terminology:
 An "ngram" is a word or phrase. "foo" is a 1-gram; "foo bar baz" is a 3-gram.
 
 "tf" refers to term frequency, that is, the number of times an ngram appears.
-"df" referse to document frequency, that is, the number of documents an ngram
+"df" refers to document frequency, that is, the number of documents an ngram
 appears in at least once.
 """
 from collections import defaultdict

--- a/mrjob/sim.py
+++ b/mrjob/sim.py
@@ -62,7 +62,7 @@ class SimMRJobRunner(MRJobRunner):
         'partitioner',
     ]
 
-    # options that we ignore becaue they require real Hadoop.
+    # options that we ignore because they require real Hadoop.
     _IGNORED_HADOOP_OPTS = [
         'libjars',
     ]


### PR DESCRIPTION
There are small typos in:
- docs/whats-new.rst
- mrjob/examples/mr_text_classifier.py
- mrjob/sim.py

Fixes:
- Should read `refers` rather than `referse`.
- Should read `consistently` rather than `consistenly`.
- Should read `because` rather than `becaue`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md