### PR TITLE
util.py (and hence mrjob) not to depend on pipes, removed in python 3.13

### DIFF
--- a/mrjob/bin.py
+++ b/mrjob/bin.py
@@ -20,8 +20,8 @@
 import logging
 import os
 import os.path
-import pipes
 import re
+import shlex
 import sys
 from mrjob.py2 import PY2
 from platform import python_implementation
@@ -468,8 +468,8 @@ class MRJobBinRunner(MRJobRunner):
                     'archive_file', path)
 
                 setup.append(_unarchive_cmd(path) % dict(
-                    file=pipes.quote(archive_file_name),
-                    dir=pipes.quote(name)))
+                    file=shlex.quote(archive_file_name),
+                    dir=shlex.quote(name)))
 
         setup.extend(self._setup)
 
@@ -633,7 +633,7 @@ class MRJobBinRunner(MRJobRunner):
                 if isinstance(token, dict):
                     # it's a path dictionary
                     line += '$__mrjob_PWD/'
-                    line += pipes.quote(self._working_dir_mgr.name(**token))
+                    line += shlex.quote(self._working_dir_mgr.name(**token))
                 else:
                     # it's raw script
                     line += token

--- a/mrjob/util.py
+++ b/mrjob/util.py
@@ -20,7 +20,6 @@
 import logging
 import os
 import os.path
-import pipes
 import random
 import shlex
 import shutil
@@ -50,7 +49,7 @@ def cmd_line(args):
     """build a command line that works in a shell.
     """
     args = [str(x) for x in args]
-    return ' '.join(pipes.quote(x) for x in args)
+    return ' '.join(shlex.quote(x) for x in args)
 
 
 def expand_path(path):

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ try:
             'ujson': ['ujson'],
         },
         'install_requires': [
+             'setuptools',
              'PyYAML>=3.10',
         ],
         'provides': ['mrjob'],


### PR DESCRIPTION
util.py (and hence mrjob) not to depend on pipes, module removed in python 3.13.

Fixes #2224.